### PR TITLE
Bugs/6417/searchbox input min width

### DIFF
--- a/common/changes/office-ui-fabric-react/bugs-6417-searchbox-input-min-width_2018-10-03-13-34.json
+++ b/common/changes/office-ui-fabric-react/bugs-6417-searchbox-input-min-width_2018-10-03-13-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add explicit min-width of 0px to SearchBox input element, to prevent overflow when SearchBox has a fixed width.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aymassey@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -136,6 +136,9 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         fontSize: 'inherit',
         color: palette.neutralPrimary,
         flex: '1 1 0px',
+        // The default implicit value of 'auto' prevents the input from shrinking. Setting min-width to
+        // 0px allows the input element to shrink to fit the container.
+        minWidth: '0px',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         // This padding forces the text placement to round up.

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           margin-left: 0px;
           margin-right: 0px;
           margin-top: 0px;
+          min-width: 0px;
           outline: none;
           overflow: hidden;
           padding-bottom: 0.5px;
@@ -223,6 +224,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
           margin-left: 0px;
           margin-right: 0px;
           margin-top: 0px;
+          min-width: 0px;
           outline: none;
           overflow: hidden;
           padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -104,6 +104,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
+              min-width: 0px;
               outline: none;
               overflow: hidden;
               padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -123,6 +123,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
+              min-width: 0px;
               outline: none;
               overflow: hidden;
               padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -103,6 +103,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
+            min-width: 0px;
             outline: none;
             overflow: hidden;
             padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -107,6 +107,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
+            min-width: 0px;
             outline: none;
             overflow: hidden;
             padding-bottom: 0.5px;
@@ -239,6 +240,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
+            min-width: 0px;
             outline: none;
             overflow: hidden;
             padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -103,6 +103,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
+            min-width: 0px;
             outline: none;
             overflow: hidden;
             padding-bottom: 0.5px;
@@ -226,6 +227,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
+            min-width: 0px;
             outline: none;
             overflow: hidden;
             padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -103,6 +103,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
+            min-width: 0px;
             outline: none;
             overflow: hidden;
             padding-bottom: 0.5px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -102,6 +102,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
           margin-left: 0px;
           margin-right: 0px;
           margin-top: 0px;
+          min-width: 0px;
           outline: none;
           overflow: hidden;
           padding-bottom: 0.5px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6417 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Issue #6417: when the `SearchBox` has a small fixed width the `<input>` element overflows the container, causing the overflowing text & X icon to be displayed outside the bounds of the container:

![image](https://user-images.githubusercontent.com/700278/46414543-a886f600-c723-11e8-9462-f29b1225f306.png)

Add a `min-width` of `0px` to the `<input>` element of the `SearchBox` to override the implicit value of `auto`. This allows the `<input>` element to shrink to any size when the `SearchBox` has a fixed width.

![image](https://user-images.githubusercontent.com/700278/46414591-b9d00280-c723-11e8-80de-2eadcff6ea20.png)

See [this comment](https://github.com/OfficeDev/office-ui-fabric-react/issues/6417#issuecomment-426583550) on the issue for a more detailed explanation.

#### Focus areas to test

- `SearchBox` component with/without a width attribute applied ([CodePen](https://codepen.io/anon/pen/LJMLby))
- Components which use SearchBox (`FloatingPeoplePicker`, `OverflowSet`)