### PR TITLE
Merge-styles: undefined props should not affect registered style rules

### DIFF
--- a/common/changes/@uifabric/merge-styles/merge-styles-undefined_2018-09-27-22-27.json
+++ b/common/changes/@uifabric/merge-styles/merge-styles-undefined_2018-09-27-22-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Ignoring registering rules which are undefined.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -1,8 +1,7 @@
 import { IStyle } from './IStyle';
 import { IStyleFunctionOrObject, IStyleFunction } from './IStyleFunction';
 
-export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T];
+export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
@@ -24,9 +23,7 @@ export type __MapToFunctionType<T> = /*[T] extends [IStyleSet<any>] ? (...args: 
  * It may optionally contain style functions for sub components in the special `subComponentStyles`
  * property.
  */
-export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
-  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle
-} & {
+export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = { [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle } & {
   subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, IStyleSet<any>> };
 };
 
@@ -43,10 +40,6 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
  * A processed style set is one which the set of styles associated with each area has been converted
  * into a class name. Additionally, all subComponentStyles are style functions.
  */
-export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
-  [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string
-} & {
-  subComponentStyles: {
-    [P in keyof TStyleSet['subComponentStyles']]: __MapToFunctionType<TStyleSet['subComponentStyles'][P]>
-  };
+export type IProcessedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = { [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: string } & {
+  subComponentStyles: { [P in keyof TStyleSet['subComponentStyles']]: __MapToFunctionType<TStyleSet['subComponentStyles'][P]> };
 };

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -83,9 +83,7 @@ describe('mergeStyleSets', () => {
     expect(result.a).toBe('a-1');
     expect(result.b).toBe('b-2');
 
-    expect(_stylesheet.getRules()).toEqual(
-      '.root-0{background:red;}' + '.a-1{background:white;}' + '.b-2{background:blue;}'
-    );
+    expect(_stylesheet.getRules()).toEqual('.root-0{background:red;}' + '.a-1{background:white;}' + '.b-2{background:blue;}');
   });
 
   it('can merge correctly when all inputs are falsey', () => {
@@ -236,9 +234,9 @@ describe('mergeStyleSets', () => {
       return;
     };
 
-    const SubComponent: (
-      props: { styles: IStyleFunctionOrObject<ISubComponentStyleProps, ISubComponentStyles> }
-    ) => any = (props: { styles: IStyleFunctionOrObject<ISubComponentStyleProps, ISubComponentStyles> }) => {
+    const SubComponent: (props: { styles: IStyleFunctionOrObject<ISubComponentStyleProps, ISubComponentStyles> }) => any = (props: {
+      styles: IStyleFunctionOrObject<ISubComponentStyleProps, ISubComponentStyles>;
+    }) => {
       return;
     };
 

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -201,4 +201,13 @@ describe('styleToClassName', () => {
 
     expect(_stylesheet.getRules()).toEqual('@supports(display: grid){' + '.css-0{display:grid;}' + '}');
   });
+
+  it('ignores undefined property values', () => {
+    styleToClassName({
+      background: 'red',
+      color: undefined
+    });
+
+    expect(_stylesheet.getRules()).toEqual('.css-0{background:red;}');
+  });
 });

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -68,13 +68,15 @@ function extractRules(args: IStyle[], rules: IRuleSet = { __order: [] }, current
             }
           }
         } else {
-          // Else, add the rule to the currentSelector.
-          if (prop === 'margin' || prop === 'padding') {
-            // tslint:disable-next-line:no-any
-            expandQuads(currentRules, prop, (arg as any)[prop]);
-          } else {
-            // tslint:disable-next-line:no-any
-            (currentRules as any)[prop] = (arg as any)[prop] as any;
+          if ((arg as any)[prop] !== undefined) {
+            // Else, add the rule to the currentSelector.
+            if (prop === 'margin' || prop === 'padding') {
+              // tslint:disable-next-line:no-any
+              expandQuads(currentRules, prop, (arg as any)[prop]);
+            } else {
+              // tslint:disable-next-line:no-any
+              (currentRules as any)[prop] = (arg as any)[prop] as any;
+            }
           }
         }
       }


### PR DESCRIPTION
This change addresses scenarios where you register rules with undefined properties. It should totally ignore them, especially when merging rules together.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6497)

