### PR TITLE
Use tslint:disable-next-line for max-line-length violators in ColorSlider to fix Screener

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-screener-maxlength_2018-09-20-00-20.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-screener-maxlength_2018-09-20-00-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Revert max-line-length change in favor of tslint disable next line for ColorSlider background  values to fix Screener regression.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
@@ -67,13 +67,15 @@ export class ColorSliderBase extends BaseComponent<IColorSliderProps, IColorSlid
     const currentPercentage = (100 * (currentValue! - minValue!)) / (maxValue! - minValue!);
 
     const hueStyle = {
-      background: `linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd
-        50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)`
+      background:
+        // tslint:disable-next-line:max-line-length
+        'linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)'
     };
 
     const alphaStyle = {
-      backgroundImage: `url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AA
-        AAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)`
+      backgroundImage:
+        // tslint:disable-next-line:max-line-length
+        'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)'
     };
 
     const sliderStyle = isAlpha ? alphaStyle : hueStyle;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -98,8 +98,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
       onMouseDown={[Function]}
       style={
         Object {
-          "background": "linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd
-        50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)",
+          "background": "linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)",
         }
       }
     >
@@ -151,8 +150,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
       onMouseDown={[Function]}
       style={
         Object {
-          "backgroundImage": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AA
-        AAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)",
+          "backgroundImage": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)",
         }
       }
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -98,8 +98,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       onMouseDown={[Function]}
       style={
         Object {
-          "background": "linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd
-        50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)",
+          "background": "linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)",
         }
       }
     >
@@ -151,8 +150,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       onMouseDown={[Function]}
       style={
         Object {
-          "backgroundImage": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AA
-        AAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)",
+          "backgroundImage": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)",
         }
       }
     >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Reverts the changes to ColorSlider component's `background` and `backgroundColor` tslint max-line-length violators in favor of tslint disable next line to fix Screener regression.

**Commit**

https://github.com/OfficeDev/office-ui-fabric-react/commit/83d150162e37bf7683e43aa1b7ba64417a44599c#diff-b615b3f7a7b13e234006346881d40e11

**Screener Failure**

https://screener.io/v2/states/ryQqxfIYZ.OfficeDev-office-ui-fabric-react/bump/1024x768/Chrome/colorpicker-blue-default-0

![image](https://user-images.githubusercontent.com/706967/45788713-051ce800-bc31-11e8-816c-ff7ca4f89a42.png)

Thanks for the catch @kenotron 

1. Check that Screener passed and that `ColorSlider` looks correct i.e. alpha channel shows checkerboard background.
1. Run this locally and navigate to `ColorSlider` to confirm that alpha and hue channels are correct i.e. alpha channel shows checkerboard background.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6423)

