### PR TITLE
DetailsList: replace neutralSecondaryAlt color as it was deprecated

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-colorDeprecation_2018-09-27-23-30.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-colorDeprecation_2018-09-27-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: replace the use of neutralSecondaryAlt color which was deprecated.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -1,12 +1,5 @@
 import { IDetailsRowStyleProps, IDetailsRowStyles, ICellStyleProps } from './DetailsRow.types';
-import {
-  AnimationClassNames,
-  FontSizes,
-  HighContrastSelector,
-  IStyle,
-  getFocusStyle,
-  getGlobalClassNames
-} from '../../Styling';
+import { AnimationClassNames, FontSizes, HighContrastSelector, IStyle, getFocusStyle, getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-DetailsRow',
@@ -65,7 +58,6 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
 
   const {
     neutralPrimary,
-    neutralSecondaryAlt,
     white,
     neutralSecondary,
     neutralLighter,
@@ -81,12 +73,11 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
   const colors = {
     // Default
     defaultHeaderTextColor: neutralPrimary,
-    defaultMetaTextColor: neutralSecondaryAlt,
+    defaultMetaTextColor: neutralSecondary,
     defaultBackgroundColor: white,
 
     // Hover
     hoverTextColor: neutralPrimary,
-    hoverMetaTextColor: neutralSecondary,
     hoverColorBackground: neutralLighter,
 
     // Selected
@@ -223,12 +214,8 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       // Masking the running shimmer background with borders when it's an Icon placeholder
       [`&$shimmerIconPlaceholder`]: {
         borderRight: `${cellStyleProps.cellRightPadding}px solid ${colors.defaultBackgroundColor}`,
-        borderBottom: `${(values.compactRowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${
-          colors.defaultBackgroundColor
-        }`,
-        borderTop: `${(values.compactRowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${
-          colors.defaultBackgroundColor
-        }`
+        borderBottom: `${(values.compactRowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${colors.defaultBackgroundColor}`,
+        borderTop: `${(values.compactRowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${colors.defaultBackgroundColor}`
       }
     }
   };
@@ -265,12 +252,8 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
 
         '&$shimmerIconPlaceholder': {
           borderRight: `${cellStyleProps.cellRightPadding}px solid ${colors.defaultBackgroundColor}`,
-          borderBottom: `${(values.rowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${
-            colors.defaultBackgroundColor
-          }`,
-          borderTop: `${(values.rowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${
-            colors.defaultBackgroundColor
-          }`
+          borderBottom: `${(values.rowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${colors.defaultBackgroundColor}`,
+          borderTop: `${(values.rowHeight - values.rowShimmerIconPlaceholderHeight) / 2}px solid ${colors.defaultBackgroundColor}`
         }
       }
     },
@@ -327,8 +310,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
           },
 
           '&:hover': {
-            background: colors.hoverColorBackground,
-            color: colors.hoverMetaTextColor
+            background: colors.hoverColorBackground
           },
 
           '&:hover $check': {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -5023,7 +5023,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         background: #ffffff;
                                         border-bottom: 1px solid #f4f4f4;
                                         box-sizing: border-box;
-                                        color: #767676;
+                                        color: #666666;
                                         cursor: default;
                                         display: inline-flex;
                                         min-height: 42px;
@@ -5058,7 +5058,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       }
                                       &:hover {
                                         background: #f4f4f4;
-                                        color: #666666;
                                       }
                                       &:hover $check {
                                         opacity: 1;
@@ -5212,7 +5211,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         background: #ffffff;
                                         border-bottom: 1px solid #f4f4f4;
                                         box-sizing: border-box;
-                                        color: #767676;
+                                        color: #666666;
                                         cursor: default;
                                         display: inline-flex;
                                         min-height: 42px;
@@ -5247,7 +5246,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       }
                                       &:hover {
                                         background: #f4f4f4;
-                                        color: #666666;
                                       }
                                       &:hover $check {
                                         opacity: 1;
@@ -5621,7 +5619,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         background: #ffffff;
                                         border-bottom: 1px solid #f4f4f4;
                                         box-sizing: border-box;
-                                        color: #767676;
+                                        color: #666666;
                                         cursor: default;
                                         display: inline-flex;
                                         min-height: 42px;
@@ -5656,7 +5654,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       }
                                       &:hover {
                                         background: #f4f4f4;
-                                        color: #666666;
                                       }
                                       &:hover $check {
                                         opacity: 1;
@@ -5810,7 +5807,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         background: #ffffff;
                                         border-bottom: 1px solid #f4f4f4;
                                         box-sizing: border-box;
-                                        color: #767676;
+                                        color: #666666;
                                         cursor: default;
                                         display: inline-flex;
                                         min-height: 42px;
@@ -5845,7 +5842,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       }
                                       &:hover {
                                         background: #f4f4f4;
-                                        color: #666666;
                                       }
                                       &:hover $check {
                                         opacity: 1;
@@ -5999,7 +5995,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         background: #ffffff;
                                         border-bottom: 1px solid #f4f4f4;
                                         box-sizing: border-box;
-                                        color: #767676;
+                                        color: #666666;
                                         cursor: default;
                                         display: inline-flex;
                                         min-height: 42px;
@@ -6034,7 +6030,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                       }
                                       &:hover {
                                         background: #f4f4f4;
-                                        color: #666666;
                                       }
                                       &:hover $check {
                                         opacity: 1;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1601,7 +1601,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         background: #ffffff;
         border-bottom: 1px solid #f4f4f4;
         box-sizing: border-box;
-        color: #767676;
+        color: #666666;
         display: inline-flex;
         min-height: 42px;
         min-width: 100%;
@@ -1634,7 +1634,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       }
       &:hover {
         background: #f4f4f4;
-        color: #666666;
       }
       &:hover $check {
         opacity: 1;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -23,7 +23,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -56,7 +56,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -689,7 +688,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -722,7 +721,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -1355,7 +1353,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -1388,7 +1386,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -2021,7 +2018,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -2054,7 +2051,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -2687,7 +2683,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -2720,7 +2716,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -3353,7 +3348,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -3386,7 +3381,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -4019,7 +4013,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -4052,7 +4046,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -4685,7 +4678,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -4718,7 +4711,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -5351,7 +5343,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -5384,7 +5376,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;
@@ -6017,7 +6008,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           background: #ffffff;
           border-bottom: 1px solid #f4f4f4;
           box-sizing: border-box;
-          color: #767676;
+          color: #666666;
           display: inline-flex;
           min-height: 42px;
           min-width: 100%;
@@ -6050,7 +6041,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
         }
         &:hover {
           background: #f4f4f4;
-          color: #666666;
         }
         &:hover $check {
           opacity: 1;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5194
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Fixing this only for DetailsList and create a separate issue for a one time removal later.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6499)

