### PR TITLE
change  barHeight for lessthan 2 data points and apply css for ratio txt

### DIFF
--- a/common/changes/@uifabric/charting/stackedBarChartBugs_2018-09-21-12-35.json
+++ b/common/changes/@uifabric/charting/stackedBarChartBugs_2018-09-21-12-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "change  barHeight for lessthan 2 data points and apply css for ratio txt",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "gorigarajesh@gmail.com"
+}

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -53,8 +53,9 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
 
   public render(): JSX.Element {
     this._adjustProps();
-    const { data, barHeight, hideNumberDisplay, hideLegend, theme, styles, barBackgroundColor } = this.props;
+    const { data, hideNumberDisplay, hideLegend, theme, styles, barBackgroundColor } = this.props;
     const { palette } = theme!;
+    const barHeight = data!.chartData!.length > 2 ? this.props.barHeight : 8;
     const bars = this._createBarsAndLegends(data!, barHeight!, palette, barBackgroundColor);
     const showRatio = hideNumberDisplay === false && data!.chartData!.length === 2;
     const showNumber = hideNumberDisplay === false && data!.chartData!.length === 1;
@@ -78,7 +79,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           )}
           {showRatio && (
             <div>
-              <strong>{data!.chartData![0].data}</strong>/{total}
+              <span className={this._classNames.ratioNumerator}>{data!.chartData![0].data}</span>/
+              <span className={this._classNames.ratioDenominator}>{total}</span>
             </div>
           )}
           {showNumber && (

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -1,4 +1,5 @@
 import { IStackedBarChartStyleProps, IStackedBarChartStyles } from './StackedBarChart.types';
+import { FontSizes, FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartStyles => {
   const { className, width, barHeight, legendColor, shouldHighlight, theme } = props;
@@ -21,7 +22,7 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       display: 'flex',
       justifyContent: 'space-between',
       marginBottom: '5px',
-      fontSize: '12px'
+      fontSize: FontSizes.small
     },
     legendContainer: {
       paddingTop: '4px'
@@ -32,9 +33,9 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
     },
     hoverCardDataStyles: {
       color: legendColor === '' ? theme.palette.black : legendColor,
-      fontSize: '28px',
+      fontSize: FontSizes.xxLarge,
       fontFamily: 'Segoe UI',
-      fontWeight: 'bold',
+      fontWeight: FontWeights.bold,
       lineHeight: '31px'
     },
     hoverCardRoot: {
@@ -47,12 +48,12 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       opacity: shouldHighlight ? '' : '0.1'
     },
     ratioNumerator: {
-      fontSize: '12px',
-      fontWeight: '600',
+      fontSize: FontSizes.small,
+      fontWeight: FontWeights.semibold,
       color: theme.palette.black
     },
     ratioDenominator: {
-      fontSize: '12px',
+      fontSize: FontSizes.small,
       color: theme.palette.black,
       opacity: '0.6'
     }

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -45,6 +45,16 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
     },
     opacityChangeOnHover: {
       opacity: shouldHighlight ? '' : '0.1'
+    },
+    ratioNumerator: {
+      fontSize: '12px',
+      fontWeight: '600',
+      color: theme.palette.black
+    },
+    ratioDenominator: {
+      fontSize: '12px',
+      color: theme.palette.black,
+      opacity: '0.6'
     }
   };
 };

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
@@ -135,4 +135,14 @@ export interface IStackedBarChartStyles {
    * Style to change the opacity of bars in dataviz when we hover on a single bar or legends
    */
   opacityChangeOnHover: IStyle;
+
+  /**
+   * Style for the chart ratio numerator
+   */
+  ratioNumerator: IStyle;
+
+  /**
+   * Style for the chart ratio denominator
+   */
+  ratioDenominator: IStyle;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
 -- change barHeight for stacked bar chart when data points are less than 2
 -- add css for ratio numerator and denominator text 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6442)

