### PR TITLE
Make lib import consistent for filetypeicons

### DIFF
--- a/common/changes/@uifabric/file-type-icons/commonjs_2018-09-17-16-26.json
+++ b/common/changes/@uifabric/file-type-icons/commonjs_2018-09-17-16-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Make lib import consistent for filetypeicons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { registerIcons, IIconOptions } from '@uifabric/styling/lib/index';
+import { registerIcons, IIconOptions } from '@uifabric/styling';
 import { FileTypeIconMap } from './FileTypeIconMap';
 
 const PNG_SUFFIX = '_png';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6380
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Make lib import consistent for filetypeicons
#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6385)

