### PR TITLE
Add current rendered querystring

### DIFF
--- a/common/changes/office-ui-fabric-react/add-currentRenderedQuerystring_2018-09-24-23-26.json
+++ b/common/changes/office-ui-fabric-react/add-currentRenderedQuerystring_2018-09-24-23-26.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Add currentRenderedQueryString to avoid discrepancy",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/add-currentRenderedQuerystring_2018-09-24-23-26.json
+++ b/common/changes/office-ui-fabric-react/add-currentRenderedQuerystring_2018-09-24-23-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add currentRenderedQueryString to avoid discrepancy",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "meng.francis@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -16,8 +16,7 @@ export interface IBaseExtendedPickerState<T> {
   suggestionItems: T[] | null;
 }
 
-export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
-  extends BaseComponent<P, IBaseExtendedPickerState<T>>
+export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extends BaseComponent<P, IBaseExtendedPickerState<T>>
   implements IBaseExtendedPicker<T> {
   public floatingPicker = createRef<BaseFloatingPicker<T, IBaseFloatingPickerProps<T>>>();
   public selectedItemsList = createRef<BaseSelectedItemsList<T, IBaseSelectedItemsListProps<T>>>();
@@ -157,6 +156,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
       inputElement: this.input.current ? this.input.current.inputElement : undefined,
       selectedItems: this.items,
       suggestionItems: this.props.suggestionItems ? this.props.suggestionItems : undefined,
+      currentRenderedQueryString: this.props.currentRenderedQueryString,
       ...this.floatingPickerProps
     });
   }
@@ -195,8 +195,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
 
     if (this.floatingPicker.current && this.inputElement) {
       // Update the value if the input value is empty or it is different than the current inputText from the floatingPicker
-      const shoudUpdateValue =
-        this.inputElement.value === '' || this.inputElement.value !== this.floatingPicker.current.inputText;
+      const shoudUpdateValue = this.inputElement.value === '' || this.inputElement.value !== this.floatingPicker.current.inputText;
       this.floatingPicker.current.showPicker(shoudUpdateValue);
     }
   };
