### PR TITLE
Added 'type' prop to SearchBox docs

### DIFF
--- a/common/changes/office-ui-fabric-react/addTypeToSearchBoxDocs_2018-10-02-22-13.json
+++ b/common/changes/office-ui-fabric-react/addTypeToSearchBoxDocs_2018-10-02-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added 'type' prop to SearchBox docs.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dardis.greg@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -66,6 +66,11 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
   value?: string;
 
   /**
+   * The HTML input type for the SearchBox. Examples: 'text', 'search'.
+   */
+  type?: string;
+
+  /**
    * The default value of the text in the SearchBox, in the case of an uncontrolled component.
    * Up till now, this has not been implemented, deprecating. Will re-implement if uncontrolled
    * component behavior is implemented.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Resolves #5891 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updated the docs in SearchBox to include the 'type' prop.

#5891 requests use of the HTML 'type' prop on the SearchBox component. A solution to this issue has already been applied, so I didn't even have to do it (native props including 'type' are already spread on the input within SearchBox).

![typeequalstel](https://user-images.githubusercontent.com/26682451/46380445-216c4c00-c657-11e8-9805-33b465992cfe.PNG)

I set the 'type' prop to 'tel' on an example and verified on an Android emulator that the telephone keyboard came up when the input was selected, as requested in #5891.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6542)

