### PR TITLE
CommandBar: Add role="menuitem" to surface buttons

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar-menuitem_2018-09-19-23-50.json
+++ b/common/changes/office-ui-fabric-react/commandbar-menuitem_2018-09-19-23-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Surface buttons now have role of menuitem",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 
 import { BaseComponent, css, nullRender } from '../../Utilities';
-import {
-  ICommandBar,
-  ICommandBarItemProps,
-  ICommandBarProps,
-  ICommandBarStyleProps,
-  ICommandBarStyles
-} from './CommandBar.types';
+import { ICommandBar, ICommandBarItemProps, ICommandBarProps, ICommandBarStyleProps, ICommandBarStyles } from './CommandBar.types';
 import { IOverflowSet, OverflowSet } from '../../OverflowSet';
 import { IResizeGroup, ResizeGroup } from '../../ResizeGroup';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -141,6 +135,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     }
     const commandButtonProps: ICommandBarItemProps = {
       allowDisabledFocus: true,
+      role: 'menuitem',
       ...item,
       styles: { root: { height: '100%' }, label: { whiteSpace: 'nowrap' }, ...item.buttonStyles },
       className: css('ms-CommandBarItem-link', item.className),

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`CommandBar renders commands correctly 1`] = `
             onKeyUp={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
+            role="menuitem"
             type="button"
           >
             <div
@@ -268,6 +269,7 @@ exports[`CommandBar renders commands correctly 1`] = `
             onKeyUp={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
+            role="menuitem"
             type="button"
           >
             <div

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`CommandBar renders commands correctly 1`] = `
             onKeyUp={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
+            role="menuitem"
             type="button"
           >
             <div
@@ -266,6 +267,7 @@ exports[`CommandBar renders commands correctly 1`] = `
             onKeyUp={[Function]}
             onMouseDown={[Function]}
             onMouseUp={[Function]}
+            role="menuitem"
             type="button"
           >
             <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -144,6 +144,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -332,6 +333,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
             >
               <div
                 className=
@@ -488,6 +490,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -645,6 +648,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -950,6 +954,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -1114,6 +1119,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                role="menuitem"
                 type="button"
               >
                 <div
@@ -1255,6 +1261,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                role="menuitem"
                 type="button"
               >
                 <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -144,6 +144,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -333,6 +334,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
             >
               <div
                 className=
@@ -490,6 +492,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -648,6 +651,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -954,6 +958,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -1119,6 +1124,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                role="menuitem"
                 type="button"
               >
                 <div
@@ -1260,6 +1266,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                role="menuitem"
                 type="button"
               >
                 <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -294,6 +294,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -450,6 +451,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -609,6 +611,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -808,6 +811,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -147,6 +147,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -306,6 +307,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div
@@ -482,6 +484,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
               onKeyUp={[Function]}
               onMouseDown={[Function]}
               onMouseUp={[Function]}
+              role="menuitem"
               type="button"
             >
               <div


### PR DESCRIPTION
We've been going back and forth on whether command bar should have aria-posinset. On one hand it was causing errors in keros, and the spec seemed to indicate it wasn't needed....but on the other hand, the omission seemed to cause errors elsewhere in other tests.

After a little more back and forth now that posinset has been removed (causing a bug for the pro-posinset team), I noticed that the reason Keros was having an issue was probably that aria-posinset is only valid on a select set of roles....of which our button did not have any.

![image](https://user-images.githubusercontent.com/1434956/45787989-cedd6980-bc2c-11e8-9922-96ca022369ce.png)

So this PR is only adding that role="menuitem" to the buttons. I've talked with the OWA dev about how he can manually add the aria values for now. I want to verify that this is the correct fix before adding the aria values back in, and if we do add them back in, I want to find a way to do so that doesn't mutate the original props (an issue with the old implementation).


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6421)

