### PR TITLE
Pass ev to onDismiss from onPanelClick. Add ex to docs.

### DIFF
--- a/common/changes/office-ui-fabric-react/deanbot-iss6342_2018-09-14-16-27.json
+++ b/common/changes/office-ui-fabric-react/deanbot-iss6342_2018-09-14-16-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: pass click events to onDismiss handler",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "deanverleger@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -1,24 +1,23 @@
 import * as React from 'react';
-
-import {
-  BaseComponent,
-  classNamesFunction,
-  divProperties,
-  getId,
-  getNativeProps,
-  getRTL,
-  createRef,
-  elementContains,
-  allowScrollOnElement,
-  isIOS
-} from '../../Utilities';
-import { IProcessedStyleSet, getTheme, IconFontSizes } from '../../Styling';
-import { FocusTrapZone } from '../FocusTrapZone/index';
-import { IPanel, IPanelProps, PanelType, IPanelStyleProps, IPanelStyles } from './Panel.types';
+import { IconButton } from '../../Button';
 import { Layer } from '../../Layer';
 import { Overlay } from '../../Overlay';
 import { Popup } from '../../Popup';
-import { IconButton } from '../../Button';
+import { getTheme, IconFontSizes, IProcessedStyleSet } from '../../Styling';
+import {
+  allowScrollOnElement,
+  BaseComponent,
+  classNamesFunction,
+  createRef,
+  divProperties,
+  elementContains,
+  getId,
+  getNativeProps,
+  getRTL,
+  isIOS
+} from '../../Utilities';
+import { FocusTrapZone } from '../FocusTrapZone/index';
+import { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
 
 const getClassNames = classNamesFunction<IPanelStyleProps, IPanelStyles>();
 
@@ -150,13 +149,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
 
     let overlay;
     if (isBlocking && isOpen) {
-      overlay = (
-        <Overlay
-          className={_classNames.overlay}
-          isDarkThemed={false}
-          onClick={isLightDismiss ? onLightDismissClick : undefined}
-        />
-      );
+      overlay = <Overlay className={_classNames.overlay} isDarkThemed={false} onClick={isLightDismiss ? onLightDismissClick : undefined} />;
     }
 
     const header = onRenderHeader(this.props, this._onRenderHeader, headerTextId);
@@ -179,9 +172,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
               className={_classNames.main}
               style={customWidthStyles}
               elementToFocusOnDismiss={elementToFocusOnDismiss}
-              isClickableOutsideFocusTrap={
-                focusTrapZoneProps && !focusTrapZoneProps.isClickableOutsideFocusTrap ? false : true
-              }
+              isClickableOutsideFocusTrap={focusTrapZoneProps && !focusTrapZoneProps.isClickableOutsideFocusTrap ? false : true}
             >
               <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent}>
                 <div className={_classNames.commands} data-is-visible={true}>
@@ -214,7 +205,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     }
   }
 
