### PR TITLE
Memoize: Don't use cached result when function instances are distinct.

### DIFF
--- a/common/changes/@uifabric/utilities/memoize-function-type-args_2018-09-25-07-03.json
+++ b/common/changes/@uifabric/utilities/memoize-function-type-args_2018-09-25-07-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Memoize: Do not use cached result when function instances are distinct.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "v-panu@microsoft.com"
+}

--- a/packages/utilities/src/memoize.test.ts
+++ b/packages/utilities/src/memoize.test.ts
@@ -1,4 +1,4 @@
-expect(test(fnB)).toEqual(2);import { memoize, memoizeFunction } from './memoize';
+import { memoize, memoizeFunction } from './memoize';
 
 describe('memoizeFunction', () => {
   it('can return a cached result with a no args function', () => {

--- a/packages/utilities/src/memoize.test.ts
+++ b/packages/utilities/src/memoize.test.ts
@@ -24,6 +24,26 @@ describe('memoizeFunction', () => {
     expect(combine(objB, objA)).toEqual('ba3');
   });
 
+  it('do not use a cached result if the function is different', () => {
+    let _timesCalled = 0;
+    let test = memoizeFunction((fn: Function) => {
+      fn();
+      return ++_timesCalled;
+    });
+
+    function createFunctionArg(): Function {
+      return () => 'test';
+    }
+
+    let fnA = createFunctionArg();
+    let fnB = createFunctionArg();
+
+    expect(test(fnA)).toEqual(1);
+    expect(test(fnA)).toEqual(1);
+    expect(test(fnB)).toEqual(2);
+    expect(test(fnA)).toEqual(1);
+  });
+
   it('can return a cached result with falsy args', () => {
     let _timesCalled = 0;
     let combine = memoizeFunction(

--- a/packages/utilities/src/memoize.test.ts
+++ b/packages/utilities/src/memoize.test.ts
@@ -1,4 +1,4 @@
-import { memoize, memoizeFunction } from './memoize';
+expect(test(fnB)).toEqual(2);import { memoize, memoizeFunction } from './memoize';
 
 describe('memoizeFunction', () => {
   it('can return a cached result with a no args function', () => {
@@ -42,6 +42,8 @@ describe('memoizeFunction', () => {
     expect(test(fnA)).toEqual(1);
     expect(test(fnB)).toEqual(2);
     expect(test(fnA)).toEqual(1);
+    expect(test(fnB)).toEqual(2);
+    expect(test(fnB)).toEqual(2);
   });
 
   it('can return a cached result with falsy args', () => {

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -82,10 +82,7 @@ export function memoize<T extends Function>(
  * @param maxCacheSize - Max results to cache. If the cache exceeds this value, it will reset on the next call.
  * @returns A memoized version of the function.
  */
-export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE>(
-  cb: T,
-  maxCacheSize: number = 100
-): T {
+export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE>(cb: T, maxCacheSize: number = 100): T {
   // Avoid breaking scenarios which don't have weak map.
   if (!_weakMap) {
     return cb;
@@ -99,11 +96,7 @@ export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE
   return function memoizedFunction(...args: any[]): RET_TYPE {
     let currentNode: any = rootNode;
 
-    if (
-      rootNode === undefined ||
-      localResetCounter !== _resetCounter ||
-      (maxCacheSize > 0 && cacheSize > maxCacheSize)
-    ) {
+    if (rootNode === undefined || localResetCounter !== _resetCounter || (maxCacheSize > 0 && cacheSize > maxCacheSize)) {
       rootNode = _createNode();
       cacheSize = 0;
       localResetCounter = _resetCounter;
@@ -136,7 +129,7 @@ function _normalizeArg(val: object): any;
 function _normalizeArg(val: any): any {
   if (!val) {
     return _emptyObject;
-  } else if (typeof val === 'object') {
+  } else if (typeof val === 'object' || typeof val === 'function') {
     return val;
   } else if (!_dictionary[val]) {
     _dictionary[val] = { val };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`memoizeFunction` used a string serialization to compare function arguments. So if they were functions from different instances of the same class, they were considered the same function when they actually belong to different objects (so had different effects).

Example of the issue I'm fixing:
1. Imagine a dialog. It will have a `validate` function. We create a controller on a memoized function which receives the `validate` method. Thus we only regenerate the controller when some of their arguments change.
1. Create and show a dialog.
2. Close the dialog.
3. Create a new instance of the dialog.
4. Controller would receive a new instance of `validate` (for the new dialog) but memoize serializes it to the same value as before, so it reuses the old controller **and calls the old validate**.

#### Focus areas to test

Usages of `memoize` and `memoizeFunction` that receive a function argument.
https://github.com/OfficeDev/office-ui-fabric-react/search?q=memoize&unscoped_q=memoize

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6464)

