### PR TITLE
version files now expose a call that can be called by apps that don't do index import

### DIFF
--- a/common/changes/@uifabric/set-version/version_2018-09-27-16-50.json
+++ b/common/changes/@uifabric/set-version/version_2018-09-27-16-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/set-version",
+      "comment": "version files now expose a call that can be called by apps that don't do index import",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/set-version",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/version_2018-09-28-04-29.json
+++ b/common/changes/office-ui-fabric-react/version_2018-09-28-04-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "now all the top level components will include version info for package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/ChoiceGroupOption.ts
+++ b/packages/office-ui-fabric-react/src/ChoiceGroupOption.ts
@@ -1,0 +1,1 @@
+export * from './components/ChoiceGroup/ChoiceGroupOption/index';

--- a/packages/office-ui-fabric-react/src/Layer.ts
+++ b/packages/office-ui-fabric-react/src/Layer.ts
@@ -1,1 +1,2 @@
+import './version';
 export * from './components/Layer/index';

--- a/packages/office-ui-fabric-react/src/PersonaPresence.ts
+++ b/packages/office-ui-fabric-react/src/PersonaPresence.ts
@@ -1,0 +1,1 @@
+export * from './components/Persona/PersonaPresence/index';

--- a/packages/office-ui-fabric-react/src/PositioningContainer.ts
+++ b/packages/office-ui-fabric-react/src/PositioningContainer.ts
@@ -1,0 +1,1 @@
+export * from './components/Coachmark/PositioningContainer/index';

--- a/packages/office-ui-fabric-react/src/Styling.ts
+++ b/packages/office-ui-fabric-react/src/Styling.ts
@@ -1,1 +1,2 @@
+import './version';
 export * from '@uifabric/styling';

--- a/packages/office-ui-fabric-react/src/Utilities.ts
+++ b/packages/office-ui-fabric-react/src/Utilities.ts
@@ -1,1 +1,2 @@
+import './version';
 export * from '@uifabric/utilities';

