### PR TITLE
Porting changes needed in fabric V5 (which are already in master branch)

### DIFF
--- a/common/changes/office-ui-fabric-react/fabric_v5_2018-09-20-08-15.json
+++ b/common/changes/office-ui-fabric-react/fabric_v5_2018-09-20-08-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "onRenderDivider prop added to DetailsList, onRender*Text types of callbacks in Persona can be used to override default behaviour",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "svaibhav@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -122,53 +122,6 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
               TN
             </span>
           </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 16px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 16px;
-                }
-            style={
-              Object {
-                "height": undefined,
-                "width": undefined,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -444,53 +397,6 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
               TN
             </span>
           </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 16px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 16px;
-                }
-            style={
-              Object {
-                "height": undefined,
-                "width": undefined,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -649,53 +555,6 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
               TN
             </span>
           </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 16px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 16px;
-                }
-            style={
-              Object {
-                "height": undefined,
-                "width": undefined,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
-          </div>
         </div>
       </div>
       <div
@@ -839,53 +698,6 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
               AN
             </span>
           </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 16px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 16px;
-                }
-            style={
-              Object {
-                "height": undefined,
-                "width": undefined,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -1007,53 +819,6 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
             <span>
               TN
             </span>
-          </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 32px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 32px;
-                }
-            style={
-              Object {
-                "height": 32,
-                "width": 32,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
           </div>
         </div>
       </div>
@@ -1296,53 +1061,6 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
               TN
             </span>
           </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 16px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 16px;
-                }
-            style={
-              Object {
-                "height": undefined,
-                "width": undefined,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
-          </div>
         </div>
       </div>
       <div
@@ -1465,53 +1183,6 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             <span>
               AN
             </span>
-          </div>
-          <div
-            className=
-                ms-Image
-                ms-Persona-image
-                {
-                  border-radius: 50%;
-                  border: 0px;
-                  height: 16px;
-                  left: 0px;
-                  margin-right: 10px;
-                  overflow: hidden;
-                  perspective: 1px;
-                  position: absolute;
-                  top: 0px;
-                  width: 16px;
-                }
-            style={
-              Object {
-                "height": undefined,
-                "width": undefined,
-              }
-            }
-          >
-            <img
-              alt=""
-              className=
-                  ms-Image-image
-                  ms-Image-image--cover
-                  ms-Image-image--portrait
-                  is-notLoaded
-                  is-fadeIn
-                  {
-                    display: block;
-                    height: auto;
-                    left: 50% /* @noflip */;
-                    opacity: 0;
-                    position: absolute;
-                    top: 50%;
-                    transform: translate(-50%,-50%);
-                    width: 100%;
-                  }
-              onError={[Function]}
-              onLoad={[Function]}
-              role={undefined}
-              src={undefined}
-            />
           </div>
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.tsx
@@ -14,13 +14,15 @@ import { ISelection, SelectionMode, SELECTION_CHANGE } from '../../utilities/sel
 import * as stylesImport from './DetailsHeader.scss';
 import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
 import { DragDropHelper } from './../../utilities/dragdrop';
-import { DetailsColumn } from './../../components/DetailsList/DetailsColumn';
+import { DetailsColumn, IDetailsColumnProps } from './../../components/DetailsList/DetailsColumn';
 
 const styles: any = stylesImport;
 const checkStyles: any = checkStylesModule;
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 const MOUSEMOVE_PRIMARY_BUTTON = 1; // for mouse move event we are using ev.buttons property, 1 means left button
+
+const NO_COLUMNS: IColumn[] = [];
 
 export interface IDetailsHeader {
   focus: () => boolean;
@@ -325,7 +327,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
               onColumnContextMenu={ onColumnContextMenu }
               isDropped={ this._onDropIndexInfo.targetIndex === columnIndex }
             />,
-            column.isResizable && this._renderColumnSizer(columnIndex)
+            this._renderColumnDivider(columnIndex)
           ];
         }) }
         { columnReorderOptions && frozenColumnCountFromEnd === 0 && this._renderDropHint(columns.length) }
@@ -549,12 +551,21 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
     }
   }
 
-  private _renderColumnSizer(columnIndex: number): JSX.Element {
-    const { columns } = this.props;
-    const column = this.props.columns[columnIndex];
+  private _renderColumnDivider(columnIndex: number): JSX.Element | null {
+    const { columns = NO_COLUMNS } = this.props;
+    const column = columns[columnIndex];
+    const { onRenderDivider } = column;
+    return onRenderDivider
+      ? onRenderDivider({ column, columnIndex }, this._renderColumnSizer)
+      : this._renderColumnSizer({ column, columnIndex });
+  }
+
+  private _renderColumnSizer = ({ columnIndex }: IDetailsColumnProps): JSX.Element | null => {
+    const { columns = NO_COLUMNS } = this.props;
+    const column = columns[columnIndex];
     const { columnResizeDetails } = this.state;
 
-    return (
+    return column.isResizable ? (
       <div
         key={ `${column.key}_sizer` }
         aria-hidden={ true }
@@ -574,7 +585,7 @@ export class DetailsHeader extends BaseComponent<IDetailsHeaderProps, IDetailsHe
         ) }
         onDoubleClick={ this._onSizerDoubleClick.bind(this, columnIndex) }
       />
-    );
+    ) : null;
   }
 
   private _renderDropHint(dropHintIndex: number): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -10,29 +10,92 @@ import {
   IDetailsList,
   IColumn
 } from './DetailsList.types';
+import { IDetailsColumnProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
 
-// Populate mock items for testing
-function mockItems(count: number): any {
-  const items = [];
-
+// Populate mock data for testing
+function mockData(count: number, isColumn: boolean = false, customDivider: boolean = false): any {
+  const data = [];
+  let _data = {};
   for (let i = 0; i < count; i++) {
-    items.push({
+    _data = {
       key: i,
       name: 'Item ' + i,
       value: i
-    });
+    };
+    if (isColumn) {
+      _data = {
+        ..._data,
+        key: `column_key_${i}`,
+        ariaLabel: `column_${i}`,
+        onRenderDivider: customDivider ? customColumnDivider : columnDividerWrapper
+      };
+    }
+    data.push(_data);
   }
+  return data;
+}
 
-  return items;
+// Wrapper function which calls the defaultRenderer with the corresponding params
+function columnDividerWrapper(
+  iDetailsColumnProps: IDetailsColumnProps,
+  defaultRenderer: (props?: IDetailsColumnProps) => JSX.Element | null
+): any {
+  return defaultRenderer(iDetailsColumnProps);
+}
+// Using a bar sign as a custom divider along with the default divider
+function customColumnDivider(
+  iDetailsColumnProps: IDetailsColumnProps,
+  defaultRenderer: (props?: IDetailsColumnProps) => JSX.Element | null
+): any {
+  return (
+    <React.Fragment key={ `divider_${iDetailsColumnProps.columnIndex}` }>
+      <span>|</span>
+      { defaultRenderer(iDetailsColumnProps) }
+    </React.Fragment>
+  );
 }
 
 describe('DetailsList', () => {
+  it('renders List correctly with onRenderDivider props', () => {
+    DetailsList.prototype.componentDidMount = jest.fn();
+    const component = renderer.create(
+      <DetailsList
+        items={ mockData(5) }
+        columns={ mockData(5, true) }
+        // tslint:disable-next-line:jsx-no-lambda
+        onRenderRow={ () => null }
+        skipViewportMeasures={ true }
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={ () => false }
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders List with custom icon as column divider', () => {
+    DetailsList.prototype.componentDidMount = jest.fn();
+    const component = renderer.create(
+      <DetailsList
+        items={ mockData(5) }
+        columns={ mockData(5, true, true) }
+        // tslint:disable-next-line:jsx-no-lambda
+        onRenderRow={ () => null }
+        skipViewportMeasures={ true }
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={ () => false }
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders List correctly', () => {
     DetailsList.prototype.componentDidMount = jest.fn();
 
     const component = renderer.create(
       <DetailsList
-        items={ mockItems(5) }
+        items={ mockData(5) }
         // tslint:disable-next-line:jsx-no-lambda
         onRenderRow={ () => null }
         skipViewportMeasures={ true }
@@ -50,7 +113,7 @@ describe('DetailsList', () => {
     let component: any;
     mount(
       <DetailsList
-        items={ mockItems(5) }
+        items={ mockData(5) }
         // tslint:disable-next-line:jsx-no-lambda
         componentRef={ ref => component = ref }
         skipViewportMeasures={ true }
@@ -87,7 +150,7 @@ describe('DetailsList', () => {
     let component: any;
     mount(
       <DetailsList
-        items={ mockItems(5) }
+        items={ mockData(5) }
         // tslint:disable-next-line:jsx-no-lambda
         componentRef={ ref => component = ref }
         skipViewportMeasures={ true }
@@ -129,7 +192,7 @@ describe('DetailsList', () => {
     let component: any;
     const detailsList = mount(
       <DetailsList
-        items={ mockItems(5) }
+        items={ mockData(5) }
         setKey={ 'key1' }
         initialFocusedIndex={ 0 }
         // tslint:disable-next-line:jsx-no-lambda
@@ -147,7 +210,7 @@ describe('DetailsList', () => {
     jest.runOnlyPendingTimers();
 
     // update props to new setKey
-    const newProps = { items: mockItems(7), setKey: 'set2', initialFocusedIndex: 0 };
+    const newProps = { items: mockData(7), setKey: 'set2', initialFocusedIndex: 0 };
     detailsList.setProps(newProps);
     detailsList.update();
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -16,6 +16,7 @@ import {
   IGroupDividerProps
 } from '../GroupedList/index';
 import { IDetailsRowProps } from '../DetailsList/DetailsRow';
+import { IDetailsColumnProps } from '../DetailsList/DetailsColumn';
 import { IDetailsHeaderProps } from './DetailsHeader';
 import { IWithViewportProps, IViewport } from '../../utilities/decorators/withViewport';
 import {
@@ -354,6 +355,11 @@ export interface IColumn {
    * If provided uses this method to render custom cell content, rather than the default text rendering.
    */
   onRender?: (item?: any, index?: number, column?: IColumn) => any;
+
+  /**
+   * If provider, can be used to render a custom column header divider
+   */
+  onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
 
   /**
    * Determines if the column is filtered, and if so shows a filter icon.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -33,6 +33,293 @@ exports[`DetailsList renders List correctly 1`] = `
           aria-labelledby={undefined}
           className="ms-FocusZone ms-DetailsHeader"
           data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone7"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header6-check"
+            className="ms-DetailsHeader-cell ms-DetailsHeader-cellIsCheck"
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className=""
+            >
+              <div
+                aria-checked={undefined}
+                aria-describedby="header6-checkTooltip"
+                aria-label={undefined}
+                className="ms-DetailsRow-check ms-DetailsRow-check--isHeader undefined"
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header6-check"
+                role="checkbox"
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Check-circle
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #c8c8c8;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 18px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          speak: none;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Check-check
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #c8c8c8;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 16px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          speak: none;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          -ms-high-contrast-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="key"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header6-key-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header6-key"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header6-key-name"
+                >
+                  key
+                </span>
+              </span>
+            </span>
+          </div>
+          <div
+            aria-hidden={true}
+            className="ms-DetailsHeader-cellSizer"
+            data-is-focusable={false}
+            data-sizer-index={0}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDoubleClick={[Function]}
+            role="button"
+          />
+        </div>
+      </div>
+      <div
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          aria-describedby={undefined}
+          aria-labelledby={undefined}
+          className="ms-FocusZone"
+          data-focuszone-id="FocusZone8"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    aria-label={undefined}
+    className="ms-DetailsList is-horizontalConstrained undefined"
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={6}
+      aria-label={undefined}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          aria-describedby={undefined}
+          aria-label={undefined}
+          aria-labelledby={undefined}
+          className="ms-FocusZone ms-DetailsHeader"
+          data-automationid="DetailsHeader"
           data-focuszone-id="FocusZone1"
           onFocus={[Function]}
           onKeyDown={[Function]}
@@ -161,7 +448,7 @@ exports[`DetailsList renders List correctly 1`] = `
             className="ms-DetailsHeader-cell is-actionable undefined"
             data-automationid="ColumnsHeaderColumn"
             data-is-draggable={false}
-            data-item-key="key"
+            data-item-key="column_key_0"
             draggable={false}
             role="columnheader"
             style={
@@ -177,33 +464,194 @@ exports[`DetailsList renders List correctly 1`] = `
                 aria-describedby={undefined}
                 aria-haspopup={false}
                 aria-label={undefined}
-                aria-labelledby="header0-key-name "
+                aria-labelledby="header0-column_key_0-name "
                 className="ms-DetailsHeader-cellTitle"
                 data-is-focusable={true}
-                id="header0-key"
+                id="header0-column_key_0"
                 onClick={[Function]}
                 onContextMenu={[Function]}
                 role="button"
               >
                 <span
                   className="ms-DetailsHeader-cellName"
-                  id="header0-key-name"
+                  id="header0-column_key_0-name"
                 >
-                  key
+                  Item 0
                 </span>
               </span>
             </span>
+            <span
+              className="ms-Layer"
+            />
           </div>
           <div
-            aria-hidden={true}
-            className="ms-DetailsHeader-cellSizer"
-            data-is-focusable={false}
-            data-sizer-index={0}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDoubleClick={[Function]}
-            role="button"
-          />
+            aria-colindex={3}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_1"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header0-column_key_1-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header0-column_key_1"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header0-column_key_1-name"
+                >
+                  Item 1
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <div
+            aria-colindex={4}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_2"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header0-column_key_2-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header0-column_key_2"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header0-column_key_2-name"
+                >
+                  Item 2
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <div
+            aria-colindex={5}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_3"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header0-column_key_3-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header0-column_key_3"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header0-column_key_3-name"
+                >
+                  Item 3
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <div
+            aria-colindex={6}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_4"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header0-column_key_4-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header0-column_key_4"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header0-column_key_4-name"
+                >
+                  Item 4
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
         </div>
       </div>
       <div
@@ -215,6 +663,469 @@ exports[`DetailsList renders List correctly 1`] = `
           aria-labelledby={undefined}
           className="ms-FocusZone"
           data-focuszone-id="FocusZone2"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
+            onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={2}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={3}
+                    role="presentation"
+                  />
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={4}
+                    role="presentation"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsList renders List with custom icon as column divider 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    aria-label={undefined}
+    className="ms-DetailsList is-horizontalConstrained undefined"
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={6}
+      aria-label={undefined}
+      aria-readonly="true"
+      aria-rowcount={6}
+      role="grid"
+    >
+      <div
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          aria-describedby={undefined}
+          aria-label={undefined}
+          aria-labelledby={undefined}
+          className="ms-FocusZone ms-DetailsHeader"
+          data-automationid="DetailsHeader"
+          data-focuszone-id="FocusZone4"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          onMouseMove={[Function]}
+          role="row"
+        >
+          <div
+            aria-colindex={1}
+            aria-labelledby="header3-check"
+            className="ms-DetailsHeader-cell ms-DetailsHeader-cellIsCheck"
+            onClick={[Function]}
+            role="columnheader"
+          >
+            <span
+              className=""
+            >
+              <div
+                aria-checked={undefined}
+                aria-describedby="header3-checkTooltip"
+                aria-label={undefined}
+                className="ms-DetailsRow-check ms-DetailsRow-check--isHeader undefined"
+                data-automationid="DetailsRowCheck"
+                data-is-focusable={true}
+                data-selection-toggle={true}
+                id="header3-check"
+                role="checkbox"
+              >
+                <div
+                  className=
+                      ms-Check
+                      {
+                        height: 18px;
+                        line-height: 1;
+                        position: relative;
+                        user-select: none;
+                        vertical-align: top;
+                        width: 18px;
+                      }
+                      &:before {
+                        background: #ffffff;
+                        border-radius: 50%;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        opacity: 1;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                      }
+                      .checkHost:hover &, .checkHost:focus &, &:hover, &:focus {
+                        opacity: 1;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Check-circle
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #c8c8c8;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 18px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 18px;
+                          left: 0px;
+                          position: absolute;
+                          speak: none;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          color: WindowText;
+                        }
+                    data-icon-name="CircleRing"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Check-check
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #c8c8c8;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 16px;
+                          font-style: normal;
+                          font-weight: normal;
+                          height: 18px;
+                          left: .5px;
+                          opacity: 0;
+                          position: absolute;
+                          speak: none;
+                          text-align: center;
+                          top: 0px;
+                          vertical-align: middle;
+                          width: 18px;
+                        }
+                        &:hover {
+                          opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          -ms-high-contrast-adjust: none;
+                        }
+                    data-icon-name="StatusCircleCheckmark"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                </div>
+              </div>
+            </span>
+          </div>
+          <div
+            aria-colindex={2}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_0"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header3-column_key_0-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header3-column_key_0"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header3-column_key_0-name"
+                >
+                  Item 0
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <span>
+            |
+          </span>
+          <div
+            aria-colindex={3}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_1"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header3-column_key_1-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header3-column_key_1"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header3-column_key_1-name"
+                >
+                  Item 1
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <span>
+            |
+          </span>
+          <div
+            aria-colindex={4}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_2"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header3-column_key_2-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header3-column_key_2"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header3-column_key_2-name"
+                >
+                  Item 2
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <span>
+            |
+          </span>
+          <div
+            aria-colindex={5}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_3"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header3-column_key_3-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header3-column_key_3"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header3-column_key_3-name"
+                >
+                  Item 3
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <span>
+            |
+          </span>
+          <div
+            aria-colindex={6}
+            aria-sort="none"
+            className="ms-DetailsHeader-cell is-actionable undefined"
+            data-automationid="ColumnsHeaderColumn"
+            data-is-draggable={false}
+            data-item-key="column_key_4"
+            draggable={false}
+            role="columnheader"
+            style={
+              Object {
+                "width": 116,
+              }
+            }
+          >
+            <span
+              className=""
+            >
+              <span
+                aria-describedby={undefined}
+                aria-haspopup={false}
+                aria-label={undefined}
+                aria-labelledby="header3-column_key_4-name "
+                className="ms-DetailsHeader-cellTitle"
+                data-is-focusable={true}
+                id="header3-column_key_4"
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                role="button"
+              >
+                <span
+                  className="ms-DetailsHeader-cellName"
+                  id="header3-column_key_4-name"
+                >
+                  Item 4
+                </span>
+              </span>
+            </span>
+            <span
+              className="ms-Layer"
+            />
+          </div>
+          <span>
+            |
+          </span>
+        </div>
+      </div>
+      <div
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          aria-describedby={undefined}
+          aria-labelledby={undefined}
+          className="ms-FocusZone"
+          data-focuszone-id="FocusZone5"
           onBlur={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.scss
@@ -22,4 +22,20 @@
     }
   }
 
+  .ms-DetailsHeader-divider {
+    display: inline-block;
+    height: 100%;
+  }
+   .ms-DetailsHeader-divider-bar {
+    display: none;
+    background: $ms-color-themePrimary;
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    width: 1px;
+    z-index: 5;
+  }
+   .ms-DetailsHeader-divider:hover + .ms-DetailsHeader-divider-bar {
+    display: inline;
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import {
   IContextualMenuProps,
   IContextualMenuItem,
@@ -22,6 +23,7 @@ import {
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, isGroupable } from '@uifabric/example-app-base';
 import './DetailsList.Advanced.Example.scss';
+import { IDetailsColumnProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
 
 const DEFAULT_ITEM_LIMIT = 5;
 const PAGING_SIZE = 10;
@@ -45,6 +47,7 @@ export interface IDetailsListAdvancedExampleState {
   layoutMode?: LayoutMode;
   selectionMode?: SelectionMode;
   sortedColumnKey?: string;
+  showRenderDividerView: boolean;
 }
 
 export class DetailsListAdvancedExample extends React.Component<{}, IDetailsListAdvancedExampleState> {
@@ -73,6 +76,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       columns: this._buildColumns(_items, true, this._onColumnClick, '', undefined, undefined, this._onColumnContextMenu),
       contextualMenuProps: undefined,
       sortedColumnKey: 'name',
+      showRenderDividerView: false,
       isSortedDescending: false,
       isLazyLoaded: false,
       isHeaderVisible: true
@@ -109,6 +113,12 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
 
     return (
       <div className='ms-DetailsListAdvancedExample'>
+        <Checkbox
+          label='Show custom color column-divider on hover'
+          checked={ this.state.showRenderDividerView }
+          onChange={ this._onRenderDividerCheckboxChange }
+        />
+        <br />
         <CommandBar items={ this._getCommandItems() } />
 
         {
@@ -141,6 +151,39 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
           <ContextualMenu { ...contextualMenuProps } />
         ) }
       </div>
+    );
+  }
+
+  private _onRenderDividerCheckboxChange = (event: React.FormEvent<HTMLInputElement>, showRenderDividerView: boolean): void => {
+    const { columns = [] } = this.state;
+    for (let i = 0; i < columns.length; i++) {
+      // based on the state of checkbox, either adding the onRenderDivider callback or removing it
+      if (showRenderDividerView) {
+        columns[i] = {
+          ...columns[i],
+          onRenderDivider: this._onRenderDivider
+        };
+      } else {
+        const { onRenderDivider, ..._column } = columns[i];
+        columns[i] = _column;
+      }
+    }
+    this.setState({
+      showRenderDividerView,
+      columns
+    });
+  }
+
+  private _onRenderDivider = (
+    iDetailsColumnProps: IDetailsColumnProps,
+    defaultRenderer: (props: IDetailsColumnProps) => JSX.Element | null
+  ): JSX.Element => {
+    const { columnIndex } = iDetailsColumnProps;
+    return (
+      <React.Fragment key={ `divider-wrapper-${columnIndex}` }>
+        <span className='ms-DetailsHeader-divider'>{ defaultRenderer(iDetailsColumnProps) }</span>
+        <span className='ms-DetailsHeader-divider-bar' />
+      </React.Fragment>
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -89,53 +89,6 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
                 
               </i>
             </div>
-            <div
-              className=
-                  ms-Image
-                  ms-Persona-image
-                  {
-                    border-radius: 50%;
-                    border: 0px;
-                    height: 32px;
-                    left: 0px;
-                    margin-right: 10px;
-                    overflow: hidden;
-                    perspective: 1px;
-                    position: absolute;
-                    top: 0px;
-                    width: 32px;
-                  }
-              style={
-                Object {
-                  "height": 32,
-                  "width": 32,
-                }
-              }
-            >
-              <img
-                alt=""
-                className=
-                    ms-Image-image
-                    ms-Image-image--cover
-                    ms-Image-image--portrait
-                    is-notLoaded
-                    is-fadeIn
-                    {
-                      display: block;
-                      height: auto;
-                      left: 50% /* @noflip */;
-                      opacity: 0;
-                      position: absolute;
-                      top: 50%;
-                      transform: translate(-50%,-50%);
-                      width: 100%;
-                    }
-                onError={[Function]}
-                onLoad={[Function]}
-                role={undefined}
-                src=""
-              />
-            </div>
           </div>
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -292,53 +292,6 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   AL
                 </span>
               </div>
-              <div
-                className=
-                    ms-Image
-                    ms-Persona-image
-                    {
-                      border-radius: 50%;
-                      border: 0px;
-                      height: 32px;
-                      left: 0px;
-                      margin-right: 10px;
-                      overflow: hidden;
-                      perspective: 1px;
-                      position: absolute;
-                      top: 0px;
-                      width: 32px;
-                    }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
-              >
-                <img
-                  alt=""
-                  className=
-                      ms-Image-image
-                      ms-Image-image--cover
-                      ms-Image-image--portrait
-                      is-notLoaded
-                      is-fadeIn
-                      {
-                        display: block;
-                        height: auto;
-                        left: 50% /* @noflip */;
-                        opacity: 0;
-                        position: absolute;
-                        top: 50%;
-                        transform: translate(-50%,-50%);
-                        width: 100%;
-                      }
-                  onError={[Function]}
-                  onLoad={[Function]}
-                  role={undefined}
-                  src={undefined}
-                />
-              </div>
             </div>
           </div>
         </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -39,12 +39,18 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
   }
 
   public render(): JSX.Element {
+    // wrapping default render behavior based on various this.props properties
+    const _onRenderPrimaryText = this._onRenderText(this._getText()),
+      _onRenderSecondaryText = this._onRenderText(this.props.secondaryText),
+      _onRenderTertiaryText = this._onRenderText(this.props.tertiaryText),
+      _onRenderOptionalText = this._onRenderText(this.props.optionalText);
+
     const {
       hidePersonaDetails,
-      onRenderOptionalText,
-      onRenderPrimaryText,
-      onRenderSecondaryText,
-      onRenderTertiaryText,
+      onRenderOptionalText = _onRenderOptionalText,
+      onRenderPrimaryText = _onRenderPrimaryText,
+      onRenderSecondaryText = _onRenderSecondaryText,
+      onRenderTertiaryText = _onRenderTertiaryText,
     } = this.props;
     const size = this.props.size as PersonaSize;
 
@@ -100,23 +106,10 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
     const divProps = getNativeProps(this.props, divProperties);
     const personaDetails = (
       <div className={ classNames.details }>
-        { this._renderElement(
-          this._getText(),
-          classNames.primaryText,
-          onRenderPrimaryText) }
-        { this._renderElement(
-          this.props.secondaryText,
-          classNames.secondaryText,
-          onRenderSecondaryText) }
-        { this._renderElement(
-          this.props.tertiaryText,
-          classNames.tertiaryText,
-          onRenderTertiaryText) }
-        { this._renderElement(
-          this.props.optionalText,
-          classNames.optionalText,
-          onRenderOptionalText) }
-        { this.props.children }
+        { this._renderElement(classNames.primaryText, onRenderPrimaryText, _onRenderPrimaryText) }
+        { this._renderElement(classNames.secondaryText, onRenderSecondaryText, _onRenderSecondaryText) }
+        { this._renderElement(classNames.tertiaryText, onRenderTertiaryText, _onRenderTertiaryText) }
+        { this._renderElement(classNames.optionalText, onRenderOptionalText, _onRenderOptionalText) }
       </div>
     );
 
@@ -139,20 +132,41 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
     return this.props.text || this.props.primaryText || '';
   }
 
-  private _renderElement = (text: string | undefined, className: string, render?: IRenderFunction<IPersonaProps>): JSX.Element => {
-    return (
-      <div className={ className }>
-        { render
-          ? render(this.props)
-          : text && (<TooltipHost
+  /**
+   * Renders various types of Text (primaryText, secondaryText, etc)
+   * based on the classNames passed
+   * @param classNames
+   * @param renderFunction
+   * @param defaultRenderFunction
+   */
+  private _renderElement(
+    classNames: string,
+    renderFunction: IRenderFunction<IPersonaProps> | undefined,
+    defaultRenderFunction: IRenderFunction<IPersonaProps> | undefined
+  ): JSX.Element {
+    return <div className={ classNames }>{ renderFunction && renderFunction(this.props, defaultRenderFunction) }</div>;
+  }
+
+  /**
+   * using closure to wrap the default render behavior
+   * to make it independent of the type of text passed
+   * @param text
+   */
+  private _onRenderText(text: string | undefined): IRenderFunction<IPersonaProps> | undefined {
+    // return default render behaviour for valid text or undefined
+    return text
+      ? (): JSX.Element => {
+        // default onRender behaviour
+        return (
+          <TooltipHost
             content={ text }
             overflowMode={ TooltipOverflowMode.Parent }
             directionalHint={ DirectionalHint.topLeftEdge }
           >
             { text }
-          </TooltipHost>)
-        }
-      </div>
-    );
+          </TooltipHost>
+        );
+      }
+      : undefined;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.test.tsx
@@ -1,10 +1,12 @@
 /* tslint:disable-next-line:no-unused-variable */
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { setRTL } from '../../Utilities';
+import { setRTL, IRenderFunction } from '../../Utilities';
 import { Persona } from './Persona';
 import { mount, ReactWrapper } from 'enzyme';
 import { getIcon } from '../../Styling';
+import { IPersonaSharedProps, IPersonaProps, PersonaSize, PersonaPresence } from '../../Persona';
+import { TestImages } from 'office-ui-fabric-react/lib/common/TestImages';
 
 const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 const STYLES = {
@@ -12,12 +14,61 @@ const STYLES = {
   initials: '.ms-Persona-initials',
   black: '.ms-Persona-initials--black',
   red: '.ms-Persona-initials--red',
+};
 
+/**
+ * function to override the default onRender callbacks
+ */
+export const wrapPersona = (
+  example: IPersonaSharedProps,
+  shouldWrapPersonaCoin: boolean = false
+): ((coinProps: IPersonaProps, defaultRenderer: IRenderFunction<IPersonaProps>) => JSX.Element | null) => {
+  return (coinProps, defaultCoinRenderer): JSX.Element | null => {
+    return shouldWrapPersonaCoin ? (
+      <span id='persona-coin-container'>{ defaultCoinRenderer(coinProps) }</span>
+    ) : (
+        defaultCoinRenderer(coinProps)
+      );
+  };
+};
+
+const examplePersona: IPersonaSharedProps = {
+  imageUrl: TestImages.personaMale,
+  imageInitials: 'SV',
+  text: 'Swapnil Vaibhav',
+  secondaryText: 'Software Engineer',
+  tertiaryText: 'In a meeting',
+  optionalText: 'Available at 4:00pm',
+  size: PersonaSize.size100,
+  presence: PersonaPresence.blocked
 };
 
 describe('Persona', () => {
   beforeEach(() => {
     setRTL(false);
+  });
+
+  it('renders Persona which calls onRenderCoin callback without imageUrl', () => {
+    // removing imageUrl prop from example
+    const { imageUrl, ...exampleWithoutImage } = examplePersona;
+    const component = renderer.create(
+      <Persona { ...exampleWithoutImage } onRenderCoin={ wrapPersona(exampleWithoutImage, true) } />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly with onRender callback', () => {
+    const component = renderer.create(
+      <Persona
+        { ...examplePersona }
+        onRenderPrimaryText={ wrapPersona(examplePersona) }
+        onRenderSecondaryText={ wrapPersona(examplePersona) }
+        onRenderTertiaryText={ wrapPersona(examplePersona) }
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('renders Persona correctly with no props', () => {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -170,6 +170,11 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
       showUnknownPersonaCoin,
     } = this.props;
 
+    // render Image component only if there is a valid imageUrl
+    if (!imageUrl) {
+      return null;
+    }
+
     const size = this.props.size as PersonaSize;
 
     const classNames = getClassNames(getStyles, {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -61,53 +61,6 @@ exports[`PersonaCoin renders correctly 1`] = `
         
       </i>
     </div>
-    <div
-      className=
-          ms-Image
-          ms-Persona-image
-          {
-            border-radius: 50%;
-            border: 0px;
-            height: 100%;
-            left: 0px;
-            margin-right: 10px;
-            overflow: hidden;
-            perspective: 1px;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-          }
-      style={
-        Object {
-          "height": 48,
-          "width": 48,
-        }
-      }
-    >
-      <img
-        alt=""
-        className=
-            ms-Image-image
-            ms-Image-image--cover
-            ms-Image-image--portrait
-            is-notLoaded
-            is-fadeIn
-            {
-              display: block;
-              height: auto;
-              left: 50% /* @noflip */;
-              opacity: 0;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%,-50%);
-              width: 100%;
-            }
-        onError={[Function]}
-        onLoad={[Function]}
-        role={undefined}
-        src={undefined}
-      />
-    </div>
   </div>
 </div>
 `;
@@ -229,53 +182,6 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
         JG
       </span>
     </div>
-    <div
-      className=
-          ms-Image
-          ms-Persona-image
-          {
-            border-radius: 50%;
-            border: 0px;
-            height: 100%;
-            left: 0px;
-            margin-right: 10px;
-            overflow: hidden;
-            perspective: 1px;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-          }
-      style={
-        Object {
-          "height": 48,
-          "width": 48,
-        }
-      }
-    >
-      <img
-        alt=""
-        className=
-            ms-Image-image
-            ms-Image-image--cover
-            ms-Image-image--portrait
-            is-notLoaded
-            is-fadeIn
-            {
-              display: block;
-              height: auto;
-              left: 50% /* @noflip */;
-              opacity: 0;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%,-50%);
-              width: 100%;
-            }
-        onError={[Function]}
-        onLoad={[Function]}
-        role={undefined}
-        src={undefined}
-      />
-    </div>
   </div>
 </div>
 `;
@@ -325,53 +231,6 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       <span>
         KL
       </span>
-    </div>
-    <div
-      className=
-          ms-Image
-          ms-Persona-image
-          {
-            border-radius: 50%;
-            border: 0px;
-            height: 100%;
-            left: 0px;
-            margin-right: 10px;
-            overflow: hidden;
-            perspective: 1px;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-          }
-      style={
-        Object {
-          "height": 48,
-          "width": 48,
-        }
-      }
-    >
-      <img
-        alt=""
-        className=
-            ms-Image-image
-            ms-Image-image--cover
-            ms-Image-image--portrait
-            is-notLoaded
-            is-fadeIn
-            {
-              display: block;
-              height: auto;
-              left: 50% /* @noflip */;
-              opacity: 0;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%,-50%);
-              width: 100%;
-            }
-        onError={[Function]}
-        onLoad={[Function]}
-        role={undefined}
-        src={undefined}
-      />
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -61,53 +61,6 @@ exports[`PersonaCoin renders correctly 1`] = `
         
       </i>
     </div>
-    <div
-      className=
-          ms-Image
-          ms-Persona-image
-          {
-            border-radius: 50%;
-            border: 0px;
-            height: 100%;
-            left: 0px;
-            margin-right: 10px;
-            overflow: hidden;
-            perspective: 1px;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-          }
-      style={
-        Object {
-          "height": 48,
-          "width": 48,
-        }
-      }
-    >
-      <img
-        alt=""
-        className=
-            ms-Image-image
-            ms-Image-image--cover
-            ms-Image-image--portrait
-            is-notLoaded
-            is-fadeIn
-            {
-              display: block;
-              height: auto;
-              left: 50% /* @noflip */;
-              opacity: 0;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%,-50%);
-              width: 100%;
-            }
-        onError={[Function]}
-        onLoad={[Function]}
-        role={undefined}
-        src={undefined}
-      />
-    </div>
   </div>
 </div>
 `;
@@ -229,53 +182,6 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
         JG
       </span>
     </div>
-    <div
-      className=
-          ms-Image
-          ms-Persona-image
-          {
-            border-radius: 50%;
-            border: 0px;
-            height: 100%;
-            left: 0px;
-            margin-right: 10px;
-            overflow: hidden;
-            perspective: 1px;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-          }
-      style={
-        Object {
-          "height": 48,
-          "width": 48,
-        }
-      }
-    >
-      <img
-        alt=""
-        className=
-            ms-Image-image
-            ms-Image-image--cover
-            ms-Image-image--portrait
-            is-notLoaded
-            is-fadeIn
-            {
-              display: block;
-              height: auto;
-              left: 50% /* @noflip */;
-              opacity: 0;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%,-50%);
-              width: 100%;
-            }
-        onError={[Function]}
-        onLoad={[Function]}
-        role={undefined}
-        src={undefined}
-      />
-    </div>
   </div>
 </div>
 `;
@@ -325,53 +231,6 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       <span>
         KL
       </span>
-    </div>
-    <div
-      className=
-          ms-Image
-          ms-Persona-image
-          {
-            border-radius: 50%;
-            border: 0px;
-            height: 100%;
-            left: 0px;
-            margin-right: 10px;
-            overflow: hidden;
-            perspective: 1px;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-          }
-      style={
-        Object {
-          "height": 48,
-          "width": 48,
-        }
-      }
-    >
-      <img
-        alt=""
-        className=
-            ms-Image-image
-            ms-Image-image--cover
-            ms-Image-image--portrait
-            is-notLoaded
-            is-fadeIn
-            {
-              display: block;
-              height: auto;
-              left: 50% /* @noflip */;
-              opacity: 0;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%,-50%);
-              width: 100%;
-            }
-        onError={[Function]}
-        onLoad={[Function]}
-        role={undefined}
-        src={undefined}
-      />
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -262,53 +262,6 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           KL
         </span>
       </div>
-      <div
-        className=
-            ms-Image
-            ms-Persona-image
-            {
-              border-radius: 50%;
-              border: 0px;
-              height: 100%;
-              left: 0px;
-              margin-right: 10px;
-              overflow: hidden;
-              perspective: 1px;
-              position: absolute;
-              top: 0px;
-              width: 100%;
-            }
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--cover
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                height: auto;
-                left: 50% /* @noflip */;
-                opacity: 0;
-                position: absolute;
-                top: 50%;
-                transform: translate(-50%,-50%);
-                width: 100%;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role={undefined}
-          src={undefined}
-        />
-      </div>
     </div>
   </div>
   <div
@@ -486,53 +439,6 @@ exports[`Persona renders Persona correctly with no props 1`] = `
           
         </i>
       </div>
-      <div
-        className=
-            ms-Image
-            ms-Persona-image
-            {
-              border-radius: 50%;
-              border: 0px;
-              height: 100%;
-              left: 0px;
-              margin-right: 10px;
-              overflow: hidden;
-              perspective: 1px;
-              position: absolute;
-              top: 0px;
-              width: 100%;
-            }
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--cover
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                height: auto;
-                left: 50% /* @noflip */;
-                opacity: 0;
-                position: absolute;
-                top: 50%;
-                transform: translate(-50%,-50%);
-                width: 100%;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role={undefined}
-          src={undefined}
-        />
-      </div>
     </div>
   </div>
   <div
@@ -562,9 +468,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
-    >
-      
-    </div>
+    />
     <div
       className=
           ms-Persona-secondaryText

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -94,53 +94,6 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
           
         </i>
       </div>
-      <div
-        className=
-            ms-Image
-            ms-Persona-image
-            {
-              border-radius: 50%;
-              border: 0px;
-              height: 100%;
-              left: 0px;
-              margin-right: 10px;
-              overflow: hidden;
-              perspective: 1px;
-              position: absolute;
-              top: 0px;
-              width: 100%;
-            }
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--cover
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                height: auto;
-                left: 50% /* @noflip */;
-                opacity: 0;
-                position: absolute;
-                top: 50%;
-                transform: translate(-50%,-50%);
-                width: 100%;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role={undefined}
-          src={undefined}
-        />
-      </div>
     </div>
   </div>
   <div
@@ -486,53 +439,6 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           KL
         </span>
       </div>
-      <div
-        className=
-            ms-Image
-            ms-Persona-image
-            {
-              border-radius: 50%;
-              border: 0px;
-              height: 100%;
-              left: 0px;
-              margin-right: 10px;
-              overflow: hidden;
-              perspective: 1px;
-              position: absolute;
-              top: 0px;
-              width: 100%;
-            }
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--cover
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                height: auto;
-                left: 50% /* @noflip */;
-                opacity: 0;
-                position: absolute;
-                top: 50%;
-                transform: translate(-50%,-50%);
-                width: 100%;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role={undefined}
-          src={undefined}
-        />
-      </div>
     </div>
   </div>
   <div
@@ -710,53 +616,6 @@ exports[`Persona renders Persona correctly with no props 1`] = `
           
         </i>
       </div>
-      <div
-        className=
-            ms-Image
-            ms-Persona-image
-            {
-              border-radius: 50%;
-              border: 0px;
-              height: 100%;
-              left: 0px;
-              margin-right: 10px;
-              overflow: hidden;
-              perspective: 1px;
-              position: absolute;
-              top: 0px;
-              width: 100%;
-            }
-        style={
-          Object {
-            "height": 48,
-            "width": 48,
-          }
-        }
-      >
-        <img
-          alt=""
-          className=
-              ms-Image-image
-              ms-Image-image--cover
-              ms-Image-image--portrait
-              is-notLoaded
-              is-fadeIn
-              {
-                display: block;
-                height: auto;
-                left: 50% /* @noflip */;
-                opacity: 0;
-                position: absolute;
-                top: 50%;
-                transform: translate(-50%,-50%);
-                width: 100%;
-              }
-          onError={[Function]}
-          onLoad={[Function]}
-          role={undefined}
-          src={undefined}
-        />
-      </div>
     </div>
   </div>
   <div
@@ -786,9 +645,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
-    >
-      
-    </div>
+    />
     <div
       className=
           ms-Persona-secondaryText
@@ -827,6 +684,578 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             white-space: nowrap;
           }
     />
+  </div>
+</div>
+`;
+
+exports[`Persona renders Persona which calls onRenderCoin callback without imageUrl 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #333333;
+        display: flex;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+      &:hover $primaryText {
+        color: #212121;
+      }
+  size={15}
+  style={undefined}
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size100
+
+    size={15}
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 100px;
+            position: relative;
+            text-align: center;
+            width: 100px;
+          }
+      style={undefined}
+    >
+      <div
+        aria-hidden="true"
+        className=
+            ms-Persona-initials
+            {
+              background-color:  #7E3878;
+              border-radius: 50%;
+              color: #ffffff;
+              font-size: 42px;
+              font-weight: 400;
+              height: 100px;
+              line-height: 100px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: Window !important;
+              border: 1px solid WindowText;
+              box-sizing: border-box;
+              color: WindowText;
+            }
+        style={undefined}
+      >
+        <span>
+          SV
+        </span>
+      </div>
+      <span
+        id="persona-coin-container"
+      />
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: content-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: -2px;
+              box-sizing: content-box;
+              height: 28px;
+              position: absolute;
+              right: -2px;
+              text-align: center;
+              top: auto;
+              width: 28px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+              border-color: Window;
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #D93B3B;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            &:after {
+              background-color: #D93B3B;
+              content: "";
+              height: 2px;
+              left: 0px;
+              position: absolute;
+              top: 50%;
+              transform: translateY(-50%) rotate(-45deg);
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+            @media screen and (-ms-high-contrast: active){&:after {
+              background-color: Window;
+              left: 2px;
+              width: calc(100% - 4px);
+            }
+        style={undefined}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon-placeHolder
+              ms-Persona-presenceIcon
+              {
+                color: #ffffff;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 28px;
+                vertical-align: top;
+                width: 1em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: Window;
+              }
+          data-icon-name=""
+          role="presentation"
+          style={undefined}
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #333333;
+            font-size: 21px;
+            font-weight: 300;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #666666;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #666666;
+            display: block;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #666666;
+            display: block;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Persona renders correctly with onRender callback 1`] = `
+<div
+  className=
+      ms-Persona
+      ms-Persona--size100
+      ms-Persona--blocked
+      {
+        align-items: center;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #333333;
+        display: flex;
+        font-size: 14px;
+        font-weight: 400;
+        height: 100px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        min-width: 100px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+      & .contextualHost {
+        display: none;
+      }
+      &:hover $primaryText {
+        color: #212121;
+      }
+  size={15}
+  style={undefined}
+>
+  <div
+    className=
+        ms-Persona-coin
+        ms-Persona--size100
+
+    size={15}
+  >
+    <div
+      className=
+          ms-Persona-imageArea
+          {
+            flex: 0 0 auto;
+            height: 100px;
+            position: relative;
+            text-align: center;
+            width: 100px;
+          }
+      style={undefined}
+    >
+      <div
+        className=
+            ms-Image
+            ms-Persona-image
+            {
+              border-radius: 50%;
+              border: 0px;
+              height: 100px;
+              left: 0px;
+              margin-right: 10px;
+              overflow: hidden;
+              perspective: 1px;
+              position: absolute;
+              top: 0px;
+              width: 100px;
+            }
+        style={
+          Object {
+            "height": 100,
+            "width": 100,
+          }
+        }
+      >
+        <img
+          alt=""
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: auto;
+                left: 50% /* @noflip */;
+                opacity: 0;
+                position: absolute;
+                top: 50%;
+                transform: translate(-50%,-50%);
+                width: 100%;
+              }
+          onError={[Function]}
+          onLoad={[Function]}
+          role={undefined}
+          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+        />
+      </div>
+      <div
+        className=
+            ms-Persona-presence
+            {
+              -ms-high-contrast-adjust: none;
+              background-clip: content-box;
+              background-color: #ffffff;
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: -2px;
+              box-sizing: content-box;
+              height: 28px;
+              position: absolute;
+              right: -2px;
+              text-align: center;
+              top: auto;
+              width: 28px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+              border-color: Window;
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #D93B3B;
+              box-sizing: border-box;
+              content: "";
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+            &:after {
+              background-color: #D93B3B;
+              content: "";
+              height: 2px;
+              left: 0px;
+              position: absolute;
+              top: 50%;
+              transform: translateY(-50%) rotate(-45deg);
+              width: 100%;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              border-color: Window;
+              height: calc(100% - 2px);
+              left: 1px;
+              top: 1px;
+              width: calc(100% - 2px);
+            }
+            @media screen and (-ms-high-contrast: active){&:after {
+              background-color: Window;
+              left: 2px;
+              width: calc(100% - 4px);
+            }
+        style={undefined}
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Icon-placeHolder
+              ms-Persona-presenceIcon
+              {
+                color: #ffffff;
+                display: inline-block;
+                font-size: 14px;
+                line-height: 28px;
+                vertical-align: top;
+                width: 1em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: Window;
+              }
+          data-icon-name=""
+          role="presentation"
+          style={undefined}
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Persona-details
+        {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0px;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 24px;
+          padding-top: 0;
+          text-align: left;
+          width: 100%;
+        }
+  >
+    <div
+      className=
+          ms-Persona-primaryText
+          {
+            color: #333333;
+            font-size: 21px;
+            font-weight: 300;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Swapnil Vaibhav
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-secondaryText
+          {
+            color: #666666;
+            font-size: 14px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Software Engineer
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-tertiaryText
+          {
+            color: #666666;
+            display: block;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        In a meeting
+      </div>
+    </div>
+    <div
+      className=
+          ms-Persona-optionalText
+          {
+            color: #666666;
+            display: block;
+            font-size: 12px;
+            font-weight: 400;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+    >
+      <div
+        aria-describedby={undefined}
+        className="ms-TooltipHost"
+        onBlurCapture={[Function]}
+        onFocusCapture={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Available at 4:00pm
+      </div>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

* onRenderDivider prop added to DetailsList which can be used to modify the default render behaviour of the column header divider, and corresponding test case
* Persona: render image IF there is a valid imageUrl, onRender*Text types of callback can be used to override the default behaviour

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6426)

