### PR TITLE
Dashboard: Multicount component rendering issue in IE

### DIFF
--- a/common/changes/@uifabric/dashboard/ie11MultiCountComponentIssue_2018-09-25-00-30.json
+++ b/common/changes/@uifabric/dashboard/ie11MultiCountComponentIssue_2018-09-25-00-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Bug fix: Multicount component body text is not rendered in IE when put inside a flex box with justifyContent of center",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "kevcha@microsoft.com"
+}

--- a/packages/dashboard/src/components/MultiCount/MultiCountStyles.ts
+++ b/packages/dashboard/src/components/MultiCount/MultiCountStyles.ts
@@ -26,7 +26,7 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       height: '1.286em'
     },
     bodyText: {
-      flex: '1 1 50%',
+      flex: '1 1 auto',
       overflow: 'hidden',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
@@ -34,7 +34,8 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       fontFamily: 'Segoe UI',
       fontWeight: 600,
       lineHeight: '1.286em',
-      marginLeft: '8px'
+      marginLeft: '8px',
+      width: '50%'
     },
     data: {
       flex: '0 0 auto',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Bug fix: Multicount component body text is not rendered in IE when put inside a flex box with justifyContent of center

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6461)