--- a/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
@@ -220,9 +220,15 @@ describe('Component File Conformance', () => {
 });
 
 describe('Top Level Component File Conformance', () => {
-  const components: string[] = glob.sync(path.resolve(process.cwd(), 'src/components/*/index.ts*')).map(file => {
-    return path.basename(path.dirname(file));
-  });
+  const privateComponents = new Set(['ContextualMenuItemWrapper']);
+
+  const components: string[] = glob
+    .sync(path.resolve(process.cwd(), 'src/components/**/index.ts*'))
+    .map(file => {
+      const componentName = path.basename(path.dirname(file));
+      return componentName[0] === componentName[0].toUpperCase() ? path.basename(path.dirname(file)) : '';
+    })
+    .filter(f => f && !privateComponents.has(f));
 
   const topLevelComponentFiles = components
     .map(f => {
@@ -243,7 +249,7 @@ describe('Top Level Component File Conformance', () => {
   // Top Level Compoennt File Compliance -
   // make sure that there is a corresponding top level component file for each component in the directory
   components.forEach(componentName => {
-    it(`${componentName} as a corresponding top level component file`, () => {
+    it(`${componentName} has a corresponding top level component file`, () => {
       expect(
         fs.existsSync(path.resolve(__dirname, `../${componentName}.ts`)) ||
           fs.existsSync(path.resolve(__dirname, `../${componentName}.tsx`))

--- a/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import * as glob from 'glob';
 import * as path from 'path';
+import * as fs from 'fs';
 
 /**
  * These tests verify that Fabric components fulfill the following conditions:
@@ -142,7 +143,7 @@ const mockNodeComponents = ['ScrollablePane'];
  * In any case, adding your component to the exclusion list is discouraged as this will make regression
  *    harder to catch.
  */
-describe('Conformance', () => {
+describe('Component File Conformance', () => {
   beforeAll(() => {
     // Mock Layer since otherwise components that use Layer will have empty JSON representations
     jest.mock('./Layer', () => {
@@ -207,13 +208,57 @@ describe('Conformance', () => {
       } catch (e) {
         console.warn(
           'ERROR: ' +
-          e +
-          ', TEST NOTE: Failure with ' +
-          componentName +
-          '. ' +
-          'Have you recently added a component? If so, please see notes in Conformance.test.tsx.'
+            e +
+            ', TEST NOTE: Failure with ' +
+            componentName +
+            '. ' +
+            'Have you recently added a component? If so, please see notes in Conformance.test.tsx.'
         );
       }
+    });
+  });
+});
+
+describe('Top Level Component File Conformance', () => {
+  const components: string[] = glob.sync(path.resolve(process.cwd(), 'src/components/*/index.ts*')).map(file => {
+    return path.basename(path.dirname(file));
+  });
+
+  const topLevelComponentFiles = components
+    .map(f => {
+      for (const fileName of [`${f}.ts`, `${f}.tsx`]) {
+        const fullPath = path.resolve(__dirname, '..', fileName);
+        if (fs.existsSync(fullPath)) {
+          return fullPath;
+        }
+      }
+      return '';
+    })
+    .filter(f => f);
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  // Top Level Compoennt File Compliance -
+  // make sure that there is a corresponding top level component file for each component in the directory
+  components.forEach(componentName => {
+    it(`${componentName} as a corresponding top level component file`, () => {
+      expect(
+        fs.existsSync(path.resolve(__dirname, `../${componentName}.ts`)) ||
+          fs.existsSync(path.resolve(__dirname, `../${componentName}.tsx`))
+      ).toBeTruthy();
+    });
+  });
+
+  // make sure that there is a version import in each corresponding top level component file
+  topLevelComponentFiles.forEach(file => {
+    const componentName = path.basename(file).split('.')[0];
+
+    it(componentName + ' imports the OUFR version file', () => {
+      (window as any).__packages__ = null;
+      require(file);
+      expect((window as any).__packages__['office-ui-fabric-react']).not.toBeUndefined();
     });
   });
 });

--- a/packages/set-version/jest.config.js
+++ b/packages/set-version/jest.config.js
@@ -1,0 +1,9 @@
+let { createConfig } = require('../../scripts/tasks/jest-resources');
+
+const config = createConfig({
+  setupFiles: [],
+  moduleNameMapper: {},
+  snapshotSerializers: []
+});
+
+module.exports = config;

--- a/packages/set-version/src/serVersion.test.ts
+++ b/packages/set-version/src/serVersion.test.ts
@@ -1,0 +1,13 @@
+import { setVersion } from './setVersion';
+
+describe('setVersion', () => {
+  it('should only insert packageversion once for a bundle', () => {
+    setVersion('a', '1');
+    setVersion('a', '1');
+    setVersion('a', '1');
+    setVersion('a', '1');
+
+    // tslint:disable-next-line:no-any
+    expect((window as any).__packages__.a.length).toBe(1);
+  });
+});

--- a/packages/set-version/src/setVersion.ts
+++ b/packages/set-version/src/setVersion.ts
@@ -2,12 +2,15 @@
 // this cache is local to the module closure inside this bundle
 const packagesCache: { [name: string]: string } = {};
 export function setVersion(packageName: string, packageVersion: string): void {
-  if (typeof window !== 'undefined' && !packagesCache[packageName]) {
-    packagesCache[packageName] = packageVersion;
-
+  if (typeof window !== 'undefined') {
     // tslint:disable-next-line:no-any
     const packages = ((window as any).__packages__ = (window as any).__packages__ || {});
-    const versions = (packages[packageName] = packages[packageName] || []);
-    versions.push(packageVersion);
+
+    // We allow either the global packages or local packages caches to invalidate so testing can just clear the global to set this state
+    if (!packages[packageName] || !packagesCache[packageName]) {
+      packagesCache[packageName] = packageVersion;
+      const versions = (packages[packageName] = packages[packageName] || []);
+      versions.push(packageVersion);
+    }
   }
 }

--- a/packages/set-version/src/setVersion.ts
+++ b/packages/set-version/src/setVersion.ts
@@ -1,5 +1,10 @@
+// A packages cache that makes sure that we don't inject the same packageName twice in the same bundle -
+// this cache is local to the module closure inside this bundle
+const packagesCache: { [name: string]: string } = {};
 export function setVersion(packageName: string, packageVersion: string): void {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && !packagesCache[packageName]) {
+    packagesCache[packageName] = packageVersion;
+
     // tslint:disable-next-line:no-any
     const packages = ((window as any).__packages__ = (window as any).__packages__ || {});
     const versions = (packages[packageName] = packages[packageName] || []);

--- a/scripts/generate-version-files.js
+++ b/scripts/generate-version-files.js
@@ -62,8 +62,7 @@ packageJsons.forEach(packageJsonPath => {
       `// ${packageJson.name}@${packageJson.version}
 // Do not modify this file, the file is generated as part of publish. The checked in version is a placeholder only.
 import { setVersion } from '@uifabric/set-version';
-export const version = () => setVersion('${packageJson.name}', '${packageJson.version}');
-version();`
+setVersion('${packageJson.name}', '${packageJson.version}');`
     );
   }
 });

--- a/scripts/generate-version-files.js
+++ b/scripts/generate-version-files.js
@@ -62,7 +62,8 @@ packageJsons.forEach(packageJsonPath => {
       `// ${packageJson.name}@${packageJson.version}
 // Do not modify this file, the file is generated as part of publish. The checked in version is a placeholder only.
 import { setVersion } from '@uifabric/set-version';
-setVersion('${packageJson.name}', '${packageJson.version}');`
+export const version = () => setVersion('${packageJson.name}', '${packageJson.version}');
+version();`
     );
   }
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

This change adds a function that can be called manually by the consumers who are not using the 'office-ui-fabric-react' at the root. Those consumers will call this function manually somewhere to record the version of fabric that is bundled for them.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6492)

