### PR TITLE
Stack wrap styles

### DIFF
--- a/common/changes/@uifabric/experiments/stack-wrap-styles_2018-09-27-01-52.json
+++ b/common/changes/@uifabric/experiments/stack-wrap-styles_2018-09-27-01-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "HorizontalStack: remove padding as a fix for collapsing margins, remove unnecessary calc() calls",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/HorizontalStack/HorizontalStack.styles.ts
+++ b/packages/experiments/src/components/Stack/HorizontalStack/HorizontalStack.styles.ts
@@ -16,9 +16,8 @@ export const styles = (props: IThemedProps<IHorizontalStackProps>): IHorizontalS
   const hGap = parseGap(gap, theme);
   const vGap = parseGap(vertGap, theme);
 
-  // account for the extra 1px padding in the root
-  const horizontalMargin = `calc(${-0.5 * hGap.value}${hGap.unit} - 1px)`;
-  const verticalMargin = `calc(${-0.5 * vGap.value}${vGap.unit} - 1px)`;
+  const horizontalMargin = `${-0.5 * hGap.value}${hGap.unit}`;
+  const verticalMargin = `${-0.5 * vGap.value}${vGap.unit}`;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -31,13 +30,14 @@ export const styles = (props: IThemedProps<IHorizontalStackProps>): IHorizontalS
           maxHeight,
           width: fillHorizontal ? '100%' : 'auto',
           height: fillVertical ? '100%' : 'auto',
-          overflow: 'visible',
-          display: 'block',
-
-          // necessary in order to prevent collapsing margins
-          padding: 1
+          overflow: 'visible'
         },
-        className
+        className,
+        {
+          // not allowed to be overridden by className
+          // since this is necessary in order to prevent collapsing margins
+          display: 'inline-block'
+        }
       ],
 
       inner: [
@@ -49,8 +49,12 @@ export const styles = (props: IThemedProps<IHorizontalStackProps>): IHorizontalS
           marginTop: verticalMargin,
           marginBottom: verticalMargin,
           overflow: 'visible',
-          width: fillHorizontal ? `calc(100% + ${hGap.value}${hGap.unit} + 2px)` : 'auto',
-          height: fillVertical ? `calc(100% + ${hGap.value}${hGap.unit} + 2px)` : 'auto'
+          maxWidth: '100vw',
+
+          // avoid unnecessary calc() calls if vertical gap is 0
+          height: fillVertical ?
+            (vGap.value === 0 ? '100%' : `calc(100% + ${vGap.value}${vGap.unit})`)
+            : 'auto'
         }
       ]
     } as IHorizontalStackStyles;

--- a/packages/experiments/src/components/Stack/HorizontalStack/__snapshots__/HorizontalStack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/HorizontalStack/__snapshots__/HorizontalStack.test.tsx.snap
@@ -278,13 +278,9 @@ exports[`HorizontalStack renders wrapped HorizontalStack correctly 1`] = `
   className=
       ms-HorizontalStack
       {
-        display: block;
+        display: inline-block;
         height: auto;
         overflow: visible;
-        padding-bottom: 1px;
-        padding-left: 1px;
-        padding-right: 1px;
-        padding-top: 1px;
         width: auto;
       }
 >
@@ -297,10 +293,11 @@ exports[`HorizontalStack renders wrapped HorizontalStack correctly 1`] = `
           flex-direction: row;
           flex-wrap: wrap;
           height: auto;
-          margin-bottom: calc(0px - 1px);
-          margin-left: calc(0px - 1px);
-          margin-right: calc(0px - 1px);
-          margin-top: calc(0px - 1px);
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          max-width: 100vw;
           overflow: visible;
           width: auto;
         }
@@ -309,7 +306,7 @@ exports[`HorizontalStack renders wrapped HorizontalStack correctly 1`] = `
           margin-left: 0px;
           margin-right: 0px;
           margin-top: 0px;
-          max-width: calc(100% - 0px - 2px);
+          max-width: 100%;
           text-overflow: ellipsis;
           white-space: nowrap;
         }

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -75,8 +75,8 @@ export const styles = (props: IThemedProps<IStackProps>): IStackStyles => {
           '> *': {
             margin: `${0.5 * vGap.value}${vGap.unit} ${0.5 * hGap.value}${hGap.unit}`,
 
-            // extra 2px to account for padding on wrapped Stacks
-            maxWidth: `calc(100% - ${hGap.value}${hGap.unit} - 2px)`,
+            // avoid unnecessary calc() calls if horizontal gap is 0
+            maxWidth: hGap.value === 0 ? '100%' : `calc(100% - ${hGap.value}${hGap.unit})`,
 
             ...childStyles
           },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1. Remove extra 1px padding on HorizontalStacks that previously was used to prevent collapsing margins (now `display: inline-block` is used instead)
2. Remove unnecessary `calc()` calls in cases where horizontal or vertical gap is 0
3. Add `maxWidth: 100vw` to inner elements of wrapped HorizontalStacks to prevent them from overflowing the body horizontally

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6488)

