### PR TITLE
merge-styles: add feature query support

### DIFF
--- a/common/changes/@uifabric/merge-styles/merge-styles-supports_2018-09-19-01-09.json
+++ b/common/changes/@uifabric/merge-styles/merge-styles-supports_2018-09-19-01-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Adding support for feature queries in selectors.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -5,6 +5,7 @@ The `merge-styles` library provides utilities for loading styles through javascr
 The library was built for speed and size; the entire package is 2.62k gzipped. It has no dependencies other than `tslib`.
 
 Simple usage:
+
 ```
 import { mergeStyles, mergeStyleSet } from '@uifabric/merge-styles';
 
@@ -28,21 +29,21 @@ The basic idea is to provide tools which can take in one or more css styling obj
 
 Defining rules at runtime has a number of benefits over traditional build time staticly produced css:
 
-* Only register classes that are needed, when they're needed, reducing the overall selector count and improving TTG.
+- Only register classes that are needed, when they're needed, reducing the overall selector count and improving TTG.
 
-* Dynamically create new class permutations based on contextual theming requirements. (Use a different theme inside of a DIV without downloading multiple copies of the css rule definitions.)
+- Dynamically create new class permutations based on contextual theming requirements. (Use a different theme inside of a DIV without downloading multiple copies of the css rule definitions.)
 
-* Use JavaScript to define the class content (using utilities like color converters, or reusing constant numbers becomes possible.)
+- Use JavaScript to define the class content (using utilities like color converters, or reusing constant numbers becomes possible.)
 
-* Allow control libraries to merge customized styling in with their rules, avoiding complexities like css selector specificity.
+- Allow control libraries to merge customized styling in with their rules, avoiding complexities like css selector specificity.
 
-* Simplify RTL processing; lefts become rights in RTL, in the actual rules. No complexity like `html[dir=rtl]` prefixes necessary, which alleviates unexpected specificity bugs. (You can use `/* noflip */` comments to avoid flipping if needed.)
+- Simplify RTL processing; lefts become rights in RTL, in the actual rules. No complexity like `html[dir=rtl]` prefixes necessary, which alleviates unexpected specificity bugs. (You can use `/* noflip */` comments to avoid flipping if needed.)
 
-* Reduce bundle size. Automatically handles vendor prefixing, unit providing, RTL flipping, and margin/padding expansion (e.g. margin will automatically expand out to margin TRBL, so that we avoid specificity problems when merging things together.)
+- Reduce bundle size. Automatically handles vendor prefixing, unit providing, RTL flipping, and margin/padding expansion (e.g. margin will automatically expand out to margin TRBL, so that we avoid specificity problems when merging things together.)
 
-* Reduce the build time overhead of running through CSS preprocessors.
+- Reduce the build time overhead of running through CSS preprocessors.
 
-* TypeScript type safety; spell "background" wrong and get build breaks.
+- TypeScript type safety; spell "background" wrong and get build breaks.
 
 ## What tradeoffs are there? Are there downsides to using JavaScript to process styling?
 
@@ -92,7 +93,7 @@ A **style set** represents a map of area to style object. When building a compon
 let styleSet = {
   root: { background: 'red' },
   button: { margin: 42 }
-}
+};
 ```
 
 ## Basic usage
