### PR TITLE
ComboBox: Allow substring search when autocomplete is enabled

### DIFF
--- a/common/changes/office-ui-fabric-react/users-chrosen-comboboxfixes_2018-09-17-18-34.json
+++ b/common/changes/office-ui-fabric-react/users-chrosen-comboboxfixes_2018-09-17-18-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a new option for allowing substring input search for comboboxes. This is largely to fix the experience for the room list combobox. If a user types in the box 32, with this option on, it will select Puget Sound - Building 32. Does not influence existing behavior. Updated examples with new option to allow for fullstringautocomplete (substring search). ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chrosen@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -19,6 +19,22 @@ const DEFAULT_OPTIONS3: IComboBoxOption[] = [
   { key: '3', text: 'Bar' }
 ];
 
+const DEFAULT_OPTIONS4 = [
+  { key: 'Header', text: 'Suggested room lists', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'A', text: 'Puget Sound - Building 31' },
+  { key: 'B', text: 'Puget Sound - Building 32' },
+  { key: 'C', text: 'Puget Sound - Building 34' },
+  { key: 'Header2', text: 'All room lists', itemType: SelectableOptionMenuItemType.Header },
+  { key: 'D', text: 'All Rooms Vernier' },
+  { key: 'E', text: 'All Rooms Wallisellen' },
+  { key: 'F', text: 'APAC-AUSTRALIA-ADELAIDE' },
+  { key: 'G', text: 'APAC-Australia-BRISBANE' },
+  { key: 'H', text: 'Puget Sound - Building 30' },
+  { key: 'I', text: 'Puget Sound - Building 32' },
+  { key: 'J', text: 'Puget Sound - Building 33' },
+  { key: 'K', text: 'Puget Sound - Building 34' }
+];
+
 describe('ComboBox', () => {
   it('Renders ComboBox correctly', () => {
     const createNodeMock = (el: React.ReactElement<{}>) => {
@@ -173,6 +189,25 @@ describe('ComboBox', () => {
     wrapper.find('input').simulate('input', { target: { value: 'f' } });
     wrapper.update();
     expect(wrapper.find('input').props().value).toEqual('Foo');
+  });
+
+  it('Can insert text in uncontrolled case with autoComplete, autoCompleteFullString, allowFreeform on', () => {
+    const wrapper = mount(
+      <ComboBox
+        label="testgroup"
+        defaultSelectedKey="1"
+        options={DEFAULT_OPTIONS4}
+        autoComplete="on"
+        autoCompleteFullString="on"
+        allowFreeform={true}
+      />
+    );
+
+    wrapper.find('input').simulate('input', { target: { value: '3' } });
+    wrapper.find('input').simulate('input', { target: { value: '0' } });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('Puget Sound - Building 30');
   });
 
   it('Can insert text in uncontrolled case with autoComplete on and allowFreeform off', () => {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -676,6 +676,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
               .indexOf(updatedValue) === 0
         );
       }
+      
       if (items.length > 0) {
         // use ariaLabel as the value when the option is set
         const text: string = this._getPreviewText(items[0]);

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -105,6 +105,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     options: [],
     allowFreeform: false,
     autoComplete: 'on',
+    autoCompleteFullString: 'off',
     buttonIconProps: { iconName: 'ChevronDown' }
   };
 
@@ -652,19 +653,28 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     // If autoComplete is on, attempt to find a match from the available options
     if (this.props.autoComplete === 'on') {
       // If autoComplete is on, attempt to find a match where the text of an option starts with the updated value
-      const items = currentOptions
+      let items = currentOptions
         .map((item, index) => {
           return { ...item, index };
         })
         .filter(
           option => option.itemType !== SelectableOptionMenuItemType.Header && option.itemType !== SelectableOptionMenuItemType.Divider
-        )
-        .filter(
+        );
+
+      if (this.props.autoCompleteFullString === 'on') {
+        items = items.filter(option =>
+          this._getPreviewText(option)
+            .toLocaleLowerCase()
+            .includes(updatedValue)
+        );
+      } else {
+        items = items.filter(
           option =>
             this._getPreviewText(option)
               .toLocaleLowerCase()
               .indexOf(updatedValue) === 0
         );
+      }
       if (items.length > 0) {
         // use ariaLabel as the value when the option is set
         const text: string = this._getPreviewText(items[0]);
@@ -999,6 +1009,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
               this._autofill.current.inputElement &&
               this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
         ) {
+          this._setSelectedIndex(currentPendingValueValidIndex, submitPendingValueEvent);
+          this._clearPendingInfo();
+          return;
+        }
+
+        // else if the pending option contains the pending value and we have auto complete and auto full string
+        // update the state
+        if (this.props.autoComplete && this.props.autoCompleteFullString) {
           this._setSelectedIndex(currentPendingValueValidIndex, submitPendingValueEvent);
           this._clearPendingInfo();
           return;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -653,23 +653,24 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     // If autoComplete is on, attempt to find a match from the available options
     if (this.props.autoComplete === 'on') {
       // If autoComplete is on, attempt to find a match where the text of an option starts with the updated value
-      let items = currentOptions
-        .map((item, index) => {
-          return { ...item, index };
-        })
-        .filter(
-          option => option.itemType !== SelectableOptionMenuItemType.Header && option.itemType !== SelectableOptionMenuItemType.Divider
-        );
+      let items = currentOptions.map((item, index) => {
+        return { ...item, index };
+      });
 
       if (this.props.autoCompleteFullString === 'on') {
-        items = items.filter(option =>
-          this._getPreviewText(option)
-            .toLocaleLowerCase()
-            .includes(updatedValue)
+        items = items.filter(
+          option =>
+            option.itemType !== SelectableOptionMenuItemType.Header &&
+            option.itemType !== SelectableOptionMenuItemType.Divider &&
+            this._getPreviewText(option)
+              .toLocaleLowerCase()
+              .includes(updatedValue)
         );
       } else {
         items = items.filter(
           option =>
+            option.itemType !== SelectableOptionMenuItemType.Header &&
+            option.itemType !== SelectableOptionMenuItemType.Divider &&
             this._getPreviewText(option)
               .toLocaleLowerCase()
               .indexOf(updatedValue) === 0
@@ -692,9 +693,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           return { ...item, index };
         })
         .filter(
-          option => option.itemType !== SelectableOptionMenuItemType.Header && option.itemType !== SelectableOptionMenuItemType.Divider
-        )
-        .filter(option => this._getPreviewText(option).toLocaleLowerCase() === updatedValue);
+          option =>
+            option.itemType !== SelectableOptionMenuItemType.Header &&
+            option.itemType !== SelectableOptionMenuItemType.Divider &&
+            this._getPreviewText(option).toLocaleLowerCase() === updatedValue
+        );
 
       // if we found a match remember the index
       if (items.length === 1) {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -103,6 +103,14 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   autoComplete?: 'on' | 'off';
 
   /**
+   * If ComboBox has autocomplete, whether it will use substring search or not when suggesting potential matches from the list of options
+   * when user inputs text.
+   *
+   * @default "off"
+   **/
+  autoCompleteFullString?: 'on' | 'off';
+
+  /**
    * Value to show in the input, does not have to map to a combobox option
    */
   text?: string;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -54,6 +54,22 @@ export class ComboBoxBasicExample extends React.Component<
     { key: 'J', text: 'Option j', disabled: true }
   ];
 
+  private _fullSearchOptions = [
+    { key: 'Header', text: 'Suggested room lists', itemType: SelectableOptionMenuItemType.Header },
+    { key: 'A', text: 'Puget Sound - Building 31' },
+    { key: 'B', text: 'Puget Sound - Building 32' },
+    { key: 'C', text: 'Puget Sound - Building 34' },
+    { key: 'Header2', text: 'All room lists', itemType: SelectableOptionMenuItemType.Header },
+    { key: 'D', text: 'All Rooms Vernier' },
+    { key: 'E', text: 'All Rooms Wallisellen' },
+    { key: 'F', text: 'APAC-AUSTRALIA-ADELAIDE' },
+    { key: 'G', text: 'APAC-Australia-BRISBANE' },
+    { key: 'H', text: 'Puget Sound - Building 30' },
+    { key: 'I', text: 'Puget Sound - Building 32' },
+    { key: 'J', text: 'Puget Sound - Building 33' },
+    { key: 'K', text: 'Puget Sound - Building 34' }
+  ];
+
   private _fontMapping: { [key: string]: string } = {
     ['Arial Black']: '"Arial Black", "Arial Black_MSFontService", sans-serif',
     ['Time New Roman']: '"Times New Roman", "Times New Roman_MSFontService", serif',
@@ -104,9 +120,7 @@ export class ComboBoxBasicExample extends React.Component<
           onBlur={() => console.log('onBlur called')}
           onMenuOpen={() => console.log('ComboBox menu opened')}
           onPendingValueChanged={(option, pendingIndex, pendingValue) =>
-            console.log(
-              'Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue
-            )
+            console.log('Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue)
           }
           // tslint:enable:jsx-no-lambda
         />
@@ -121,6 +135,24 @@ export class ComboBoxBasicExample extends React.Component<
           ariaLabel="Basic ComboBox example"
           allowFreeform={true}
           autoComplete="on"
+          options={this._testOptions}
+          onRenderOption={this._onRenderFontOption}
+          // tslint:disable:jsx-no-lambda
+          onFocus={() => console.log('onFocus called')}
+          onBlur={() => console.log('onBlur called')}
+          onMenuOpen={() => console.log('ComboBox menu opened')}
+          // tslint:enable:jsx-no-lambda
+        />
+
+        <ComboBox
+          multiSelect
+          defaultSelectedKey={['C', 'E']}
+          label="Basic uncontrolled multi select example (allowFreeform: T, AutoComplete: T, AutoCompleteFullString: T):"
+          id="Basicdrop11"
+          ariaLabel="Basic ComboBox example"
+          allowFreeform={true}
+          autoComplete="on"
+          autoCompleteFullString="on"
           options={this._testOptions}
           onRenderOption={this._onRenderFontOption}
           // tslint:disable:jsx-no-lambda
@@ -175,9 +207,7 @@ export class ComboBoxBasicExample extends React.Component<
           onBlur={() => console.log('onBlur called')}
           onMenuOpen={() => console.log('ComboBox menu opened')}
           onPendingValueChanged={(option, pendingIndex, pendingValue) =>
-            console.log(
-              'Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue
-            )
+            console.log('Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue)
           }
           // tslint:enable:jsx-no-lambda
           dropdownMaxWidth={200}
@@ -197,9 +227,28 @@ export class ComboBoxBasicExample extends React.Component<
           onBlur={() => console.log('onBlur called')}
           onMenuOpen={() => console.log('ComboBox menu opened')}
           onPendingValueChanged={(option, pendingIndex, pendingValue) =>
-            console.log(
-              'Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue
-            )
+            console.log('Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue)
+          }
+          // tslint:enable:jsx-no-lambda
+          dropdownMaxWidth={400}
+          useComboBoxAsMenuWidth={true}
+        />
+
+        <VirtualizedComboBox
+          defaultSelectedKey="C"
+          label="Scaled example with 1000 items (allowFreeform: T, AutoComplete: T, AutoCompleteFullString: T):"
+          id="Basicdrop1"
+          ariaLabel="Basic ComboBox example"
+          allowFreeform={true}
+          autoComplete="on"
+          autoCompleteFullString="on"
+          options={this._fullSearchOptions}
+          // tslint:disable:jsx-no-lambda
+          onFocus={() => console.log('onFocus called')}
+          onBlur={() => console.log('onBlur called')}
+          onMenuOpen={() => console.log('ComboBox menu opened')}
+          onPendingValueChanged={(option, pendingIndex, pendingValue) =>
+            console.log('Preview value was changed. Pending index: ' + pendingIndex + '. Pending value: ' + pendingValue)
           }
           // tslint:enable:jsx-no-lambda
           dropdownMaxWidth={400}
@@ -318,10 +367,7 @@ export class ComboBoxBasicExample extends React.Component<
 
   // Render content of item
   private _onRenderFontOption = (item: IComboBoxOption): JSX.Element => {
-    if (
-      item.itemType === SelectableOptionMenuItemType.Header ||
-      item.itemType === SelectableOptionMenuItemType.Divider
-    ) {
+    if (item.itemType === SelectableOptionMenuItemType.Header || item.itemType === SelectableOptionMenuItemType.Divider) {
       return <span className={'ms-ComboBox-optionText'}>{item.text}</span>;
     }
 
@@ -375,12 +421,7 @@ export class ComboBoxBasicExample extends React.Component<
     return INITIAL_OPTIONS;
   };
 
-  private _onChange = (
-    event: React.FormEvent<IComboBox>,
-    option: IComboBoxOption,
-    index: number,
-    value: string
-  ): void => {
+  private _onChange = (event: React.FormEvent<IComboBox>, option: IComboBoxOption, index: number, value: string): void => {
     console.log('_onChanged() is called: option = ' + JSON.stringify(option));
     if (option !== undefined) {
       this.setState({
@@ -403,12 +444,7 @@ export class ComboBoxBasicExample extends React.Component<
     }
   };
 
-  private _onChangeMulti = (
-    event: React.FormEvent<IComboBox>,
-    option: IComboBoxOption,
-    index: number,
-    value: string
-  ) => {
+  private _onChangeMulti = (event: React.FormEvent<IComboBox>, option: IComboBoxOption, index: number, value: string) => {
     console.log('_onChangeMulti() is called: option = ' + JSON.stringify(option));
     if (option !== undefined) {
       // User selected/de-selected an existing option

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -747,6 +747,315 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
+    autoComplete="on"
+    className="ms-ComboBox-container "
+    id="Basicdrop11"
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <label
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Basicdrop11-input"
+      id="Basicdrop11-label"
+    >
+      Basic uncontrolled multi select example (allowFreeform: T, AutoComplete: T, AutoCompleteFullString: T):
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+      id="Basicdrop11wrapper"
+    >
+      <input
+        aria-autocomplete="inline"
+        aria-expanded={false}
+        aria-labelledby="Basicdrop11-label"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #333333;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+        data-is-interactable={true}
+        data-lpignore={true}
+        id="Basicdrop11-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        readOnly={false}
+        role="combobox"
+        spellCheck={false}
+        type="text"
+        value="Comic Sans MS, Option e"
+      />
+      <button
+        aria-hidden={true}
+        checked={false}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: none;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+        data-is-focusable={false}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <div
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
+            data-icon-name="ChevronDown"
+            role="presentation"
+          >
+            
+          </i>
+        </div>
+      </button>
+    </div>
+  </div>
+  <div
     autoComplete="off"
     className="ms-ComboBox-container "
     id="Basicdrop2"
@@ -1983,6 +2292,315 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
+    autoComplete="on"
+    className="ms-ComboBox-container "
+    id="Basicdrop1"
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <label
+      className=
+          ms-Label
+          {
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Basicdrop1-input"
+      id="Basicdrop1-label"
+    >
+      Scaled example with 1000 items (allowFreeform: T, AutoComplete: T, AutoCompleteFullString: T):
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #a6a6a6;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 12px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
+          &.is-open {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+      id="Basicdrop1wrapper"
+    >
+      <input
+        aria-autocomplete="inline"
+        aria-expanded={false}
+        aria-labelledby="Basicdrop1-label"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #333333;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+        data-is-interactable={true}
+        data-lpignore={true}
+        id="Basicdrop1-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        readOnly={false}
+        role="combobox"
+        spellCheck={false}
+        type="text"
+        value="Puget Sound - Building 34"
+      />
+      <button
+        aria-hidden={true}
+        checked={false}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: none;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f4f4f4;
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #eaeaea;
+              color: #212121;
+            }
+        data-is-focusable={false}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <div
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
+            data-icon-name="ChevronDown"
+            role="presentation"
+          >
+            
+          </i>
+        </div>
+      </button>
+    </div>
+  </div>
+  <div
     autoComplete="off"
     className="ms-ComboBox-container "
     id="Basicdrop4"
@@ -2607,8 +3225,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& {
             color: GrayText;
           }
-      htmlFor="ComboBox27-input"
-      id="ComboBox27-label"
+      htmlFor="ComboBox33-input"
+      id="ComboBox33-label"
     >
       Disabled uncontrolled example with defaultSelectedKey:
     </label>
@@ -2672,13 +3290,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             border-color: GrayText;
             color: GrayText;
           }
-      id="ComboBox27wrapper"
+      id="ComboBox33wrapper"
     >
       <input
         aria-autocomplete="none"
         aria-disabled={true}
         aria-expanded={false}
-        aria-labelledby="ComboBox27-label"
+        aria-labelledby="ComboBox33-label"
         autoCapitalize="off"
         autoComplete="off"
         className=
@@ -2706,7 +3324,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
         data-is-interactable={false}
         data-lpignore={true}
-        id="ComboBox27-input"
+        id="ComboBox33-input"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Add a new option to allow for substring search in the combo box input field when autocomplete is also enabled. This makes the combobox for room lists much more usable for large tenants. For MSFT, a user can type 32 to navigate directly to the "Puget Sound - Building 32" combobox option. 

#### Focus areas to test

combobox:  with free-form + autocomplete enabled, and free-form + autocomplete + autocompletefullstring 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6388)