@@ -248,9 +247,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
   };
 
   protected _onSuggestionSelected = (item: T): void => {
-    const processedItem: T | PromiseLike<T> | null = this.props.onItemSelected
-      ? (this.props.onItemSelected as any)(item)
-      : item;
+    const processedItem: T | PromiseLike<T> | null = this.props.onItemSelected ? (this.props.onItemSelected as any)(item) : item;
 
     if (processedItem === null) {
       return;

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -158,7 +158,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
       inputElement: this.input.current ? this.input.current.inputElement : undefined,
       selectedItems: this.items,
       suggestionItems: this.props.suggestionItems ? this.props.suggestionItems : undefined,
-      currentRenderedQueryString: this.props.currentRenderedQueryString,
       ...this.floatingPickerProps
     });
   }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -251,7 +251,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
   protected _onSuggestionSelected = (item: T): void => {
     const currentRenderedQueryString = this.props.currentRenderedQueryString;
     const queryString = this.state.queryString;
-    if (currentRenderedQueryString !== undefined && currentRenderedQueryString === queryString) {
+    if (currentRenderedQueryString === undefined || currentRenderedQueryString === queryString) {
       const processedItem: T | PromiseLike<T> | null = this.props.onItemSelected ? (this.props.onItemSelected as any)(item) : item;
 
       if (processedItem === null) {

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -127,4 +127,9 @@ export interface IBaseExtendedPickerProps<T> {
    * Focus zone props
    */
   focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * Current rendered query string that's corealte to current rendered result
+   **/
+  currentRenderedQueryString?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -218,7 +218,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   protected onChange(item: T): void {
     const currentRenderedQueryString = this.props.currentRenderedQueryString;
     const queryString = this.state.queryString;
-    if (this.props.onChange && currentRenderedQueryString && currentRenderedQueryString === queryString) {
+    if (this.props.onChange && currentRenderedQueryString !== undefined && currentRenderedQueryString === queryString) {
       (this.props.onChange as ((items: T) => void))(item);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -216,9 +216,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   }
 
   protected onChange(item: T): void {
-    const currentRenderedQueryString = this.props.currentRenderedQueryString;
-    const queryString = this.state.queryString;
-    if (this.props.onChange && currentRenderedQueryString !== undefined && currentRenderedQueryString === queryString) {
+    if (this.props.onChange) {
       (this.props.onChange as ((items: T) => void))(item);
     }
   }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -2,11 +2,7 @@ import * as React from 'react';
 import * as stylesImport from './BaseFloatingPicker.scss';
 import { BaseComponent, createRef, css, KeyCodes } from '../../Utilities';
 import { Callout, DirectionalHint } from '../../Callout';
-import {
-  IBaseFloatingPicker,
-  IBaseFloatingPickerProps,
-  IBaseFloatingPickerSuggestionProps
-} from './BaseFloatingPicker.types';
+import { IBaseFloatingPicker, IBaseFloatingPickerProps, IBaseFloatingPickerSuggestionProps } from './BaseFloatingPicker.types';
 import { ISuggestionModel } from '../../Pickers';
 import { ISuggestionsControlProps } from './Suggestions/Suggestions.types';
 import { SuggestionsControl } from './Suggestions/SuggestionsControl';
@@ -20,17 +16,16 @@ export interface IBaseFloatingPickerState {
   didBind: boolean;
 }
 
-export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
-  extends BaseComponent<P, IBaseFloatingPickerState>
+export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extends BaseComponent<P, IBaseFloatingPickerState>
   implements IBaseFloatingPicker {
   protected selection: Selection;
 
   protected root = createRef<HTMLDivElement>();
   protected suggestionStore: SuggestionsStore<T>;
   protected suggestionsControl: SuggestionsControl<T>;
-  protected SuggestionsControlOfProperType: new (props: ISuggestionsControlProps<T>) => SuggestionsControl<
-    T
-  > = SuggestionsControl as new (props: ISuggestionsControlProps<T>) => SuggestionsControl<T>;
+  protected SuggestionsControlOfProperType: new (props: ISuggestionsControlProps<T>) => SuggestionsControl<T> = SuggestionsControl as new (
+    props: ISuggestionsControlProps<T>
+  ) => SuggestionsControl<T>;
   // tslint:disable-next-line:no-any
   protected currentPromise: PromiseLike<any>;
 
@@ -221,7 +216,9 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
   }
 
   protected onChange(item: T): void {
-    if (this.props.onChange) {
+    const currentRenderedQueryString = this.props.currentRenderedQueryString;
+    const queryString = this.state.queryString;
+    if (this.props.onChange && currentRenderedQueryString && currentRenderedQueryString === queryString) {
       (this.props.onChange as ((items: T) => void))(item);
     }
   }
@@ -298,10 +295,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
   };
 
   private _onResolveSuggestions(updatedValue: string): void {
-    const suggestions: T[] | PromiseLike<T[]> | null = this.props.onResolveSuggestions(
-      updatedValue,
-      this.props.selectedItems
-    );
+    const suggestions: T[] | PromiseLike<T[]> | null = this.props.onResolveSuggestions(updatedValue, this.props.selectedItems);
 
     this._updateSuggestionsVisible(true /*shouldShow*/);
     if (suggestions !== null) {

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -140,11 +140,6 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
    * If using as a controlled component, the items to show in the suggestion list
    */
   suggestionItems?: T[];
-
-  /**
-   * Current rendered query string that's corealte to current rendered result
-   **/
-  currentRenderedQueryString?: string;
 }
 
 export interface IBaseFloatingPickerSuggestionProps {

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -140,6 +140,11 @@ export interface IBaseFloatingPickerProps<T> extends React.Props<any> {
    * If using as a controlled component, the items to show in the suggestion list
    */
   suggestionItems?: T[];
+
+  /**
+   * Current rendered query string that's corealte to current rendered result
+   **/
+  currentRenderedQueryString?: string;
 }
 
 export interface IBaseFloatingPickerSuggestionProps {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes
Currently when pressing enter button. The old rendered results will be selected. Add currentRenderedQueryString to check if the queryString is the same as renderedQueryString. Only select when current rendered result is the same as the current queryString.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6460)

