### PR TITLE
Fixing generate version files script: take into account that rush isn't installed on CI

### DIFF
--- a/scripts/generate-version-files.js
+++ b/scripts/generate-version-files.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const glob = require('glob');
 
 const generateOnly = process.argv.indexOf('-g') > -1;
+const rushCmd = `"${process.execPath}" "${path.resolve(__dirname, '../common/scripts/install-run-rush.js')}"`;
 
 function run(cmd) {
   return execSync(cmd, { cwd: path.resolve(__dirname, '..') }).toString();
@@ -21,7 +22,7 @@ if (!generateOnly) {
   }
 
   // Do a dry-run on all packages
-  run(`"${process.execPath}" "${path.resolve(__dirname, '../common/scripts/install-run-rush.js')}" publish -a`);
+  run(`${rushCmd} publish -a`);
   status = run('git status --porcelain=1');
   status.split(/\n/g).forEach(line => {
     if (line) {

--- a/scripts/generate-version-files.js
+++ b/scripts/generate-version-files.js
@@ -29,8 +29,10 @@ if (!generateOnly) {
       const parts = line.trim().split(/\s/);
 
       if (parts[0] === '??') {
+        // untracked files at this point would be things like CHANGELOG files for a brand new project
         untracked.push(parts[1]);
       } else {
+        // modified files include package.json, generated CHANGELOG files from rush publish dry run
         modified.push('"' + parts[1] + '"');
       }
     }

--- a/scripts/generate-version-files.js
+++ b/scripts/generate-version-files.js
@@ -20,7 +20,7 @@ if (!generateOnly) {
   }
 
   // Do a dry-run on all packages
-  run('rush publish -a');
+  run(`"${process.execPath}" "${path.resolve(__dirname, '../common/scripts/install-run-rush.js')}" publish -a`);
   status = run('git status --porcelain=1');
   modified = status
     .split(/\n/g)

--- a/scripts/generate-version-files.js
+++ b/scripts/generate-version-files.js
@@ -28,7 +28,7 @@ if (!generateOnly) {
       const parts = line.trim().split(/\s/);
 
       if (parts[0] === '??') {
-        untracked.push('"' + parts[1] + '"');
+        untracked.push(parts[1]);
       } else {
         modified.push('"' + parts[1] + '"');
       }


### PR DESCRIPTION
#### Description of changes
The issue is that CI machines do not have rush installed. Also the CHANGELOG.md / .json pair of files do not exist in @uifabric/set-version project yet. So it is "untracked." `git checkout` will fail in those cases.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6444)

