### PR TITLE
DocumentCardTitle: fixing an infinite loop condition calling setState.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-DocumentCardMaxSize_2018-09-29-03-08.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-DocumentCardMaxSize_2018-09-29-03-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCardTitle: Fixes an infinite loop condition caused by componentDidUpdate calling _srinkTitle() over and over again due to setState being triggered every time without a stop condition.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.tsx
@@ -77,7 +77,9 @@ export class DocumentCardTitle extends BaseComponent<IDocumentCardTitleProps, ID
           ref={this._titleElement}
           title={title}
         >
-          {truncatedTitleFirstPiece}&hellip;{truncatedTitleSecondPiece}
+          {truncatedTitleFirstPiece}
+          &hellip;
+          {truncatedTitleSecondPiece}
         </div>
       );
     } else {
@@ -108,17 +110,12 @@ export class DocumentCardTitle extends BaseComponent<IDocumentCardTitleProps, ID
         this._isTruncated = true;
         this.setState({
           truncatedTitleFirstPiece: originalTitle.slice(0, maxLength / 2 + TRUNCATION_FIRST_PIECE_LONGER_BY),
-          truncatedTitleSecondPiece: originalTitle.slice(
-            originalTitle.length - (maxLength / 2 - TRUNCATION_FIRST_PIECE_LONGER_BY)
-          )
+          truncatedTitleSecondPiece: originalTitle.slice(originalTitle.length - (maxLength / 2 - TRUNCATION_FIRST_PIECE_LONGER_BY))
         });
       } else {
         // The text is not so long, so we'll just break it into two pieces
         this.setState({
-          truncatedTitleFirstPiece: originalTitle.slice(
-            0,
-            Math.ceil(originalTitle.length / 2) + TRUNCATION_FIRST_PIECE_LONGER_BY
-          ),
+          truncatedTitleFirstPiece: originalTitle.slice(0, Math.ceil(originalTitle.length / 2) + TRUNCATION_FIRST_PIECE_LONGER_BY),
           truncatedTitleSecondPiece: originalTitle.slice(
             originalTitle.length - Math.floor(originalTitle.length / 2) + TRUNCATION_FIRST_PIECE_LONGER_BY
           )
@@ -137,14 +134,12 @@ export class DocumentCardTitle extends BaseComponent<IDocumentCardTitleProps, ID
       const { truncatedTitleFirstPiece, truncatedTitleSecondPiece } = this.state;
       this._isTruncated = true;
 
-      if (!truncatedTitleFirstPiece && !truncatedTitleSecondPiece) {
-        this._startTruncation(this.props);
+      if (truncatedTitleFirstPiece || truncatedTitleSecondPiece) {
+        this.setState({
+          truncatedTitleFirstPiece: truncatedTitleFirstPiece!.slice(0, truncatedTitleFirstPiece!.length - 1),
+          truncatedTitleSecondPiece: truncatedTitleSecondPiece!.slice(1)
+        });
       }
-
-      this.setState({
-        truncatedTitleFirstPiece: truncatedTitleFirstPiece!.slice(0, truncatedTitleFirstPiece!.length - 1),
-        truncatedTitleSecondPiece: truncatedTitleSecondPiece!.slice(1)
-      });
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5308 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
The infinite loop is caused by this succession of events: 

`onResize` event triggers the `_updateTruncation()` which in turn triggers `_startTruncation()` which is calling `setState()` causing the `componentDidUpdate()` to be invoked. Next in line is `_shrinkTitle()` and here were everything is breaking.

Initially this `setState()` is called here:

https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.tsx#L144

... which is causing `componentDidUpdate()` to be called again and it circles back to the same `setState()` as before until it fails the check in here:

https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.tsx#L140

... when this happens it calls `_startTruncation()` again causing another `componentDidUpdate()` which circles back to this line over and over again. ThE EnD 🤓 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6518)

Before: https://gyazo.com/134540469dc71adc4fad96d446770568
After: https://gyazo.com/bab7fe1ed685cc7f3f899d6e2ff729cf