### PR TITLE
fixed korean characters typing issue in IE11

### DIFF
--- a/common/changes/office-ui-fabric-react/huaxi-korean-characters-typing_2018-09-20-06-32.json
+++ b/common/changes/office-ui-fabric-react/huaxi-korean-characters-typing_2018-09-20-06-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fixed Korean characters typing issue in IE11.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "huaxi@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -155,8 +155,15 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
   private _onCompositionEnd = (ev: React.CompositionEvent<HTMLInputElement>) => {
     const inputValue = this._getCurrentInputValue();
     this._tryEnableAutofill(inputValue, this.value, false, true);
+    // Korean characters typing issue has been addressed in React 16.5
+    // TODO: revert back below lines when we upgrade to React 16.5
+    // Find out at https://github.com/facebook/react/pull/12563/commits/06524c6c542c571705c0fd7df61ac48f3d5ce244
+    const isKorean = (ev.nativeEvent as any).locale === 'ko';
     // Due to timing, this needs to be async, otherwise no text will be selected.
-    this._async.setTimeout(() => this._updateValue(inputValue), 0);
+    this._async.setTimeout(() => {
+      const updatedInputValue = isKorean ? this.value : inputValue;
+      this._updateValue(updatedInputValue);
+    }, 0);
   };
 
   private _onClick = () => {
@@ -294,4 +301,4 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
 /**
  *  Legacy, @deprecated, do not use.
  */
-export class BaseAutoFill extends Autofill {}
+export class BaseAutoFill extends Autofill { }


### PR DESCRIPTION
#### Pull request checklist

- [ yes ] Addresses an existing issue: Fixes #6420
- [ yes ] Include a change request file using `$ npm run change`

#### Description of changes
https://github.com/OfficeDev/office-ui-fabric-react/issues/6420

#### Focus areas to test
Anywhere that is using AutoFill component.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6424)

