### PR TITLE
Add linkProps to DocumentCard

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2018-09-documentCardLinkProps_2018-09-14-18-46.json
+++ b/common/changes/office-ui-fabric-react/edwl-2018-09-documentCardLinkProps_2018-09-14-18-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCard: Update component to use Link",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.scss
@@ -112,6 +112,7 @@ $ms-DocumentCardActions-verticalPadding: 4px;
 .views {
   @include text-align(right);
   line-height: $ms-DocumentCardActions-actionSize;
+  color: $ms-color-neutralPrimary;
 }
 
 .viewsIcon {
@@ -279,6 +280,7 @@ $ms-DocumentCardActivity-personaTextGutter: 8px;
   @include padding(0px, 16px, 8px, 16px);
   display: block;
   font-size: $ms-font-size-s;
+  color: $ms-color-neutralPrimary;
 }
 
 /** Title **/

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -51,7 +51,9 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
         onClick={actionable ? this._onClick : undefined}
         style={style}
       >
-        <Link {...linkProps}>{children}</Link>
+        <Link as="a" {...linkProps}>
+          {children}
+        </Link>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IDocumentCardProps, DocumentCardType } from './DocumentCard.types';
 import { BaseComponent, KeyCodes, css } from '../../Utilities';
+import { Link } from '../Link';
 import * as stylesImport from './DocumentCard.scss';
 const styles: any = stylesImport;
 
@@ -18,7 +19,7 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
   }
 
   public render(): JSX.Element {
-    const { onClick, onClickHref, children, className, type, accentColor } = this.props;
+    const { onClick, onClickHref, children, className, type, accentColor, linkProps } = this.props;
     const actionable = onClick || onClickHref ? true : false;
 
     // Override the border color if an accent color was provided (compact card only)
@@ -50,7 +51,7 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> {
         onClick={actionable ? this._onClick : undefined}
         style={style}
       >
-        {children}
+        <Link {...linkProps}>{children}</Link>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -8,6 +8,7 @@ import { DocumentCardStatus } from './DocumentCardStatus';
 import { PersonaInitialsColor } from '../../Persona';
 import { ImageFit } from '../../Image';
 import { IButtonProps } from '../../Button';
+import { ILinkProps } from '../../Link';
 import { IIconProps } from '../../Icon';
 import { IBaseProps, IRefObject } from '../../Utilities';
 
@@ -28,12 +29,14 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
 
   /**
    * Function to call when the card is clicked or keyboard Enter/Space is pushed.
+   * @deprecated Use linkProps instead.
    */
   onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
 
   /**
    * A URL to navigate to when the card is clicked. If a function has also been provided,
    * it will be used instead of the URL.
+   * @deprecated Use linkProps instead.
    */
   onClickHref?: string;
 
@@ -41,6 +44,11 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
    * Optional class for document card.
    */
   className?: string;
+
+  /**
+   * Props for the Link component.  Use this instead of the deprecated onClick and onClickHref.
+   */
+  linkProps?: ILinkProps;
 
   /**
    * Hex color value of the line below the card, which should correspond to the document type.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -4,107 +4,169 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
 <div
   className="ms-DocumentCard"
 >
-  <div
-    className="ms-DocumentCardPreview"
-  />
-  <div
-    className="ms-DocumentCardTitle"
-    title=""
-  >
-    
-  </div>
-  <div
-    className="ms-DocumentCardActivity"
+  <a
+    className=
+        ms-Link
+        {
+          background-color: transparent;
+          background: none;
+          border-bottom: 1px solid transparent;
+          border: none;
+          color: #0078d4;
+          cursor: pointer;
+          display: inline;
+          font-size: inherit;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          outline: transparent;
+          overflow: inherit;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          text-align: left;
+          text-overflow: inherit;
+          user-select: text;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -1px;
+          content: "";
+          left: -1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: white-on-black){& {
+          color: #FFFF00;
+        }
+        @media screen and (-ms-high-contrast: black-on-white){& {
+          color: #00009F;
+        }
+        @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+          border-bottom: none;
+        }
+        &:active, &:hover, &:active:hover {
+          color: #004578;
+        }
+        @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+          text-decoration: underline;
+        }
+        &:focus {
+          color: #0078d4;
+        }
+    onClick={[Function]}
   >
     <div
-      className="ms-DocumentCardActivity-avatars"
+      className="ms-DocumentCardPreview"
+    />
+    <div
+      className="ms-DocumentCardTitle"
+      title=""
+    >
+      
+    </div>
+    <div
+      className="ms-DocumentCardActivity"
     >
       <div
-        className="ms-DocumentCardActivity-avatar"
+        className="ms-DocumentCardActivity-avatars"
       >
         <div
-          className=
-              ms-Persona-coin
-              ms-Persona--size32
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-              }
-          role="persentation"
-          size={11}
+          className="ms-DocumentCardActivity-avatar"
         >
           <div
             className=
-                ms-Persona-imageArea
+                ms-Persona-coin
+                ms-Persona--size32
                 {
-                  flex: 0 0 auto;
-                  height: 32px;
-                  position: relative;
-                  text-align: center;
-                  width: 32px;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                 }
+            role="persentation"
+            size={11}
           >
             <div
-              aria-hidden="true"
               className=
-                  ms-Persona-initials
+                  ms-Persona-imageArea
                   {
-                    background-color: #2D89EF;
-                    border-radius: 50%;
-                    color: #ffffff;
-                    font-size: 14px;
-                    font-weight: 400;
+                    flex: 0 0 auto;
                     height: 32px;
-                    line-height: 32px;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    -ms-high-contrast-adjust: none;
-                    background-color: Window !important;
-                    border: 1px solid WindowText;
-                    box-sizing: border-box;
-                    color: WindowText;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
                   }
             >
-              <i
-                aria-hidden={true}
+              <div
+                aria-hidden="true"
                 className=
-
+                    ms-Persona-initials
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons-0";
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
+                      background-color: #2D89EF;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
                     }
-                data-icon-name="Contact"
-                role="presentation"
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
               >
-                
-              </i>
+                <i
+                  aria-hidden={true}
+                  className=
+
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons-0";
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                  data-icon-name="Contact"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-DocumentCardActivity-details"
-    >
-      <span
-        className="ms-DocumentCardActivity-name"
+      <div
+        className="ms-DocumentCardActivity-details"
       >
-        
-      </span>
-      <span
-        className="ms-DocumentCardActivity-activity"
-      >
-        
-      </span>
+        <span
+          className="ms-DocumentCardActivity-name"
+        >
+          
+        </span>
+        <span
+          className="ms-DocumentCardActivity-activity"
+        >
+          
+        </span>
+      </div>
     </div>
-  </div>
+  </a>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
@@ -7,6 +7,7 @@ import {
   IDocumentCardPreviewProps
 } from 'office-ui-fabric-react/lib/DocumentCard';
 import { ImageFit } from 'office-ui-fabric-react/lib/Image';
+import { ILinkProps } from 'office-ui-fabric-react/lib/Link';
 import { TestImages } from '../../../common/TestImages';
 import './DocumentCard.Example.scss';
 
@@ -26,8 +27,13 @@ export class DocumentCardBasicExample extends React.Component<any, any> {
       ]
     };
 
+    const linkProps: ILinkProps = {
+      href: 'http://bing.com',
+      target: '_blank'
+    };
+
     return (
-      <DocumentCard onClickHref="http://bing.com">
+      <DocumentCard linkProps={linkProps}>
         <DocumentCardPreview {...previewProps} />
         <DocumentCardTitle
           title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -8,6 +8,7 @@ import {
   DocumentCardType
 } from 'office-ui-fabric-react/lib/DocumentCard';
 import { TestImages } from '../../../common/TestImages';
+import { ILinkProps } from 'office-ui-fabric-react/lib/components/Link';
 
 export class DocumentCardCompactExample extends React.Component<any, any> {
   public render(): JSX.Element {
@@ -64,9 +65,14 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
       ]
     };
 
+    const linkProps: ILinkProps = {
+      href: 'http://bing.com',
+      target: '_blank'
+    };
+
     return (
       <div>
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard type={DocumentCardType.compact} linkProps={linkProps}>
           <DocumentCardPreview {...previewProps} />
           <div className="ms-DocumentCard-details">
             <DocumentCardTitle title="4 files were uploaded" shouldTruncate={true} />
@@ -77,7 +83,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
           </div>
         </DocumentCard>
         <p />
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard type={DocumentCardType.compact} linkProps={linkProps}>
           <DocumentCardPreview previewImages={[previewProps.previewImages[0]]} />
           <div className="ms-DocumentCard-details">
             <DocumentCardTitle title="Revenue stream proposal fiscal year 2016 version02.pptx" shouldTruncate={true} />
@@ -88,7 +94,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
           </div>
         </DocumentCard>
         <p />
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard type={DocumentCardType.compact} linkProps={linkProps}>
           <DocumentCardPreview {...previewPropsUsingIcon} />
           <div className="ms-DocumentCard-details">
             <DocumentCardTitle title="View and share files" shouldTruncate={true} />
@@ -99,13 +105,10 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
           </div>
         </DocumentCard>
         <p />
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard type={DocumentCardType.compact} linkProps={linkProps}>
           <DocumentCardPreview {...previewOutlookUsingIcon} />
           <div className="ms-DocumentCard-details">
-            <DocumentCardTitle
-              title="Conversation about anual report from SharePoint conference"
-              shouldTruncate={true}
-            />
+            <DocumentCardTitle title="Conversation about anual report from SharePoint conference" shouldTruncate={true} />
             <DocumentCardActivity
               activity="Sent a few minutes ago"
               people={[{ name: 'Kat Larrson', profileImageSrc: TestImages.personaFemale }]}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -12,6 +12,7 @@ import {
   IDocumentCardLogoProps
 } from 'office-ui-fabric-react/lib/DocumentCard';
 import { ImageFit } from 'office-ui-fabric-react/lib/Image';
+import { ILinkProps } from 'office-ui-fabric-react/lib/Link';
 import { TestImages } from '../../../common/TestImages';
 
 export class DocumentCardCompleteExample extends React.Component<any, any> {
@@ -90,9 +91,18 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
       logoIcon: 'OutlookLogo'
     };
 
+    const linkPropsOne: ILinkProps = {
+      onClick: this._onClick
+    };
+
+    const linkPropsTwo: ILinkProps = {
+      href: 'http://bing.com',
+      target: '_blank'
+    };
+
     return (
       <div>
-        <DocumentCard onClick={this._onClick}>
+        <DocumentCard linkProps={linkPropsOne}>
           <DocumentCardPreview {...previewProps} />
           <DocumentCardLocation
             location="Marketing Documents"
@@ -141,8 +151,10 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
             views={432}
           />
         </DocumentCard>
-        <p />Card Logo, Text Preview CardStatus are used on below examples.<p />
-        <DocumentCard onClickHref="http://bing.com">
+        <p />
+        Card Logo, Text Preview CardStatus are used on below examples.
+        <p />
+        <DocumentCard linkProps={linkPropsTwo}>
           <DocumentCardLogo {...logoProps} />
           <div className="ms-ConversationTile-TitlePreviewArea">
             <DocumentCardTitle
@@ -166,7 +178,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           />
         </DocumentCard>
         <p />
-        <DocumentCard onClickHref="http://bing.com">
+        <DocumentCard linkProps={linkPropsTwo}>
           <DocumentCardLogo {...logoProps} />
           <div className="ms-ConversationTile-TitlePreviewArea">
             <DocumentCardTitle title="Conversation about anual Report" />
@@ -183,7 +195,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           />
         </DocumentCard>
         <p />
-        <DocumentCard onClickHref="http://bing.com">
+        <DocumentCard linkProps={linkPropsTwo}>
           <DocumentCardLogo {...logoProps} />
           <div className="ms-ConversationTile-TitlePreviewArea">
             <DocumentCardTitle title="Conversation about anual report" shouldTruncate={true} />
@@ -203,7 +215,7 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
           />
         </DocumentCard>
         <p />
-        <DocumentCard onClickHref="http://bing.com">
+        <DocumentCard linkProps={linkPropsTwo}>
           <DocumentCardPreview {...previewPropsUsingIcon} />
           <div className="ms-DocumentCard-details">
             <DocumentCardTitle title="View and share files" shouldTruncate={true} />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -2,191 +2,224 @@
 
 exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`] = `
 <div
-  className="ms-DocumentCard ms-DocumentCard--actionable undefined"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="link"
-  tabIndex={0}
+  className="ms-DocumentCard"
 >
-  <div
-    className="ms-DocumentCardPreview"
-  >
-    <div>
-      <div
-        className=
-            ms-Image
-            {
-              overflow: hidden;
-              position: relative;
-            }
-        style={
-          Object {
-            "height": 196,
-            "width": 318,
-          }
+  <a
+    className=
+        ms-Link
+        {
+          color: #0078d4;
+          outline: transparent;
+          position: relative;
+          text-decoration: none;
         }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--cover
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                height: auto;
-                left: 50% /* @noflip */;
-                opacity: 0;
-                position: absolute;
-                top: 50%;
-                transform: translate(-50%,-50%);
-                width: 100%;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role="presentation"
-          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview.png"
-        />
-      </div>
-      <div
-        className=
-            ms-Image
-            ms-DocumentCardPreview-icon
-            {
-              overflow: hidden;
-            }
-        style={
-          Object {
-            "height": undefined,
-            "width": undefined,
-          }
+        &::-moz-focus-inner {
+          border: 0;
         }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                opacity: 0;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role="presentation"
-          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-        />
-      </div>
-    </div>
-  </div>
-  <div
-    className="ms-DocumentCardTitle"
-    title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"
-  >
-    Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx
-  </div>
-  <div
-    className="ms-DocumentCardActivity"
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: -1px;
+          content: "";
+          left: -1px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+          z-index: 1;
+        }
+        &:active, &:hover, &:active:hover {
+          color: #004578;
+        }
+        @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+          text-decoration: underline;
+        }
+        &:focus {
+          color: #0078d4;
+        }
+    href="http://bing.com"
+    onClick={[Function]}
+    target="_blank"
   >
     <div
-      className="ms-DocumentCardActivity-avatars"
+      className="ms-DocumentCardPreview"
     >
-      <div
-        className="ms-DocumentCardActivity-avatar"
-      >
+      <div>
         <div
           className=
-              ms-Persona-coin
-              ms-Persona--size32
+              ms-Image
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
+                overflow: hidden;
+                position: relative;
               }
