### PR TITLE
Redirect links for data viz

### DIFF
--- a/common/changes/@uifabric/charting/redirectLinksForDataViz_2018-10-03-20-40.json
+++ b/common/changes/@uifabric/charting/redirectLinksForDataViz_2018-10-03-20-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Adding optional href prop to dataviz, to redirect upon clicking on the dataviz",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
@@ -1,7 +1,10 @@
 import { IArcProps, IArcStyles } from './Arc.types';
 export const getStyles = (props: IArcProps): IArcStyles => {
-  const { color } = props;
+  const { color, href } = props;
   return {
-    root: { fill: color }
+    root: {
+      fill: color,
+      cursor: href ? 'pointer' : 'default'
+    }
   };
 };

--- a/packages/charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.tsx
@@ -31,9 +31,9 @@ export class Arc extends React.Component<IArcProps, { isCalloutVisible: boolean 
   }
 
   public render(): JSX.Element {
-    const { color, arc } = this.props;
+    const { color, arc, href } = this.props;
     const getClassNames = classNamesFunction<IArcProps, IArcStyles>();
-    const classNames = getClassNames(getStyles, { color });
+    const classNames = getClassNames(getStyles, { color, href });
     const id = this.props.uniqText! + this.props.data!.data.legend!.replace(/\s+/, '') + this.props.data!.data.data;
     const opacity: number = this.props.activeArc === this.props.data!.data.legend || this.props.activeArc === '' ? 1 : 0.1;
     return (
@@ -46,6 +46,7 @@ export class Arc extends React.Component<IArcProps, { isCalloutVisible: boolean 
           onMouseMove={this._hoverOn.bind(this, this.props.data!.data)}
           onMouseLeave={this._hoverOff}
           opacity={opacity}
+          onClick={this._redirectToUrl.bind(this, href)}
         />
       </g>
     );
@@ -56,7 +57,12 @@ export class Arc extends React.Component<IArcProps, { isCalloutVisible: boolean 
       this.props.hoverOnCallback!(data, mouseEvent);
     }
   }
+
   private _hoverOff(): void {
     this.props.hoverLeaveCallback!();
+  }
+
+  private _redirectToUrl(href: string | undefined): void {
+    href ? (window.location.href = href) : '';
   }
 }

