### PR TITLE
Initial checkin to add pagination control into experiment packages

### DIFF
--- a/common/changes/@uifabric/experiments/pagination1001_2018-10-01-20-51.json
+++ b/common/changes/@uifabric/experiments/pagination1001_2018-10-01-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "ainitial checkin to add pagination controldd pagination control",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "yudon@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/pagination1001_2018-10-01-20-51.json
+++ b/common/changes/@uifabric/experiments/pagination1001_2018-10-01-20-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/experiments",
-      "comment": "ainitial checkin to add pagination controldd pagination control",
+      "comment": "initial checkin to add pagination control",
       "type": "minor"
     }
   ],

--- a/packages/experiments/src/Pagination.ts
+++ b/packages/experiments/src/Pagination.ts
@@ -1,0 +1,1 @@
+export * from './components/Pagination/index';

--- a/packages/experiments/src/components/Pagination/PageNumber.tsx
+++ b/packages/experiments/src/components/Pagination/PageNumber.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IPageNumberProps } from './Pagination.types';
+import { IPageNumberProps } from './PageNumber.types';
 
 export class PageNumber extends React.Component<IPageNumberProps, {}> {
   constructor(props: IPageNumberProps) {
@@ -7,20 +7,20 @@ export class PageNumber extends React.Component<IPageNumberProps, {}> {
   }
 
   public render(): JSX.Element {
-    const { pageAriaLabel, page } = this.props;
+    const { className, pageAriaLabel, page, selected } = this.props;
     const ariaLabel = pageAriaLabel && `${pageAriaLabel} ${page}`;
 
     return (
-      <li key={this.props.page}>
+      <li key={page}>
         <button
-          className={this.props.className}
+          className={className}
           onClick={this.onClick}
-          aria-selected={this.props.selected}
+          aria-selected={selected}
           aria-label={ariaLabel}
-          data-page-number={this.props.page}
+          data-page-number={page}
           role={'tab'}
         >
-          {this.props.page}
+          {page}
         </button>
       </li>
     );

--- a/packages/experiments/src/components/Pagination/PageNumber.tsx
+++ b/packages/experiments/src/components/Pagination/PageNumber.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { IPageNumberProps } from './Pagination.types';
+
+export class PageNumber extends React.Component<IPageNumberProps, {}> {
+  constructor(props: IPageNumberProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const ariaLabel = this.props.pageAriaLabel ? this.props.pageAriaLabel + '' + this.props.page : 'Page ' + this.props.page;
+
+    return (
+      <li>
+        <button
+          className={this.props.className}
+          onClick={this.onClick}
+          aria-selected={this.props.selected}
+          aria-label={ariaLabel}
+          data-page-number={this.props.page}
+          role={'tab'}
+        >
+          {this.props.page}
+        </button>
+      </li>
+    );
+  }
+
+  private onClick = () => {
+    this.props.applyPage(this.props.page - 1);
+  };
+}

--- a/packages/experiments/src/components/Pagination/PageNumber.tsx
+++ b/packages/experiments/src/components/Pagination/PageNumber.tsx
@@ -7,10 +7,11 @@ export class PageNumber extends React.Component<IPageNumberProps, {}> {
   }
 
   public render(): JSX.Element {
-    const ariaLabel = this.props.pageAriaLabel ? this.props.pageAriaLabel + '' + this.props.page : 'Page ' + this.props.page;
+    const { pageAriaLabel, page } = this.props;
+    const ariaLabel = pageAriaLabel && `${pageAriaLabel} ${page}`;
 
     return (
-      <li>
+      <li key={this.props.page}>
         <button
           className={this.props.className}
           onClick={this.onClick}

--- a/packages/experiments/src/components/Pagination/PageNumber.types.ts
+++ b/packages/experiments/src/components/Pagination/PageNumber.types.ts
@@ -1,0 +1,16 @@
+export interface IPageNumberProps {
+  /** The call back function when click on the page number . */
+  applyPage: (page: number) => void;
+
+  /** The page number. This should be starting from 1, i.e., index + 1 */
+  page: number;
+
+  /** If this page if currently selected */
+  selected: boolean;
+
+  /** The aria label template. Should contain one place holder, e.g. Page {0} */
+  pageAriaLabel?: string;
+
+  /** The className */
+  className?: string;
+}

--- a/packages/experiments/src/components/Pagination/Pagination.base.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.base.tsx
@@ -12,7 +12,7 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
     previousLabel: '<<',
     selectedPageIndex: 0,
     pageRange: 2,
-    marginPagesDisplayed: 1,
+    marginPages: 1,
     omissionLabel: '...'
   };
 
@@ -68,11 +68,12 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
   }
 
   private handleSelectedPage = (selected: number) => {
-    if (selected === this.props.selectedPageIndex) {
+    const { selectedPageIndex, onPageChange } = this.props;
+    if (selected === selectedPageIndex) {
       return; // same page, no action
     }
-    if (this.props.onPageChange) {
-      this.props.onPageChange(selected);
+    if (onPageChange) {
+      onPageChange(selected);
     }
   };
 
@@ -85,12 +86,13 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
   };
 
   private _pageElement(index: number): JSX.Element {
+    const { pageAriaLabel, selectedPageIndex } = this.props;
     return (
       <PageNumber
         key={index + 1}
         page={index + 1}
-        pageAriaLabel={this.props.pageAriaLabel}
-        selected={index === this.props.selectedPageIndex}
+        pageAriaLabel={pageAriaLabel}
+        selected={index === selectedPageIndex}
         applyPage={this.handleSelectedPage}
         className={this._classNames.pageNumber}
       />
@@ -98,33 +100,34 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
   }
 
   private _pageList(): JSX.Element[] {
+    const { marginPages, omittedPagesAriaLabel, omissionLabel, pageCount, pageRange, selectedPageIndex } = this.props;
     const pageList = [];
-    if (this.props.pageCount <= this.props.pageRange!) {
-      for (let index = 0; index < this.props.pageCount; index++) {
+    if (pageCount <= pageRange!) {
+      for (let index = 0; index < pageCount; index++) {
         pageList.push(this._pageElement(index));
       }
     } else {
-      const leftHalfCount = this.props.pageRange! / 2;
-      const rightHalfCount = this.props.pageRange! - leftHalfCount;
+      const leftHalfCount = pageRange! / 2;
+      const rightHalfCount = pageRange! - leftHalfCount;
 
       let leftSide = leftHalfCount;
       let rightSide = rightHalfCount;
 
-      if (this.props.selectedPageIndex! > this.props.pageCount - 1 - leftHalfCount) {
-        rightSide = this.props.pageCount - 1 - this.props.selectedPageIndex!;
-        leftSide = this.props.pageRange! - rightSide;
-      } else if (this.props.selectedPageIndex! < leftHalfCount) {
-        leftSide = this.props.selectedPageIndex!;
-        rightSide = this.props.pageRange! - leftSide;
+      if (selectedPageIndex! > pageCount - 1 - leftHalfCount) {
+        rightSide = pageCount - 1 - selectedPageIndex!;
+        leftSide = pageRange! - rightSide;
+      } else if (selectedPageIndex! < leftHalfCount) {
+        leftSide = selectedPageIndex!;
+        rightSide = pageRange! - leftSide;
       }
 
       let previousIndexIsOmitted = false;
-      for (let index = 0; index < this.props.pageCount; index++) {
+      for (let index = 0; index < pageCount; index++) {
         const page = index + 1;
         if (
-          page <= this.props.marginPagesDisplayed! ||
-          page > this.props.pageCount - this.props.marginPagesDisplayed! ||
-          (index >= this.props.selectedPageIndex! - leftSide && index <= this.props.selectedPageIndex! + rightSide)
+          page <= marginPages! ||
+          page > pageCount - marginPages! ||
+          (index >= selectedPageIndex! - leftSide && index <= selectedPageIndex! + rightSide)
         ) {
           pageList.push(this._pageElement(index));
           previousIndexIsOmitted = false;
@@ -134,8 +137,8 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
         if (previousIndexIsOmitted === false) {
           const listKey = 'ellipsis' + index.toString();
           pageList.push(
-            <li key={listKey} className={this._classNames.omission} aria-label={this.props.omittedPagesAriaLabel}>
-              {this.props.omissionLabel}
+            <li key={listKey} className={this._classNames.omission} aria-label={omittedPagesAriaLabel}>
+              {omissionLabel}
             </li>
           );
           previousIndexIsOmitted = true;

--- a/packages/experiments/src/components/Pagination/Pagination.base.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.base.tsx
@@ -98,10 +98,10 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
   }
 
   private _pageList(classNames: { [key in keyof IPaginationStyles]: string }): JSX.Element[] {
-    const element = [];
+    const pageList = [];
     if (this.props.pageCount <= this.props.pageRange!) {
       for (let index = 0; index < this.props.pageCount; index++) {
-        element.push(this._pageElement(index));
+        pageList.push(this._pageElement(index));
       }
     } else {
       const leftHalfCount = this.props.pageRange! / 2;
@@ -126,14 +126,14 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
           page > this.props.pageCount - this.props.marginPagesDisplayed! ||
           (index >= this.props.selectedPageIndex! - leftSide && index <= this.props.selectedPageIndex! + rightSide)
         ) {
-          element.push(this._pageElement(index));
+          pageList.push(this._pageElement(index));
           previousIndexIsOmitted = false;
           continue;
         }
 
         if (previousIndexIsOmitted === false) {
           const listKey = 'ellipsis' + index.toString();
-          element.push(
+          pageList.push(
             <li key={listKey} className={this._classNames.omission} aria-label={this.props.omittedPagesAriaLabel}>
               {this.props.omissionLabel}
             </li>
@@ -143,6 +143,6 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
       }
     }
 
-    return element;
+    return pageList;
   }
 }

--- a/packages/experiments/src/components/Pagination/Pagination.base.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.base.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { PageNumber } from './PageNumber';
+import { IPaginationProps, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
+
+const getClassNames = classNamesFunction<IPaginationStyleProps, IPaginationStyles>();
+
+export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
+  public static defaultProps: Partial<IPaginationProps> = {
+    pageRange: 2,
+    marginPagesDisplayed: 1,
+    omissionLabel: '...'
+  };
+
+  private _classNames: { [key in keyof IPaginationStyles]: string };
+
+  constructor(props: IPaginationProps) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    const { styles, theme } = this.props;
+
+    this._classNames = getClassNames(styles!, {
+      theme: theme!
+    });
+
+    const canPrevious = this.props.selectedPageIndex > 0;
+    const canNext = this.props.selectedPageIndex + 1 < this.props.pageCount;
+
+    // FocusZone handles A11Y requirement such as:
+    // Dynamically set tabindex (0 or -1) to the correct item
+    // Refocus to the active item when component re-renders
+    // Handles all key strokes, e.g., left/right, space, enter
+    return (
+      <FocusZone direction={FocusZoneDirection.horizontal}>
+        <ul className={this._classNames.root} role="tablist">
+          <li key="previousPage">
+            <button
+              className={canPrevious ? this._classNames.previousNextPage : this._classNames.disabledPreviousNextPage}
+              onClick={this.handlePreviousPage}
+              disabled={!canPrevious}
+              role="tab"
+              aria-label={this.props.previousAriaLabel}
+            >
+              {this.props.previousLabel}
+            </button>
+          </li>
+          {this._pageList(this._classNames)}
+          <li key="nextPage">
+            <button
+              className={canNext ? this._classNames.previousNextPage : this._classNames.disabledPreviousNextPage}
+              onClick={this.handleNextPage}
+              disabled={!canNext}
+              role="tab"
+              aria-label={this.props.nextAriaLabel}
+            >
+              {this.props.nextLabel}
+            </button>
+          </li>
+        </ul>
+      </FocusZone>
+    );
+  }
+
+  private handleSelectedPage = (selected: number) => {
+    if (selected === this.props.selectedPageIndex) {
+      return; // same page, no action
+    }
+    if (this.props.onPageChange) {
+      this.props.onPageChange(selected);
+    }
+  };
+
+  private handlePreviousPage = () => {
+    this.handleSelectedPage(this.props.selectedPageIndex - 1);
+  };
+
+  private handleNextPage = () => {
+    this.handleSelectedPage(this.props.selectedPageIndex + 1);
+  };
+
+  private _pageElement(index: number, classNames: { [key in keyof IPaginationStyles]: string }): JSX.Element {
+    return (
+      <PageNumber
+        key={index + 1}
+        page={index + 1}
+        pageAriaLabel={this.props.pageAriaLabel}
+        selected={index === this.props.selectedPageIndex}
+        applyPage={this.handleSelectedPage}
+        className={index === this.props.selectedPageIndex ? classNames.selectedPageNumber : classNames.pageNumber}
+      />
+    );
+  }
+
+  private _pageList(classNames: { [key in keyof IPaginationStyles]: string }): JSX.Element[] {
+    const element = [];
+    if (this.props.pageCount <= this.props.pageRange!) {
+      for (let index = 0; index < this.props.pageCount; index++) {
+        element.push(this._pageElement(index, classNames));
+      }
+    } else {
+      let leftSide = this.props.pageRange! / 2;
+      let rightSide = this.props.pageRange! - leftSide;
+
+      if (this.props.selectedPageIndex > this.props.pageCount - 1 - this.props.pageRange! / 2) {
+        rightSide = this.props.pageCount - 1 - this.props.selectedPageIndex;
+        leftSide = this.props.pageRange! - rightSide;
+      } else if (this.props.selectedPageIndex < this.props.pageRange! / 2) {
+        leftSide = this.props.selectedPageIndex;
+        rightSide = this.props.pageRange! - leftSide;
+      }
+
+      let previousIndexIsOmitted = false;
+      for (let index = 0; index < this.props.pageCount; index++) {
+        const page = index + 1;
+        if (page <= this.props.marginPagesDisplayed!) {
+          element.push(this._pageElement(index, classNames));
+          previousIndexIsOmitted = false;
+          continue;
+        }
+
+        if (page > this.props.pageCount - this.props.marginPagesDisplayed!) {
+          element.push(this._pageElement(index, classNames));
+          previousIndexIsOmitted = false;
+          continue;
+        }
+
+        if (index >= this.props.selectedPageIndex - leftSide && index <= this.props.selectedPageIndex + rightSide) {
+          element.push(this._pageElement(index, classNames));
+          previousIndexIsOmitted = false;
+          continue;
+        }
+
+        if (previousIndexIsOmitted === false) {
+          const listKey = 'ellipsis' + index.toString();
+          element.push(
+            <li key={listKey} className="detailsListPagination-ellipsis" aria-label={this.props.omittedPagesAriaLabel}>
+              {this.props.omissionLabel}
+            </li>
+          );
+          previousIndexIsOmitted = true;
+        }
+      }
+    }
+
+    return element;
+  }
+}

--- a/packages/experiments/src/components/Pagination/Pagination.base.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.base.tsx
@@ -23,14 +23,14 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
   }
 
   public render(): JSX.Element {
-    const { styles, theme } = this.props;
+    const { nextAriaLabel, nextLabel, pageCount, previousAriaLabel, previousLabel, selectedPageIndex, styles, theme } = this.props;
 
     this._classNames = getClassNames(styles!, {
       theme: theme!
     });
 
-    const canPrevious = this.props.selectedPageIndex! > 0;
-    const canNext = this.props.selectedPageIndex! + 1 < this.props.pageCount;
+    const canPrevious = selectedPageIndex! > 0;
+    const canNext = selectedPageIndex! + 1 < pageCount;
 
     // FocusZone handles A11Y requirement such as:
     // Dynamically set tabindex (0 or -1) to the correct item
@@ -45,21 +45,21 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
               onClick={this.handlePreviousPage}
               disabled={!canPrevious}
               role="tab"
-              aria-label={this.props.previousAriaLabel}
+              aria-label={previousAriaLabel}
             >
-              {this.props.previousLabel}
+              {previousLabel}
             </button>
           </li>
-          {this._pageList(this._classNames)}
+          {this._pageList()}
           <li key="nextPage">
             <button
               className={this._classNames.previousNextPage}
               onClick={this.handleNextPage}
               disabled={!canNext}
               role="tab"
-              aria-label={this.props.nextAriaLabel}
+              aria-label={nextAriaLabel}
             >
-              {this.props.nextLabel}
+              {nextLabel}
             </button>
           </li>
         </ul>
@@ -97,7 +97,7 @@ export class PaginationBase extends BaseComponent<IPaginationProps, {}> {
     );
   }
 
-  private _pageList(classNames: { [key in keyof IPaginationStyles]: string }): JSX.Element[] {
+  private _pageList(): JSX.Element[] {
     const pageList = [];
     if (this.props.pageCount <= this.props.pageRange!) {
       for (let index = 0; index < this.props.pageCount; index++) {

--- a/packages/experiments/src/components/Pagination/Pagination.styles.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.styles.ts
@@ -1,0 +1,59 @@
+import { IPaginationStyles, IPaginationStyleProps } from './Pagination.types';
+import { getGlobalClassNames } from '../../Styling';
+
+const GlobalClassNames = {
+  root: 'ms-Pagination-container',
+  pageNumber: 'ms-Pagination-page-number',
+  selectedPageNumber: 'ms-Pagination-page-number-selected'
+};
+
+export function getStyles(props: IPaginationStyleProps): IPaginationStyles {
+  const { theme } = props;
+
+  const { palette } = theme;
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  return {
+    root: [
+      classNames.root,
+      {
+        listStyle: 'none',
+        selectors: {
+          li: {
+            display: 'inline'
+          }
+        }
+      }
+    ],
+    previousNextPage: {
+      color: palette.black,
+      cursor: 'pointer',
+      border: 'none',
+      backgroundColor: 'Transparent'
+    },
+    disabledPreviousNextPage: {
+      color: palette.neutralTertiaryAlt,
+      border: 'none',
+      backgroundColor: 'Transparent'
+    },
+    pageNumber: [
+      classNames.pageNumber,
+      {
+        color: palette.black,
+        cursor: 'pointer',
+        border: 'none',
+        backgroundColor: 'Transparent'
+      }
+    ],
+    selectedPageNumber: [
+      classNames.selectedPageNumber,
+      {
+        color: palette.blue,
+        fontWeight: 'bold',
+        cursor: 'pointer',
+        border: 'none',
+        backgroundColor: 'Transparent'
+      }
+    ]
+  };
+}

--- a/packages/experiments/src/components/Pagination/Pagination.styles.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.styles.ts
@@ -1,10 +1,10 @@
 import { IPaginationStyles, IPaginationStyleProps } from './Pagination.types';
-import { getGlobalClassNames } from '../../Styling';
+import { getGlobalClassNames, IStyle } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-Pagination-container',
   pageNumber: 'ms-Pagination-page-number',
-  selectedPageNumber: 'ms-Pagination-page-number-selected'
+  omission: 'ms-Pagination-omission'
 };
 
 export function getStyles(props: IPaginationStyleProps): IPaginationStyles {
@@ -12,6 +12,12 @@ export function getStyles(props: IPaginationStyleProps): IPaginationStyles {
 
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  const buttonStyles: IStyle = {
+    cursor: 'pointer',
+    border: 'none',
+    backgroundColor: 'transparent'
+  };
 
   return {
     root: [
@@ -25,34 +31,43 @@ export function getStyles(props: IPaginationStyleProps): IPaginationStyles {
         }
       }
     ],
-    previousNextPage: {
-      color: palette.black,
-      cursor: 'pointer',
-      border: 'none',
-      backgroundColor: 'Transparent'
-    },
-    disabledPreviousNextPage: {
-      color: palette.neutralTertiaryAlt,
-      border: 'none',
-      backgroundColor: 'Transparent'
-    },
-    pageNumber: [
-      classNames.pageNumber,
+    previousNextPage: [
+      buttonStyles,
       {
         color: palette.black,
-        cursor: 'pointer',
-        border: 'none',
-        backgroundColor: 'Transparent'
+        selectors: {
+          '&:disabled': {
+            cursor: 'default',
+            color: palette.neutralTertiaryAlt
+          },
+          '&[disabled]': {
+            cursor: 'default',
+            color: palette.neutralTertiaryAlt
+          }
+        }
       }
     ],
-    selectedPageNumber: [
-      classNames.selectedPageNumber,
+    pageNumber: [
+      classNames.pageNumber,
+      buttonStyles,
       {
-        color: palette.blue,
-        fontWeight: 'bold',
-        cursor: 'pointer',
-        border: 'none',
-        backgroundColor: 'Transparent'
+        color: palette.black,
+        selectors: {
+          '&:aria-selected=true': {
+            color: palette.blue,
+            fontWeight: 'bold'
+          },
+          '&[aria-selected=true]': {
+            color: palette.blue,
+            fontWeight: 'bold'
+          }
+        }
+      }
+    ],
+    omission: [
+      classNames.omission,
+      {
+        color: palette.neutralSecondary
       }
     ]
   };

--- a/packages/experiments/src/components/Pagination/Pagination.styles.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.styles.ts
@@ -3,7 +3,7 @@ import { getGlobalClassNames, IStyle } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-Pagination-container',
-  pageNumber: 'ms-Pagination-page-number',
+  pageNumber: 'ms-Pagination-pageNumber',
   omission: 'ms-Pagination-omission'
 };
 

--- a/packages/experiments/src/components/Pagination/Pagination.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,11 @@
+import { styled } from '../../Utilities';
+import { IPaginationProps, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
+import { getStyles } from './Pagination.styles';
+import { PaginationBase } from './Pagination.base';
+
+export const Pagination: (props: IPaginationProps) => JSX.Element = styled<IPaginationProps, IPaginationStyleProps, IPaginationStyles>(
+  PaginationBase,
+  getStyles,
+  undefined,
+  { scope: 'Pagination' }
+);

--- a/packages/experiments/src/components/Pagination/Pagination.types.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.types.ts
@@ -1,0 +1,117 @@
+import { IStyle, ITheme } from '../../Styling';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
+
+export interface IPagination {}
+
+export interface IPaginationProps {
+  /**
+   * Required: Selected index
+   */
+  selectedPageIndex: number;
+
+  /**
+   * label for the previous page button
+   */
+  previousLabel: string;
+
+  /**
+   * Required: label for the next page button
+   */
+  nextLabel: string;
+
+  /**
+   * Required: The total number of pages.
+   */
+  pageCount: number;
+
+  /**
+   * Required: aria label for the omitted pages
+   */
+  omittedPagesAriaLabel?: string;
+
+  /**
+   * Required: aria label for the next page button
+   */
+  nextAriaLabel?: string;
+
+  /**
+   * aria label for the page buttons
+   */
+  pageAriaLabel?: string;
+
+  /**
+   * The call back function to load another page in the table. This needs to be defined in the parent component.
+   */
+  onPageChange?: (index: number) => void;
+
+  /**
+   * aria label for the previous page button
+   */
+  previousAriaLabel?: string;
+
+  /**
+   * The page range to show around the selected page. e.g., if this is 2, there will be 2 page numbers in total
+   * showing next to the selected page on the left and/or the right
+   * @default 2
+   */
+  pageRange?: number;
+
+  /**
+   * The number of pages in the beginning and the end of the list.
+   * @default 1
+   */
+  marginPagesDisplayed?: number;
+
+  /**
+   * The label representing omitted page numbers.
+   * @default '...'
+   */
+  omissionLabel?: string;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<IPaginationStyleProps, IPaginationStyles>;
+
+  /**
+   * Optional callback to access the IPagination interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: IRefObject<IPagination>;
+
+  /**
+   * Theme provided by High-Order Component.
+   */
+  theme?: ITheme;
+}
+
+export interface IPageNumberProps {
+  /** The call back function when click on the page number . */
+  applyPage: (page: number) => void;
+
+  /** The page number. This should be starting from 1, i.e., index + 1 */
+  page: number;
+
+  /** If this page if currently selected */
+  selected: boolean;
+
+  /** The aria label template. Should contain one place holder, e.g. Page {0} */
+  pageAriaLabel?: string;
+
+  className?: string;
+}
+
+export interface IPaginationStyleProps {
+  theme: ITheme;
+}
+
+export interface IPaginationStyles {
+  /**
+   * Style for the root element in the default enabled/unchecked state.
+   */
+  root?: IStyle;
+  pageNumber?: IStyle;
+  selectedPageNumber?: IStyle;
+  previousNextPage?: IStyle;
+  disabledPreviousNextPage?: IStyle;
+}

--- a/packages/experiments/src/components/Pagination/Pagination.types.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.types.ts
@@ -38,7 +38,7 @@ export interface IPaginationProps {
    * The number of pages in the beginning and the end of the list.
    * @default 1
    */
-  marginPagesDisplayed?: number;
+  marginPages?: number;
 
   /**
    * Selected page index

--- a/packages/experiments/src/components/Pagination/Pagination.types.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.types.ts
@@ -5,49 +5,27 @@ export interface IPagination {}
 
 export interface IPaginationProps {
   /**
-   * Required: Selected index
-   */
-  selectedPageIndex: number;
-
-  /**
-   * label for the previous page button
-   */
-  previousLabel: string;
-
-  /**
-   * Required: label for the next page button
-   */
-  nextLabel: string;
-
-  /**
-   * Required: The total number of pages.
+   * The total number of pages.
    */
   pageCount: number;
 
   /**
-   * Required: aria label for the omitted pages
+   * label for the next page button
+   * @default '>>'
    */
-  omittedPagesAriaLabel?: string;
+  nextLabel?: string;
 
   /**
-   * Required: aria label for the next page button
+   * label for the previous page button
+   * @default '<<'
    */
-  nextAriaLabel?: string;
+  previousLabel?: string;
 
   /**
-   * aria label for the page buttons
+   * The label representing omitted page numbers.
+   * @default '...'
    */
-  pageAriaLabel?: string;
-
-  /**
-   * The call back function to load another page in the table. This needs to be defined in the parent component.
-   */
-  onPageChange?: (index: number) => void;
-
-  /**
-   * aria label for the previous page button
-   */
-  previousAriaLabel?: string;
+  omissionLabel?: string;
 
   /**
    * The page range to show around the selected page. e.g., if this is 2, there will be 2 page numbers in total
@@ -63,10 +41,30 @@ export interface IPaginationProps {
   marginPagesDisplayed?: number;
 
   /**
-   * The label representing omitted page numbers.
-   * @default '...'
+   * Selected page index
+   * @default 0
    */
-  omissionLabel?: string;
+  selectedPageIndex?: number;
+
+  /**
+   * aria label for the next page button
+   */
+  nextAriaLabel?: string;
+
+  /**
+   * aria label for the previous page button
+   */
+  previousAriaLabel?: string;
+
+  /**
+   * aria label for the omitted pages
+   */
+  omittedPagesAriaLabel?: string;
+
+  /**
+   * aria label for the page buttons
+   */
+  pageAriaLabel?: string;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
@@ -83,6 +81,11 @@ export interface IPaginationProps {
    * Theme provided by High-Order Component.
    */
   theme?: ITheme;
+
+  /**
+   * The call back function to load another page in the table. This needs to be defined in the parent component.
+   */
+  onPageChange?: (index: number) => void;
 }
 
 export interface IPageNumberProps {
@@ -98,6 +101,7 @@ export interface IPageNumberProps {
   /** The aria label template. Should contain one place holder, e.g. Page {0} */
   pageAriaLabel?: string;
 
+  /** The className */
   className?: string;
 }
 
@@ -111,7 +115,6 @@ export interface IPaginationStyles {
    */
   root?: IStyle;
   pageNumber?: IStyle;
-  selectedPageNumber?: IStyle;
   previousNextPage?: IStyle;
-  disabledPreviousNextPage?: IStyle;
+  omission?: IStyle;
 }

--- a/packages/experiments/src/components/Pagination/Pagination.types.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.types.ts
@@ -88,23 +88,6 @@ export interface IPaginationProps {
   onPageChange?: (index: number) => void;
 }
 
-export interface IPageNumberProps {
-  /** The call back function when click on the page number . */
-  applyPage: (page: number) => void;
-
-  /** The page number. This should be starting from 1, i.e., index + 1 */
-  page: number;
-
-  /** If this page if currently selected */
-  selected: boolean;
-
-  /** The aria label template. Should contain one place holder, e.g. Page {0} */
-  pageAriaLabel?: string;
-
-  /** The className */
-  className?: string;
-}
-
 export interface IPaginationStyleProps {
   theme: ITheme;
 }

--- a/packages/experiments/src/components/Pagination/Pagination.types.ts
+++ b/packages/experiments/src/components/Pagination/Pagination.types.ts
@@ -113,8 +113,8 @@ export interface IPaginationStyles {
   /**
    * Style for the root element in the default enabled/unchecked state.
    */
-  root?: IStyle;
-  pageNumber?: IStyle;
-  previousNextPage?: IStyle;
-  omission?: IStyle;
+  root: IStyle;
+  pageNumber: IStyle;
+  previousNextPage: IStyle;
+  omission: IStyle;
 }

--- a/packages/experiments/src/components/Pagination/PaginationPage.tsx
+++ b/packages/experiments/src/components/Pagination/PaginationPage.tsx
@@ -3,9 +3,11 @@ import { ExampleCard, ComponentPage, IComponentDemoPageProps, PropertiesTableSet
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { PaginationBasicExample } from './examples/Pagination.Basic.Example';
 import { PaginationCustomizationExample } from './examples/Pagination.Customization.Example';
+import { PaginationCustomizationRoundExample } from './examples/Pagination.Customization.Round.Example';
 
 const PaginationBasicExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx') as string;
 const PaginationCustomizationExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx') as string;
+const PaginationCustomizationRoundExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Customization.Round.Example.tsx') as string;
 
 export class PaginationPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -20,6 +22,9 @@ export class PaginationPage extends React.Component<IComponentDemoPageProps, {}>
             </ExampleCard>
             <ExampleCard title="Pagination with customization" code={PaginationCustomizationExampleCode}>
               <PaginationCustomizationExample />
+            </ExampleCard>
+            <ExampleCard title="Pagination with customization using round background" code={PaginationCustomizationRoundExampleCode}>
+              <PaginationCustomizationRoundExample />
             </ExampleCard>
           </div>
         }

--- a/packages/experiments/src/components/Pagination/PaginationPage.tsx
+++ b/packages/experiments/src/components/Pagination/PaginationPage.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { ExampleCard, ComponentPage, IComponentDemoPageProps, PropertiesTableSet } from '@uifabric/example-app-base';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { PaginationBasicExample } from './examples/Pagination.Basic.Example';
-import { PaginationCustomizaionExample } from './examples/Pagination.Customization.Example';
+import { PaginationCustomizationExample } from './examples/Pagination.Customization.Example';
 
 const PaginationBasicExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx') as string;
-const PaginationCustomizaionExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx') as string;
+const PaginationCustomizationExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx') as string;
 
 export class PaginationPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -18,8 +18,8 @@ export class PaginationPage extends React.Component<IComponentDemoPageProps, {}>
             <ExampleCard title="Pagination with basic elements" code={PaginationBasicExampleCode}>
               <PaginationBasicExample />
             </ExampleCard>
-            <ExampleCard title="Pagination with customization" code={PaginationCustomizaionExampleCode}>
-              <PaginationCustomizaionExample />
+            <ExampleCard title="Pagination with customization" code={PaginationCustomizationExampleCode}>
+              <PaginationCustomizationExample />
             </ExampleCard>
           </div>
         }

--- a/packages/experiments/src/components/Pagination/PaginationPage.tsx
+++ b/packages/experiments/src/components/Pagination/PaginationPage.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { ExampleCard, ComponentPage, IComponentDemoPageProps, PropertiesTableSet } from '@uifabric/example-app-base';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import { PaginationBasicExample } from './examples/Pagination.Basic.Example';
+import { PaginationCustomizaionExample } from './examples/Pagination.Customization.Example';
+
+const PaginationBasicExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx') as string;
+const PaginationCustomizaionExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx') as string;
+
+export class PaginationPage extends React.Component<IComponentDemoPageProps, {}> {
+  public render(): JSX.Element {
+    return (
+      <ComponentPage
+        title="Pagination"
+        componentName="PaginationExample"
+        exampleCards={
+          <div>
+            <ExampleCard title="Pagination with basic elements" code={PaginationBasicExampleCode}>
+              <PaginationBasicExample />
+            </ExampleCard>
+            <ExampleCard title="Pagination with customization" code={PaginationCustomizaionExampleCode}>
+              <PaginationCustomizaionExample />
+            </ExampleCard>
+          </div>
+        }
+        propertiesTables={
+          <PropertiesTableSet
+            sources={[require<string>('!raw-loader!@uifabric/experiments/src/components/Pagination/Pagination.types.ts')]}
+          />
+        }
+        overview={
+          <div>
+            <p>Pagination control</p>
+            <p>This control provides a customizable pagination component that can be used to achieve specific design requirement.</p>
+            <p>
+              For cases when your application supports theming, Pagination component is equiped with everything you need to just load the
+              custom theme to the application, and as long as the color palette you provide has an overried for the{' '}
+              <Link href="https://developer.microsoft.com/en-us/fabric#/styles/colors">
+                <code>Fabric colors</code>
+              </Link>{' '}
+              used in Pagination, everything should be ok. If no theming is supported, then follow the example showing the use of the{' '}
+              <code>styles</code> prop.
+            </p>
+          </div>
+        }
+        isHeaderVisible={this.props.isHeaderVisible}
+      />
+    );
+  }
+}

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Pagination } from '../Pagination';
+import { Pagination } from '@uifabric/experiments/lib/Pagination';
 
 export interface IPaginationBasicExampleState {
   selectedPageIndex: number;

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Pagination } from '../Pagination';
+
+export interface IPaginationBasicExampleState {
+  selectedPageIndex: number;
+}
+export class PaginationBasicExample extends React.Component<{}, IPaginationBasicExampleState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = { selectedPageIndex: 0 };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <Pagination
+        selectedPageIndex={this.state.selectedPageIndex}
+        pageCount={15}
+        previousLabel={'previous'}
+        nextLabel={'next'}
+        pageAriaLabel={'page'}
+        onPageChange={this.onPageChange}
+      />
+    );
+  }
+
+  private onPageChange = (index: number): void => {
+    this.setState({
+      selectedPageIndex: index
+    });
+  };
+}

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Basic.Example.tsx
@@ -17,8 +17,11 @@ export class PaginationBasicExample extends React.Component<{}, IPaginationBasic
         selectedPageIndex={this.state.selectedPageIndex}
         pageCount={15}
         previousLabel={'previous'}
+        previousAriaLabel={'previous page'}
         nextLabel={'next'}
+        nextAriaLabel={'next page'}
         pageAriaLabel={'page'}
+        omittedPagesAriaLabel={'more pages'}
         onPageChange={this.onPageChange}
       />
     );

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
@@ -4,7 +4,7 @@ import { Pagination } from '@uifabric/experiments/lib/Pagination';
 export interface IPaginationBasicExampleState {
   selectedPageIndex: number;
 }
-export class PaginationCustomizaionExample extends React.Component<{}, IPaginationBasicExampleState> {
+export class PaginationCustomizationExample extends React.Component<{}, IPaginationBasicExampleState> {
   constructor(props: {}) {
     super(props);
 

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Pagination } from '../Pagination';
+
+export interface IPaginationBasicExampleState {
+  selectedPageIndex: number;
+}
+export class PaginationCustomizaionExample extends React.Component<{}, IPaginationBasicExampleState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = { selectedPageIndex: 15 };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <Pagination
+        selectedPageIndex={this.state.selectedPageIndex}
+        pageCount={50}
+        previousLabel={'<<'}
+        nextLabel={'>>'}
+        omissionLabel={'......'}
+        marginPagesDisplayed={2}
+        pageAriaLabel={'page'}
+        onPageChange={this.onPageChange}
+        styles={{
+          pageNumber: {
+            fontWeight: 'bold',
+            selectors: {
+              ':hover': { backgroundColor: '#c8c8c8' }
+            }
+          },
+          selectedPageNumber: {
+            color: 'red',
+            textDecoration: 'underline'
+          }
+        }}
+      />
+    );
+  }
+
+  private onPageChange = (index: number): void => {
+    this.setState({
+      selectedPageIndex: index
+    });
+  };
+}

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Pagination } from '../Pagination';
+import { Pagination } from '@uifabric/experiments/lib/Pagination';
 
 export interface IPaginationBasicExampleState {
   selectedPageIndex: number;
@@ -26,12 +26,18 @@ export class PaginationCustomizaionExample extends React.Component<{}, IPaginati
           pageNumber: {
             fontWeight: 'bold',
             selectors: {
-              ':hover': { backgroundColor: '#c8c8c8' }
+              ':hover': { backgroundColor: '#c8c8c8' },
+              '&:aria-selected=true': {
+                color: 'red',
+                fontWeight: 'bold',
+                textDecoration: 'underline'
+              },
+              '&[aria-selected=true]': {
+                color: 'red',
+                fontWeight: 'bold',
+                textDecoration: 'underline'
+              }
             }
-          },
-          selectedPageNumber: {
-            color: 'red',
-            textDecoration: 'underline'
           }
         }}
       />

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Example.tsx
@@ -19,7 +19,7 @@ export class PaginationCustomizationExample extends React.Component<{}, IPaginat
         previousLabel={'<<'}
         nextLabel={'>>'}
         omissionLabel={'......'}
-        marginPagesDisplayed={2}
+        marginPages={2}
         pageAriaLabel={'page'}
         onPageChange={this.onPageChange}
         styles={{

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Round.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Round.Example.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Pagination } from '@uifabric/experiments/lib/Pagination';
+
+export interface IPaginationBasicExampleState {
+  selectedPageIndex: number;
+}
+export class PaginationCustomizationRoundExample extends React.Component<{}, IPaginationBasicExampleState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = { selectedPageIndex: 15 };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <Pagination
+        selectedPageIndex={this.state.selectedPageIndex}
+        pageCount={50}
+        previousLabel={'<<'}
+        nextLabel={'>>'}
+        marginPagesDisplayed={2}
+        pageAriaLabel={'page'}
+        onPageChange={this.onPageChange}
+        styles={{
+          omission: {
+            color: '#0f8387',
+            width: '32px',
+            height: '32px'
+          },
+          previousNextPage: {
+            width: '32px',
+            height: '32px',
+            color: '#0f8387'
+          },
+          pageNumber: {
+            fontWeight: 'bold',
+            width: '32px',
+            height: '32px',
+            color: '#0f8387',
+            textAlign: 'center',
+            selectors: {
+              ':hover': { textDecoration: 'underline' },
+              '&:aria-selected=true': {
+                backgroundColor: '#0f8387',
+                fontWeight: 'bold',
+                borderRadius: '16px',
+                color: 'white'
+              },
+              '&[aria-selected=true]': {
+                backgroundColor: '#0f8387',
+                fontWeight: 'bold',
+                borderRadius: '16px',
+                color: 'white'
+              }
+            }
+          }
+        }}
+      />
+    );
+  }
+
+  private onPageChange = (index: number): void => {
+    this.setState({
+      selectedPageIndex: index
+    });
+  };
+}

--- a/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Round.Example.tsx
+++ b/packages/experiments/src/components/Pagination/examples/Pagination.Customization.Round.Example.tsx
@@ -8,7 +8,7 @@ export class PaginationCustomizationRoundExample extends React.Component<{}, IPa
   constructor(props: {}) {
     super(props);
 
-    this.state = { selectedPageIndex: 15 };
+    this.state = { selectedPageIndex: 0 };
   }
 
   public render(): JSX.Element {
@@ -18,7 +18,7 @@ export class PaginationCustomizationRoundExample extends React.Component<{}, IPa
         pageCount={50}
         previousLabel={'<<'}
         nextLabel={'>>'}
-        marginPagesDisplayed={2}
+        marginPages={2}
         pageAriaLabel={'page'}
         onPageChange={this.onPageChange}
         styles={{

--- a/packages/experiments/src/components/Pagination/index.ts
+++ b/packages/experiments/src/components/Pagination/index.ts
@@ -1,0 +1,2 @@
+export * from './Pagination';
+export * from './Pagination.types';

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -82,6 +82,12 @@ export const AppDefinition: IAppDefinition = {
           url: '#/examples/tileslist'
         },
         {
+          component: require<any>('../components/Pagination/PaginationPage').PaginationPage,
+          key: 'Pagination',
+          name: 'Pagination',
+          url: '#/examples/pagination'
+        },
+        {
           component: require<any>('../components/Shimmer/ShimmerPage').ShimmerPage,
           key: 'Shimmer',
           name: 'Shimmer',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #349
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As part of the M365Analytics project, I have implemented a pagination control for the project and I put together this checkin to add this component to the experiment packages.  I would love to work with the fabric team to finish this control. I aslo have unit tests for this component and will create follow up checkins. The default styles captures the design provided by office designers and it also meet the accessibility requirement. 

Our project also has a intergrated component combining this pagination and the details list as a common control. I would love to include that component as well into the experiment package in the near future.

#### Focus areas to test

![pagination1001](https://user-images.githubusercontent.com/20460495/46491290-26e4a600-c7bf-11e8-9c46-d8f4ea9dabc3.JPG)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6532)

