### PR TITLE
Dropdown arialabelledby

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-arialabelledby_2018-10-03-21-30.json
+++ b/common/changes/office-ui-fabric-react/dropdown-arialabelledby_2018-10-03-21-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: only apply an aria-labelledby attribute if a non-empty label property is given",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -218,7 +218,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
               aria-expanded={isOpen ? 'true' : 'false'}
               role={ariaAttrs.role}
               aria-label={ariaLabel}
-              aria-labelledby={id + '-label'}
+              aria-labelledby={label ? (id + '-label') : undefined}
               aria-describedby={mergeAriaAttributeValues(optionId, keytipAttributes['aria-describedby'])}
               aria-activedescendant={ariaAttrs.ariaActiveDescendant}
               aria-disabled={disabled}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -575,4 +575,36 @@ describe('Dropdown', () => {
       expect(titleElement.textContent).toEqual('3');
     });
   });
+
+  describe('Aria attributes', () => {
+    it('does not apply aria-labelledby if no label is provided', () => {
+      const container = document.createElement('div');
+      const options = [{ key: 0, text: '1' }, { key: 1, text: '2', disabled: true }, { key: 2, text: '3' }];
+
+      ReactDOM.render(<Dropdown options={options} />, container);
+      const dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+      expect(dropdownRoot.attributes.getNamedItem('aria-labelledby')).toBeNull();
+    });
+
+    it('does not apply aria-labelledby if an empty label is provided', () => {
+      const container = document.createElement('div');
+      const options = [{ key: 0, text: '1' }, { key: 1, text: '2', disabled: true }, { key: 2, text: '3' }];
+
+      ReactDOM.render(<Dropdown label="" options={options} />, container);
+      const dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+      expect(dropdownRoot.attributes.getNamedItem('aria-labelledby')).toBeNull();
+    });
+
+    it('applies aria-labelledby if a non-empty label is provided', () => {
+      const container = document.createElement('div');
+      const options = [{ key: 0, text: '1' }, { key: 1, text: '2', disabled: true }, { key: 2, text: '3' }];
+
+      ReactDOM.render(<Dropdown label="Test label" options={options} />, container);
+      const dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+      expect(dropdownRoot.attributes.getNamedItem('aria-labelledby')).not.toBeNull();
+    });
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
   <div
     aria-describedby="Dropdown0-option"
     aria-expanded="false"
-    aria-labelledby="Dropdown0-label"
     className=
         ms-Dropdown
         {
@@ -184,7 +183,6 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
     aria-activedescendant="Dropdown0-option"
     aria-describedby="Dropdown0-option"
     aria-expanded="false"
-    aria-labelledby="Dropdown0-label"
     className=
         ms-Dropdown
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -178,7 +178,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   aria-describedby="Dropdown2-option"
                   aria-disabled={false}
                   aria-expanded="false"
-                  aria-labelledby="Dropdown2-label"
                   className=
                       ms-Dropdown
                       {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6545 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

If the Dropdown's label property is empty or undefined, set the Dropdown's aria-labelledby attribute to undefined. This prevents the aria-labelledby attribute from being invalid (the id of a nonexistent DOM element).

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6555)

