### PR TITLE
Correct Calendar hover and selectable states for dates outside of date boundary

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-10-02-21-58.json
+++ b/common/changes/office-ui-fabric-react/master_2018-10-02-21-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Correct hover and highlight states for Calendar (DateRangeType.Week)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jehell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
@@ -4,7 +4,7 @@ import { IDocPageProps } from '../../common/DocPage.types';
 import { CalendarButtonExample } from './examples/Calendar.Button.Example';
 import { CalendarInlineExample } from './examples/Calendar.Inline.Example';
 import { CalendarStatus } from './Calendar.checklist';
-import { addMonths, addYears } from '../../utilities/dateMath/DateMath';
+import { addMonths, addYears, addWeeks } from '../../utilities/dateMath/DateMath';
 
 const CalendarButtonExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx') as string;
 const CalendarButtonExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Calendar/Calendar.Button.Example.Codepen.txt') as string;
@@ -16,8 +16,7 @@ const today = new Date(Date.now());
 export const CalendarPageProps: IDocPageProps = {
   title: 'Calendar',
   componentName: 'Calendar',
-  componentUrl:
-    'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Calendar',
+  componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Calendar',
   componentStatus: CalendarStatus,
   examples: [
     {
@@ -75,6 +74,23 @@ export const CalendarPageProps: IDocPageProps = {
           highlightSelectedMonth={true}
           showGoToToday={true}
           showNavigateButtons={true}
+        />
+      )
+    },
+    {
+      title: 'Inline Calendar with week selection and date boundary (minDate, maxDate)',
+      code: CalendarInlineExampleCode,
+
+      view: (
+        <CalendarInlineExample
+          dateRangeType={DateRangeType.Week}
+          autoNavigateOnSelection={true}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          showNavigateButtons={true}
+          minDate={addWeeks(today, -2)}
+          maxDate={addWeeks(today, 2)}
         />
       )
     },
@@ -153,8 +169,7 @@ export const CalendarPageProps: IDocPageProps = {
       )
     },
     {
-      title:
-        'Calendar with selectableDays = [Tuesday, Wednesday, Friday, Saturday] provided, first day of week = Monday',
+      title: 'Calendar with selectableDays = [Tuesday, Wednesday, Friday, Saturday] provided, first day of week = Monday',
       code: CalendarButtonExampleCode,
 
       view: (
@@ -217,9 +232,7 @@ export const CalendarPageProps: IDocPageProps = {
       )
     }
   ],
-  propertiesTablesSources: [
-    require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/Calendar.types.ts')
-  ],
+  propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/Calendar.types.ts')],
   overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/docs/CalendarOverview.md'),
   bestPractices: '',
   dos: require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/docs/CalendarDos.md'),

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -141,6 +141,7 @@ $Calendar-dayPicker-margin: 10px;
   border: none;
   padding: 0;
   background-color: transparent;
+  line-height: 100%;
 }
 
 // Today.

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -284,22 +284,22 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                         )}
                         ref={element => this._setDayCellRef(element, day, isNavigatedDate)}
                         onMouseOver={
-                          dateRangeType !== DateRangeType.Day
+                          dateRangeType !== DateRangeType.Day && day.isInBounds
                             ? this._onDayMouseOver(day.originalDate, weekIndex, dayIndex, dateRangeType)
                             : undefined
                         }
                         onMouseLeave={
-                          dateRangeType !== DateRangeType.Day
+                          dateRangeType !== DateRangeType.Day && day.isInBounds
                             ? this._onDayMouseLeave(day.originalDate, weekIndex, dayIndex, dateRangeType)
                             : undefined
                         }
                         onMouseDown={
-                          dateRangeType !== DateRangeType.Day
+                          dateRangeType !== DateRangeType.Day && day.isInBounds
                             ? this._onDayMouseDown(day.originalDate, weekIndex, dayIndex, dateRangeType)
                             : undefined
                         }
                         onMouseUp={
-                          dateRangeType !== DateRangeType.Day
+                          dateRangeType !== DateRangeType.Day && day.isInBounds
                             ? this._onDayMouseUp(day.originalDate, weekIndex, dayIndex, dateRangeType)
                             : undefined
                         }

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -483,14 +483,14 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       // set the press styling
       if (dateRangeType === DateRangeType.Month) {
         this._applyFunctionToDayRefs((ref, day) => {
-          if (ref && day.originalDate.getMonth() === originalDate.getMonth()) {
+          if (ref && day.originalDate.getMonth() === originalDate.getMonth() && day.isInBounds) {
             ref.classList.add(styles.dayPress);
           }
         });
       } else {
         // week or work week view
         this._applyFunctionToDayRefs((ref, day, dayWeekIndex) => {
-          if (ref && dayWeekIndex === weekIndex) {
+          if (ref && dayWeekIndex === weekIndex && day.isInBounds) {
             ref.classList.add(styles.dayPress);
             ref.classList.add(styles.dayIsHighlighted);
           } else if (ref) {
@@ -511,14 +511,14 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       // remove press styling
       if (dateRangeType === DateRangeType.Month) {
         this._applyFunctionToDayRefs((ref, day) => {
-          if (ref && day.originalDate.getMonth() === originalDate.getMonth()) {
+          if (ref && day.originalDate.getMonth() === originalDate.getMonth() && day.isInBounds) {
             ref.classList.remove(styles.dayPress);
           }
         });
       } else {
         // week or work week view
         this._applyFunctionToDayRefs((ref, day, dayWeekIndex) => {
-          if (ref && dayWeekIndex === weekIndex) {
+          if (ref && dayWeekIndex === weekIndex && day.isInBounds) {
             ref.classList.remove(styles.dayPress);
           }
         });
@@ -536,14 +536,14 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       // set the hover styling on every day in the same month
       if (dateRangeType === DateRangeType.Month) {
         this._applyFunctionToDayRefs((ref, day) => {
-          if (ref && day.originalDate.getMonth() === originalDate.getMonth()) {
+          if (ref && day.originalDate.getMonth() === originalDate.getMonth() && day.isInBounds) {
             ref.classList.add(styles.dayHover);
           }
         });
       } else {
         // week or work week view
         this._applyFunctionToDayRefs((ref, day, dayWeekIndex) => {
-          if (ref && dayWeekIndex === weekIndex) {
+          if (ref && dayWeekIndex === weekIndex && day.isInBounds) {
             ref.classList.add(styles.dayHover);
           }
         });
@@ -561,14 +561,14 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       // remove the hover and pressed styling
       if (dateRangeType === DateRangeType.Month) {
         this._applyFunctionToDayRefs((ref, day) => {
-          if (ref && day.originalDate.getMonth() === originalDate.getMonth()) {
+          if (ref && day.originalDate.getMonth() === originalDate.getMonth() && day.isInBounds) {
             ref.classList.remove(styles.dayHover);
           }
         });
       } else {
         // week or work week view
         this._applyFunctionToDayRefs((ref, day, dayWeekIndex) => {
-          if (ref && dayWeekIndex === weekIndex) {
+          if (ref && dayWeekIndex === weekIndex && day.isInBounds) {
             ref.classList.remove(styles.dayHover);
           }
         });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #6017
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Calendar supports specifying date boundaries via minDate and maxDate properties which prevent users from selecting or highlighting dates outside of the provided date boundary.  The date boundary is currently respected when the DateRangeType is Day, but not Week or Month.  

Add logic to respect the date boundary when the DateRangeType is not Day.

#### Focus areas to test

Day, Week and Month hovering and selecting with and without date boundaries.  Added new example to the doc with week selection and date boundaries.