--- a/packages/charting/src/components/DonutChart/Arc/Arc.types.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.types.ts
@@ -45,6 +45,11 @@ export interface IArcProps {
    * Active Arc for chart
    */
   activeArc?: string;
+
+  /**
+   * internal prop for href
+   */
+  href?: string;
 }
 
 export interface IArcData {

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -59,7 +59,7 @@ export class DonutChartBase extends React.Component<
     });
   }
   public render(): JSX.Element {
-    const { data } = this.props;
+    const { data, href } = this.props;
     const { _width, _height } = this.state;
 
     const { theme, className, styles, innerRadius } = this.props;
@@ -88,6 +88,7 @@ export class DonutChartBase extends React.Component<
             hoverLeaveCallback={this._hoverLeave}
             uniqText={this._uniqText}
             activeArc={this.state.activeLegend}
+            href={href}
           />
         </svg>
         {this.state.showHover ? (

--- a/packages/charting/src/components/DonutChart/DonutChart.types.ts
+++ b/packages/charting/src/components/DonutChart/DonutChart.types.ts
@@ -43,7 +43,12 @@ export interface IDonutChartProps {
   /**
    * Width of line stroke
    */
-  strokeWidth?: number;
+  strokeWidth?: string;
+
+  /**
+   * Url that the data-viz needs to redirect to upon clicking on it
+   */
+  href?: string;
 }
 
 export interface IDonutChartStyleProps {

--- a/packages/charting/src/components/DonutChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.tsx
@@ -20,7 +20,7 @@ export class Pie extends React.Component<IPieProps, {}> {
     this._hoverCallback = this._hoverCallback.bind(this);
   }
 
-  public arcGenerator = (d: IArcData, i: number): JSX.Element => {
+  public arcGenerator = (d: IArcData, i: number, href?: string): JSX.Element => {
     const color = d && d.data && d.data.color;
     return (
       <Arc
@@ -33,17 +33,18 @@ export class Pie extends React.Component<IPieProps, {}> {
         hoverLeaveCallback={this.props.hoverLeaveCallback}
         uniqText={this.props.uniqText}
         activeArc={this.props.activeArc}
+        href={href}
       />
     );
   };
 
   public render(): JSX.Element {
-    const { pie, data, width, height } = this.props;
+    const { pie, data, width, height, href } = this.props;
 
     const piechart = pie(data),
       translate = `translate(${width / 2}, ${height / 2})`;
 
-    return <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i))}</g>;
+    return <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i, href))}</g>;
   }
   private _hoverCallback(data: IChartDataPoint, e: React.MouseEvent<SVGPathElement>): void {
     this.props.hoverOnCallback!(data, e);

--- a/packages/charting/src/components/DonutChart/Pie/Pie.types.ts
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.types.ts
@@ -43,6 +43,11 @@ export interface IPieProps {
    * Active Arc for chart
    */
   activeArc?: string;
+
+  /**
+   * internal prop for href
+   */
+  href?: string;
 }
 
 export interface IPieStyles {

--- a/packages/charting/src/components/DonutChart/examples/DonutChart.Basic.Example.tsx
+++ b/packages/charting/src/components/DonutChart/examples/DonutChart.Basic.Example.tsx
@@ -20,6 +20,6 @@ export class DonutChartBasicExample extends React.Component<IDonutChartProps, {}
       chartTitle: chartTitle,
       chartData: points
     };
-    return <DonutChart data={data} innerRadius={30} />;
+    return <DonutChart data={data} innerRadius={30} href={'https://developer.microsoft.com/en-us/'} />;
   }
 }

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -55,13 +55,13 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
   }
 
   public render(): JSX.Element {
-    const { barHeight, data, theme, hideRatio, styles } = this.props;
+    const { barHeight, data, theme, hideRatio, styles, href } = this.props;
     this._adjustProps();
     const { palette } = theme!;
     const legends = this._getLegendData(data!, hideRatio!, palette);
     const bars: JSX.Element[] = [];
     data!.map((singleChartData: IChartProps, index: number) => {
-      const singleChartBars = this._createBarsAndLegends(singleChartData!, barHeight!, palette, hideRatio![index]);
+      const singleChartBars = this._createBarsAndLegends(singleChartData!, barHeight!, palette, hideRatio![index], href);
       bars.push(<div key={index}>{singleChartBars}</div>);
     });
     this._classNames = getClassNames(styles!, {
@@ -91,7 +91,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     );
   }
 
-  private _createBarsAndLegends(data: IChartProps, barHeight: number, palette: IPalette, hideRatio: boolean): JSX.Element {
+  private _createBarsAndLegends(data: IChartProps, barHeight: number, palette: IPalette, hideRatio: boolean, href?: string): JSX.Element {
     const defaultPalette: string[] = [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     // calculating starting point of each bar and it's range
     const startingPoint: number[] = [];
@@ -113,7 +113,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       }
       this._classNames = getClassNames(styles!, {
         theme: this.props.theme!,
-        shouldHighlight: shouldHighlight
+        shouldHighlight: shouldHighlight,
+        href: href
       });
       return (
         <g
@@ -125,6 +126,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           onMouseOver={this._onBarHover.bind(this, point.legend!, pointData, color)}
           onMouseMove={this._onBarHover.bind(this, point.legend!, pointData, color)}
           onMouseLeave={this._onBarLeave}
+          onClick={this._redirectToUrl.bind(this, href)}
         >
           <rect key={index} x={startingPoint[index] + '%'} y={0} width={value + '%'} height={barHeight} fill={color} />
         </g>
@@ -132,7 +134,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     });
     if (data.chartData!.length === 0) {
       bars.push(
-        <g key={0}>
+        <g key={0} className={this._classNames.noData} onClick={this._redirectToUrl.bind(this, href)}>
           <rect key={0} x={'0%'} y={0} width={'100%'} height={barHeight} fill={palette.neutralTertiaryAlt} />
         </g>
       );
@@ -282,5 +284,9 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     this.setState({
       isCalloutVisible: false
     });
+  }
+
+  private _redirectToUrl(href: string | undefined): void {
+    href ? (window.location.href = href) : '';
   }
 }

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -2,7 +2,7 @@ import { IMultiStackedBarChartStyles } from '@uifabric/charting/lib/StackedBarCh
 import { IMultiStackedBarChartStyleProps } from './MultiStackedBarChart.types';
 
 export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleProps): IMultiStackedBarChartStyles => {
-  const { className, width, barHeight, legendColor, shouldHighlight, theme } = props;
+  const { className, width, barHeight, legendColor, shouldHighlight, theme, href } = props;
   return {
     root: [
       'ms-StackedBarChart',
@@ -52,7 +52,11 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       paddingBottom: '8px'
     },
     opacityChangeOnHover: {
-      opacity: shouldHighlight ? '' : '0.1'
+      opacity: shouldHighlight ? '' : '0.1',
+      cursor: href ? 'pointer' : 'default'
+    },
+    noData: {
+      cursor: href ? 'pointer' : 'default'
     }
   };
 };

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -38,6 +38,11 @@ export interface IMultiStackedBarChartProps {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>;
+
+  /**
+   * Url that the data-viz needs to redirect to upon clicking on it
+   */
+  href?: string;
 }
 
 export interface IMultiStackedBarChartStyleProps {
@@ -70,6 +75,11 @@ export interface IMultiStackedBarChartStyleProps {
    * prop to check if the chart is selcted or hovered upon to determine opacity
    */
   shouldHighlight?: boolean;
+
+  /**
+   * prop to check to decide cursor type
+   */
+  href?: string;
 }
 
 export interface IMultiStackedBarChartStyles {
@@ -117,4 +127,9 @@ export interface IMultiStackedBarChartStyles {
    * Style to change the opacity of bars in dataviz when we hover on a single bar or legends
    */
   opacityChangeOnHover: IStyle;
+
+  /**
+   * Style for stacked bar chart with no data
+   */
+  noData: IStyle;
 }

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -29,8 +29,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
   public static defaultProps: Partial<IStackedBarChartProps> = {
     barHeight: 16,
     hideNumberDisplay: false,
-    hideLegend: false,
-    isMultiStackedBarChart: false
+    hideLegend: false
   };
   private _classNames: IProcessedStyleSet<IStackedBarChartStyles>;
 
@@ -53,10 +52,10 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
 
   public render(): JSX.Element {
     this._adjustProps();
-    const { data, hideNumberDisplay, hideLegend, theme, styles, barBackgroundColor } = this.props;
+    const { data, hideNumberDisplay, hideLegend, theme, styles, barBackgroundColor, href } = this.props;
     const { palette } = theme!;
     const barHeight = data!.chartData!.length > 2 ? this.props.barHeight : 8;
-    const bars = this._createBarsAndLegends(data!, barHeight!, palette, barBackgroundColor);
+    const bars = this._createBarsAndLegends(data!, barHeight!, palette, barBackgroundColor, href);
     const showRatio = hideNumberDisplay === false && data!.chartData!.length === 2;
     const showNumber = hideNumberDisplay === false && data!.chartData!.length === 1;
     let total = 0;
@@ -127,7 +126,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     data: IChartProps,
     barHeight: number,
     palette: IPalette,
-    barBackgroundColor?: string
+    barBackgroundColor?: string,
+    href?: string
   ): [JSX.Element[], JSX.Element] {
     const defaultPalette: string[] = [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     const legendDataItems: ILegend[] = [];
@@ -175,7 +175,8 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
       }
       this._classNames = getClassNames(styles!, {
         theme: this.props.theme!,
-        shouldHighlight: shouldHighlight
+        shouldHighlight: shouldHighlight,
+        href: href
       });
       return (
         <g
@@ -188,6 +189,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           onMouseMove={this._onBarHover.bind(this, point.legend!, pointData, color)}
           onMouseLeave={this._onBarLeave}
           pointerEvents="all"
+          onClick={this._redirectToUrl.bind(this, href)}
         >
           <rect key={index} x={startingPoint[index] + '%'} y={0} width={value + '%'} height={barHeight} fill={color} />
         </g>
@@ -269,5 +271,9 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
     this.setState({
       isCalloutVisible: false
     });
+  }
+
+  private _redirectToUrl(href: string | undefined): void {
+    href ? (window.location.href = href) : '';
   }
 }

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -2,7 +2,7 @@ import { IStackedBarChartStyleProps, IStackedBarChartStyles } from './StackedBar
 import { FontSizes, FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartStyles => {
-  const { className, width, barHeight, legendColor, shouldHighlight, theme } = props;
+  const { className, width, barHeight, legendColor, shouldHighlight, theme, href } = props;
   return {
     root: [
       'ms-StackedBarChart',
@@ -45,7 +45,8 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
       paddingBottom: '8px'
     },
     opacityChangeOnHover: {
-      opacity: shouldHighlight ? '' : '0.1'
+      opacity: shouldHighlight ? '' : '0.1',
+      cursor: href ? 'pointer' : 'default'
     },
     ratioNumerator: {
       fontSize: FontSizes.small,

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.types.ts
@@ -50,12 +50,15 @@ export interface IStackedBarChartProps {
    */
   styles?: IStyleFunctionOrObject<IStackedBarChartStyleProps, IStackedBarChartStyles>;
 
-  isMultiStackedBarChart?: boolean;
-
   /**
    * Color setting of bar background color, this will show while all data points value is 0
    */
   barBackgroundColor?: string;
+
+  /**
+   * Url that the data-viz needs to redirect to upon clicking on it
+   */
+  href?: string;
 }
 
 export interface IStackedBarChartStyleProps {
@@ -93,6 +96,11 @@ export interface IStackedBarChartStyleProps {
    * prop to check which specific section of the stacked bar chart is selected or hovered upon
    */
   isChartSelected?: boolean;
+
+  /**
+   * prop to check to decide cursor type
+   */
+  href?: string;
 }
 
 export interface IStackedBarChartStyles {

--- a/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChart.Example.tsx
+++ b/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChart.Example.tsx
@@ -30,5 +30,5 @@ export const MultiStackedBarChartExample: React.SFC<{}> = () => {
     }
   ];
 
-  return <MultiStackedBarChart data={data} hideRatio={hideRatio} width={600} />;
+  return <MultiStackedBarChart data={data} hideRatio={hideRatio} width={600} href={'https://developer.microsoft.com/en-us/'} />;
 };

--- a/packages/charting/src/components/StackedBarChart/examples/StackedBarChart.BaseBar.Example.tsx
+++ b/packages/charting/src/components/StackedBarChart/examples/StackedBarChart.BaseBar.Example.tsx
@@ -18,6 +18,8 @@ export class StackedBarChartBaseBarExample extends React.Component<{}, {}> {
       chartData: points
     };
 
-    return <StackedBarChart data={data} barBackgroundColor={DefaultPalette.neutralTertiary} />;
+    return (
+      <StackedBarChart data={data} barBackgroundColor={DefaultPalette.neutralTertiary} href={'https://developer.microsoft.com/en-us/'} />
+    );
   }
 }

--- a/packages/charting/src/components/StackedBarChart/examples/StackedBarChart.Basic.Example.tsx
+++ b/packages/charting/src/components/StackedBarChart/examples/StackedBarChart.Basic.Example.tsx
@@ -16,6 +16,6 @@ export class StackedBarChartBasicExample extends React.Component<{}, {}> {
       chartData: points
     };
 
-    return <StackedBarChart data={data} />;
+    return <StackedBarChart data={data} href={'https://developer.microsoft.com/en-us/'} />;
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adding optional href props for DataViz. Upon passing this prop, DataViz will be clickable and will redirect to the specified URL.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6554)