@@ -137,9 +138,9 @@ export const MyComponent = () => {
   let { root, button, buttonIcon } = getClassNames();
 
   return (
-    <div className={ root }>
-      <button className={ button }>
-        <i className={ buttonIcon } />
+    <div className={root}>
+      <button className={button}>
+        <i className={buttonIcon} />
       </button>
     </div>
   );
@@ -166,9 +167,14 @@ Custom selectors can be defined within `IStyle` definitions under the `selectors
 By default, the rule will be appended to the current selector scope. That is, in the above scenario, there will be 2 rules inserted when using `mergeStyles`:
 
 ```css
-.css-0 { background: red; }
-.css-0:hover { background: green; }
+.css-0 {
+  background: red;
+}
+.css-0:hover {
+  background: green;
+}
 ```
+
 ### Parent/child selectors
 
 In some cases, you may need to use parent or child selectors. To do so, you can define a selector from scratch and use the `&` character to represent the generated class name. When using the `&`, the current scope is ignored. Example:
@@ -191,8 +197,12 @@ In some cases, you may need to use parent or child selectors. To do so, you can 
 This would register the rules:
 
 ```css
-.ms-Fabric--isFocusVisible .css-0 { background: red; }
-.css-0 .child { background: green; }
+.ms-Fabric--isFocusVisible .css-0 {
+  background: red;
+}
+.css-0 .child {
+  background: green;
+}
 ```
 
 ### Global selectors
@@ -211,7 +221,7 @@ To register a selector globally, wrap it in a `:global()` wrapper:
 }
 ```
 
-### Media queries
+### Media and feature queries
 
 Media queries can be applied via selectors. For example, this style will produce a class which has a red background when above 600px, and green when at or below 600px:
 
@@ -221,6 +231,9 @@ mergeStyles({
   selectors: {
     '@media(max-width: 600px)': {
       background: 'green'
+    },
+    '@supports(display: grid)': {
+      display: 'grid'
     }
   }
 });
@@ -229,10 +242,20 @@ mergeStyles({
 Produces:
 
 ```css
-.css-0 { background: red; }
+.css-0 {
+  background: red;
+}
 
-@media(max-width: 600px) {
-  .css-0 { background: green; }
+@media (max-width: 600px) {
+  .css-0 {
+    background: green;
+  }
+}
+
+@supports (display: grid) {
+  .css-0 {
+    display: grid;
+  }
 }
 ```
 
@@ -250,8 +273,12 @@ mergeStyleSets({
 Produces:
 
 ```css
-.root-0 { background: red; }
-.thumb-1 { background: green; }
+.root-0 {
+  background: red;
+}
+.thumb-1 {
+  background: green;
+}
 ```
 
 In some cases, you may need to alter a child area by interacting with the parent. For example, when the parent is hovered, change the child background. You can reference the areas defined in the style set using $ tokens:
@@ -299,7 +326,9 @@ If you'd like to override the default prefix in either case, you can pass in a `
 This generates:
 
 ```css
-.MyComponent-0 { background: red; }
+.MyComponent-0 {
+  background: red;
+}
 ```
 
 ## Managing conditionals and states
@@ -309,10 +338,7 @@ Style objects can be represented by a simple object, but also can be an array of
 In the following example, the root class generated will be different depending on the `isToggled` state:
 
 ```tsx
-export const getClassNames = (
-  isToggled: boolean
-): IComponentClassNames => {
-
+export const getClassNames = (isToggled: boolean): IComponentClassNames => {
   return mergeStyleSet({
     root: [
       {
@@ -322,7 +348,7 @@ export const getClassNames = (
         background: 'green'
       }
     ]
-  })
+  });
 };
 ```
 
@@ -351,9 +377,7 @@ Resolving the class names on every render can be an unwanted expense especially 
 ```tsx
 import { memoizeFunction } from '@uifabric/utilities';
 
-export const getClassNames = memoizeFunction((
-  isToggled: boolean
-) => {
+export const getClassNames = memoizeFunction((isToggled: boolean) => {
   return mergeStyleSet({
     // ...
   });
@@ -370,7 +394,7 @@ import { fontFace } from '@uifabric/merge-styles';
 fontFace({
   fontFamily: `"Segoe UI"`,
   src: `url("//cdn.com/fontface.woff2) format(woff2)`,
-  fontWeight: "normal"
+  fontWeight: 'normal'
 });
 ```
 
@@ -384,10 +408,10 @@ Registering animation keyframes example:
 import { keyframes, mergeStyleSets } from '@uifabric/merge-styles';
 
 let fadeIn = keyframes({
-  "from": {
+  from: {
     opacity: 0
   },
-  "to": {
+  to: {
     opacity: 1
   }
 });
@@ -417,12 +441,12 @@ let { html, css } = renderStatic(() => {
 
 Caveats for server-side rendering (TODOs):
 
-* Currently font face definitions and keyframes won't be included in the result.
+- Currently font face definitions and keyframes won't be included in the result.
 
-* Using the `memoizeFunction` utility may short circuit calling merge-styles APIs to register styles, which may cause the helper here to skip returning css. This can be fixed, but it is currently a known limitation.
+- Using the `memoizeFunction` utility may short circuit calling merge-styles APIs to register styles, which may cause the helper here to skip returning css. This can be fixed, but it is currently a known limitation.
 
-* Until all Fabric components use the merge-styles library, this will only return a subset of the styling. Also a known limitation and work in progress.
+- Until all Fabric components use the merge-styles library, this will only return a subset of the styling. Also a known limitation and work in progress.
 
-* The rehydration logic has not yet been implemented, so we may run into issues when you rehydrate.
+- The rehydration logic has not yet been implemented, so we may run into issues when you rehydrate.
 
-* Only components which USE mergeStyles will have their css included. In Fabric, not all components have been converted from using SASS yet.
+- Only components which USE mergeStyles will have their css included. In Fabric, not all components have been converted from using SASS yet.

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -73,13 +73,7 @@ describe('styleToClassName', () => {
   });
 
   it('can merge rules', () => {
-    let className = styleToClassName(
-      null,
-      false,
-      undefined,
-      { backgroundColor: 'red', color: 'white' },
-      { backgroundColor: 'green' }
-    );
+    let className = styleToClassName(null, false, undefined, { backgroundColor: 'red', color: 'white' }, { backgroundColor: 'green' });
 
     expect(className).toEqual('css-0');
     expect(_stylesheet.getRules()).toEqual('.css-0{background-color:green;color:white;}');
@@ -194,5 +188,17 @@ describe('styleToClassName', () => {
         '.css-0:hover{background:green;}' +
         '}'
     );
+  });
+
+  it('can apply @support queries', () => {
+    styleToClassName({
+      selectors: {
+        '@supports(display: grid)': {
+          display: 'grid'
+        }
+      }
+    });
+
+    expect(_stylesheet.getRules()).toEqual('@supports(display: grid){' + '.css-0{display:grid;}' + '}');
   });
 });

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -56,7 +56,7 @@ function extractRules(args: IStyle[], rules: IRuleSet = { __order: [] }, current
 
               if (newSelector.indexOf(':global(') === 0) {
                 newSelector = newSelector.replace(/:global\(|\)$/g, '');
-              } else if (newSelector.indexOf('@media') === 0) {
+              } else if (newSelector.indexOf('@') === 0) {
                 newSelector = newSelector + '{' + currentSelector;
               } else if (newSelector.indexOf(':') === 0) {
                 newSelector = currentSelector + newSelector;
@@ -199,7 +199,7 @@ export function applyRegistration(registration: IRegistration, classMap?: { [key
         );
 
         // Insert. Note if a media query, we must close the query with a final bracket.
-        const processedRule = `${selector}{${rules}}${selector.indexOf('@media') === 0 ? '}' : ''}`;
+        const processedRule = `${selector}{${rules}}${selector.indexOf('@') === 0 ? '}' : ''}`;
 
         stylesheet.insertRule(processedRule);
       }


### PR DESCRIPTION
Adding the ability to use `@supports` feature queries in merge-styles. Example:

```tsx
mergeStyles({
  background: 'red',
  selectors: {
    '@media(max-width: 600px)': {
      background: 'green'
    },
    '@supports(display: grid)': {
      display: 'grid'
    }
  }
});
```

Produces:

```css
.css-0 {
  background: red;
}

@media (max-width: 600px) {
  .css-0 {
    background: green;
  }
}

@supports (display: grid) {
  .css-0 {
    display: grid;
  }
}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6410)