-          role="persentation"
-          size={11}
+          style={
+            Object {
+              "height": 196,
+              "width": 318,
+            }
+          }
         >
-          <div
+          <img
+            alt=""
             className=
-                ms-Persona-imageArea
+                ms-Image-image
+                ms-Image-image--cover
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
                 {
-                  flex: 0 0 auto;
-                  height: 32px;
-                  position: relative;
-                  text-align: center;
-                  width: 32px;
+                  display: block;
+                  height: auto;
+                  left: 50% /* @noflip */;
+                  opacity: 0;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%,-50%);
+                  width: 100%;
                 }
-          >
-            <div
-              className=
-                  ms-Image
-                  ms-Persona-image
-                  {
-                    border-radius: 50%;
-                    border: 0px;
-                    height: 32px;
-                    left: 0px;
-                    margin-right: 10px;
-                    overflow: hidden;
-                    perspective: 1px;
-                    position: absolute;
-                    top: 0px;
-                    width: 32px;
-                  }
-              style={
-                Object {
-                  "height": 32,
-                  "width": 32,
-                }
+            onError={[Function]}
+            onLoad={[Function]}
+            role="presentation"
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview.png"
+          />
+        </div>
+        <div
+          className=
+              ms-Image
+              ms-DocumentCardPreview-icon
+              {
+                overflow: hidden;
               }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--cover
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: auto;
-                      left: 50% /* @noflip */;
-                      opacity: 0;
-                      position: absolute;
-                      top: 50%;
-                      transform: translate(-50%,-50%);
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-              />
-            </div>
-          </div>
+          style={
+            Object {
+              "height": undefined,
+              "width": undefined,
+            }
+          }
+        >
+          <img
+            alt=""
+            className=
+                ms-Image-image
+                ms-Image-image--portrait
+                is-notLoaded
+                is-fadeIn
+                {
+                  display: block;
+                  opacity: 0;
+                }
+            onError={[Function]}
+            onLoad={[Function]}
+            role="presentation"
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+          />
         </div>
       </div>
     </div>
     <div
-      className="ms-DocumentCardActivity-details"
+      className="ms-DocumentCardTitle"
+      title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"
     >
-      <span
-        className="ms-DocumentCardActivity-name"
-      >
-        Annie Lindqvist
-      </span>
-      <span
-        className="ms-DocumentCardActivity-activity"
-      >
-        Created a few minutes ago
-      </span>
+      Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx
     </div>
-  </div>
+    <div
+      className="ms-DocumentCardActivity"
+    >
+      <div
+        className="ms-DocumentCardActivity-avatars"
+      >
+        <div
+          className="ms-DocumentCardActivity-avatar"
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="persentation"
+            size={11}
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      border-radius: 50%;
+                      border: 0px;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
+                style={
+                  Object {
+                    "height": 32,
+                    "width": 32,
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCardActivity-details"
+      >
+        <span
+          className="ms-DocumentCardActivity-name"
+        >
+          Annie Lindqvist
+        </span>
+        <span
+          className="ms-DocumentCardActivity-activity"
+        >
+          Created a few minutes ago
+        </span>
+      </div>
+    </div>
+  </a>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -3,275 +3,555 @@
 exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined ms-DocumentCard--compact undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
+    className="ms-DocumentCard ms-DocumentCard--compact undefined"
   >
-    <div
-      className="ms-DocumentCardPreview is-fileList undefined"
-    >
-      <div>
-        <ul
-          className="ms-DocumentCardPreview-fileList"
-        >
-          <li>
-            <div
-              className=
-                  ms-Image
-                  ms-DocumentCardPreview-fileListIcon
-                  {
-                    overflow: hidden;
-                  }
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: 100%;
-                      opacity: 0;
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role="presentation"
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-              />
-            </div>
-            <a
-              href="http://bing.com"
-            >
-              Revenue stream proposal fiscal year 2016 version02.pptx
-            </a>
-          </li>
-          <li>
-            <div
-              className=
-                  ms-Image
-                  ms-DocumentCardPreview-fileListIcon
-                  {
-                    overflow: hidden;
-                  }
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: 100%;
-                      opacity: 0;
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role="presentation"
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-              />
-            </div>
-            <a
-              href="http://bing.com"
-            >
-              New Contoso Collaboration for Conference Presentation Draft
-            </a>
-          </li>
-          <li>
-            <div
-              className=
-                  ms-Image
-                  ms-DocumentCardPreview-fileListIcon
-                  {
-                    overflow: hidden;
-                  }
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: 100%;
-                      opacity: 0;
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role="presentation"
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-              />
-            </div>
-            <a
-              href="http://bing.com"
-            >
-              Spec Sheet for design
-            </a>
-          </li>
-        </ul>
-        <span
-          className="ms-DocumentCardPreview-fileListMore"
-        >
-          +1 more
-        </span>
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCard-details"
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
     >
       <div
-        className="ms-DocumentCardTitle"
-        title="4 files were uploaded"
+        className="ms-DocumentCardPreview is-fileList undefined"
       >
-        4 files were uploaded
+        <div>
+          <ul
+            className="ms-DocumentCardPreview-fileList"
+          >
+            <li>
+              <div
+                className=
+                    ms-Image
+                    ms-DocumentCardPreview-fileListIcon
+                    {
+                      overflow: hidden;
+                    }
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  role="presentation"
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+                />
+              </div>
+              <a
+                href="http://bing.com"
+              >
+                Revenue stream proposal fiscal year 2016 version02.pptx
+              </a>
+            </li>
+            <li>
+              <div
+                className=
+                    ms-Image
+                    ms-DocumentCardPreview-fileListIcon
+                    {
+                      overflow: hidden;
+                    }
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  role="presentation"
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+                />
+              </div>
+              <a
+                href="http://bing.com"
+              >
+                New Contoso Collaboration for Conference Presentation Draft
+              </a>
+            </li>
+            <li>
+              <div
+                className=
+                    ms-Image
+                    ms-DocumentCardPreview-fileListIcon
+                    {
+                      overflow: hidden;
+                    }
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  role="presentation"
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+                />
+              </div>
+              <a
+                href="http://bing.com"
+              >
+                Spec Sheet for design
+              </a>
+            </li>
+          </ul>
+          <span
+            className="ms-DocumentCardPreview-fileListMore"
+          >
+            +1 more
+          </span>
+        </div>
       </div>
       <div
-        className="ms-DocumentCardActivity"
+        className="ms-DocumentCard-details"
       >
         <div
-          className="ms-DocumentCardActivity-avatars"
+          className="ms-DocumentCardTitle"
+          title="4 files were uploaded"
+        >
+          4 files were uploaded
+        </div>
+        <div
+          className="ms-DocumentCardActivity"
         >
           <div
-            className="ms-DocumentCardActivity-avatar"
+            className="ms-DocumentCardActivity-avatars"
           >
             <div
-              className=
-                  ms-Persona-coin
-                  ms-Persona--size32
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                  }
-              role="persentation"
-              size={11}
+              className="ms-DocumentCardActivity-avatar"
             >
               <div
                 className=
-                    ms-Persona-imageArea
+                    ms-Persona-coin
+                    ms-Persona--size32
                     {
-                      flex: 0 0 auto;
-                      height: 32px;
-                      position: relative;
-                      text-align: center;
-                      width: 32px;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
                     }
+                role="persentation"
+                size={11}
               >
                 <div
                   className=
-                      ms-Image
-                      ms-Persona-image
+                      ms-Persona-imageArea
                       {
-                        border-radius: 50%;
-                        border: 0px;
+                        flex: 0 0 auto;
                         height: 32px;
-                        left: 0px;
-                        margin-right: 10px;
-                        overflow: hidden;
-                        perspective: 1px;
-                        position: absolute;
-                        top: 0px;
+                        position: relative;
+                        text-align: center;
                         width: 32px;
                       }
-                  style={
-                    Object {
-                      "height": 32,
-                      "width": 32,
-                    }
-                  }
                 >
-                  <img
-                    alt=""
+                  <div
                     className=
-                        ms-Image-image
-                        ms-Image-image--cover
-                        ms-Image-image--portrait
-                        is-notLoaded
-                        is-fadeIn
+                        ms-Image
+                        ms-Persona-image
                         {
-                          display: block;
-                          height: auto;
-                          left: 50% /* @noflip */;
-                          opacity: 0;
+                          border-radius: 50%;
+                          border: 0px;
+                          height: 32px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
                           position: absolute;
-                          top: 50%;
-                          transform: translate(-50%,-50%);
-                          width: 100%;
+                          top: 0px;
+                          width: 32px;
                         }
-                    onError={[Function]}
-                    onLoad={[Function]}
-                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                  />
+                    style={
+                      Object {
+                        "height": 32,
+                        "width": 32,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: auto;
+                            left: 50% /* @noflip */;
+                            opacity: 0;
+                            position: absolute;
+                            top: 50%;
+                            transform: translate(-50%,-50%);
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-details"
-        >
-          <span
-            className="ms-DocumentCardActivity-name"
+          <div
+            className="ms-DocumentCardActivity-details"
           >
-            Kat Larrson
-          </span>
-          <span
-            className="ms-DocumentCardActivity-activity"
-          >
-            Created a few minutes ago
-          </span>
+            <span
+              className="ms-DocumentCardActivity-name"
+            >
+              Kat Larrson
+            </span>
+            <span
+              className="ms-DocumentCardActivity-activity"
+            >
+              Created a few minutes ago
+            </span>
+          </div>
         </div>
       </div>
-    </div>
+    </a>
   </div>
   <p />
   <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined ms-DocumentCard--compact undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
+    className="ms-DocumentCard ms-DocumentCard--compact undefined"
   >
-    <div
-      className="ms-DocumentCardPreview"
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
     >
-      <div>
-        <div
-          className=
-              ms-Image
-              {
-                overflow: hidden;
+      <div
+        className="ms-DocumentCardPreview"
+      >
+        <div>
+          <div
+            className=
+                ms-Image
+                {
+                  overflow: hidden;
+                }
+            style={
+              Object {
+                "height": undefined,
+                "width": 144,
               }
+            }
+          >
+            <img
+              alt=""
+              className=
+                  ms-Image-image
+                  ms-Image-image--portrait
+                  is-notLoaded
+                  is-fadeIn
+                  {
+                    display: block;
+                    height: auto;
+                    opacity: 0;
+                    width: 100%;
+                  }
+              onError={[Function]}
+              onLoad={[Function]}
+              role="presentation"
+              src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview.png"
+            />
+          </div>
+          <div
+            className=
+                ms-Image
+                ms-DocumentCardPreview-icon
+                {
+                  overflow: hidden;
+                }
+            style={
+              Object {
+                "height": undefined,
+                "width": undefined,
+              }
+            }
+          >
+            <img
+              alt=""
+              className=
+                  ms-Image-image
+                  ms-Image-image--portrait
+                  is-notLoaded
+                  is-fadeIn
+                  {
+                    display: block;
+                    opacity: 0;
+                  }
+              onError={[Function]}
+              onLoad={[Function]}
+              role="presentation"
+              src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCard-details"
+      >
+        <div
+          className="ms-DocumentCardTitle"
+          title="Revenue stream proposal fiscal year 2016 version02.pptx"
+        >
+          Revenue stream proposal fiscal year 2016 version02.pptx
+        </div>
+        <div
+          className="ms-DocumentCardActivity"
+        >
+          <div
+            className="ms-DocumentCardActivity-avatars"
+          >
+            <div
+              className="ms-DocumentCardActivity-avatar"
+            >
+              <div
+                className=
+                    ms-Persona-coin
+                    ms-Persona--size32
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                    }
+                role="persentation"
+                size={11}
+              >
+                <div
+                  className=
+                      ms-Persona-imageArea
+                      {
+                        flex: 0 0 auto;
+                        height: 32px;
+                        position: relative;
+                        text-align: center;
+                        width: 32px;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Image
+                        ms-Persona-image
+                        {
+                          border-radius: 50%;
+                          border: 0px;
+                          height: 32px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
+                          position: absolute;
+                          top: 0px;
+                          width: 32px;
+                        }
+                    style={
+                      Object {
+                        "height": 32,
+                        "width": 32,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: auto;
+                            left: 50% /* @noflip */;
+                            opacity: 0;
+                            position: absolute;
+                            top: 50%;
+                            transform: translate(-50%,-50%);
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-DocumentCardActivity-details"
+          >
+            <span
+              className="ms-DocumentCardActivity-name"
+            >
+              Kat Larrson
+            </span>
+            <span
+              className="ms-DocumentCardActivity-activity"
+            >
+              Created a few minutes ago
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
+  </div>
+  <p />
+  <div
+    className="ms-DocumentCard ms-DocumentCard--compact undefined"
+  >
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <div
+        className="ms-DocumentCardPreview"
+      >
+        <div
+          className="ms-DocumentCardPreview-iconContainer"
           style={
             Object {
               "height": undefined,
@@ -279,471 +559,323 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
             }
           }
         >
-          <img
-            alt=""
+          <i
+            aria-hidden={true}
             className=
-                ms-Image-image
-                ms-Image-image--portrait
-                is-notLoaded
-                is-fadeIn
+
                 {
-                  display: block;
-                  height: auto;
-                  opacity: 0;
-                  width: 100%;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-1";
+                  font-size: 42px;
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
                 }
-            onError={[Function]}
-            onLoad={[Function]}
+            data-icon-name="OpenFile"
             role="presentation"
-            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview.png"
-          />
+          >
+            
+          </i>
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCard-details"
+      >
+        <div
+          className="ms-DocumentCardTitle"
+          title="View and share files"
+        >
+          View and share files
         </div>
         <div
-          className=
-              ms-Image
-              ms-DocumentCardPreview-icon
-              {
-                overflow: hidden;
-              }
+          className="ms-DocumentCardActivity"
+        >
+          <div
+            className="ms-DocumentCardActivity-avatars"
+          >
+            <div
+              className="ms-DocumentCardActivity-avatar"
+            >
+              <div
+                className=
+                    ms-Persona-coin
+                    ms-Persona--size32
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                    }
+                role="persentation"
+                size={11}
+              >
+                <div
+                  className=
+                      ms-Persona-imageArea
+                      {
+                        flex: 0 0 auto;
+                        height: 32px;
+                        position: relative;
+                        text-align: center;
+                        width: 32px;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Image
+                        ms-Persona-image
+                        {
+                          border-radius: 50%;
+                          border: 0px;
+                          height: 32px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
+                          position: absolute;
+                          top: 0px;
+                          width: 32px;
+                        }
+                    style={
+                      Object {
+                        "height": 32,
+                        "width": 32,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: auto;
+                            left: 50% /* @noflip */;
+                            opacity: 0;
+                            position: absolute;
+                            top: 50%;
+                            transform: translate(-50%,-50%);
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-DocumentCardActivity-details"
+          >
+            <span
+              className="ms-DocumentCardActivity-name"
+            >
+              Kat Larrson
+            </span>
+            <span
+              className="ms-DocumentCardActivity-activity"
+            >
+              Created a few minutes ago
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
+  </div>
+  <p />
+  <div
+    className="ms-DocumentCard ms-DocumentCard--compact undefined"
+  >
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <div
+        className="ms-DocumentCardPreview"
+      >
+        <div
+          className="ms-DocumentCardPreview-iconContainer2"
           style={
             Object {
               "height": undefined,
-              "width": undefined,
+              "width": 144,
             }
           }
         >
-          <img
-            alt=""
+          <i
+            aria-hidden={true}
             className=
-                ms-Image-image
-                ms-Image-image--portrait
-                is-notLoaded
-                is-fadeIn
+
                 {
-                  display: block;
-                  opacity: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #0078d7;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-8";
+                  font-size: 42px;
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
                 }
-            onError={[Function]}
-            onLoad={[Function]}
+            data-icon-name="OutlookLogo"
             role="presentation"
-            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-          />
+          >
+            
+          </i>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-DocumentCard-details"
-    >
       <div
-        className="ms-DocumentCardTitle"
-        title="Revenue stream proposal fiscal year 2016 version02.pptx"
-      >
-        Revenue stream proposal fiscal year 2016 version02.pptx
-      </div>
-      <div
-        className="ms-DocumentCardActivity"
+        className="ms-DocumentCard-details"
       >
         <div
-          className="ms-DocumentCardActivity-avatars"
+          className="ms-DocumentCardTitle"
+          title="Conversation about anual report from SharePoint conference"
+        >
+          Conversation about anual report from SharePoint conference
+        </div>
+        <div
+          className="ms-DocumentCardActivity"
         >
           <div
-            className="ms-DocumentCardActivity-avatar"
+            className="ms-DocumentCardActivity-avatars"
           >
             <div
-              className=
-                  ms-Persona-coin
-                  ms-Persona--size32
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                  }
-              role="persentation"
-              size={11}
+              className="ms-DocumentCardActivity-avatar"
             >
               <div
                 className=
-                    ms-Persona-imageArea
+                    ms-Persona-coin
+                    ms-Persona--size32
                     {
-                      flex: 0 0 auto;
-                      height: 32px;
-                      position: relative;
-                      text-align: center;
-                      width: 32px;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
                     }
+                role="persentation"
+                size={11}
               >
                 <div
                   className=
-                      ms-Image
-                      ms-Persona-image
+                      ms-Persona-imageArea
                       {
-                        border-radius: 50%;
-                        border: 0px;
+                        flex: 0 0 auto;
                         height: 32px;
-                        left: 0px;
-                        margin-right: 10px;
-                        overflow: hidden;
-                        perspective: 1px;
-                        position: absolute;
-                        top: 0px;
+                        position: relative;
+                        text-align: center;
                         width: 32px;
                       }
-                  style={
-                    Object {
-                      "height": 32,
-                      "width": 32,
-                    }
-                  }
                 >
-                  <img
-                    alt=""
+                  <div
                     className=
-                        ms-Image-image
-                        ms-Image-image--cover
-                        ms-Image-image--portrait
-                        is-notLoaded
-                        is-fadeIn
+                        ms-Image
+                        ms-Persona-image
                         {
-                          display: block;
-                          height: auto;
-                          left: 50% /* @noflip */;
-                          opacity: 0;
+                          border-radius: 50%;
+                          border: 0px;
+                          height: 32px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
                           position: absolute;
-                          top: 50%;
-                          transform: translate(-50%,-50%);
-                          width: 100%;
+                          top: 0px;
+                          width: 32px;
                         }
-                    onError={[Function]}
-                    onLoad={[Function]}
-                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                  />
+                    style={
+                      Object {
+                        "height": 32,
+                        "width": 32,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: auto;
+                            left: 50% /* @noflip */;
+                            opacity: 0;
+                            position: absolute;
+                            top: 50%;
+                            transform: translate(-50%,-50%);
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-details"
-        >
-          <span
-            className="ms-DocumentCardActivity-name"
-          >
-            Kat Larrson
-          </span>
-          <span
-            className="ms-DocumentCardActivity-activity"
-          >
-            Created a few minutes ago
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <p />
-  <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined ms-DocumentCard--compact undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
-  >
-    <div
-      className="ms-DocumentCardPreview"
-    >
-      <div
-        className="ms-DocumentCardPreview-iconContainer"
-        style={
-          Object {
-            "height": undefined,
-            "width": 144,
-          }
-        }
-      >
-        <i
-          aria-hidden={true}
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #ffffff;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-1";
-                font-size: 42px;
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-          data-icon-name="OpenFile"
-          role="presentation"
-        >
-          
-        </i>
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCard-details"
-    >
-      <div
-        className="ms-DocumentCardTitle"
-        title="View and share files"
-      >
-        View and share files
-      </div>
-      <div
-        className="ms-DocumentCardActivity"
-      >
-        <div
-          className="ms-DocumentCardActivity-avatars"
-        >
           <div
-            className="ms-DocumentCardActivity-avatar"
+            className="ms-DocumentCardActivity-details"
           >
-            <div
-              className=
-                  ms-Persona-coin
-                  ms-Persona--size32
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                  }
-              role="persentation"
-              size={11}
+            <span
+              className="ms-DocumentCardActivity-name"
             >
-              <div
-                className=
-                    ms-Persona-imageArea
-                    {
-                      flex: 0 0 auto;
-                      height: 32px;
-                      position: relative;
-                      text-align: center;
-                      width: 32px;
-                    }
-              >
-                <div
-                  className=
-                      ms-Image
-                      ms-Persona-image
-                      {
-                        border-radius: 50%;
-                        border: 0px;
-                        height: 32px;
-                        left: 0px;
-                        margin-right: 10px;
-                        overflow: hidden;
-                        perspective: 1px;
-                        position: absolute;
-                        top: 0px;
-                        width: 32px;
-                      }
-                  style={
-                    Object {
-                      "height": 32,
-                      "width": 32,
-                    }
-                  }
-                >
-                  <img
-                    alt=""
-                    className=
-                        ms-Image-image
-                        ms-Image-image--cover
-                        ms-Image-image--portrait
-                        is-notLoaded
-                        is-fadeIn
-                        {
-                          display: block;
-                          height: auto;
-                          left: 50% /* @noflip */;
-                          opacity: 0;
-                          position: absolute;
-                          top: 50%;
-                          transform: translate(-50%,-50%);
-                          width: 100%;
-                        }
-                    onError={[Function]}
-                    onLoad={[Function]}
-                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                  />
-                </div>
-              </div>
-            </div>
+              Kat Larrson
+            </span>
+            <span
+              className="ms-DocumentCardActivity-activity"
+            >
+              Sent a few minutes ago
+            </span>
           </div>
         </div>
-        <div
-          className="ms-DocumentCardActivity-details"
-        >
-          <span
-            className="ms-DocumentCardActivity-name"
-          >
-            Kat Larrson
-          </span>
-          <span
-            className="ms-DocumentCardActivity-activity"
-          >
-            Created a few minutes ago
-          </span>
-        </div>
       </div>
-    </div>
-  </div>
-  <p />
-  <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined ms-DocumentCard--compact undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
-  >
-    <div
-      className="ms-DocumentCardPreview"
-    >
-      <div
-        className="ms-DocumentCardPreview-iconContainer2"
-        style={
-          Object {
-            "height": undefined,
-            "width": 144,
-          }
-        }
-      >
-        <i
-          aria-hidden={true}
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #0078d7;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-8";
-                font-size: 42px;
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-          data-icon-name="OutlookLogo"
-          role="presentation"
-        >
-          
-        </i>
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCard-details"
-    >
-      <div
-        className="ms-DocumentCardTitle"
-        title="Conversation about anual report from SharePoint conference"
-      >
-        Conversation about anual report from SharePoint conference
-      </div>
-      <div
-        className="ms-DocumentCardActivity"
-      >
-        <div
-          className="ms-DocumentCardActivity-avatars"
-        >
-          <div
-            className="ms-DocumentCardActivity-avatar"
-          >
-            <div
-              className=
-                  ms-Persona-coin
-                  ms-Persona--size32
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                  }
-              role="persentation"
-              size={11}
-            >
-              <div
-                className=
-                    ms-Persona-imageArea
-                    {
-                      flex: 0 0 auto;
-                      height: 32px;
-                      position: relative;
-                      text-align: center;
-                      width: 32px;
-                    }
-              >
-                <div
-                  className=
-                      ms-Image
-                      ms-Persona-image
-                      {
-                        border-radius: 50%;
-                        border: 0px;
-                        height: 32px;
-                        left: 0px;
-                        margin-right: 10px;
-                        overflow: hidden;
-                        perspective: 1px;
-                        position: absolute;
-                        top: 0px;
-                        width: 32px;
-                      }
-                  style={
-                    Object {
-                      "height": 32,
-                      "width": 32,
-                    }
-                  }
-                >
-                  <img
-                    alt=""
-                    className=
-                        ms-Image-image
-                        ms-Image-image--cover
-                        ms-Image-image--portrait
-                        is-notLoaded
-                        is-fadeIn
-                        {
-                          display: block;
-                          height: auto;
-                          left: 50% /* @noflip */;
-                          opacity: 0;
-                          position: absolute;
-                          top: 50%;
-                          transform: translate(-50%,-50%);
-                          width: 100%;
-                        }
-                    onError={[Function]}
-                    onLoad={[Function]}
-                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-details"
-        >
-          <span
-            className="ms-DocumentCardActivity-name"
-          >
-            Kat Larrson
-          </span>
-          <span
-            className="ms-DocumentCardActivity-activity"
-          >
-            Sent a few minutes ago
-          </span>
-        </div>
-      </div>
-    </div>
+    </a>
   </div>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -3,1425 +3,279 @@
 exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="button"
-    tabIndex={0}
+    className="ms-DocumentCard"
   >
-    <div
-      className="ms-DocumentCardPreview is-fileList undefined"
-    >
-      <div>
-        <ul
-          className="ms-DocumentCardPreview-fileList"
-        >
-          <li>
-            <div
-              className=
-                  ms-Image
-                  ms-DocumentCardPreview-fileListIcon
-                  {
-                    overflow: hidden;
-                  }
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: 100%;
-                      opacity: 0;
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role="presentation"
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-              />
-            </div>
-            <a
-              href="http://bing.com"
-            >
-              2016 Conference Presentation
-            </a>
-          </li>
-          <li>
-            <div
-              className=
-                  ms-Image
-                  ms-DocumentCardPreview-fileListIcon
-                  {
-                    overflow: hidden;
-                  }
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: 100%;
-                      opacity: 0;
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role="presentation"
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-              />
-            </div>
-            <a
-              href="http://bing.com"
-            >
-              New Contoso Collaboration for Conference Presentation Draft
-            </a>
-          </li>
-          <li>
-            <div
-              className=
-                  ms-Image
-                  ms-DocumentCardPreview-fileListIcon
-                  {
-                    overflow: hidden;
-                  }
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: 100%;
-                      opacity: 0;
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role="presentation"
-                src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
-              />
-            </div>
-            <a
-              href="http://bing.com"
-            >
-              Spec Sheet for design
-            </a>
-          </li>
-        </ul>
-        <span
-          className="ms-DocumentCardPreview-fileListMore"
-        >
-          +3 more
-        </span>
-      </div>
-    </div>
     <a
-      aria-label="Location, Marketing Documents"
-      className="ms-DocumentCardLocation"
-      href="http://microsoft.com"
-    >
-      Marketing Documents
-    </a>
-    <div
-      className="ms-DocumentCardTitle"
-      title="6 files were uploaded"
-    >
-      6 files were uploaded
-    </div>
-    <div
-      className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
-    >
-      <div
-        className="ms-DocumentCardActivity-avatars"
-      >
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                aria-hidden="true"
-                className=
-                    ms-Persona-initials
-                    {
-                      background-color: #00ABA9;
-                      border-radius: 50%;
-                      color: #ffffff;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 32px;
-                      line-height: 32px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      background-color: Window !important;
-                      border: 1px solid WindowText;
-                      box-sizing: border-box;
-                      color: WindowText;
-                    }
-              >
-                <span>
-                  JH
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                className=
-                    ms-Image
-                    ms-Persona-image
-                    {
-                      border-radius: 50%;
-                      border: 0px;
-                      height: 32px;
-                      left: 0px;
-                      margin-right: 10px;
-                      overflow: hidden;
-                      perspective: 1px;
-                      position: absolute;
-                      top: 0px;
-                      width: 32px;
-                    }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  className=
-                      ms-Image-image
-                      ms-Image-image--cover
-                      ms-Image-image--portrait
-                      is-notLoaded
-                      is-fadeIn
-                      {
-                        display: block;
-                        height: auto;
-                        left: 50% /* @noflip */;
-                        opacity: 0;
-                        position: absolute;
-                        top: 50%;
-                        transform: translate(-50%,-50%);
-                        width: 100%;
-                      }
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-DocumentCardActivity-details"
-      >
-        <span
-          className="ms-DocumentCardActivity-name"
-        >
-          Annie Lindqvist +2
-        </span>
-        <span
-          className="ms-DocumentCardActivity-activity"
-        >
-          Created Feb 23, 2016
-        </span>
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCardActions"
-    >
-      <div
-        className="ms-DocumentCardActions-action"
-      >
-        <button
-          aria-label="share action"
-          className=
-              ms-Button
-              ms-Button--icon
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: none;
-                box-sizing: border-box;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 32px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 4px;
-                padding-right: 4px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-                width: 32px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                outline: 1px solid #666666;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                color: #004578;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                color: #0078d4;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
-        >
-          <div
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-          >
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Button-icon
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    display: inline-block;
-                    flex-shrink: 0;
-                    font-family: "FabricMDL2Icons";
-                    font-size: 16px;
-                    font-style: normal;
-                    font-weight: normal;
-                    height: 16px;
-                    line-height: 16px;
-                    margin-bottom: 0;
-                    margin-left: 4px;
-                    margin-right: 4px;
-                    margin-top: 0;
-                    speak: none;
-                    text-align: center;
-                    vertical-align: middle;
-                  }
-              data-icon-name="Share"
-              role="presentation"
-            >
-              
-            </i>
-          </div>
-        </button>
-      </div>
-      <div
-        className="ms-DocumentCardActions-action"
-      >
-        <button
-          aria-label="pin action"
-          className=
-              ms-Button
-              ms-Button--icon
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: none;
-                box-sizing: border-box;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 32px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 4px;
-                padding-right: 4px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-                width: 32px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                outline: 1px solid #666666;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                color: #004578;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                color: #0078d4;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
-        >
-          <div
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-          >
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Button-icon
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    display: inline-block;
-                    flex-shrink: 0;
-                    font-family: "FabricMDL2Icons-0";
-                    font-size: 16px;
-                    font-style: normal;
-                    font-weight: normal;
-                    height: 16px;
-                    line-height: 16px;
-                    margin-bottom: 0;
-                    margin-left: 4px;
-                    margin-right: 4px;
-                    margin-top: 0;
-                    speak: none;
-                    text-align: center;
-                    vertical-align: middle;
-                  }
-              data-icon-name="Pin"
-              role="presentation"
-            >
-              
-            </i>
-          </div>
-        </button>
-      </div>
-      <div
-        className="ms-DocumentCardActions-action"
-      >
-        <button
-          aria-label="ringer action"
-          className=
-              ms-Button
-              ms-Button--icon
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: none;
-                box-sizing: border-box;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 32px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 4px;
-                padding-right: 4px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-                width: 32px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                outline: 1px solid #666666;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                color: #004578;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                color: #0078d4;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
-        >
-          <div
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-          >
-            <i
-              aria-hidden={true}
-              className=
-                  ms-Button-icon
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    display: inline-block;
-                    flex-shrink: 0;
-                    font-family: "FabricMDL2Icons-3";
-                    font-size: 16px;
-                    font-style: normal;
-                    font-weight: normal;
-                    height: 16px;
-                    line-height: 16px;
-                    margin-bottom: 0;
-                    margin-left: 4px;
-                    margin-right: 4px;
-                    margin-top: 0;
-                    speak: none;
-                    text-align: center;
-                    vertical-align: middle;
-                  }
-              data-icon-name="Ringer"
-              role="presentation"
-            >
-              
-            </i>
-          </div>
-        </button>
-      </div>
-      <div
-        className="ms-DocumentCardActions-views"
-      >
-        <i
-          aria-hidden={true}
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-          data-icon-name="View"
-          role="presentation"
-        >
-          
-        </i>
-        432
-      </div>
-    </div>
-  </div>
-  <p />
-  Card Logo, Text Preview CardStatus are used on below examples.
-  <p />
-  <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
-  >
-    <div
-      className="ms-DocumentCardLogo"
-    >
-      <i
-        aria-hidden={true}
-        className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: inline-block;
-              font-family: "FabricMDL2Icons-8";
-              font-style: normal;
-              font-weight: normal;
-              speak: none;
-            }
-        data-icon-name="OutlookLogo"
-        role="presentation"
-      >
-        
-      </i>
-    </div>
-    <div
-      className="ms-ConversationTile-TitlePreviewArea"
-    >
-      <div
-        className="ms-DocumentCardTitle"
-        title="Conversation about anual report a very long long name, Title should be truncated on the long name."
-      >
-        Conversation about anual report a very long long name, Title should be truncated on the long name.
-      </div>
-      <div
-        className="ms-DocumentCardTitle"
-        title="This is the email content preview, please feel free to give feedback. SharePoint Site Acitivity add conversation card! This is the last."
-      >
-        This is the email content preview, please feel free to give feedback. SharePoint Site Acitivity add conversation card! This is the last.
-      </div>
-      <div
-        className="ms-DocumentCardStatus"
-      >
-        <i
-          aria-hidden={true}
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-0";
-                font-style: normal;
-                font-weight: normal;
-                padding-bottom: 8px;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 8px;
-                speak: none;
-              }
-          data-icon-name="attach"
-          role="presentation"
-        >
-          
-        </i>
-         3 Attachments
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
-    >
-      <div
-        className="ms-DocumentCardActivity-avatars"
-      >
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                aria-hidden="true"
-                className=
-                    ms-Persona-initials
-                    {
-                      background-color: #00ABA9;
-                      border-radius: 50%;
-                      color: #ffffff;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 32px;
-                      line-height: 32px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      background-color: Window !important;
-                      border: 1px solid WindowText;
-                      box-sizing: border-box;
-                      color: WindowText;
-                    }
-              >
-                <span>
-                  JH
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                className=
-                    ms-Image
-                    ms-Persona-image
-                    {
-                      border-radius: 50%;
-                      border: 0px;
-                      height: 32px;
-                      left: 0px;
-                      margin-right: 10px;
-                      overflow: hidden;
-                      perspective: 1px;
-                      position: absolute;
-                      top: 0px;
-                      width: 32px;
-                    }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  className=
-                      ms-Image-image
-                      ms-Image-image--cover
-                      ms-Image-image--portrait
-                      is-notLoaded
-                      is-fadeIn
-                      {
-                        display: block;
-                        height: auto;
-                        left: 50% /* @noflip */;
-                        opacity: 0;
-                        position: absolute;
-                        top: 50%;
-                        transform: translate(-50%,-50%);
-                        width: 100%;
-                      }
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-DocumentCardActivity-details"
-      >
-        <span
-          className="ms-DocumentCardActivity-name"
-        >
-          Annie Lindqvist +2
-        </span>
-        <span
-          className="ms-DocumentCardActivity-activity"
-        >
-          Sent March 13, 2018
-        </span>
-      </div>
-    </div>
-  </div>
-  <p />
-  <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
-  >
-    <div
-      className="ms-DocumentCardLogo"
-    >
-      <i
-        aria-hidden={true}
-        className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: inline-block;
-              font-family: "FabricMDL2Icons-8";
-              font-style: normal;
-              font-weight: normal;
-              speak: none;
-            }
-        data-icon-name="OutlookLogo"
-        role="presentation"
-      >
-        
-      </i>
-    </div>
-    <div
-      className="ms-ConversationTile-TitlePreviewArea"
-    >
-      <div
-        className="ms-DocumentCardTitle"
-        title="Conversation about anual Report"
-      >
-        Conversation about anual Report
-      </div>
-      <div
-        className="ms-DocumentCardTitle"
-        title="This is the email content preview, help."
-      >
-        This is the email content preview, help.
-      </div>
-      <div
-        className="ms-DocumentCardStatus"
-      >
-        <i
-          aria-hidden={true}
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-0";
-                font-style: normal;
-                font-weight: normal;
-                padding-bottom: 8px;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 8px;
-                speak: none;
-              }
-          data-icon-name="attach"
-          role="presentation"
-        >
-          
-        </i>
-         3 Attachments
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
-    >
-      <div
-        className="ms-DocumentCardActivity-avatars"
-      >
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                aria-hidden="true"
-                className=
-                    ms-Persona-initials
-                    {
-                      background-color: #00ABA9;
-                      border-radius: 50%;
-                      color: #ffffff;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 32px;
-                      line-height: 32px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      background-color: Window !important;
-                      border: 1px solid WindowText;
-                      box-sizing: border-box;
-                      color: WindowText;
-                    }
-              >
-                <span>
-                  JH
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                className=
-                    ms-Image
-                    ms-Persona-image
-                    {
-                      border-radius: 50%;
-                      border: 0px;
-                      height: 32px;
-                      left: 0px;
-                      margin-right: 10px;
-                      overflow: hidden;
-                      perspective: 1px;
-                      position: absolute;
-                      top: 0px;
-                      width: 32px;
-                    }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  className=
-                      ms-Image-image
-                      ms-Image-image--cover
-                      ms-Image-image--portrait
-                      is-notLoaded
-                      is-fadeIn
-                      {
-                        display: block;
-                        height: auto;
-                        left: 50% /* @noflip */;
-                        opacity: 0;
-                        position: absolute;
-                        top: 50%;
-                        transform: translate(-50%,-50%);
-                        width: 100%;
-                      }
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-DocumentCardActivity-details"
-      >
-        <span
-          className="ms-DocumentCardActivity-name"
-        >
-          Annie Lindqvist +2
-        </span>
-        <span
-          className="ms-DocumentCardActivity-activity"
-        >
-          Sent March 13, 2018
-        </span>
-      </div>
-    </div>
-  </div>
-  <p />
-  <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
-  >
-    <div
-      className="ms-DocumentCardLogo"
-    >
-      <i
-        aria-hidden={true}
-        className=
-
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: inline-block;
-              font-family: "FabricMDL2Icons-8";
-              font-style: normal;
-              font-weight: normal;
-              speak: none;
-            }
-        data-icon-name="OutlookLogo"
-        role="presentation"
-      >
-        
-      </i>
-    </div>
-    <div
-      className="ms-ConversationTile-TitlePreviewArea"
-    >
-      <div
-        className="ms-DocumentCardTitle"
-        title="Conversation about anual report"
-      >
-        Conversation about anual report
-      </div>
-      <div
-        className="ms-DocumentCardTitle"
-        title="This is the email content preview, please feel free to give!"
-      >
-        This is the email content preview, please feel free to give!
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
-    >
-      <div
-        className="ms-DocumentCardActivity-avatars"
-      >
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                aria-hidden="true"
-                className=
-                    ms-Persona-initials
-                    {
-                      background-color: #00ABA9;
-                      border-radius: 50%;
-                      color: #ffffff;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 32px;
-                      line-height: 32px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      background-color: Window !important;
-                      border: 1px solid WindowText;
-                      box-sizing: border-box;
-                      color: WindowText;
-                    }
-              >
-                <span>
-                  JH
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-DocumentCardActivity-avatar"
-        >
-          <div
-            className=
-                ms-Persona-coin
-                ms-Persona--size32
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                }
-            role="persentation"
-            size={11}
-          >
-            <div
-              className=
-                  ms-Persona-imageArea
-                  {
-                    flex: 0 0 auto;
-                    height: 32px;
-                    position: relative;
-                    text-align: center;
-                    width: 32px;
-                  }
-            >
-              <div
-                className=
-                    ms-Image
-                    ms-Persona-image
-                    {
-                      border-radius: 50%;
-                      border: 0px;
-                      height: 32px;
-                      left: 0px;
-                      margin-right: 10px;
-                      overflow: hidden;
-                      perspective: 1px;
-                      position: absolute;
-                      top: 0px;
-                      width: 32px;
-                    }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  className=
-                      ms-Image-image
-                      ms-Image-image--cover
-                      ms-Image-image--portrait
-                      is-notLoaded
-                      is-fadeIn
-                      {
-                        display: block;
-                        height: auto;
-                        left: 50% /* @noflip */;
-                        opacity: 0;
-                        position: absolute;
-                        top: 50%;
-                        transform: translate(-50%,-50%);
-                        width: 100%;
-                      }
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-DocumentCardActivity-details"
-      >
-        <span
-          className="ms-DocumentCardActivity-name"
-        >
-          Annie Lindqvist +2
-        </span>
-        <span
-          className="ms-DocumentCardActivity-activity"
-        >
-          Sent March 13, 2018
-        </span>
-      </div>
-    </div>
-  </div>
-  <p />
-  <div
-    className="ms-DocumentCard ms-DocumentCard--actionable undefined"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="link"
-    tabIndex={0}
-  >
-    <div
-      className="ms-DocumentCardPreview"
-    >
-      <div
-        className="ms-DocumentCardPreview-iconContainer"
-        style={
-          Object {
-            "height": 196,
-            "width": 318,
+      className=
+          ms-Link
+          {
+            background-color: transparent;
+            background: none;
+            border-bottom: 1px solid transparent;
+            border: none;
+            color: #0078d4;
+            cursor: pointer;
+            display: inline;
+            font-size: inherit;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: transparent;
+            overflow: inherit;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            text-align: left;
+            text-overflow: inherit;
+            user-select: text;
           }
-        }
-      >
-        <i
-          aria-hidden={true}
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #ffffff;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-1";
-                font-size: 42px;
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-          data-icon-name="OpenFile"
-          role="presentation"
-        >
-          
-        </i>
-      </div>
-    </div>
-    <div
-      className="ms-DocumentCard-details"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){& {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){& {
+            color: #00009F;
+          }
+          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+            border-bottom: none;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      onClick={[Function]}
     >
       <div
-        className="ms-DocumentCardTitle"
-        title="View and share files"
+        className="ms-DocumentCardPreview is-fileList undefined"
       >
-        View and share files
+        <div>
+          <ul
+            className="ms-DocumentCardPreview-fileList"
+          >
+            <li>
+              <div
+                className=
+                    ms-Image
+                    ms-DocumentCardPreview-fileListIcon
+                    {
+                      overflow: hidden;
+                    }
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  role="presentation"
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+                />
+              </div>
+              <a
+                href="http://bing.com"
+              >
+                2016 Conference Presentation
+              </a>
+            </li>
+            <li>
+              <div
+                className=
+                    ms-Image
+                    ms-DocumentCardPreview-fileListIcon
+                    {
+                      overflow: hidden;
+                    }
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  role="presentation"
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+                />
+              </div>
+              <a
+                href="http://bing.com"
+              >
+                New Contoso Collaboration for Conference Presentation Draft
+              </a>
+            </li>
+            <li>
+              <div
+                className=
+                    ms-Image
+                    ms-DocumentCardPreview-fileListIcon
+                    {
+                      overflow: hidden;
+                    }
+                style={
+                  Object {
+                    "height": "16px",
+                    "width": "16px",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: 100%;
+                        opacity: 0;
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  role="presentation"
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/icon-ppt.png"
+                />
+              </div>
+              <a
+                href="http://bing.com"
+              >
+                Spec Sheet for design
+              </a>
+            </li>
+          </ul>
+          <span
+            className="ms-DocumentCardPreview-fileListMore"
+          >
+            +3 more
+          </span>
+        </div>
+      </div>
+      <a
+        aria-label="Location, Marketing Documents"
+        className="ms-DocumentCardLocation"
+        href="http://microsoft.com"
+      >
+        Marketing Documents
+      </a>
+      <div
+        className="ms-DocumentCardTitle"
+        title="6 files were uploaded"
+      >
+        6 files were uploaded
       </div>
       <div
-        className="ms-DocumentCardActivity"
+        className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
       >
         <div
           className="ms-DocumentCardActivity-avatars"
         >
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  aria-hidden="true"
+                  className=
+                      ms-Persona-initials
+                      {
+                        background-color: #00ABA9;
+                        border-radius: 50%;
+                        color: #ffffff;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        line-height: 32px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Window !important;
+                        border: 1px solid WindowText;
+                        box-sizing: border-box;
+                        color: WindowText;
+                      }
+                >
+                  <span>
+                    JH
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
           <div
             className="ms-DocumentCardActivity-avatar"
           >
@@ -1506,16 +360,1352 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
           <span
             className="ms-DocumentCardActivity-name"
           >
-            Kat Larrson
+            Annie Lindqvist +2
           </span>
           <span
             className="ms-DocumentCardActivity-activity"
           >
-            Created a few minutes ago
+            Created Feb 23, 2016
           </span>
         </div>
       </div>
-    </div>
+      <div
+        className="ms-DocumentCardActions"
+      >
+        <div
+          className="ms-DocumentCardActions-action"
+        >
+          <button
+            aria-label="share action"
+            className=
+                ms-Button
+                ms-Button--icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 0px;
+                  border: none;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 32px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  color: #004578;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  color: #0078d4;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+            </div>
+          </button>
+        </div>
+        <div
+          className="ms-DocumentCardActions-action"
+        >
+          <button
+            aria-label="pin action"
+            className=
+                ms-Button
+                ms-Button--icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 0px;
+                  border: none;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 32px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  color: #004578;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  color: #0078d4;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons-0";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Pin"
+                role="presentation"
+              >
+                
+              </i>
+            </div>
+          </button>
+        </div>
+        <div
+          className="ms-DocumentCardActions-action"
+        >
+          <button
+            aria-label="ringer action"
+            className=
+                ms-Button
+                ms-Button--icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 0px;
+                  border: none;
+                  box-sizing: border-box;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 32px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  color: #004578;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  color: #0078d4;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons-3";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Ringer"
+                role="presentation"
+              >
+                
+              </i>
+            </div>
+          </button>
+        </div>
+        <div
+          className="ms-DocumentCardActions-views"
+        >
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+            data-icon-name="View"
+            role="presentation"
+          >
+            
+          </i>
+          432
+        </div>
+      </div>
+    </a>
+  </div>
+  <p />
+  Card Logo, Text Preview CardStatus are used on below examples.
+  <p />
+  <div
+    className="ms-DocumentCard"
+  >
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <div
+        className="ms-DocumentCardLogo"
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-8";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="OutlookLogo"
+          role="presentation"
+        >
+          
+        </i>
+      </div>
+      <div
+        className="ms-ConversationTile-TitlePreviewArea"
+      >
+        <div
+          className="ms-DocumentCardTitle"
+          title="Conversation about anual report a very long long name, Title should be truncated on the long name."
+        >
+          Conversation about anual report a very long long name, Title should be truncated on the long name.
+        </div>
+        <div
+          className="ms-DocumentCardTitle"
+          title="This is the email content preview, please feel free to give feedback. SharePoint Site Acitivity add conversation card! This is the last."
+        >
+          This is the email content preview, please feel free to give feedback. SharePoint Site Acitivity add conversation card! This is the last.
+        </div>
+        <div
+          className="ms-DocumentCardStatus"
+        >
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-0";
+                  font-style: normal;
+                  font-weight: normal;
+                  padding-bottom: 8px;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 8px;
+                  speak: none;
+                }
+            data-icon-name="attach"
+            role="presentation"
+          >
+            
+          </i>
+           3 Attachments
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
+      >
+        <div
+          className="ms-DocumentCardActivity-avatars"
+        >
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  aria-hidden="true"
+                  className=
+                      ms-Persona-initials
+                      {
+                        background-color: #00ABA9;
+                        border-radius: 50%;
+                        color: #ffffff;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        line-height: 32px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Window !important;
+                        border: 1px solid WindowText;
+                        box-sizing: border-box;
+                        color: WindowText;
+                      }
+                >
+                  <span>
+                    JH
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-DocumentCardActivity-details"
+        >
+          <span
+            className="ms-DocumentCardActivity-name"
+          >
+            Annie Lindqvist +2
+          </span>
+          <span
+            className="ms-DocumentCardActivity-activity"
+          >
+            Sent March 13, 2018
+          </span>
+        </div>
+      </div>
+    </a>
+  </div>
+  <p />
+  <div
+    className="ms-DocumentCard"
+  >
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <div
+        className="ms-DocumentCardLogo"
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-8";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="OutlookLogo"
+          role="presentation"
+        >
+          
+        </i>
+      </div>
+      <div
+        className="ms-ConversationTile-TitlePreviewArea"
+      >
+        <div
+          className="ms-DocumentCardTitle"
+          title="Conversation about anual Report"
+        >
+          Conversation about anual Report
+        </div>
+        <div
+          className="ms-DocumentCardTitle"
+          title="This is the email content preview, help."
+        >
+          This is the email content preview, help.
+        </div>
+        <div
+          className="ms-DocumentCardStatus"
+        >
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-0";
+                  font-style: normal;
+                  font-weight: normal;
+                  padding-bottom: 8px;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 8px;
+                  speak: none;
+                }
+            data-icon-name="attach"
+            role="presentation"
+          >
+            
+          </i>
+           3 Attachments
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
+      >
+        <div
+          className="ms-DocumentCardActivity-avatars"
+        >
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  aria-hidden="true"
+                  className=
+                      ms-Persona-initials
+                      {
+                        background-color: #00ABA9;
+                        border-radius: 50%;
+                        color: #ffffff;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        line-height: 32px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Window !important;
+                        border: 1px solid WindowText;
+                        box-sizing: border-box;
+                        color: WindowText;
+                      }
+                >
+                  <span>
+                    JH
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-DocumentCardActivity-details"
+        >
+          <span
+            className="ms-DocumentCardActivity-name"
+          >
+            Annie Lindqvist +2
+          </span>
+          <span
+            className="ms-DocumentCardActivity-activity"
+          >
+            Sent March 13, 2018
+          </span>
+        </div>
+      </div>
+    </a>
+  </div>
+  <p />
+  <div
+    className="ms-DocumentCard"
+  >
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <div
+        className="ms-DocumentCardLogo"
+      >
+        <i
+          aria-hidden={true}
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-8";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+          data-icon-name="OutlookLogo"
+          role="presentation"
+        >
+          
+        </i>
+      </div>
+      <div
+        className="ms-ConversationTile-TitlePreviewArea"
+      >
+        <div
+          className="ms-DocumentCardTitle"
+          title="Conversation about anual report"
+        >
+          Conversation about anual report
+        </div>
+        <div
+          className="ms-DocumentCardTitle"
+          title="This is the email content preview, please feel free to give!"
+        >
+          This is the email content preview, please feel free to give!
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCardActivity ms-DocumentCardActivity--multiplePeople undefined"
+      >
+        <div
+          className="ms-DocumentCardActivity-avatars"
+        >
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  aria-hidden="true"
+                  className=
+                      ms-Persona-initials
+                      {
+                        background-color: #00ABA9;
+                        border-radius: 50%;
+                        color: #ffffff;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 32px;
+                        line-height: 32px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        background-color: Window !important;
+                        border: 1px solid WindowText;
+                        box-sizing: border-box;
+                        color: WindowText;
+                      }
+                >
+                  <span>
+                    JH
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-DocumentCardActivity-avatar"
+          >
+            <div
+              className=
+                  ms-Persona-coin
+                  ms-Persona--size32
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                  }
+              role="persentation"
+              size={11}
+            >
+              <div
+                className=
+                    ms-Persona-imageArea
+                    {
+                      flex: 0 0 auto;
+                      height: 32px;
+                      position: relative;
+                      text-align: center;
+                      width: 32px;
+                    }
+              >
+                <div
+                  className=
+                      ms-Image
+                      ms-Persona-image
+                      {
+                        border-radius: 50%;
+                        border: 0px;
+                        height: 32px;
+                        left: 0px;
+                        margin-right: 10px;
+                        overflow: hidden;
+                        perspective: 1px;
+                        position: absolute;
+                        top: 0px;
+                        width: 32px;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--cover
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: auto;
+                          left: 50% /* @noflip */;
+                          opacity: 0;
+                          position: absolute;
+                          top: 50%;
+                          transform: translate(-50%,-50%);
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-DocumentCardActivity-details"
+        >
+          <span
+            className="ms-DocumentCardActivity-name"
+          >
+            Annie Lindqvist +2
+          </span>
+          <span
+            className="ms-DocumentCardActivity-activity"
+          >
+            Sent March 13, 2018
+          </span>
+        </div>
+      </div>
+    </a>
+  </div>
+  <p />
+  <div
+    className="ms-DocumentCard"
+  >
+    <a
+      className=
+          ms-Link
+          {
+            color: #0078d4;
+            outline: transparent;
+            position: relative;
+            text-decoration: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -1px;
+            content: "";
+            left: -1px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -1px;
+            top: -1px;
+            z-index: 1;
+          }
+          &:active, &:hover, &:active:hover {
+            color: #004578;
+          }
+          @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+            text-decoration: underline;
+          }
+          &:focus {
+            color: #0078d4;
+          }
+      href="http://bing.com"
+      onClick={[Function]}
+      target="_blank"
+    >
+      <div
+        className="ms-DocumentCardPreview"
+      >
+        <div
+          className="ms-DocumentCardPreview-iconContainer"
+          style={
+            Object {
+              "height": 196,
+              "width": 318,
+            }
+          }
+        >
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-1";
+                  font-size: 42px;
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+            data-icon-name="OpenFile"
+            role="presentation"
+          >
+            
+          </i>
+        </div>
+      </div>
+      <div
+        className="ms-DocumentCard-details"
+      >
+        <div
+          className="ms-DocumentCardTitle"
+          title="View and share files"
+        >
+          View and share files
+        </div>
+        <div
+          className="ms-DocumentCardActivity"
+        >
+          <div
+            className="ms-DocumentCardActivity-avatars"
+          >
+            <div
+              className="ms-DocumentCardActivity-avatar"
+            >
+              <div
+                className=
+                    ms-Persona-coin
+                    ms-Persona--size32
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                    }
+                role="persentation"
+                size={11}
+              >
+                <div
+                  className=
+                      ms-Persona-imageArea
+                      {
+                        flex: 0 0 auto;
+                        height: 32px;
+                        position: relative;
+                        text-align: center;
+                        width: 32px;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Image
+                        ms-Persona-image
+                        {
+                          border-radius: 50%;
+                          border: 0px;
+                          height: 32px;
+                          left: 0px;
+                          margin-right: 10px;
+                          overflow: hidden;
+                          perspective: 1px;
+                          position: absolute;
+                          top: 0px;
+                          width: 32px;
+                        }
+                    style={
+                      Object {
+                        "height": 32,
+                        "width": 32,
+                      }
+                    }
+                  >
+                    <img
+                      alt=""
+                      className=
+                          ms-Image-image
+                          ms-Image-image--cover
+                          ms-Image-image--portrait
+                          is-notLoaded
+                          is-fadeIn
+                          {
+                            display: block;
+                            height: auto;
+                            left: 50% /* @noflip */;
+                            opacity: 0;
+                            position: absolute;
+                            top: 50%;
+                            transform: translate(-50%,-50%);
+                            width: 100%;
+                          }
+                      onError={[Function]}
+                      onLoad={[Function]}
+                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-DocumentCardActivity-details"
+          >
+            <span
+              className="ms-DocumentCardActivity-name"
+            >
+              Kat Larrson
+            </span>
+            <span
+              className="ms-DocumentCardActivity-activity"
+            >
+              Created a few minutes ago
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6313 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Adds `linkProps` to DocumentCard
- Deprecate `onClick` and `onClickHref` favor of `linkProps`
- Update examples to use `linkProps` .

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6371)

