### PR TITLE
Add linkProps to IDocumentCardPreviewImage

### DIFF
--- a/apps/vr-tests/src/stories/DocumentCard.stories.tsx
+++ b/apps/vr-tests/src/stories/DocumentCard.stories.tsx
@@ -19,7 +19,9 @@ let previewProps = {
   previewImages: [
     {
       name: 'Revenue stream proposal fiscal year 2016 version02.pptx',
-      url: 'http://bing.com',
+      linkProps: {
+        href: 'http://bing.com'
+      },
       previewImageSrc: TestImages.documentPreview,
       iconSrc: TestImages.iconPpt,
       imageFit: ImageFit.cover,
@@ -34,28 +36,36 @@ let previewPropsCompact = {
   previewImages: [
     {
       name: 'Revenue stream proposal fiscal year 2016 version02.pptx',
-      url: 'http://bing.com',
+      linkProps: {
+        href: 'http://bing.com'
+      },
       previewImageSrc: TestImages.documentPreview,
       iconSrc: TestImages.iconPpt,
       width: 144
     },
     {
       name: 'New Contoso Collaboration for Conference Presentation Draft',
-      url: 'http://bing.com',
+      linkProps: {
+        href: 'http://bing.com'
+      },
       previewImageSrc: TestImages.documentPreviewTwo,
       iconSrc: TestImages.iconPpt,
       width: 144
     },
     {
       name: 'Spec Sheet for design',
-      url: 'http://bing.com',
+      linkProps: {
+        href: 'http://bing.com'
+      },
       previewImageSrc: TestImages.documentPreviewThree,
       iconSrc: TestImages.iconPpt,
       width: 144
     },
     {
       name: 'Contoso Marketing Presentation',
-      url: 'http://bing.com',
+      linkProps: {
+        href: 'http://bing.com'
+      },
       previewImageSrc: TestImages.documentPreview,
       iconSrc: TestImages.iconPpt,
       width: 144

--- a/common/changes/office-ui-fabric-react/edwl-2018-09-documentCardPreviewLinkProps_2018-09-17-17-07.json
+++ b/common/changes/office-ui-fabric-react/edwl-2018-09-documentCardPreviewLinkProps_2018-09-17-17-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCardPreview: Change component to use Link and add linkProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -95,7 +95,7 @@ export interface IDocumentCardPreviewImage {
 
   /**
    * URL to view the file.
-   * @deprecated Use linkProps instead.
+   * @deprecated Use href inside of linkProps instead.
    */
   url?: string;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -10,7 +10,7 @@ import { ImageFit } from '../../Image';
 import { IButtonProps } from '../../Button';
 import { IIconProps } from '../../Icon';
 import { IBaseProps, IRefObject } from '../../Utilities';
-import { ILinkProps } from 'office-ui-fabric-react/lib/components/Link';
+import { ILinkProps } from '../../Link';
 
 export interface IDocumentCard {}
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -10,6 +10,7 @@ import { ImageFit } from '../../Image';
 import { IButtonProps } from '../../Button';
 import { IIconProps } from '../../Icon';
 import { IBaseProps, IRefObject } from '../../Utilities';
+import { ILinkProps } from 'office-ui-fabric-react/lib/components/Link';
 
 export interface IDocumentCard {}
 
@@ -94,8 +95,14 @@ export interface IDocumentCardPreviewImage {
 
   /**
    * URL to view the file.
+   * @deprecated Use linkProps instead.
    */
   url?: string;
+
+  /**
+   * Props to pass to Link component
+   */
+  linkProps?: ILinkProps;
 
   /**
    * Path to the preview image.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IDocumentCardPreviewProps, IDocumentCardPreviewImage } from './DocumentCard.types';
 import { Image } from '../../Image';
 import { Icon } from '../../Icon';
+import { Link } from '../../Link';
 import { BaseComponent, css } from '../../Utilities';
 import * as stylesImport from './DocumentCard.scss';
 const styles: any = stylesImport;
@@ -31,26 +32,15 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
     }
 
     return (
-      <div
-        className={css(
-          'ms-DocumentCardPreview',
-          styles.preview,
-          isFileList && 'is-fileList ' + styles.previewIsFileList
-        )}
-        style={style}
-      >
+      <div className={css('ms-DocumentCardPreview', styles.preview, isFileList && 'is-fileList ' + styles.previewIsFileList)} style={style}>
         {preview}
       </div>
     );
   }
 
-  private _renderPreviewImage(
-    previewImage: IDocumentCardPreviewImage
-  ): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
+  private _renderPreviewImage(previewImage: IDocumentCardPreviewImage): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> {
     const { width, height, imageFit, previewIconProps, previewIconContainerClass } = previewImage;
-    const iconContainerClass = previewIconContainerClass
-      ? previewIconContainerClass
-      : 'ms-DocumentCardPreview-iconContainer';
+    const iconContainerClass = previewIconContainerClass ? previewIconContainerClass : 'ms-DocumentCardPreview-iconContainer';
 
     if (previewIconProps) {
       return (
@@ -60,27 +50,11 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
       );
     }
 
-    const image = (
-      <Image
-        width={width}
-        height={height}
-        imageFit={imageFit}
-        src={previewImage.previewImageSrc}
-        role="presentation"
-        alt=""
-      />
-    );
+    const image = <Image width={width} height={height} imageFit={imageFit} src={previewImage.previewImageSrc} role="presentation" alt="" />;
 
     let icon;
     if (previewImage.iconSrc) {
-      icon = (
-        <Image
-          className={css('ms-DocumentCardPreview-icon', styles.icon)}
-          src={previewImage.iconSrc}
-          role="presentation"
-          alt=""
-        />
-      );
+      icon = <Image className={css('ms-DocumentCardPreview-icon', styles.icon)} src={previewImage.iconSrc} role="presentation" alt="" />;
     }
 
     return (
@@ -91,9 +65,7 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
     );
   }
 
-  private _renderPreviewList = (
-    previewImages: IDocumentCardPreviewImage[]
-  ): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> => {
+  private _renderPreviewList = (previewImages: IDocumentCardPreviewImage[]): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> => {
     const { getOverflowDocumentCountText } = this.props;
 
     // Determine how many documents we won't be showing
@@ -117,16 +89,14 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
           width="16px"
           height="16px"
         />
-        <a href={file.url}>{file.name}</a>
+        <Link {...file.linkProps}>{file.name}</Link>
       </li>
     ));
 
     return (
       <div>
         <ul className={css('ms-DocumentCardPreview-fileList', styles.fileList)}>{fileListItems}</ul>
-        {overflowText && (
-          <span className={css('ms-DocumentCardPreview-fileListMore', styles.fileListMore)}>{overflowText}</span>
-        )}
+        {overflowText && <span className={css('ms-DocumentCardPreview-fileListMore', styles.fileListMore)}>{overflowText}</span>}
       </div>
     );
   };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.tsx
@@ -89,7 +89,7 @@ export class DocumentCardPreview extends BaseComponent<IDocumentCardPreviewProps
           width="16px"
           height="16px"
         />
-        <Link {...file.linkProps}>{file.name}</Link>
+        <Link {...(file.linkProps, { href: file.url || (file.linkProps && file.linkProps.href) })}>{file.name}</Link>
       </li>
     ));
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
@@ -16,7 +16,9 @@ export class DocumentCardBasicExample extends React.Component<any, any> {
       previewImages: [
         {
           name: 'Revenue stream proposal fiscal year 2016 version02.pptx',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://google.com'
+          },
           previewImageSrc: TestImages.documentPreview,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -16,28 +16,36 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
       previewImages: [
         {
           name: 'Revenue stream proposal fiscal year 2016 version02.pptx',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreview,
           iconSrc: TestImages.iconPpt,
           width: 144
         },
         {
           name: 'New Contoso Collaboration for Conference Presentation Draft',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreviewTwo,
           iconSrc: TestImages.iconPpt,
           width: 144
         },
         {
           name: 'Spec Sheet for design',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreviewThree,
           iconSrc: TestImages.iconPpt,
           width: 144
         },
         {
           name: 'Contoso Marketing Presentation',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreview,
           iconSrc: TestImages.iconPpt,
           width: 144
@@ -102,10 +110,7 @@ export class DocumentCardCompactExample extends React.Component<any, any> {
         <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
           <DocumentCardPreview {...previewOutlookUsingIcon} />
           <div className="ms-DocumentCard-details">
-            <DocumentCardTitle
-              title="Conversation about anual report from SharePoint conference"
-              shouldTruncate={true}
-            />
+            <DocumentCardTitle title="Conversation about anual report from SharePoint conference" shouldTruncate={true} />
             <DocumentCardActivity
               activity="Sent a few minutes ago"
               people={[{ name: 'Kat Larrson', profileImageSrc: TestImages.personaFemale }]}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -21,7 +21,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
       previewImages: [
         {
           name: '2016 Conference Presentation',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreview,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
@@ -30,7 +32,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
         },
         {
           name: 'New Contoso Collaboration for Conference Presentation Draft',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreviewTwo,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
@@ -39,7 +43,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
         },
         {
           name: 'Spec Sheet for design',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreviewThree,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
@@ -48,7 +54,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
         },
         {
           name: 'Contoso Marketing Presentation',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreview,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
@@ -57,7 +65,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
         },
         {
           name: 'Notes from Ignite conference',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreviewTwo,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
@@ -66,7 +76,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
         },
         {
           name: 'FY17 Cost Projections',
-          url: 'http://bing.com',
+          linkProps: {
+            href: 'http://bing.com'
+          },
           previewImageSrc: TestImages.documentPreviewThree,
           iconSrc: TestImages.iconPpt,
           imageFit: ImageFit.cover,
@@ -141,7 +153,9 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
             views={432}
           />
         </DocumentCard>
-        <p />Card Logo, Text Preview CardStatus are used on below examples.<p />
+        <p />
+        Card Logo, Text Preview CardStatus are used on below examples.
+        <p />
         <DocumentCard onClickHref="http://bing.com">
           <DocumentCardLogo {...logoProps} />
           <div className="ms-ConversationTile-TitlePreviewArea">

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -51,7 +51,39 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
               />
             </div>
             <a
+              className=
+                  ms-Link
+                  {
+                    color: #0078d4;
+                    outline: transparent;
+                    position: relative;
+                    text-decoration: none;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  &:active, &:hover, &:active:hover {
+                    color: #004578;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                    text-decoration: underline;
+                  }
+                  &:focus {
+                    color: #0078d4;
+                  }
               href="http://bing.com"
+              onClick={[Function]}
             >
               Revenue stream proposal fiscal year 2016 version02.pptx
             </a>
@@ -91,7 +123,39 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
               />
             </div>
             <a
+              className=
+                  ms-Link
+                  {
+                    color: #0078d4;
+                    outline: transparent;
+                    position: relative;
+                    text-decoration: none;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  &:active, &:hover, &:active:hover {
+                    color: #004578;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                    text-decoration: underline;
+                  }
+                  &:focus {
+                    color: #0078d4;
+                  }
               href="http://bing.com"
+              onClick={[Function]}
             >
               New Contoso Collaboration for Conference Presentation Draft
             </a>
@@ -131,7 +195,39 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
               />
             </div>
             <a
+              className=
+                  ms-Link
+                  {
+                    color: #0078d4;
+                    outline: transparent;
+                    position: relative;
+                    text-decoration: none;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  &:active, &:hover, &:active:hover {
+                    color: #004578;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                    text-decoration: underline;
+                  }
+                  &:focus {
+                    color: #0078d4;
+                  }
               href="http://bing.com"
+              onClick={[Function]}
             >
               Spec Sheet for design
             </a>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -51,7 +51,39 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               />
             </div>
             <a
+              className=
+                  ms-Link
+                  {
+                    color: #0078d4;
+                    outline: transparent;
+                    position: relative;
+                    text-decoration: none;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  &:active, &:hover, &:active:hover {
+                    color: #004578;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                    text-decoration: underline;
+                  }
+                  &:focus {
+                    color: #0078d4;
+                  }
               href="http://bing.com"
+              onClick={[Function]}
             >
               2016 Conference Presentation
             </a>
@@ -91,7 +123,39 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               />
             </div>
             <a
+              className=
+                  ms-Link
+                  {
+                    color: #0078d4;
+                    outline: transparent;
+                    position: relative;
+                    text-decoration: none;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  &:active, &:hover, &:active:hover {
+                    color: #004578;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                    text-decoration: underline;
+                  }
+                  &:focus {
+                    color: #0078d4;
+                  }
               href="http://bing.com"
+              onClick={[Function]}
             >
               New Contoso Collaboration for Conference Presentation Draft
             </a>
@@ -131,7 +195,39 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               />
             </div>
             <a
+              className=
+                  ms-Link
+                  {
+                    color: #0078d4;
+                    outline: transparent;
+                    position: relative;
+                    text-decoration: none;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  &:active, &:hover, &:active:hover {
+                    color: #004578;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                    text-decoration: underline;
+                  }
+                  &:focus {
+                    color: #0078d4;
+                  }
               href="http://bing.com"
+              onClick={[Function]}
             >
               Spec Sheet for design
             </a>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6313 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add Link component to DocumentCardPreview.  Add linkProps and deprecate url in favor of linkProps.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6387)

