### PR TITLE
Experimental Separator Component

### DIFF
--- a/common/changes/@uifabric/experiments/separator_2018-09-25-21-30.json
+++ b/common/changes/@uifabric/experiments/separator_2018-09-25-21-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Separator: new experimental component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "naethell@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/separator_2018-09-25-21-30.json
+++ b/common/changes/office-ui-fabric-react/separator_2018-09-25-21-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: prettier fixes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/experiments/src/Separator.ts
+++ b/packages/experiments/src/Separator.ts
@@ -1,0 +1,1 @@
+export * from './components/Separator/index';

--- a/packages/experiments/src/components/Separator/Separator.base.tsx
+++ b/packages/experiments/src/components/Separator/Separator.base.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { IProcessedStyleSet } from '../../Styling';
+import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { ISeparatorProps, ISeparatorStyles, ISeparatorStyleProps } from './Separator.types';
+
+const getClassNames = classNamesFunction<ISeparatorStyleProps, ISeparatorStyles>();
+
+export class SeparatorBase extends BaseComponent<ISeparatorProps, {}> {
+  private _classNames: IProcessedStyleSet<ISeparatorStyles>;
+
+  constructor(props: ISeparatorProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const { message, styles, theme, className } = this.props;
+
+    this._classNames = getClassNames(styles!, {
+      theme: theme!,
+      className
+    });
+
+    return (
+      <div className={this._classNames.root}>
+        <div className={this._classNames.text} role="heading">
+          {message}
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/experiments/src/components/Separator/Separator.base.tsx
+++ b/packages/experiments/src/components/Separator/Separator.base.tsx
@@ -22,13 +22,7 @@ export class SeparatorBase extends BaseComponent<ISeparatorProps, {}> {
       vertical: vertical
     });
 
-    return vertical ? (
-      <div className={this._classNames.root}>
-        <div className={this._classNames.text} role="heading">
-          {text}
-        </div>
-      </div>
-    ) : (
+    return (
       <div className={this._classNames.root}>
         <div className={this._classNames.text} role="heading">
           {text}

--- a/packages/experiments/src/components/Separator/Separator.base.tsx
+++ b/packages/experiments/src/components/Separator/Separator.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IProcessedStyleSet } from '../../Styling';
+import { IProcessedStyleSet, mergeStyles } from '../../Styling';
 import { BaseComponent, classNamesFunction } from '../../Utilities';
 import { ISeparatorProps, ISeparatorStyles, ISeparatorStyleProps } from './Separator.types';
 
@@ -13,17 +13,23 @@ export class SeparatorBase extends BaseComponent<ISeparatorProps, {}> {
   }
 
   public render(): JSX.Element {
-    const { message, styles, theme, className } = this.props;
+    const { text, styles, theme, className, vertical, alignText } = this.props;
 
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className
     });
 
-    return (
-      <div className={this._classNames.root}>
+    return vertical ? (
+      <div className={mergeStyles(this._classNames.isVertical, alignText ? this._classNames[alignText] : null)}>
         <div className={this._classNames.text} role="heading">
-          {message}
+          {text}
+        </div>
+      </div>
+    ) : (
+      <div className={mergeStyles(this._classNames.root, alignText ? this._classNames[alignText] : null)}>
+        <div className={this._classNames.text} role="heading">
+          {text}
         </div>
       </div>
     );

--- a/packages/experiments/src/components/Separator/Separator.base.tsx
+++ b/packages/experiments/src/components/Separator/Separator.base.tsx
@@ -17,17 +17,19 @@ export class SeparatorBase extends BaseComponent<ISeparatorProps, {}> {
 
     this._classNames = getClassNames(styles!, {
       theme: theme!,
-      className
+      className,
+      alignText: alignText,
+      vertical: vertical
     });
 
     return vertical ? (
-      <div className={mergeStyles(this._classNames.isVertical, alignText ? this._classNames[alignText] : null)}>
+      <div className={this._classNames.root}>
         <div className={this._classNames.text} role="heading">
           {text}
         </div>
       </div>
     ) : (
-      <div className={mergeStyles(this._classNames.root, alignText ? this._classNames[alignText] : null)}>
+      <div className={this._classNames.root}>
         <div className={this._classNames.text} role="heading">
           {text}
         </div>

--- a/packages/experiments/src/components/Separator/Separator.base.tsx
+++ b/packages/experiments/src/components/Separator/Separator.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IProcessedStyleSet, mergeStyles } from '../../Styling';
+import { IProcessedStyleSet } from '../../Styling';
 import { BaseComponent, classNamesFunction } from '../../Utilities';
 import { ISeparatorProps, ISeparatorStyles, ISeparatorStyleProps } from './Separator.types';
 

--- a/packages/experiments/src/components/Separator/Separator.base.tsx
+++ b/packages/experiments/src/components/Separator/Separator.base.tsx
@@ -24,7 +24,7 @@ export class SeparatorBase extends BaseComponent<ISeparatorProps, {}> {
 
     return (
       <div className={this._classNames.root}>
-        <div className={this._classNames.text} role="heading">
+        <div className={this._classNames.text} role="separator" aria-orientation={vertical ? 'vertical' : 'horizontal'}>
           {text}
         </div>
       </div>

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -32,7 +32,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         },
       vertical && {
         padding: '0 5px',
-        height: '200px',
+        height: 'inherit',
         display: 'table-cell',
         zIndex: 1,
         selectors: {

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -37,7 +37,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         zIndex: 1,
         selectors: {
           ':after': {
-            backgroundColor: theme!.palette.neutralLight,
+            backgroundColor: theme.palette.neutralLight,
             width: '1px',
             content: '""',
             position: 'absolute',
@@ -53,7 +53,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         padding: '5px 0',
         selectors: {
           ':before': {
-            backgroundColor: theme!.palette.neutralLight,
+            backgroundColor: theme.palette.neutralLight,
             height: '1px',
             content: '""',
             display: 'block',
@@ -73,8 +73,8 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         display: 'inline-block',
         fontSize: '16px',
         padding: '0 20px',
-        color: theme!.semanticColors.bodyText,
-        background: theme!.semanticColors.bodyBackground
+        color: theme.semanticColors.bodyText,
+        background: theme.semanticColors.bodyBackground
       },
       vertical && {
         padding: '20px 0'

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -1,0 +1,41 @@
+import { ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
+
+export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
+  return {
+    root: [
+      {
+        textAlign: 'center',
+        position: 'relative',
+        whiteSpace: 'nowrap',
+        // width: '400px',
+        padding: '5px',
+        selectors: {
+          '::before': {
+            borderTop: '1px solid black',
+            content: '',
+            width: '100%',
+            display: 'inline-block',
+            position: 'relative',
+            bottom: '5px'
+          },
+          '::after': {
+            borderTop: '1px solid black',
+            content: '',
+            width: '100%',
+            display: 'inline-block',
+            position: 'relative',
+            bottom: '5px'
+          }
+        }
+      }
+    ],
+    text: [
+      {
+        position: 'relative',
+        whiteSpace: 'nowrap',
+        fontSize: '20px',
+        padding: '0 10px'
+      }
+    ]
+  };
+};

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -3,6 +3,10 @@ import { ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
 export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
   const { theme, alignText, vertical } = props;
 
+  const alignStart = alignText === 'start';
+  const alignCenter = alignText === 'center';
+  const alignEnd = alignText === 'end';
+
   return {
     root: [
       {
@@ -14,13 +18,23 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
       !alignText && {
         textAlign: 'center'
       },
+      vertical &&
+        (alignCenter || !alignText) && {
+          verticalAlign: 'middle'
+        },
+      vertical &&
+        alignStart && {
+          verticalAlign: 'top'
+        },
+      vertical &&
+        alignEnd && {
+          verticalAlign: 'bottom'
+        },
       vertical && {
         padding: '0 5px',
         height: '200px',
-        textAlign: 'center',
-        zIndex: 1,
         display: 'table-cell',
-        verticalAlign: 'middle',
+        zIndex: 1,
         selectors: {
           ':after': {
             backgroundColor: theme!.palette.neutralLight,

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -7,20 +7,20 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         textAlign: 'center',
         position: 'relative',
         whiteSpace: 'nowrap',
-        // width: '400px',
+        width: '400px',
         padding: '5px',
         selectors: {
-          '::before': {
+          ':before': {
             borderTop: '1px solid black',
-            content: '',
+            content: '""',
             width: '100%',
             display: 'inline-block',
             position: 'relative',
             bottom: '5px'
           },
-          '::after': {
+          ':after': {
             borderTop: '1px solid black',
-            content: '',
+            content: '""',
             width: '100%',
             display: 'inline-block',
             position: 'relative',
@@ -33,6 +33,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
       {
         position: 'relative',
         whiteSpace: 'nowrap',
+        display: 'inline-block',
         fontSize: '20px',
         padding: '0 10px'
       }

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -5,6 +5,9 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
 
   return {
     root: [
+      {
+        position: 'relative'
+      },
       alignText && {
         textAlign: alignText
       },
@@ -12,33 +15,28 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         textAlign: 'center'
       },
       vertical && {
-        position: 'relative',
-        paddingTop: '20%',
-        paddingBottom: '20%',
-        zIndex: '1',
+        padding: '0 5px',
+        height: '200px',
         textAlign: 'center',
-        display: 'block',
-        height: '40px',
+        zIndex: 1,
+        display: 'table-cell',
+        verticalAlign: 'middle',
         selectors: {
-          ':before': {
+          ':after': {
             backgroundColor: theme!.palette.neutralLight,
             width: '1px',
-            height: '100%',
             content: '""',
             position: 'absolute',
             top: '0',
             bottom: '0',
             left: '50%',
             right: '0',
-            zIndex: '-1'
+            zIndex: -1
           }
         }
       },
       !vertical && {
-        position: 'relative',
-        paddingTop: '5px',
-        paddingBottom: '5px',
-        display: 'block',
+        padding: '5px 0',
         selectors: {
           ':before': {
             backgroundColor: theme!.palette.neutralLight,
@@ -54,35 +52,16 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         }
       }
     ],
-    center: [
-      {
-        textAlign: 'center'
-      }
-    ],
-    start: [
-      {
-        textAlign: 'start'
-      }
-    ],
-    end: [
-      {
-        textAlign: 'end'
-      }
-    ],
     text: [
-      vertical && {
-        position: 'relative',
-        display: 'inline-block',
-        fontSize: '16px',
-        padding: '20px 0',
-        background: 'white'
-      },
-      !vertical && {
+      {
         position: 'relative',
         display: 'inline-block',
         fontSize: '16px',
         padding: '0 20px',
         background: 'white'
+      },
+      vertical && {
+        padding: '20px 0'
       }
     ]
   };

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -11,18 +11,45 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
       !alignText && {
         textAlign: 'center'
       },
-      vertical && {},
-      {
+      vertical && {
         position: 'relative',
-        padding: '5px',
+        paddingTop: '20%',
+        paddingBottom: '20%',
+        zIndex: '1',
+        textAlign: 'center',
+        display: 'block',
+        height: '40px',
+        selectors: {
+          ':before': {
+            backgroundColor: theme!.palette.neutralLight,
+            width: '1px',
+            height: '100%',
+            content: '""',
+            position: 'absolute',
+            top: '0',
+            bottom: '0',
+            left: '50%',
+            right: '0',
+            zIndex: '-1'
+          }
+        }
+      },
+      !vertical && {
+        position: 'relative',
+        paddingTop: '5px',
+        paddingBottom: '5px',
         display: 'block',
         selectors: {
           ':before': {
-            borderTop: `1px solid ${theme!.palette.neutralLight}`,
+            backgroundColor: theme!.palette.neutralLight,
+            height: '1px',
             content: '""',
             display: 'block',
-            position: 'relative',
-            top: '12px'
+            position: 'absolute',
+            top: '50%',
+            bottom: '0',
+            left: '0',
+            right: '0'
           }
         }
       }
@@ -42,25 +69,15 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         textAlign: 'end'
       }
     ],
-    isVertical: [
-      {
-        textAlign: 'center',
-        position: 'relative',
-        padding: '5px',
-        display: 'block',
-        selectors: {
-          ':before': {
-            borderLeft: `1px solid ${theme!.palette.neutralLight}`,
-            content: '""',
-            display: 'block',
-            position: 'relative'
-            // left: '12px'
-          }
-        }
-      }
-    ],
     text: [
-      {
+      vertical && {
+        position: 'relative',
+        display: 'inline-block',
+        fontSize: '16px',
+        padding: '20px 0',
+        background: 'white'
+      },
+      !vertical && {
         position: 'relative',
         display: 'inline-block',
         fontSize: '16px',

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -1,6 +1,8 @@
 import { ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
 
 export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
+  const { theme } = props;
+
   return {
     root: [
       {
@@ -11,7 +13,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         padding: '5px',
         selectors: {
           ':before': {
-            borderTop: '1px solid black',
+            borderTop: `1px solid ${theme!.palette.neutralLight}`,
             content: '""',
             width: '100%',
             display: 'inline-block',
@@ -19,7 +21,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
             bottom: '5px'
           },
           ':after': {
-            borderTop: '1px solid black',
+            borderTop: `1px solid ${theme!.palette.neutralLight}`,
             content: '""',
             width: '100%',
             display: 'inline-block',
@@ -35,7 +37,7 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         whiteSpace: 'nowrap',
         display: 'inline-block',
         fontSize: '20px',
-        padding: '0 10px'
+        padding: '0 20px'
       }
     ]
   };

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -73,7 +73,8 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
         display: 'inline-block',
         fontSize: '16px',
         padding: '0 20px',
-        background: 'white'
+        color: theme!.semanticColors.bodyText,
+        background: theme!.semanticColors.bodyBackground
       },
       vertical && {
         padding: '20px 0'

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -1,10 +1,17 @@
 import { ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
 
 export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
-  const { theme } = props;
+  const { theme, alignText, vertical } = props;
 
   return {
     root: [
+      alignText && {
+        textAlign: alignText
+      },
+      !alignText && {
+        textAlign: 'center'
+      },
+      vertical && {},
       {
         position: 'relative',
         padding: '5px',

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -6,27 +6,48 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
   return {
     root: [
       {
-        textAlign: 'center',
         position: 'relative',
-        whiteSpace: 'nowrap',
-        width: '400px',
         padding: '5px',
+        display: 'block',
         selectors: {
           ':before': {
             borderTop: `1px solid ${theme!.palette.neutralLight}`,
             content: '""',
-            width: '100%',
-            display: 'inline-block',
+            display: 'block',
             position: 'relative',
-            bottom: '5px'
-          },
-          ':after': {
-            borderTop: `1px solid ${theme!.palette.neutralLight}`,
+            top: '12px'
+          }
+        }
+      }
+    ],
+    center: [
+      {
+        textAlign: 'center'
+      }
+    ],
+    start: [
+      {
+        textAlign: 'start'
+      }
+    ],
+    end: [
+      {
+        textAlign: 'end'
+      }
+    ],
+    isVertical: [
+      {
+        textAlign: 'center',
+        position: 'relative',
+        padding: '5px',
+        display: 'block',
+        selectors: {
+          ':before': {
+            borderLeft: `1px solid ${theme!.palette.neutralLight}`,
             content: '""',
-            width: '100%',
-            display: 'inline-block',
-            position: 'relative',
-            bottom: '5px'
+            display: 'block',
+            position: 'relative'
+            // left: '12px'
           }
         }
       }
@@ -34,10 +55,10 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
     text: [
       {
         position: 'relative',
-        whiteSpace: 'nowrap',
         display: 'inline-block',
-        fontSize: '20px',
-        padding: '0 20px'
+        fontSize: '16px',
+        padding: '0 20px',
+        background: 'white'
       }
     ]
   };

--- a/packages/experiments/src/components/Separator/Separator.styles.ts
+++ b/packages/experiments/src/components/Separator/Separator.styles.ts
@@ -1,7 +1,7 @@
 import { ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
 
 export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
-  const { theme, alignText, vertical } = props;
+  const { theme, alignText, vertical, className } = props;
 
   const alignStart = alignText === 'start';
   const alignCenter = alignText === 'center';
@@ -64,7 +64,8 @@ export const getStyles = (props: ISeparatorStyleProps): ISeparatorStyles => {
             right: '0'
           }
         }
-      }
+      },
+      className
     ],
     text: [
       {

--- a/packages/experiments/src/components/Separator/Separator.tsx
+++ b/packages/experiments/src/components/Separator/Separator.tsx
@@ -1,0 +1,8 @@
+import { styled } from '../../Utilities';
+import { ISeparatorProps, ISeparatorStyleProps, ISeparatorStyles } from './Separator.types';
+import { getStyles } from './Separator.styles';
+import { SeparatorBase } from './Separator.base';
+
+export const Separator = styled<ISeparatorProps, ISeparatorStyleProps, ISeparatorStyles>(SeparatorBase, getStyles, undefined, {
+  scope: 'Separator'
+});

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -43,27 +43,7 @@ export interface ISeparatorProps extends React.Props<SeparatorBase> {
   className?: string;
 }
 
-export interface ISeparatorStyleProps {
-  /**
-   * Theme for the component.
-   */
-  theme: ITheme;
-
-  /**
-   * Accept custom classNames.
-   */
-  className?: string;
-
-  /**
-   * How to align text in the separator.
-   */
-  alignText?: 'start' | 'center' | 'end';
-
-  /**
-   * Whether the separator is vertical.
-   */
-  vertical?: boolean;
-}
+export type ISeparatorStyleProps = Required<Pick<ISeparatorProps, 'theme'>> & Pick<ISeparatorProps, 'className' | 'alignText' | 'vertical'>;
 
 export interface ISeparatorStyles {
   /**

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -72,13 +72,6 @@ export interface ISeparatorStyles {
   root?: IStyle;
 
   /**
-   * Text align
-   */
-  center?: IStyle;
-  start?: IStyle;
-  end?: IStyle;
-
-  /**
    * Style for the text element
    */
   text?: IStyle;

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -50,9 +50,19 @@ export interface ISeparatorStyleProps {
   theme?: ITheme;
 
   /**
-   * Accept custom classNames
+   * Accept custom classNames.
    */
   className?: string;
+
+  /**
+   * How to align text in the separator.
+   */
+  alignText?: 'start' | 'center' | 'end';
+
+  /**
+   * Whether the separator is vertical.
+   */
+  vertical?: boolean;
 }
 
 export interface ISeparatorStyles {
@@ -66,6 +76,9 @@ export interface ISeparatorStyles {
    */
   isVertical?: IStyle;
 
+  /**
+   * Text align
+   */
   center?: IStyle;
   start?: IStyle;
   end?: IStyle;

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -72,11 +72,6 @@ export interface ISeparatorStyles {
   root?: IStyle;
 
   /**
-   * Style for vertical separator.
-   */
-  isVertical?: IStyle;
-
-  /**
    * Text align
    */
   center?: IStyle;

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { SeparatorBase } from './Separator.base';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
+import { IStyle, ITheme } from '../../Styling';
+
+export interface ISeparator {}
+
+export interface ISeparatorProps extends React.Props<SeparatorBase> {
+  /**
+   * Optional callback to access the IChiclet interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: IRefObject<ISeparator>;
+
+  /**
+   * Theme (provided through customization.)
+   */
+  theme?: ITheme;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<ISeparatorStyleProps, ISeparatorStyles>;
+
+  /**
+   * Optional message to display in the separator.
+   */
+  message?: string;
+
+  /**
+   * Optional class for separator.
+   */
+  className?: string;
+}
+
+export interface ISeparatorStyleProps {
+  /**
+   * Theme for the component.
+   */
+  theme?: ITheme;
+
+  /**
+   * Accept custom classNames
+   */
+  className?: string;
+}
+
+export interface ISeparatorStyles {
+  /**
+   * Style for the root element
+   */
+  root?: IStyle;
+
+  /**
+   * Style for the text element
+   */
+  text?: IStyle;
+}

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -7,7 +7,7 @@ export interface ISeparator {}
 
 export interface ISeparatorProps extends React.Props<SeparatorBase> {
   /**
-   * Optional callback to access the IChiclet interface. Use this instead of ref for accessing
+   * Optional callback to access the ISeparator interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<ISeparator>;

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -47,7 +47,7 @@ export interface ISeparatorStyleProps {
   /**
    * Theme for the component.
    */
-  theme?: ITheme;
+  theme: ITheme;
 
   /**
    * Accept custom classNames.
@@ -69,10 +69,10 @@ export interface ISeparatorStyles {
   /**
    * Style for the root element
    */
-  root?: IStyle;
+  root: IStyle;
 
   /**
    * Style for the text element
    */
-  text?: IStyle;
+  text: IStyle;
 }

--- a/packages/experiments/src/components/Separator/Separator.types.ts
+++ b/packages/experiments/src/components/Separator/Separator.types.ts
@@ -23,9 +23,19 @@ export interface ISeparatorProps extends React.Props<SeparatorBase> {
   styles?: IStyleFunctionOrObject<ISeparatorStyleProps, ISeparatorStyles>;
 
   /**
-   * Optional message to display in the separator.
+   * Optional text to display in the separator.
    */
-  message?: string;
+  text?: string;
+
+  /**
+   * Whether the element is a vertical separator.
+   */
+  vertical?: boolean;
+
+  /**
+   * Where the text should be aligned in the separator.
+   */
+  alignText?: 'start' | 'center' | 'end';
 
   /**
    * Optional class for separator.
@@ -50,6 +60,15 @@ export interface ISeparatorStyles {
    * Style for the root element
    */
   root?: IStyle;
+
+  /**
+   * Style for vertical separator.
+   */
+  isVertical?: IStyle;
+
+  center?: IStyle;
+  start?: IStyle;
+  end?: IStyle;
 
   /**
    * Style for the text element

--- a/packages/experiments/src/components/Separator/SeparatorPage.tsx
+++ b/packages/experiments/src/components/Separator/SeparatorPage.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { ExampleCard, IComponentDemoPageProps, ComponentPage, PropertiesTableSet } from '@uifabric/example-app-base';
+
+import { SeparatorBasicExample } from './examples/Separator.Basic.Example';
+const SeparatorBasicExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx') as string;
+
+export class SeparatorPage extends React.Component<IComponentDemoPageProps, {}> {
+  public render(): JSX.Element {
+    return (
+      <ComponentPage
+        title="Separator"
+        componentName="Separator"
+        exampleCards={
+          <div>
+            <ExampleCard title="Basic Separator with Text" isOptIn={true} code={SeparatorBasicExampleCode}>
+              <SeparatorBasicExample />
+            </ExampleCard>
+          </div>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={[require<string>('!raw-loader!@uifabric/experiments/src/components/Separator/Separator.types.ts')]}
+          />
+        }
+        overview={<div />}
+        bestPractices={<div />}
+        dos={
+          <div>
+            <ul>
+              <li />
+            </ul>
+          </div>
+        }
+        donts={
+          // @todo: fill in description
+          <div>
+            <ul>
+              <li />
+            </ul>
+          </div>
+        }
+        isHeaderVisible={this.props.isHeaderVisible}
+      />
+    );
+  }
+}

--- a/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
+++ b/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
@@ -7,7 +7,7 @@ export class SeparatorBasicExample extends React.Component<{}, {}> {
   }
 
   public render(): JSX.Element {
-    const message = 'I am a separator';
+    const message = 'Today';
 
     return <Separator message={message} />;
   }

--- a/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
+++ b/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
@@ -17,6 +17,8 @@ export class SeparatorBasicExample extends React.Component<{}, {}> {
         <Separator text={message} alignText="start" />
         <p>Right aligned</p>
         <Separator text={message} alignText="end" />
+        <p>Vertical</p>
+        <Separator vertical text={message} />
       </div>
     );
   }

--- a/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
+++ b/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
@@ -11,14 +11,22 @@ export class SeparatorBasicExample extends React.Component<{}, {}> {
 
     return (
       <div>
-        <p>Center aligned</p>
+        <p>Horizontal center aligned</p>
         <Separator text={message} alignText="center" />
-        <p>Left aligned</p>
+        <p>Horizontal left aligned</p>
         <Separator text={message} alignText="start" />
-        <p>Right aligned</p>
+        <p>Horizontal right aligned</p>
         <Separator text={message} alignText="end" />
-        <p>Vertical</p>
-        <Separator vertical text={message} />
+        <p>Empty horizontal</p>
+        <Separator />
+        <p>Vertical center aligned</p>
+        <Separator vertical text={message} alignText="center" />
+        <p>Vertical start aligned</p>
+        <Separator vertical text={message} alignText="start" />
+        <p>Vertical end aligned</p>
+        <Separator vertical text={message} alignText="end" />
+        <p>Empty vertical</p>
+        <Separator vertical />
       </div>
     );
   }

--- a/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
+++ b/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
@@ -9,6 +9,15 @@ export class SeparatorBasicExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     const message = 'Today';
 
-    return <Separator message={message} />;
+    return (
+      <div>
+        <p>Center aligned</p>
+        <Separator text={message} alignText="center" />
+        <p>Left aligned</p>
+        <Separator text={message} alignText="start" />
+        <p>Right aligned</p>
+        <Separator text={message} alignText="end" />
+      </div>
+    );
   }
 }

--- a/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
+++ b/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Separator } from '../Separator';
+import { mergeStyles } from 'office-ui-fabric-react';
 
 export class SeparatorBasicExample extends React.Component<{}, {}> {
   constructor(props: {}) {
@@ -8,6 +9,10 @@ export class SeparatorBasicExample extends React.Component<{}, {}> {
 
   public render(): JSX.Element {
     const message = 'Today';
+
+    const verticalStyle = mergeStyles({
+      height: '200px'
+    });
 
     return (
       <div>
@@ -19,14 +24,16 @@ export class SeparatorBasicExample extends React.Component<{}, {}> {
         <Separator text={message} alignText="end" />
         <p>Empty horizontal</p>
         <Separator />
-        <p>Vertical center aligned</p>
-        <Separator vertical text={message} alignText="center" />
-        <p>Vertical start aligned</p>
-        <Separator vertical text={message} alignText="start" />
-        <p>Vertical end aligned</p>
-        <Separator vertical text={message} alignText="end" />
-        <p>Empty vertical</p>
-        <Separator vertical />
+        <div className={verticalStyle}>
+          <p>Vertical center aligned</p>
+          <Separator vertical text={message} alignText="center" />
+          <p>Vertical start aligned</p>
+          <Separator vertical text={message} alignText="start" />
+          <p>Vertical end aligned</p>
+          <Separator vertical text={message} alignText="end" />
+          <p>Empty vertical</p>
+          <Separator vertical />
+        </div>
       </div>
     );
   }

--- a/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
+++ b/packages/experiments/src/components/Separator/examples/Separator.Basic.Example.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Separator } from '../Separator';
+
+export class SeparatorBasicExample extends React.Component<{}, {}> {
+  constructor(props: {}) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const message = 'I am a separator';
+
+    return <Separator message={message} />;
+  }
+}

--- a/packages/experiments/src/components/Separator/index.ts
+++ b/packages/experiments/src/components/Separator/index.ts
@@ -1,0 +1,2 @@
+export * from './Separator.base';
+export * from './Separator';

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -46,6 +46,12 @@ export const AppDefinition: IAppDefinition = {
           url: '#/examples/layoutgroup'
         },
         {
+          component: require<any>('../components/Separator/SeparatorPage').SeparatorPage,
+          key: 'Separator',
+          name: 'Separator',
+          url: '#/examples/separator'
+        },
+        {
           component: require<any>('../components/signals/SignalsPage').SignalsPage,
           key: 'Signals',
           name: 'Signals',

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -1,11 +1,4 @@
-import {
-  AnimationClassNames,
-  FontSizes,
-  getGlobalClassNames,
-  HighContrastSelector,
-  IStyle,
-  normalize
-} from '../../Styling';
+import { AnimationClassNames, FontSizes, getGlobalClassNames, HighContrastSelector, IStyle, normalize } from '../../Styling';
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds the experimental separator component. There are two main variations: vertical and horizontal. The default is horizontal, and the vertical variation can be obtained by passing in the `vertical` prop. A developer can also specify how they would like to align the text, using the `alignText` prop. Below I've included screenshots of the demo page in experiments.

![image](https://user-images.githubusercontent.com/14134000/46043827-ddfd6500-c0cd-11e8-85cf-8ca61b97a7dd.png)
![image](https://user-images.githubusercontent.com/14134000/46044058-93c8b380-c0ce-11e8-9c3a-482e2dffcd1c.png)


Some thing(s) to note:
* The height of the vertical separator is currently set to 200px. I'm not sure if we'd want some sort of default value here or if we'd like it to inherit the parent's height, so let me know if you have any thoughts on that!
* The background color of the text is set to white, however, I believe that we'd like this to always match the background color of the web app the separator is placed in. Would we want this to be a prop? Or is a white default okay?
* I set the color of the line to `theme.palette.neutralLight`. Let me know if we'd like to use a different color from palette instead!


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6471)