-  public dismiss = (ev?: React.KeyboardEvent<HTMLElement>): void => {
+  public dismiss = (ev?: React.SyntheticEvent<HTMLElement>): void => {
     if (this.state.isOpen) {
       if (this.props.onDismiss) {
         this.props.onDismiss(ev);
@@ -352,8 +343,8 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     }
   }
 
-  private _onPanelClick = (): void => {
-    this.dismiss();
+  private _onPanelClick = (ev?: any): void => {
+    this.dismiss(ev);
   };
 
   private _onTransitionComplete = (): void => {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
-import { PanelSmallRightExample } from './examples/Panel.SmallRight.Example';
-
 import { IDocPageProps } from '../../common/DocPage.types';
-import { PanelSmallLeftExample } from './examples/Panel.SmallLeft.Example';
-import { PanelSmallFluidExample } from './examples/Panel.SmallFluid.Example';
-import { PanelMediumExample } from './examples/Panel.Medium.Example';
+import { PanelCustomExample } from './examples/Panel.Custom.Example';
+import { PanelExtraLargeExample } from './examples/Panel.ExtraLarge.Example';
+import { PanelFooterExample } from './examples/Panel.Footer.Example';
+import { PanelHandleDismissTargetExample } from './examples/Panel.HandleDismissTarget.Example';
+import { PanelHiddenOnDismissExample } from './examples/Panel.HiddenOnDismiss.Example';
 import { PanelLargeExample } from './examples/Panel.Large.Example';
 import { PanelLargeFixedExample } from './examples/Panel.LargeFixed.Example';
-import { PanelExtraLargeExample } from './examples/Panel.ExtraLarge.Example';
-import { PanelCustomExample } from './examples/Panel.Custom.Example';
-import { PanelHiddenOnDismissExample } from './examples/Panel.HiddenOnDismiss.Example';
 import { PanelLightDismissExample } from './examples/Panel.LightDismiss.Example';
 import { PanelLightDismissCustomExample } from './examples/Panel.LightDismissCustom.Example';
+import { PanelMediumExample } from './examples/Panel.Medium.Example';
 import { PanelNonModalExample } from './examples/Panel.NonModal.Example';
-import { PanelFooterExample } from './examples/Panel.Footer.Example';
 import { PanelPreventDefaultExample } from './examples/Panel.PreventDefault.Example';
+import { PanelSmallFluidExample } from './examples/Panel.SmallFluid.Example';
+import { PanelSmallLeftExample } from './examples/Panel.SmallLeft.Example';
+import { PanelSmallRightExample } from './examples/Panel.SmallRight.Example';
 import { PanelStatus } from './Panel.checklist';
 
 const PanelSmallRightExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.SmallRight.Example.tsx') as string;
@@ -32,12 +32,12 @@ const PanelLightDismissCustomExampleCode = require('!raw-loader!office-ui-fabric
 const PanelNonModalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.NonModal.Example.tsx') as string;
 const PanelFooterExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Footer.Example.tsx') as string;
 const PanelPreventDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.PreventDefault.Example.tsx') as string;
+const PanelHandleDismissTargetExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx') as string;
 
 export const PanelPageProps: IDocPageProps = {
   title: 'Panel',
   componentName: 'Panel',
-  componentUrl:
-    'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Panel',
+  componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Panel',
   componentStatus: PanelStatus,
   examples: [
     {
@@ -110,6 +110,11 @@ export const PanelPageProps: IDocPageProps = {
       title: 'Panel - Prevent Default Sample',
       code: PanelPreventDefaultExampleCode,
       view: <PanelPreventDefaultExample />
+    },
+    {
+      title: 'Panel - Handle Dismiss Target Sample',
+      code: PanelHandleDismissTargetExampleCode,
+      view: <PanelHandleDismissTargetExample />
     }
   ],
   propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Panel/Panel.types.ts')],

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { PanelBase } from './Panel.base';
-import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
-import { IStyle, ITheme } from '../../Styling';
-import { ILayerProps } from '../../Layer';
 import { IFocusTrapZoneProps } from '../../FocusTrapZone';
+import { ILayerProps } from '../../Layer';
+import { IStyle, ITheme } from '../../Styling';
+import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
+import { PanelBase } from './Panel.base';
 
 export interface IPanel {
   /**
@@ -70,7 +70,7 @@ export interface IPanelProps extends React.Props<PanelBase> {
    * A callback function for when the panel is closed, before the animation completes.
    * If the panel should NOT be dismissed based on some keyboard event, then simply call ev.preventDefault() on it
    */
-  onDismiss?: (ev?: React.KeyboardEvent<HTMLElement>) => void;
+  onDismiss?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
 
   /**
    * A callback function which is called after the Panel is dismissed and the animation is complete.

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx
@@ -1,0 +1,66 @@
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+import * as React from 'react';
+
+export class PanelHandleDismissTargetExample extends React.Component<
+  {},
+  {
+    showPanel: boolean;
+  }
+> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { showPanel: false };
+    this._onClosePanel = this._onClosePanel.bind(this);
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <DefaultButton
+          secondaryText="Opens the Sample Panel"
+          // tslint:disable-next-line:jsx-no-lambda
+          onClick={() => this.setState({ showPanel: true })}
+          text="Open Panel"
+        />
+        <Panel
+          headerText="Panel - Handle close button clicks or light dismissal"
+          isOpen={this.state.showPanel}
+          type={PanelType.smallFixedNear}
+          isFooterAtBottom={true}
+          // tslint:disable-next-line:jsx-no-lambda
+          onDismiss={ev => {
+            if (!ev) {
+              console.log('Panel dismissed.');
+              return;
+            }
+
+            console.log('Close button clicked or light dismissed.');
+            if (ev.nativeEvent.srcElement && ev.nativeEvent.srcElement.className.indexOf('ms-Button-icon') !== -1) {
+              console.log('Close button clicked.');
+            }
+            if (ev.nativeEvent.srcElement && ev.nativeEvent.srcElement.className.indexOf('ms-Overlay') !== -1) {
+              console.log('Light dismissed.');
+            }
+          }}
+          onRenderFooterContent={this._onRenderFooterContent}
+          isLightDismiss={true}
+        >
+          <span>Content goes here.</span>
+        </Panel>
+      </div>
+    );
+  }
+
+  private _onRenderFooterContent = (): JSX.Element => {
+    return (
+      <div>
+        <DefaultButton onClick={this._onClosePanel}>Dismiss</DefaultButton>
+      </div>
+    );
+  };
+
+  private _onClosePanel = () => {
+    this.setState({ showPanel: false });
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HandleDismissTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HandleDismissTarget.Example.tsx.shot
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Panel.HandleDismissTarget.Example.tsx correctly 1`] = `
+<div>
+  <button
+    aria-describedby="id__1"
+    aria-labelledby="id__0"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Open Panel
+        </div>
+      </div>
+    </div>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6342 
- [x] Include a change request file using `$ npm run change`
(couldn't get this to work, made manually)

#### Description of changes

- Pass click event from onPanelClick (called on close button click and light dismiss) to dismiss method.
- Update dismiss method to use synthetic event param instead of keyboard event to support keyboard and click events.
- Add example to docs showing how to handle different dismiss targets (close button click or light dismiss) within onDismiss handler.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6374)

