### PR TITLE
Sticky second null check for currElem

### DIFF
--- a/common/changes/office-ui-fabric-react/stickyCurrElem_2018-09-25-18-06.json
+++ b/common/changes/office-ui-fabric-react/stickyCurrElem_2018-09-25-18-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Sticky: second null check for currElem",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -58,15 +58,11 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   }
 
   public get canStickyTop(): boolean {
-    return (
-      this.props.stickyPosition === StickyPositionType.Both || this.props.stickyPosition === StickyPositionType.Header
-    );
+    return this.props.stickyPosition === StickyPositionType.Both || this.props.stickyPosition === StickyPositionType.Header;
   }
 
   public get canStickyBottom(): boolean {
-    return (
-      this.props.stickyPosition === StickyPositionType.Both || this.props.stickyPosition === StickyPositionType.Footer
-    );
+    return this.props.stickyPosition === StickyPositionType.Both || this.props.stickyPosition === StickyPositionType.Footer;
   }
 
   public syncScroll = (container: HTMLElement): void => {
@@ -136,20 +132,12 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     return (
       <div ref={this._root}>
         {this.canStickyTop && (
-          <div
-            ref={this._stickyContentTop}
-            aria-hidden={!isStickyTop}
-            style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}
-          >
+          <div ref={this._stickyContentTop} aria-hidden={!isStickyTop} style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />
           </div>
         )}
         {this.canStickyBottom && (
-          <div
-            ref={this._stickyContentBottom}
-            aria-hidden={!isStickyBottom}
-            style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}
-          >
+          <div ref={this._stickyContentBottom} aria-hidden={!isStickyBottom} style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
@@ -224,8 +212,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       // Can sticky bottom if the scrollablePane - total sticky footer height is smaller than the sticky's distance from the top of the pane
       if (this.canStickyBottom && container.clientHeight - footerStickyContainer.offsetHeight <= this.distanceFromTop) {
         isStickyBottom =
-          this.distanceFromTop - container.scrollTop >=
-          this._getStickyDistanceFromTopForFooter(container, footerStickyContainer);
+          this.distanceFromTop - container.scrollTop >= this._getStickyDistanceFromTopForFooter(container, footerStickyContainer);
       }
 
       this.setState({
@@ -244,14 +231,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     return distance;
   };
 
-  private _getStickyDistanceFromTopForFooter = (
-    container: HTMLElement,
-    footerStickyVisibleContainer: HTMLElement
-  ): number => {
+  private _getStickyDistanceFromTopForFooter = (container: HTMLElement, footerStickyVisibleContainer: HTMLElement): number => {
     let distance = 0;
     if (this.stickyContentBottom) {
-      distance =
-        container.clientHeight - footerStickyVisibleContainer.offsetHeight + this.stickyContentBottom.offsetTop;
+      distance = container.clientHeight - footerStickyVisibleContainer.offsetHeight + this.stickyContentBottom.offsetTop;
     }
 
     return distance;
@@ -267,7 +250,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
         currElem = currElem.offsetParent as HTMLDivElement;
       }
 
-      if (currElem.offsetParent === container) {
+      if (currElem && currElem.offsetParent === container) {
         distance += currElem.offsetTop;
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6056 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adding a second null check for currElem that was overlooked in my first PR here: https://github.com/OfficeDev/office-ui-fabric-react/pull/6079 and brought to my attention here: https://github.com/OfficeDev/office-ui-fabric-react/commit/c0cef2680cc99b41f92f2f66bd528a605a0cc2a3#commitcomment-30642409
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6467)

