### PR TITLE
Card grid list item left align issue

### DIFF
--- a/common/changes/@uifabric/dashboard/CardGridListItemLeftAlignIssue_2018-10-01-06-32.json
+++ b/common/changes/@uifabric/dashboard/CardGridListItemLeftAlignIssue_2018-10-01-06-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "grid list item left align issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "polu.balakrishna96@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/GridList/GridList.tsx
+++ b/packages/dashboard/src/components/Card/GridList/GridList.tsx
@@ -5,7 +5,10 @@ import {
   IColumn,
   ColumnActionsMode,
   DetailsListLayoutMode,
-  ConstrainMode
+  ConstrainMode,
+  DetailsRow,
+  IDetailsRowProps,
+  IDetailsRowStyles
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
@@ -32,6 +35,7 @@ export class GridList extends React.Component<IGridListProps> {
           items={rows}
           setKey="set"
           columns={columns}
+          onRenderRow={this._onRenderRow}
           onRenderItemColumn={this._renderItemColumn}
           isHeaderVisible={this.props.isHeaderVisible}
           checkboxVisibility={CheckboxVisibility.hidden}
@@ -42,6 +46,15 @@ export class GridList extends React.Component<IGridListProps> {
         {actionButton}
       </div>
     );
+  }
+
+  private _onRenderRow(props: IDetailsRowProps): JSX.Element {
+    const styles: Partial<IDetailsRowStyles> = {
+      cell: {
+        paddingLeft: '0px'
+      }
+    };
+    return <DetailsRow {...props} styles={styles} />;
   }
 
   // Disabling ts-lint for the signature because Details List expects row parameter as any


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
    Card gird list left align issue solved

#### Screen shots
![gridlistitemleftalign](https://user-images.githubusercontent.com/21668111/46273431-14762c80-c573-11e8-9d7d-8675666aa77d.png)



(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6522)

