### PR TITLE
Layer: Fix FocusTrapZone detection of Layered children

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-6484-layer-fix_2018-09-27-02-05.json
+++ b/common/changes/office-ui-fabric-react/jg-6484-layer-fix_2018-09-27-02-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Layer: Do not render content until virtual parent is set.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
@@ -14,10 +14,14 @@ import {
 } from '../../Utilities';
 import { registerLayer, getDefaultTarget, unregisterLayer } from './Layer.notification';
 
+export type ILayerBaseState = {
+  hasMounted: boolean;
+};
+
 const getClassNames = classNamesFunction<ILayerStyleProps, ILayerStyles>();
 
 @customizable('Layer', ['theme', 'hostId'])
-export class LayerBase extends BaseComponent<ILayerProps, {}> {
+export class LayerBase extends BaseComponent<ILayerProps, ILayerBaseState> {
   public static defaultProps: ILayerProps = {
     onLayerDidMount: () => undefined,
     onLayerWillUnmount: () => undefined
@@ -29,6 +33,10 @@ export class LayerBase extends BaseComponent<ILayerProps, {}> {
 
   constructor(props: ILayerProps) {
     super(props);
+
+    this.state = {
+      hasMounted: false
+    };
 
     this._warnDeprecations({
       onLayerMounted: 'onLayerDidMount'
@@ -50,6 +58,10 @@ export class LayerBase extends BaseComponent<ILayerProps, {}> {
   }
 
   public componentDidMount(): void {
+    // We can safely set state immediately because the ref wrapper will make sure the virtual
+    //    parent has been set before componentDidMount is called.
+    this.setState({ hasMounted: true });
+
     this._setVirtualParent();
 
     const { onLayerDidMount, onLayerMounted } = this.props;
@@ -82,10 +94,12 @@ export class LayerBase extends BaseComponent<ILayerProps, {}> {
   public render(): React.ReactNode {
     const classNames = this._getClassNames();
     const { eventBubblingEnabled } = this.props;
+    const { hasMounted } = this.state;
 
     return (
-      <span className="ms-layer" ref={this._rootElement}>
+      <span className="ms-layer" ref={this._handleRootElementRef}>
         {this._layerElement &&
+          hasMounted &&
           ReactDOM.createPortal(
             eventBubblingEnabled ? (
               <Fabric className={classNames.content}>{this.props.children}</Fabric>
@@ -128,6 +142,20 @@ export class LayerBase extends BaseComponent<ILayerProps, {}> {
       </span>
     );
   }
+
+  /**
+   * rootElement wrapper for setting virtual parent as soon as root element ref is available.
+   */
+  private _handleRootElementRef = (ref: HTMLDivElement): void => {
+    this._rootElement(ref);
+    if (ref) {
+      // TODO: Calling _setVirtualParent in this ref wrapper SHOULD allow us to remove
+      //    other calls to _setVirtualParent throughout this class. However,
+      //    as this is an immediate fix for a P0 issue the existing _setVirtualParent
+      //    calls are left for now to minimize potential regression.
+      this._setVirtualParent();
+    }
+  };
 
   /**
    * Helper to stop events from bubbling up out of Layer.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -2483,7 +2483,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                         margin-top: 0;
                         white-space: nowrap;
                       }
-                  id="id__13"
+                  id="id__10"
                 >
                   Download
                 </div>
@@ -2789,7 +2789,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                         margin-top: 0;
                         white-space: nowrap;
                       }
-                  id="id__19"
+                  id="id__16"
                 >
                   Sort
                 </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6484
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Layer (before Portals) did not render content until after the virtual parent was set (after the first render pass in `componentDidUpdate`.) When Portals was introduced in #6211, the Layer content is rendered immediately in the first render pass, before virtual parent can be properly set. This is the root cause for #6484.

This PR prevents Layer content from rendering (and thus triggering focus events) until the virtual parent can be properly set.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6489)

