### PR TITLE
fix transient dependency on react-resizable

### DIFF
--- a/common/changes/@uifabric/dashboard/dashboard-dependency_2018-09-27-19-24.json
+++ b/common/changes/@uifabric/dashboard/dashboard-dependency_2018-09-27-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Fix transient dependency on react-resizable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "xbtsw.chen@gmail.com"
+}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,6 +11,7 @@
     "css-loader": "^0.15.1",
     "office-ui-fabric-react": ">=6.74.1 <7.0.0",
     "react-grid-layout": "samiyaakhtar/react-grid-layout",
+    "react-resizable": "^1.7.5",
     "style-loader": "^0.21.0",
     "tslib": "^1.7.1"
   },


### PR DESCRIPTION
#### Description of changes

Fix transient dependency on react-resizable

#### Focus areas to test

Build should not fail

In the future we should move this CSS into JS-style like rest of fabric.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6494)

