### PR TITLE
ComboBox: when clicking on scrollbar do not call onBlur

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-ComboBox_onBlurBUG_2018-09-26-00-57.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ComboBox_onBlurBUG_2018-09-26-00-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: add logic to stop onBlur handler to be invoked when clicking on Callout's scrollbar.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -16,7 +16,8 @@ import {
   focusAsync,
   getId,
   getNativeProps,
-  shallowCompare
+  shallowCompare,
+  findElementRecursive
 } from '../../Utilities';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { SelectableOptionMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
@@ -936,8 +937,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     }
     if (
       relatedTarget &&
+      // when event coming from withing the comboBox title
       ((this._root.current && this._root.current.contains(relatedTarget as HTMLElement)) ||
-        (this._comboBoxMenu.current && this._comboBoxMenu.current.contains(relatedTarget as HTMLElement)))
+        // when event coming from within the comboBox list menu
+        (this._comboBoxMenu.current &&
+          (this._comboBoxMenu.current.contains(relatedTarget as HTMLElement) ||
+            // when event coming from the callout containing the comboBox list menu (ex: when scrollBar of the Callout clicked)
+            // checks if the relatedTarget is a parent of _comboBoxMenu
+            findElementRecursive(this._comboBoxMenu.current, element => element === relatedTarget))))
     ) {
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6392
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Adds additional logic to stop the `onBlur` handler to be invoked when clicking on the scrollbar of the `Callout` holding the `ComboBox` items

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6475)

