### PR TITLE
Line chart timeout issue

### DIFF
--- a/common/changes/@uifabric/charting/lineChartIssues_2018-09-28-22-29.json
+++ b/common/changes/@uifabric/charting/lineChartIssues_2018-09-28-22-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Adding timeout so that line chart can scale according to the container size and occupy the entire width thereby",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -122,16 +122,18 @@ export class LineChartBase extends React.Component<
   }
 
   private _fitParentContainer(): void {
-    const { containerWidth, containerHeight } = this.state;
-    const currentContainerWidth = this.chartContainer.getBoundingClientRect().width;
-    const currentContainerHeight = this.chartContainer.getBoundingClientRect().height;
-    const shouldResize = containerWidth !== currentContainerWidth || containerHeight !== currentContainerHeight;
-    if (shouldResize) {
-      this.setState({
-        containerWidth: currentContainerWidth,
-        containerHeight: currentContainerHeight - 26
-      });
-    }
+    setTimeout(() => {
+      const { containerWidth, containerHeight } = this.state;
+      const currentContainerWidth = this.chartContainer.getBoundingClientRect().width;
+      const currentContainerHeight = this.chartContainer.getBoundingClientRect().height;
+      const shouldResize = containerWidth !== currentContainerWidth || containerHeight !== currentContainerHeight;
+      if (shouldResize) {
+        this.setState({
+          containerWidth: currentContainerWidth,
+          containerHeight: currentContainerHeight - 26
+        });
+      }
+    }, 100);
   }
 
   private _createLegends(data: ILineChartPoints[]): JSX.Element {
@@ -193,6 +195,21 @@ export class LineChartBase extends React.Component<
     return dataPointsArray;
   }
 
+  private _getXAxisValues(xAxisData: string[]): string[] {
+    let tickValues: string[] = [];
+    if (xAxisData.length <= 7) {
+      tickValues = xAxisData;
+    } else {
+      tickValues.push(xAxisData[0]);
+      const length = Math.ceil((xAxisData.length - 2) / 5);
+      for (let i = length; i < xAxisData.length - 2; i += length) {
+        tickValues.push(xAxisData[i]);
+      }
+      tickValues.push(xAxisData[xAxisData.length - 1]);
+    }
+    return tickValues;
+  }
+
   private _createStringXAxis = () => {
     const xAxisData: string[] = [];
     this._points.map((singleLineChartData: ILineChartPoints) => {
@@ -200,6 +217,7 @@ export class LineChartBase extends React.Component<
         xAxisData.push(point.x as string);
       });
     });
+    const tickValues: string[] = this._getXAxisValues(xAxisData);
     const xAxisScale = d3ScaleBand()
       .padding(1)
       .domain(xAxisData)
@@ -208,7 +226,7 @@ export class LineChartBase extends React.Component<
     const xAxis = d3AxisBottom(xAxisScale)
       .tickSize(10)
       .tickPadding(12)
-      .ticks([7])
+      .tickValues(tickValues)
       .tickSizeOuter(0);
     if (this.xAxisElement) {
       d3Select(this.xAxisElement)


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adding timeout so that line chart can scale according to the container size and occupy the entire width thereby. Controlling values on xAxis by using the tickValues method from d3.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6515)

