### PR TITLE
SwatchColorPicker: let height and width be customizable

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-swatchImprovements_2018-09-27-00-05.json
+++ b/common/changes/office-ui-fabric-react/phkuo-swatchImprovements_2018-09-27-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SwatchColorPicker: let height and width be customizable",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -15,7 +15,7 @@ import { classNamesFunction } from '../../Utilities';
 
 const getClassNames = classNamesFunction<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>();
 
-class ColorCell extends GridCell<IColorCellProps, IGridCellProps<IColorCellProps>> {}
+class ColorCell extends GridCell<IColorCellProps, IGridCellProps<IColorCellProps>> { }
 
 export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCellProps, {}> {
   public static defaultProps = {
@@ -43,7 +43,10 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
       onMouseMove,
       onMouseLeave,
       onWheel,
-      onKeyDown
+      onKeyDown,
+      height,
+      width,
+      borderWidth
     } = this.props;
 
     this._classNames = getClassNames(styles!, {
@@ -51,7 +54,10 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
       disabled,
       selected,
       circle,
-      isWhite: this._isWhiteCell(color)
+      isWhite: this._isWhiteCell(color),
+      height,
+      width,
+      borderWidth
     });
 
     return (
@@ -129,21 +135,21 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
         checked && ['is-checked', styles.rootChecked],
         disabled && ['is-disabled', styles.rootDisabled],
         !disabled &&
-          !checked && {
-            selectors: {
-              ':hover': styles.rootHovered,
-              ':focus': styles.rootFocused,
-              ':active': styles.rootPressed
-            }
-          },
+        !checked && {
+          selectors: {
+            ':hover': styles.rootHovered,
+            ':focus': styles.rootFocused,
+            ':active': styles.rootPressed
+          }
+        },
         disabled && checked && [styles.rootCheckedDisabled],
         !disabled &&
-          checked && {
-            selectors: {
-              ':hover': styles.rootCheckedHovered,
-              ':active': styles.rootCheckedPressed
-            }
+        checked && {
+          selectors: {
+            ':hover': styles.rootCheckedHovered,
+            ':active': styles.rootCheckedPressed
           }
+        }
       ],
       flexContainer: ['ms-Button-flexContainer', styles.flexContainer]
     });

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -21,7 +21,10 @@ export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCel
   public static defaultProps = {
     circle: true,
     disabled: false,
-    selected: false
+    selected: false,
+    height: 20,
+    width: 20,
+    borderWidth: 2
   } as IColorPickerGridCellProps;
 
   private _classNames: { [key in keyof IColorPickerGridCellStyles]: string };

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -1,26 +1,9 @@
-// import { IRawStyle, HighContrastSelector } from '../../Styling';
-import { IStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
 
 export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGridCellStyles => {
   const { theme, disabled, selected, circle, isWhite, height = 20, width = 20, borderWidth = 2 } = props;
   const { semanticColors } = theme;
-
-  // constructing this first, since array syntax breaks '&'s for 'selectors'
-  let colorCellSelectors: { [key: string]: IStyle } = {
-    // remove default focus border
-    [`.${IsFocusVisibleClassName} &:focus::after`]: { display: 'none' },
-    // add a custom focus border
-    [`.${IsFocusVisibleClassName} &:focus`]: { outline: `1px solid ${semanticColors.focusBorder}` }
-  };
-  if (!selected) {
-    colorCellSelectors['&:hover, &:active, &:focus'] = {
-      backgroundColor: semanticColors.bodyBackground, // overwrite white's override
-      padding: borderWidth,
-      border: `${borderWidth}px solid ${theme.palette.neutralLight}`
-    };
-  }
 
   return {
     // this is a button that wraps the color
@@ -35,7 +18,12 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
         userSelect: 'none',
         height: height,
         width: width,
-        selectors: colorCellSelectors
+        selectors: {
+          // remove default focus border
+          [`.${IsFocusVisibleClassName} &:focus::after`]: { display: 'none' },
+          // add a custom focus border
+          [`.${IsFocusVisibleClassName} &:focus`]: { outline: `1px solid ${semanticColors.focusBorder}` }
+        }
       },
       circle && {
         borderRadius: '100%'
@@ -43,6 +31,15 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
       selected && {
         padding: borderWidth,
         border: `${borderWidth}px solid ${theme.palette.neutralTertiaryAlt}`
+      },
+      !selected && {
+        selectors: {
+          ['&:hover, &:active, &:focus']: {
+            backgroundColor: semanticColors.bodyBackground, // overwrite white's override
+            padding: borderWidth,
+            border: `${borderWidth}px solid ${theme.palette.neutralLight}`
+          }
+        }
       },
       disabled && {
         color: semanticColors.disabledBodyText,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -2,7 +2,7 @@ import { IsFocusVisibleClassName } from '../../Utilities';
 import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
 
 export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGridCellStyles => {
-  const { theme, disabled, selected, circle, isWhite, height = 20, width = 20, borderWidth = 2 } = props;
+  const { theme, disabled, selected, circle, isWhite, height, width, borderWidth } = props;
   const { semanticColors } = theme;
 
   return {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -1,110 +1,67 @@
-import { IRawStyle, HighContrastSelector } from '../../Styling';
+// import { IRawStyle, HighContrastSelector } from '../../Styling';
+import { IStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
 
-const ACTIVE_BORDER_COLOR = '#969696';
-
-function getSvgSelectorStyles(borderColor: string, isHover: boolean): IRawStyle {
-  return {
-    width: 12,
-    height: 12,
-    border: '4px solid',
-    borderColor: borderColor,
-    boxShadow: isHover ? 'none' : '0 0 0 1px #969696',
-    padding: 4,
-    margin: 0
-  };
-}
-
 export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGridCellStyles => {
-  const { theme, disabled, selected, circle, isWhite } = props;
+  const { theme, disabled, selected, circle, isWhite, height = 20, width = 20, borderWidth = 2 } = props;
   const { semanticColors } = theme;
 
+  // constructing this first, since array syntax breaks '&'s for 'selectors'
+  let colorCellSelectors: { [key: string]: IStyle } = {
+    // remove default focus border
+    [`.${IsFocusVisibleClassName} &:focus::after`]: { display: 'none' },
+    // add a custom focus border
+    [`.${IsFocusVisibleClassName} &:focus`]: { outline: `1px solid ${semanticColors.focusBorder}` }
+  };
+  if (!selected) {
+    colorCellSelectors['&:hover, &:active, &:focus'] = {
+      backgroundColor: semanticColors.bodyBackground, // overwrite white's override
+      padding: borderWidth,
+      border: `${borderWidth}px solid ${theme.palette.neutralLight}`
+    };
+  }
+
   return {
+    // this is a button that wraps the color
     colorCell: [
       {
-        backgroundColor: 'transparent',
+        backgroundColor: semanticColors.bodyBackground,
         padding: 0,
-        overflow: 'visible',
         position: 'relative',
         boxSizing: 'border-box',
         display: 'inline-block',
-        border: '1px solid transparent',
-        background: 'transparent',
         cursor: 'pointer',
-        textAlign: 'center',
-        verticalAlign: 'top',
         userSelect: 'none',
-        height: 40,
-        selectors: {
-          [HighContrastSelector]: { border: 'none' },
-          [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus::after`]: { borderColor: 'transparent' },
-          [`.${IsFocusVisibleClassName} &:focus $svg`]: getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, false),
-          ':hover $svg': getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, true),
-          ':focus $svg': getSvgSelectorStyles(theme.palette.neutralQuaternaryAlt, false),
-          ':active $svg': getSvgSelectorStyles(ACTIVE_BORDER_COLOR, false)
-        }
+        height: height,
+        width: width,
+        selectors: colorCellSelectors
       },
-      isWhite && {
-        selectors: {
-          $svg: {
-            width: 12,
-            height: 12,
-            border: '4px solid',
-            boxShadow: `inset 0 0 0 1px ${theme.palette.neutralTertiary}`,
-            borderColor: 'transparent'
-          }
-        }
+      circle && {
+        borderRadius: '100%'
       },
-      circle &&
-        'is-circle' && {
-          selectors: {
-            $svg: { borderRadius: '100%' }
-          }
-        },
-      selected &&
-        'isSelected' && {
-          selectors: {
-            $svg: {
-              boxShadow: '0 0 0 1px #969696',
-              border: '4px solid',
-              borderColor: theme.palette.neutralTertiaryAlt,
-              width: 12,
-              height: 12
-            },
-            ':hover $svg': { boxShadow: '0 0 0 1px #969696' },
-            ':focus $svg': {
-              boxShadow: '0 0 0 1px #969696'
-            },
-            ':active $svg': {
-              boxShadow: '0 0 0 1px #969696',
-              borderColor: ACTIVE_BORDER_COLOR
-            }
-          }
-        },
-      selected &&
-        isWhite && {
-          selectors: {
-            $svg: {
-              padding: 4,
-              margin: 0
-            }
-          }
-        },
-      disabled &&
-        'is-disabled' && {
-          color: semanticColors.disabledBodyText,
-          cursor: 'default',
-          pointerEvents: 'none',
-          opacity: 0.3
-        }
+      selected && {
+        padding: borderWidth,
+        border: `${borderWidth}px solid ${theme.palette.neutralTertiaryAlt}`
+      },
+      disabled && {
+        color: semanticColors.disabledBodyText,
+        pointerEvents: 'none',
+        opacity: 0.3
+      },
+      isWhite && !selected && { // fake a border for white
+        backgroundColor: semanticColors.bodyDivider,
+        padding: 1
+      }
     ],
+    // the <svg> that holds the color
     svg: [
       {
-        width: 20,
-        height: 20,
-        padding: 4,
-        boxSizing: 'content-box'
+        width: '100%',
+        height: '100%'
+      },
+      circle && {
+        borderRadius: '100%'
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
@@ -50,6 +50,21 @@ export interface IColorPickerGridCellProps {
   selected: boolean;
 
   /**
+   * Height of the cell, in pixels
+   */
+  height?: number;
+
+  /**
+   * Width of the cell, in pixels
+   */
+  width?: number;
+
+  /**
+   * Width of the border that indicates a selected/hovered cell, in pixels
+   */
+  borderWidth?: number;
+
+  /**
    * The on click handler
    */
   onClick?: (item: IColorCellProps) => void;
@@ -149,6 +164,21 @@ export interface IColorPickerGridCellStyleProps {
    * Whether the color being rendered is white or not. If it is white we show a border around it.
    */
   isWhite?: boolean;
+
+  /**
+   * The height of this cell, in pixels.
+   */
+  height?: number;
+
+  /**
+   * The width of this cell, in pixels.
+   */
+  width?: number;
+
+  /**
+   * The width of the border indicating a hovered or selected cell, in pixels.
+   */
+  borderWidth?: number;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
@@ -51,16 +51,19 @@ export interface IColorPickerGridCellProps {
 
   /**
    * Height of the cell, in pixels
+   * @default 20
    */
   height?: number;
 
   /**
    * Width of the cell, in pixels
+   * @default 20
    */
   width?: number;
 
   /**
    * Width of the border that indicates a selected/hovered cell, in pixels
+   * @default 2
    */
   borderWidth?: number;
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -21,7 +21,8 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
   public static defaultProps = {
     cellShape: 'circle',
     disabled: false,
-    shouldFocusCircularNavigate: true
+    shouldFocusCircularNavigate: true,
+    cellMargin: 10
   } as ISwatchColorPickerProps;
 
   private _id: string;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -90,12 +90,14 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
       shouldFocusCircularNavigate,
       className,
       doNotContainWithinFocusZone,
-      styles
+      styles,
+      cellMargin
     } = this.props;
 
     const classNames = getClassNames(styles!, {
       theme: this.props.theme!,
-      className
+      className,
+      cellMargin
     });
 
     if (colorCells.length < 1 || columnCount < 1) {
@@ -173,6 +175,9 @@ export class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps
         onMouseLeave={this._onMouseLeave}
         onWheel={this._onWheel}
         onKeyDown={this._onKeyDown}
+        height={this.props.cellHeight}
+        width={this.props.cellWidth}
+        borderWidth={this.props.cellBorderWidth}
       />
     );
   };

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.styles.ts
@@ -6,23 +6,17 @@ const GlobalClassNames = {
 };
 
 export const getStyles = (props: ISwatchColorPickerStyleProps): ISwatchColorPickerStyles => {
-  const { className, theme, cellMargin = 10 } = props;
+  const { className, theme, cellMargin } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
     root: {
-      margin: '12px 5px',
+      margin: '8px 0',
       borderCollapse: 'collapse'
     },
     tableCell: {
-      paddingRight: cellMargin,
-      paddingBottom: cellMargin,
-      selectors: {
-        ':last-child': {
-          paddingRight: 0
-        }
-      }
+      padding: cellMargin! / 2
     },
     focusedContainer: [
       classNames.focusedContainer,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.styles.ts
@@ -6,17 +6,23 @@ const GlobalClassNames = {
 };
 
 export const getStyles = (props: ISwatchColorPickerStyleProps): ISwatchColorPickerStyles => {
-  const { className, theme } = props;
+  const { className, theme, cellMargin = 10 } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
     root: {
-      padding: 2,
-      outline: 'none'
+      margin: '12px 5px',
+      borderCollapse: 'collapse'
     },
     tableCell: {
-      padding: 0
+      paddingRight: cellMargin,
+      paddingBottom: cellMargin,
+      selectors: {
+        ':last-child': {
+          paddingRight: 0
+        }
+      }
     },
     focusedContainer: [
       classNames.focusedContainer,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -93,21 +93,25 @@ export interface ISwatchColorPickerProps {
 
   /**
    * The distance between cells, in pixels
+   * @default 10
    */
   cellMargin?: number;
 
   /**
    * Height of an individual cell, in pixels
+   * @default 20
    */
   cellHeight?: number;
 
   /**
    * Width of an individual cell, in pixels
+   * @default 20
    */
   cellWidth?: number;
 
   /**
    * Width of the border indicating a hovered/selected cell, in pixels
+   * @default 2
    */
   cellBorderWidth?: number;
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -6,7 +6,7 @@ import {
   IColorPickerGridCellStyles
 } from './ColorPickerGridCell.types';
 
-export interface ISwatchColorPicker {}
+export interface ISwatchColorPicker { }
 
 export interface ISwatchColorPickerProps {
   /**
@@ -79,7 +79,7 @@ export interface ISwatchColorPickerProps {
   setSize?: number;
 
   /**
-   * Should focus cycle to the beginning of once the user navigates past the end (and visa vsersa).
+   * Should focus cycle to the beginning of once the user navigates past the end (and vice versa).
    * This prop is only relevant if doNotcontainWithinFocusZone is not true
    * @default to true
    */
@@ -90,6 +90,26 @@ export interface ISwatchColorPickerProps {
    * If false contain the grid inside of a FocusZone.
    */
   doNotContainWithinFocusZone?: boolean;
+
+  /**
+   * The distance between cells, in pixels
+   */
+  cellMargin?: number;
+
+  /**
+   * Height of an individual cell, in pixels
+   */
+  cellHeight?: number;
+
+  /**
+   * Width of an individual cell, in pixels
+   */
+  cellWidth?: number;
+
+  /**
+   * Width of the border indicating a hovered/selected cell, in pixels
+   */
+  cellBorderWidth?: number;
 
   /**
    * Theme to apply to the component.
@@ -132,6 +152,11 @@ export interface ISwatchColorPickerStyleProps {
    * Custom className to apply to the container.
    */
   className?: string;
+
+  /**
+   * The distance between cells
+   */
+  cellMargin?: number;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -21,6 +21,11 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
     className=
 
         {
+          border-collapse: collapse;
+          margin-bottom: 12px;
+          margin-left: 5px;
+          margin-right: 5px;
+          margin-top: 12px;
           outline: none;
           padding-bottom: 2px;
           padding-left: 2px;
@@ -39,10 +44,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -56,10 +64,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -67,9 +74,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -79,6 +85,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -107,74 +114,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -218,13 +170,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="#00ff00"
                 viewBox="0 0 20 20"
@@ -242,10 +190,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -259,10 +210,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -270,9 +220,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -282,6 +231,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -310,74 +260,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -421,13 +316,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="#ffa500"
                 viewBox="0 0 20 20"
@@ -445,10 +336,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -462,10 +356,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -473,9 +366,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -485,6 +377,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -513,74 +406,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -624,13 +462,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="#0000ff"
                 viewBox="0 0 20 20"
@@ -648,10 +482,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -665,10 +502,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -676,9 +512,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -688,6 +523,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -716,74 +552,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -827,13 +608,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="#ff0000"
                 viewBox="0 0 20 20"
@@ -855,10 +632,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -872,10 +652,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -883,9 +662,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -895,6 +673,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -923,74 +702,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -1034,13 +758,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="green"
                 viewBox="0 0 20 20"
@@ -1058,10 +778,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -1075,10 +798,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1086,9 +808,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1098,6 +819,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1126,74 +848,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -1237,13 +904,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="orange"
                 viewBox="0 0 20 20"
@@ -1261,10 +924,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -1278,10 +944,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1289,9 +954,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1301,6 +965,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1329,74 +994,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -1440,13 +1050,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="blue"
                 viewBox="0 0 20 20"
@@ -1464,10 +1070,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -1481,10 +1090,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1492,9 +1100,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1504,6 +1111,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1532,74 +1140,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -1643,13 +1196,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="red"
                 viewBox="0 0 20 20"
@@ -1671,10 +1220,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -1688,10 +1240,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1699,9 +1250,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1711,6 +1261,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1739,74 +1290,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -1850,13 +1346,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="black"
                 viewBox="0 0 20 20"
@@ -1874,10 +1366,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -1891,10 +1386,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1902,9 +1396,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1914,6 +1407,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -1942,74 +1436,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -2053,13 +1492,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="grey"
                 viewBox="0 0 20 20"
@@ -2077,10 +1512,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -2094,10 +1532,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -2105,9 +1542,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -2117,6 +1553,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -2145,74 +1582,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -2256,13 +1638,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="purple"
                 viewBox="0 0 20 20"
@@ -2280,10 +1658,13 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 0px;
+                padding-bottom: 10px;
                 padding-left: 0px;
-                padding-right: 0px;
+                padding-right: 10px;
                 padding-top: 0px;
+              }
+              &:last-child {
+                padding-right: 0px;
               }
           role="presentation"
         >
@@ -2297,10 +1678,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  background: transparent;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
+                  background-color: #ffffff;
+                  border-radius: 100%;
+                  border: none;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -2308,9 +1688,8 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
-                  height: 40px;
+                  height: 20px;
                   outline: transparent;
-                  overflow: visible;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -2320,6 +1699,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-decoration: none;
                   user-select: none;
                   vertical-align: top;
+                  width: 20px;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -2348,74 +1728,19 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   position: relative;
                   top: 0px;
                 }
-                @media screen and (-ms-high-contrast: active){& {
-                  border: none;
+                .ms-Fabric--isFocusVisible &:focus::after {
+                  display: none;
                 }
-                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                  border-color: transparent;
+                .ms-Fabric--isFocusVisible &:focus {
+                  outline: 1px solid #000000;
                 }
-                .ms-Fabric--isFocusVisible &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:hover $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: none;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:focus $svg {
-                  border-color: #dadada;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                &:active $svg {
-                  border-color: #969696;
-                  border: 4px solid;
-                  box-shadow: 0 0 0 1px #969696;
-                  height: 12px;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 4px;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 4px;
-                  width: 12px;
-                }
-                & $svg {
-                  border-radius: 100%;
+                &:hover, &:active, &:focus {
+                  background-color: #ffffff;
+                  border: 2px solid #eaeaea;
+                  padding-bottom: 2px;
+                  padding-left: 2px;
+                  padding-right: 2px;
+                  padding-top: 2px;
                 }
                 &:hover {
                   color: #0078d4;
@@ -2459,13 +1784,9 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                 className=
 
                     {
-                      box-sizing: content-box;
-                      height: 20px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 20px;
+                      border-radius: 100%;
+                      height: 100%;
+                      width: 100%;
                     }
                 fill="yellow"
                 viewBox="0 0 20 20"

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -22,10 +22,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
 
         {
           border-collapse: collapse;
-          margin-bottom: 12px;
-          margin-left: 5px;
-          margin-right: 5px;
-          margin-top: 12px;
+          margin-bottom: 8px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 8px;
           outline: none;
           padding-bottom: 2px;
           padding-left: 2px;
@@ -44,13 +44,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -190,13 +187,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -336,13 +330,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -482,13 +473,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -632,13 +620,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -778,13 +763,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -924,13 +906,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -1070,13 +1049,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -1220,13 +1196,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -1366,13 +1339,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -1512,13 +1482,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >
@@ -1658,13 +1625,10 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           className=
 
               {
-                padding-bottom: 10px;
-                padding-left: 0px;
-                padding-right: 10px;
-                padding-top: 0px;
-              }
-              &:last-child {
-                padding-right: 0px;
+                padding-bottom: 5px;
+                padding-left: 5px;
+                padding-right: 5px;
+                padding-top: 5px;
               }
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/examples/SwatchColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/examples/SwatchColorPicker.Basic.Example.tsx
@@ -46,7 +46,7 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
             { id: 'e', label: 'white', color: '#ffffff' }
           ]}
         />
-        <div>Simple swatch color picker with multiple rows that updates it's icon color and shows a preview color:</div>
+        <div>Simple swatch color picker with multiple rows and larger cells that updates its icon color and shows a preview color:</div>
         <div
           style={{
             color: this.state.previewColor ? this.state.previewColor : this.state.color ? this.state.color : undefined,
@@ -63,6 +63,9 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
           // tslint:enable:jsx-no-lambda
           columnCount={4}
           cellShape={'circle'}
+          cellHeight={35}
+          cellWidth={35}
+          cellBorderWidth={3}
           colorCells={[
             { id: 'a', label: 'green', color: '#00ff00' },
             { id: 'b', label: 'orange', color: '#ffa500' },
@@ -91,48 +94,6 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
             { id: 'e', label: 'white', color: '#ffffff' }
           ]}
         />
-        <div id="foo" tab-index="-1">
-          <div>
-            Simple swatch color picker with multiple rows that updates it's icon color and shows a preview color:
-          </div>
-          <div
-            style={{
-              color: this.state.previewColor2
-                ? this.state.previewColor2
-                : this.state.color2
-                  ? this.state.color2
-                  : undefined,
-              fontSize: '24px'
-            }}
-          >
-            Sample Text
-          </div>
-          <SwatchColorPicker
-            focusOnHover={true}
-            mouseLeaveParentSelector={'#foo'}
-            // tslint:disable:jsx-no-lambda
-            onCellHovered={(id, color) => this.setState({ previewColor2: color! })}
-            onCellFocused={(id, color) => this.setState({ previewColor2: color! })}
-            onColorChanged={(id, newColor) => this.setState({ color2: newColor })}
-            // tslint:enable:jsx-no-lambda
-            columnCount={4}
-            cellShape={'circle'}
-            colorCells={[
-              { id: 'a', label: 'green', color: '#00ff00' },
-              { id: 'b', label: 'orange', color: '#ffa500' },
-              { id: 'c', label: 'blue', color: '#0000ff' },
-              { id: 'd', label: 'red', color: '#ff0000' },
-              { id: 'g', label: 'green', color: 'green' },
-              { id: 'h', label: 'orange', color: 'orange' },
-              { id: 'i', label: 'blue', color: 'blue' },
-              { id: 'j', label: 'red', color: 'red' },
-              { id: 'k', label: 'black', color: 'black' },
-              { id: 'l', label: 'grey', color: 'grey' },
-              { id: 'm', label: 'purple', color: 'purple' },
-              { id: 'n', label: 'yellow', color: 'yellow' }
-            ]}
-          />
-        </div>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -26,10 +26,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
 
           {
             border-collapse: collapse;
-            margin-bottom: 12px;
-            margin-left: 5px;
-            margin-right: 5px;
-            margin-top: 12px;
+            margin-bottom: 8px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 8px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -48,13 +48,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -194,13 +191,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -340,13 +334,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -486,13 +477,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -632,13 +620,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -802,10 +787,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
 
           {
             border-collapse: collapse;
-            margin-bottom: 12px;
-            margin-left: 5px;
-            margin-right: 5px;
-            margin-top: 12px;
+            margin-bottom: 8px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 8px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -824,13 +809,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -968,13 +950,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -1112,13 +1091,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -1256,13 +1232,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -1400,13 +1373,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -1578,10 +1548,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
 
           {
             border-collapse: collapse;
-            margin-bottom: 12px;
-            margin-left: 5px;
-            margin-right: 5px;
-            margin-top: 12px;
+            margin-bottom: 8px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 8px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -1600,13 +1570,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -1746,13 +1713,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -1892,13 +1856,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2038,13 +1999,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2188,13 +2146,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2334,13 +2289,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2480,13 +2432,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2626,13 +2575,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2776,13 +2722,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -2922,13 +2865,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -3068,13 +3008,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -3214,13 +3151,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -3384,10 +3318,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
 
           {
             border-collapse: collapse;
-            margin-bottom: 12px;
-            margin-left: 5px;
-            margin-right: 5px;
-            margin-top: 12px;
+            margin-bottom: 8px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 8px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -3406,13 +3340,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -3558,13 +3489,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -3710,13 +3638,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -3862,13 +3787,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >
@@ -4014,13 +3936,10 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 10px;
-                  padding-left: 0px;
-                  padding-right: 10px;
-                  padding-top: 0px;
-                }
-                &:last-child {
-                  padding-right: 0px;
+                  padding-bottom: 5px;
+                  padding-left: 5px;
+                  padding-right: 5px;
+                  padding-top: 5px;
                 }
             role="presentation"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -25,6 +25,11 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
       className=
 
           {
+            border-collapse: collapse;
+            margin-bottom: 12px;
+            margin-left: 5px;
+            margin-right: 5px;
+            margin-top: 12px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -43,10 +48,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -60,10 +68,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -71,9 +78,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -83,6 +89,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -111,74 +118,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -222,13 +174,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
@@ -246,10 +194,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -263,10 +214,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -274,9 +224,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -286,6 +235,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -314,74 +264,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -425,13 +320,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
@@ -449,10 +340,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -466,10 +360,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -477,9 +370,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -489,6 +381,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -517,74 +410,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -628,13 +466,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
@@ -652,10 +486,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -669,10 +506,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -680,9 +516,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -692,6 +527,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -720,74 +556,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -831,13 +612,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
@@ -855,10 +632,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -872,10 +652,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #eaeaea;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -883,18 +662,18 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
+                    padding-bottom: 1px;
+                    padding-left: 1px;
+                    padding-right: 1px;
+                    padding-top: 1px;
                     position: relative;
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -923,79 +702,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-color: transparent;
-                    border-radius: 100%;
-                    border: 4px solid;
-                    box-shadow: inset 0 0 0 1px #a6a6a6;
-                    height: 12px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -1039,13 +758,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffffff"
                   viewBox="0 0 20 20"
@@ -1086,6 +801,11 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
       className=
 
           {
+            border-collapse: collapse;
+            margin-bottom: 12px;
+            margin-left: 5px;
+            margin-right: 5px;
+            margin-top: 12px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -1104,10 +824,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -1121,10 +844,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
+                    background-color: #ffffff;
                     border-radius: 0px;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1132,9 +854,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -1144,6 +865,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1172,71 +894,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -1280,13 +950,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
@@ -1303,10 +968,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -1320,10 +988,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
+                    background-color: #ffffff;
                     border-radius: 0px;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1331,9 +998,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -1343,6 +1009,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1371,71 +1038,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -1479,13 +1094,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
@@ -1502,10 +1112,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -1519,10 +1132,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
+                    background-color: #ffffff;
                     border-radius: 0px;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1530,9 +1142,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -1542,6 +1153,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1570,71 +1182,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -1678,13 +1238,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
@@ -1701,10 +1256,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -1718,10 +1276,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
+                    background-color: #ffffff;
                     border-radius: 0px;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1729,9 +1286,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -1741,6 +1297,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1769,71 +1326,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -1877,13 +1382,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
@@ -1900,10 +1400,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -1917,10 +1420,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
+                    background-color: #eaeaea;
                     border-radius: 0px;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1928,18 +1430,18 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     outline: transparent;
-                    overflow: visible;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
+                    padding-bottom: 1px;
+                    padding-left: 1px;
+                    padding-right: 1px;
+                    padding-top: 1px;
                     position: relative;
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1968,78 +1470,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-color: transparent;
-                    border: 4px solid;
-                    box-shadow: inset 0 0 0 1px #a6a6a6;
-                    height: 12px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -2083,13 +1526,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffffff"
                   viewBox="0 0 20 20"
@@ -2107,7 +1545,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
     </table>
   </div>
   <div>
-    Simple swatch color picker with multiple rows that updates it's icon color and shows a preview color:
+    Simple swatch color picker with multiple rows and larger cells that updates its icon color and shows a preview color:
   </div>
   <div
     style={
@@ -2139,6 +1577,11 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
       className=
 
           {
+            border-collapse: collapse;
+            margin-bottom: 12px;
+            margin-left: 5px;
+            margin-right: 5px;
+            margin-top: 12px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -2157,10 +1600,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -2174,10 +1620,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2185,9 +1630,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -2197,6 +1641,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2225,74 +1670,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -2336,13 +1726,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
@@ -2360,10 +1746,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -2377,10 +1766,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2388,9 +1776,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -2400,6 +1787,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2428,74 +1816,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -2539,13 +1872,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
@@ -2563,10 +1892,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -2580,10 +1912,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2591,9 +1922,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -2603,6 +1933,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2631,74 +1962,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -2742,13 +2018,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
@@ -2766,10 +2038,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -2783,10 +2058,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2794,9 +2068,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -2806,6 +2079,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2834,74 +2108,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -2945,13 +2164,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
@@ -2973,10 +2188,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -2990,10 +2208,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3001,9 +2218,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3013,6 +2229,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3041,74 +2258,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -3152,13 +2314,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="green"
                   viewBox="0 0 20 20"
@@ -3176,10 +2334,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -3193,10 +2354,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3204,9 +2364,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3216,6 +2375,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3244,74 +2404,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -3355,13 +2460,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="orange"
                   viewBox="0 0 20 20"
@@ -3379,10 +2480,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -3396,10 +2500,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3407,9 +2510,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3419,6 +2521,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3447,74 +2550,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -3558,13 +2606,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="blue"
                   viewBox="0 0 20 20"
@@ -3582,10 +2626,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -3599,10 +2646,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3610,9 +2656,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3622,6 +2667,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3650,74 +2696,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -3761,13 +2752,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="red"
                   viewBox="0 0 20 20"
@@ -3789,10 +2776,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -3806,10 +2796,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3817,9 +2806,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3829,6 +2817,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3857,74 +2846,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -3968,13 +2902,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="black"
                   viewBox="0 0 20 20"
@@ -3992,10 +2922,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -4009,10 +2942,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -4020,9 +2952,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4032,6 +2963,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -4060,74 +2992,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -4171,13 +3048,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="grey"
                   viewBox="0 0 20 20"
@@ -4195,10 +3068,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -4212,10 +3088,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -4223,9 +3098,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4235,6 +3109,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -4263,74 +3138,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -4374,13 +3194,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="purple"
                   viewBox="0 0 20 20"
@@ -4398,10 +3214,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -4415,10 +3234,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    background-color: #ffffff;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -4426,9 +3244,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 35px;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4438,6 +3255,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 35px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -4466,74 +3284,19 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 3px solid #eaeaea;
+                    padding-bottom: 3px;
+                    padding-left: 3px;
+                    padding-right: 3px;
+                    padding-top: 3px;
                   }
                   &:hover {
                     color: #0078d4;
@@ -4577,13 +3340,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="yellow"
                   viewBox="0 0 20 20"
@@ -4624,6 +3383,11 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
       className=
 
           {
+            border-collapse: collapse;
+            margin-bottom: 12px;
+            margin-left: 5px;
+            margin-right: 5px;
+            margin-top: 12px;
             outline: none;
             padding-bottom: 2px;
             padding-left: 2px;
@@ -4642,10 +3406,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -4663,9 +3430,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -4673,10 +3439,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     opacity: 0.3;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4687,6 +3452,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -4715,82 +3481,29 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
-                    bordercolor: grayText;
-                    color: grayText;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     outline: 0px;
                   }
                   &:focus {
                     outline: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    bordercolor: grayText;
+                    color: grayText;
                   }
               data-index={0}
               data-is-focusable={false}
@@ -4825,13 +3538,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#00ff00"
                   viewBox="0 0 20 20"
@@ -4849,10 +3558,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -4870,9 +3582,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -4880,10 +3591,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     opacity: 0.3;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4894,6 +3604,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -4922,82 +3633,29 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
-                    bordercolor: grayText;
-                    color: grayText;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     outline: 0px;
                   }
                   &:focus {
                     outline: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    bordercolor: grayText;
+                    color: grayText;
                   }
               data-index={1}
               data-is-focusable={false}
@@ -5032,13 +3690,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffa500"
                   viewBox="0 0 20 20"
@@ -5056,10 +3710,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -5077,9 +3734,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -5087,10 +3743,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     opacity: 0.3;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -5101,6 +3756,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -5129,82 +3785,29 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
-                    bordercolor: grayText;
-                    color: grayText;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     outline: 0px;
                   }
                   &:focus {
                     outline: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    bordercolor: grayText;
+                    color: grayText;
                   }
               data-index={2}
               data-is-focusable={false}
@@ -5239,13 +3842,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#0000ff"
                   viewBox="0 0 20 20"
@@ -5263,10 +3862,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -5284,9 +3886,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -5294,10 +3895,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     opacity: 0.3;
                     outline: transparent;
-                    overflow: visible;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -5308,6 +3908,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -5336,82 +3937,29 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
-                    bordercolor: grayText;
-                    color: grayText;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-radius: 100%;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     outline: 0px;
                   }
                   &:focus {
                     outline: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    bordercolor: grayText;
+                    color: grayText;
                   }
               data-index={3}
               data-is-focusable={false}
@@ -5446,13 +3994,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ff0000"
                   viewBox="0 0 20 20"
@@ -5470,10 +4014,13 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             className=
 
                 {
-                  padding-bottom: 0px;
+                  padding-bottom: 10px;
                   padding-left: 0px;
-                  padding-right: 0px;
+                  padding-right: 10px;
                   padding-top: 0px;
+                }
+                &:last-child {
+                  padding-right: 0px;
                 }
             role="presentation"
           >
@@ -5491,9 +4038,8 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
-                    background: transparent;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
+                    border-radius: 100%;
+                    border: none;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -5501,20 +4047,20 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 40px;
+                    height: 20px;
                     opacity: 0.3;
                     outline: transparent;
-                    overflow: visible;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
+                    padding-bottom: 1px;
+                    padding-left: 1px;
+                    padding-right: 1px;
+                    padding-top: 1px;
                     pointer-events: none;
                     position: relative;
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 20px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -5543,87 +4089,29 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     position: relative;
                     top: 0px;
                   }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border: none;
-                    bordercolor: grayText;
-                    color: grayText;
+                  .ms-Fabric--isFocusVisible &:focus::after {
+                    display: none;
                   }
-                  .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                    border-color: transparent;
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #000000;
                   }
-                  .ms-Fabric--isFocusVisible &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:hover $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: none;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:focus $svg {
-                    border-color: #dadada;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  &:active $svg {
-                    border-color: #969696;
-                    border: 4px solid;
-                    box-shadow: 0 0 0 1px #969696;
-                    height: 12px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 4px;
-                    padding-left: 4px;
-                    padding-right: 4px;
-                    padding-top: 4px;
-                    width: 12px;
-                  }
-                  & $svg {
-                    border-color: transparent;
-                    border-radius: 100%;
-                    border: 4px solid;
-                    box-shadow: inset 0 0 0 1px #a6a6a6;
-                    height: 12px;
-                    width: 12px;
+                  &:hover, &:active, &:focus {
+                    background-color: #ffffff;
+                    border: 2px solid #eaeaea;
+                    padding-bottom: 2px;
+                    padding-left: 2px;
+                    padding-right: 2px;
+                    padding-top: 2px;
                   }
                   &:hover {
                     outline: 0px;
                   }
                   &:focus {
                     outline: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    bordercolor: grayText;
+                    color: grayText;
                   }
               data-index={4}
               data-is-focusable={false}
@@ -5658,13 +4146,9 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   className=
 
                       {
-                        box-sizing: content-box;
-                        height: 20px;
-                        padding-bottom: 4px;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 4px;
-                        width: 20px;
+                        border-radius: 100%;
+                        height: 100%;
+                        width: 100%;
                       }
                   fill="#ffffff"
                   viewBox="0 0 20 20"
@@ -5681,2506 +4165,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
         </tr>
       </tbody>
     </table>
-  </div>
-  <div
-    id="foo"
-    tab-index="-1"
-  >
-    <div>
-      Simple swatch color picker with multiple rows that updates it's icon color and shows a preview color:
-    </div>
-    <div
-      style={
-        Object {
-          "color": undefined,
-          "fontSize": "24px",
-        }
-      }
-    >
-      Sample Text
-    </div>
-    <div
-      className=
-          ms-FocusZone
-          ms-swatchColorPickerBodyContainer
-          {
-            clear: both;
-            display: block;
-            min-width: 180px;
-          }
-      data-focuszone-id="FocusZone95"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-      role="presentation"
-    >
-      <table
-        className=
-
-            {
-              outline: none;
-              padding-bottom: 2px;
-              padding-left: 2px;
-              padding-right: 2px;
-              padding-top: 2px;
-            }
-        id="id__94"
-        onBlur={[Function]}
-        role="grid"
-      >
-        <tbody>
-          <tr
-            role="row"
-          >
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="green"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={0}
-                data-is-focusable={true}
-                id="swatchColorPicker93-a-0"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="green"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="#00ff00"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="orange"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={1}
-                data-is-focusable={true}
-                id="swatchColorPicker93-b-1"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="orange"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="#ffa500"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="blue"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={2}
-                data-is-focusable={true}
-                id="swatchColorPicker93-c-2"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="blue"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="#0000ff"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="red"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={3}
-                data-is-focusable={true}
-                id="swatchColorPicker93-d-3"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="red"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="#ff0000"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="green"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={4}
-                data-is-focusable={true}
-                id="swatchColorPicker93-g-4"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="green"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="green"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="orange"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={5}
-                data-is-focusable={true}
-                id="swatchColorPicker93-h-5"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="orange"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="orange"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="blue"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={6}
-                data-is-focusable={true}
-                id="swatchColorPicker93-i-6"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="blue"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="blue"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="red"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={7}
-                data-is-focusable={true}
-                id="swatchColorPicker93-j-7"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="red"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="red"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-          </tr>
-          <tr
-            role="row"
-          >
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="black"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={8}
-                data-is-focusable={true}
-                id="swatchColorPicker93-k-8"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="black"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="black"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="grey"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={9}
-                data-is-focusable={true}
-                id="swatchColorPicker93-l-9"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="grey"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="grey"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="purple"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={10}
-                data-is-focusable={true}
-                id="swatchColorPicker93-m-10"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="purple"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="purple"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-            <td
-              className=
-
-                  {
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                  }
-              role="presentation"
-            >
-              <button
-                aria-label="yellow"
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      background: transparent;
-                      border-radius: 0px;
-                      border: 1px solid transparent;
-                      box-sizing: border-box;
-                      color: #333333;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 40px;
-                      outline: transparent;
-                      overflow: visible;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      outline: 1px solid #666666;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      border: none;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus::after {
-                      border-color: transparent;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:hover $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: none;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:focus $svg {
-                      border-color: #dadada;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    &:active $svg {
-                      border-color: #969696;
-                      border: 4px solid;
-                      box-shadow: 0 0 0 1px #969696;
-                      height: 12px;
-                      margin-bottom: 0px;
-                      margin-left: 0px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                      padding-bottom: 4px;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 4px;
-                      width: 12px;
-                    }
-                    & $svg {
-                      border-radius: 100%;
-                    }
-                    &:hover {
-                      color: #0078d4;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      color: #000000;
-                    }
-                data-index={11}
-                data-is-focusable={true}
-                id="swatchColorPicker93-n-11"
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseMove={[Function]}
-                onMouseUp={[Function]}
-                role="gridcell"
-                title="yellow"
-                type="button"
-              >
-                <div
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                >
-                  <svg
-                    className=
-
-                        {
-                          box-sizing: content-box;
-                          height: 20px;
-                          padding-bottom: 4px;
-                          padding-left: 4px;
-                          padding-right: 4px;
-                          padding-top: 4px;
-                          width: 20px;
-                        }
-                    fill="yellow"
-                    viewBox="0 0 20 20"
-                  >
-                    <circle
-                      cx="50%"
-                      cy="50%"
-                      r="50%"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Let height, width, borderWidth, and cellMargins be customizable for the SwatchColorPicker.
Also modified interaction states to match latest redlines, and cleaned up lots of styles.

Before:
![image](https://user-images.githubusercontent.com/20691641/46116013-c34eed00-c1ae-11e8-8735-6504b1f274ca.png)
![image](https://user-images.githubusercontent.com/20691641/46116038-e4174280-c1ae-11e8-893f-bc62aefcfaad.png)


After:
![image](https://user-images.githubusercontent.com/20691641/46116023-d2ce3600-c1ae-11e8-8ba7-6cfc7854b5c9.png)
![image](https://user-images.githubusercontent.com/20691641/46116045-eed1d780-c1ae-11e8-97d8-25a097b88494.png)
(this last circles image has a customized larger height/width)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6486)

