### PR TITLE
Refactor PivotItem and DialogFooter type comparison to address hot module replacement issue

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-pivotitem_2018-09-18-17-56.json
+++ b/common/changes/office-ui-fabric-react/keco-pivotitem_2018-09-18-17-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Refactor PivotItem & DialogFooter type comparison to use React.Element.type to address hot module replacement break.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -3,9 +3,12 @@ import { BaseComponent, classNamesFunction } from '../../Utilities';
 import { DialogType, IDialogContentProps, IDialogContentStyleProps, IDialogContentStyles } from './DialogContent.types';
 import { IconButton } from '../../Button';
 import { DialogFooter } from './DialogFooter';
+import { IDialogFooterProps } from './DialogFooter.types';
 import { withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 
 const getClassNames = classNamesFunction<IDialogContentStyleProps, IDialogContentStyles>();
+
+const DialogFooterType = (<DialogFooter /> as React.ReactElement<IDialogFooterProps>).type;
 
 @withResponsiveMode
 export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
@@ -93,7 +96,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
     };
 
     React.Children.map(this.props.children, child => {
-      if (typeof child === 'object' && child !== null && child.type === DialogFooter) {
+      if (typeof child === 'object' && child !== null && child.type === DialogFooterType) {
         groupings.footers.push(child);
       } else {
         groupings.contents.push(child);

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
-import {
-  BaseComponent,
-  KeyCodes,
-  getId,
-  getNativeProps,
-  divProperties,
-  createRef,
-  classNamesFunction
-} from '../../Utilities';
+import { BaseComponent, KeyCodes, getId, getNativeProps, divProperties, createRef, classNamesFunction } from '../../Utilities';
 import { CommandButton } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
@@ -41,8 +33,7 @@ export interface IPivotState {
   selectedTabId: string;
 }
 
-// Use regular React.createElement because `<PivotItem />.type` breaks prettier.
-const PivotItemType = React.createElement(PivotItem).type;
+const PivotItemType = (<PivotItem /> as React.ReactElement<IPivotItemProps>).type;
 
 export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
   private _keyToIndexMapping: { [key: string]: number };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6294
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Holding off on change file until I get a consistent repro w/ hot module replacement.

This PR refactors the type comparison for `<PivotItem />` and `<DialogFooter />` to avoid errors with hot module reload, see #6294 and https://github.com/gaearon/react-hot-loader/issues/938#issue-315580578 for a description of the problem.

This change follows the type comparison pattern we use for [`<Accordion />`](https://github.com/OfficeDev/office-ui-fabric-react/blob/951ef9e3ff869d4658f0bdf6fda314aa3e1ffae6/packages/experiments/src/components/Accordion/Accordion.tsx#L20) and [`<Stack />`](https://github.com/OfficeDev/office-ui-fabric-react/blob/951ef9e3ff869d4658f0bdf6fda314aa3e1ffae6/packages/experiments/src/components/Stack/Stack.tsx#L39).

#### Focus areas to test

Waiting on initial reporter(s) to repro w/ hot module reload. For now, make sure `<PivotItem />` and `<DialogFooter />` render on the example pages.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6395)

