### PR TITLE
Fix .ms-Panel--custom missing on .root if PanelType is PanelType.custom

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-output-panel-custom-className_2018-09-21-21-40.json
+++ b/common/changes/office-ui-fabric-react/keco-output-panel-custom-className_2018-09-21-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Panel Custom className not output if PanelType is Custom",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -122,6 +122,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         isHiddenOnDismiss && {
           visibility: 'hidden'
         },
+      type === PanelType.custom && classNames.custom,
       className
     ],
     overlay: [

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -101,8 +101,8 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     type
   } = props;
   const { palette } = theme;
-
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const isCustomPanel = type === PanelType.custom;
 
   return {
     root: [
@@ -122,7 +122,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         isHiddenOnDismiss && {
           visibility: 'hidden'
         },
-      type === PanelType.custom && classNames.custom,
+      isCustomPanel && classNames.custom,
       className
     ],
     overlay: [
@@ -230,7 +230,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
                 }
               }
             },
-            type === PanelType.custom && {
+            isCustomPanel && {
               maxWidth: '100vw'
             }
           ]


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6434
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `.ms-Panel--custom` on `root` if `PanelType === PanelType.custom` to fix regression while converting Panel to use CSS-in-JS in #5823. Specifically this LoC: https://github.com/OfficeDev/office-ui-fabric-react/pull/5823/files#diff-2d341ba7fad8eb7764c3a06fe47f6c16L170

#### Focus areas to test

**Before**

![image](https://user-images.githubusercontent.com/706967/45907472-dfb4e900-bdac-11e8-8f04-58c027d32d8e.png)

**After**

![image](https://user-images.githubusercontent.com/706967/45907452-cb70ec00-bdac-11e8-8f6c-cac2518fc65b.png)

