### PR TITLE
FocusZone: check for RTL and do correct top to bottom comparisons

### DIFF
--- a/common/changes/office-ui-fabric-react/bidirectionalRTL_2018-09-25-23-53.json
+++ b/common/changes/office-ui-fabric-react/bidirectionalRTL_2018-09-25-23-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: check for RTL before making top bottom comparisons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -509,10 +509,11 @@ describe('FocusZone', () => {
     // Pressing up should go to a.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
     expect(lastFocusedElement).toBe(buttonA);
+
+    setRTL(false);
   });
 
   it('can use arrows bidirectionally with data-no-vertical-wrap', () => {
-    setRTL(false);
     const component = ReactTestUtils.renderIntoDocument(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone checkForNoWrap={true} data-no-vertical-wrap={true}>

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
-import { KeyCodes } from '../../Utilities';
+import { setRTL, KeyCodes } from '../../Utilities';
 
 import { FocusZone } from './FocusZone';
 import { FocusZoneDirection, FocusZoneTabbableElements } from './FocusZone.types';
@@ -396,7 +396,123 @@ describe('FocusZone', () => {
     expect(lastFocusedElement).toBe(buttonA);
   });
 
+  it('can use arrows bidirectionally in RTL', () => {
+    setRTL(true);
+    const component = ReactTestUtils.renderIntoDocument(
+      <div {...{ onFocusCapture: _onFocus }}>
+        <FocusZone>
+          <button className="a">a</button>
+          <button className="b">b</button>
+          <button className="c">c</button>
+          <button className="hidden">hidden</button>
+          <button className="d">d</button>
+          <button className="e">e</button>
+        </FocusZone>
+      </div>
+    );
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance)!.firstChild as Element;
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
+    const hiddenButton = focusZone.querySelector('.hidden') as HTMLElement;
+    const buttonD = focusZone.querySelector('.d') as HTMLElement;
+    const buttonE = focusZone.querySelector('.e') as HTMLElement;
+
+    // Set up a grid like so:
+    // B A
+    // hiddenButton C
+    // E D
+    //
+    // We will iterate from A to B, press down to skip hidden and go to C,
+    // down again to E, right to D, then back up to A.
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 30,
+        right: 0
+      }
+    });
+
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 60,
+        right: 30
+      }
+    });
+
+    setupElement(buttonC, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 20,
+        right: 0
+      }
+    });
+
+    // hidden button should be ignored.
+    setupElement(hiddenButton, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 30,
+        right: 20
+      },
+      isVisible: false
+    });
+
+    setupElement(buttonD, {
+      clientRect: {
+        top: 40,
+        bottom: 60,
+        left: 25,
+        right: 0
+      }
+    });
+
+    setupElement(buttonE, {
+      clientRect: {
+        top: 40,
+        bottom: 60,
+        left: 40,
+        right: 25
+      }
+    });
+
+    // Focus the first button.
+    ReactTestUtils.Simulate.focus(buttonA);
+    expect(lastFocusedElement).toBe(buttonA);
+
+    // Pressing left should go to b.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    expect(lastFocusedElement).toBe(buttonB);
+
+    // Pressing down should go to c.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    expect(lastFocusedElement).toBe(buttonC);
+
+    // Pressing down should go to e.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    expect(lastFocusedElement).toBe(buttonE);
+
+    // Pressing right should go to d.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    expect(lastFocusedElement).toBe(buttonD);
+
+    // Pressing up should go to c.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    expect(lastFocusedElement).toBe(buttonC);
+
+    // Pressing up should go to a.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.up });
+    expect(lastFocusedElement).toBe(buttonA);
+  });
+
   it('can use arrows bidirectionally with data-no-vertical-wrap', () => {
+    setRTL(false);
     const component = ReactTestUtils.renderIntoDocument(
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone checkForNoWrap={true} data-no-vertical-wrap={true}>

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -310,7 +310,7 @@ describe('FocusZone', () => {
     // D E
     //
     // We will iterate from A to B, press down to skip hidden and go to C,
-    // down again to E, left to D, then back up to A.
+    // down again to E, left to D, up to C, then back up to A.
     setupElement(buttonA, {
       clientRect: {
         top: 0,
@@ -425,7 +425,7 @@ describe('FocusZone', () => {
     // E D
     //
     // We will iterate from A to B, press down to skip hidden and go to C,
-    // down again to E, right to D, then back up to A.
+    // down again to E, right to D, up to C, then back up to A.
     setupElement(buttonA, {
       clientRect: {
         top: 0,

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -663,6 +663,10 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           let topBottomComparison;
 
           if (getRTL()) {
+            // When in RTL, this comparison should be the same as the one in _moveFocusRight for LTR.
+            // Going left at a leftmost rectangle will go down a line instead of up a line like in LTR.
+            // This is important, because we want to be comparing the top of the target rect
+            // with the bottom of the active rect.
             topBottomComparison = targetRect.top.toFixed(3) < activeRect.bottom.toFixed(3);
           } else {
             topBottomComparison = targetRect.bottom.toFixed(3) > activeRect.top.toFixed(3);
@@ -699,6 +703,10 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           let topBottomComparison;
 
           if (getRTL()) {
+            // When in RTL, this comparison should be the same as the one in _moveFocusLeft for LTR.
+            // Going right at a rightmost rectangle will go up a line instead of down a line like in LTR.
+            // This is important, because we want to be comparing the bottom of the target rect
+            // with the top of the active rect.
             topBottomComparison = targetRect.bottom.toFixed(3) > activeRect.top.toFixed(3);
           } else {
             topBottomComparison = targetRect.top.toFixed(3) < activeRect.bottom.toFixed(3);

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -660,12 +660,15 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         getRTL(),
         (activeRect: ClientRect, targetRect: ClientRect) => {
           let distance = -1;
+          let topBottomComparison;
 
-          if (
-            targetRect.bottom > activeRect.top &&
-            targetRect.right <= activeRect.right &&
-            this.props.direction !== FocusZoneDirection.vertical
-          ) {
+          if (getRTL()) {
+            topBottomComparison = targetRect.top.toFixed(3) < activeRect.bottom.toFixed(3);
+          } else {
+            topBottomComparison = targetRect.bottom.toFixed(3) > activeRect.top.toFixed(3);
+          }
+
+          if (topBottomComparison && targetRect.right <= activeRect.right && this.props.direction !== FocusZoneDirection.vertical) {
             distance = activeRect.right - targetRect.right;
           } else {
             if (!shouldWrap) {
@@ -693,12 +696,15 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         !getRTL(),
         (activeRect: ClientRect, targetRect: ClientRect) => {
           let distance = -1;
+          let topBottomComparison;
 
-          if (
-            targetRect.top < activeRect.bottom &&
-            targetRect.left >= activeRect.left &&
-            this.props.direction !== FocusZoneDirection.vertical
-          ) {
+          if (getRTL()) {
+            topBottomComparison = targetRect.bottom.toFixed(3) > activeRect.top.toFixed(3);
+          } else {
+            topBottomComparison = targetRect.top.toFixed(3) < activeRect.bottom.toFixed(3);
+          }
+
+          if (topBottomComparison && targetRect.left >= activeRect.left && this.props.direction !== FocusZoneDirection.vertical) {
             distance = targetRect.left - activeRect.left;
           } else if (!shouldWrap) {
             distance = LARGE_NEGATIVE_DISTANCE_FROM_CENTER;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5438 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

This PR changes one of the comparisons in `_moveFocusLeft` and `_moveFocusRight` when in RTL.
When moving focus left in RTL, instead of comparing the target rect bottom with the active rect top, we should compare the target rect top with the active rect bottom. Similarly, when moving focus right in RTL, instead of comparing the target rect top with the active rect bottom, we should compare the target rect bottom with the active rect top. 

Before (hitting the left arrow key): 
![focuszone bidirectional rtl not working](https://user-images.githubusercontent.com/14134000/46109098-7d852b00-c194-11e8-886f-fafadbc96b3d.gif)

After (hitting the left arrow key):
![focuszone rtl bidirectional working](https://user-images.githubusercontent.com/14134000/46109105-7fe78500-c194-11e8-8971-71729f904c73.gif)

Here's my reasoning, let me know if it makes sense.

RTL is different than LTR in this scenario in a couple ways. For one, going right at a rightmost rectangle will go up a line instead of down a line like in LTR. Similarly, going left at a leftmost rectangle will go down a line instead of up a line like in LTR. This is important for comparisons, because the `_moveFocusLeft` function, when triggered on a rightmost element, will compare everything to the left of the active rectangle, as well as the rectangle immediately below it. Vice versa for `_moveFocusRight`.

LTR:
Moving right
![image](https://user-images.githubusercontent.com/14134000/46098786-ff1b8f80-c179-11e8-8fe6-ca556e082b87.png)

Moving left
![image](https://user-images.githubusercontent.com/14134000/46098818-12c6f600-c17a-11e8-9e44-16f9ceb07108.png)

RTL (what we have now):
Moving right
![image](https://user-images.githubusercontent.com/14134000/46098685-cda2c400-c179-11e8-95a4-a8504f7bcd12.png)

Moving left
![image](https://user-images.githubusercontent.com/14134000/46098708-d5faff00-c179-11e8-9dab-bf8884aa7379.png)


RTL (what we will have with these changes):
Moving right
![image](https://user-images.githubusercontent.com/14134000/46098748-e7dca200-c179-11e8-9ff7-fd312eacea89.png)

Moving left
![image](https://user-images.githubusercontent.com/14134000/46098767-f1660a00-c179-11e8-90bc-ff70afc5dca3.png)

I also made a change to round the bottom and top comparisons to the 3rd decimal place, so that small rounding errors will not affect these comparisons and move focus down a line when it should just be moved to the left or to the right.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6485)

