### PR TITLE
Pivot: fix invalid HTML

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-Pivot_Invalid_HTML_2018-09-29-00-40.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-Pivot_Invalid_HTML_2018-09-29-00-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pivot: update the wrapper holding the tab buttons from ul tags to div for HTML validation and keep the narrator working correctly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/v-vibr-Pivot_Invalid_HTML_2018-09-29-00-40.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-Pivot_Invalid_HTML_2018-09-29-00-40.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Pivot: update the wrapper holding the tab buttons from ul tags to div for HTML validation and keep the narrator working correctly.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -118,9 +118,9 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
 
     return (
       <FocusZone componentRef={this.focusZone} direction={FocusZoneDirection.horizontal}>
-        <ul className={this._classNames.root} role="tablist">
+        <div className={this._classNames.root} role="tablist">
           {items}
-        </ul>
+        </div>
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <ul
+    <div
       className=
           ms-Pivot
           {
@@ -337,7 +337,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
           </span>
         </div>
       </button>
-    </ul>
+    </div>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -360,7 +360,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <ul
+    <div
       className=
           ms-Pivot
           {
@@ -874,7 +874,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           </span>
         </div>
       </button>
-    </ul>
+    </div>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -895,7 +895,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <ul
+    <div
       className=
           ms-Pivot
           ms-Pivot--large
@@ -1221,7 +1221,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
           </span>
         </div>
       </button>
-    </ul>
+    </div>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -1242,7 +1242,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <ul
+    <div
       className=
           ms-Pivot
           ms-Pivot--large
@@ -1592,7 +1592,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           </span>
         </div>
       </button>
-    </ul>
+    </div>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -1613,7 +1613,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <ul
+    <div
       className=
           ms-Pivot
           {
@@ -1938,7 +1938,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           </span>
         </div>
       </button>
-    </ul>
+    </div>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -1959,7 +1959,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
     onMouseDownCapture={[Function]}
     role="presentation"
   >
-    <ul
+    <div
       className=
           ms-Pivot
           ms-Pivot--tabs
@@ -2308,7 +2308,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           </span>
         </div>
       </button>
-    </ul>
+    </div>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             {
@@ -494,7 +494,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             {
@@ -487,7 +487,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             {
@@ -485,7 +485,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             {
@@ -966,7 +966,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             ms-Pivot--large
@@ -486,7 +486,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             ms-Pivot--large
@@ -679,7 +679,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             {
@@ -485,7 +485,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             ms-Pivot--large
@@ -679,7 +679,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -23,7 +23,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             {
@@ -497,7 +497,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             ms-Pivot--tabs
@@ -678,7 +678,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -11,7 +11,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
       onMouseDownCapture={[Function]}
       role="presentation"
     >
-      <ul
+      <div
         className=
             ms-Pivot
             ms-Pivot--large
@@ -679,7 +679,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
             </span>
           </div>
         </button>
-      </ul>
+      </div>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6504 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
I looked into wrapping each button with an `<li>` tag but this required some movement of some accessibility props which were not announcing correctly the tabs when tested with voiceOver on macOS. So than I researched this matter online a little and found both version work as long as you put the `role` and `aria` properties correctly. The version I went with is demonstrated [HERE](https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html) which I would assume it's trusty enough when it comes to accessibility issues and DOM structure looks almost exactly as our `Pivot` control.

#### Focus areas to test
Not sure how to qualify this change a `patch` or a `minor` as in case someone targeted the `ul` tag to style it instead of using the className???

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6517)

