### PR TITLE
Add animationDelay prop to Coachmark

### DIFF
--- a/common/changes/@uifabric/styling/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
+++ b/common/changes/@uifabric/styling/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/styling",
-      "comment": "add delayLength parameter to _createDefaultAnimation",
+      "comment": "add delayLength parameter to _createDefaultAnimation in PulsingBeaconAnimationStyles",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/styling/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
+++ b/common/changes/@uifabric/styling/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "add delayLength parameter to _createDefaultAnimation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "edwl@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
+++ b/common/changes/@uifabric/styling/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@uifabric/styling",
       "comment": "add delayLength parameter to _createDefaultAnimation in PulsingBeaconAnimationStyles",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@uifabric/styling",

--- a/common/changes/office-ui-fabric-react/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
+++ b/common/changes/office-ui-fabric-react/edwl-2018-10-fixCoachmarkDelay_2018-10-03-21-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark: Add delayBeforeCoachmarkAnimation prop",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -70,6 +70,11 @@ export interface ICoachmarkStyleProps {
    * Transform origin for teaching bubble content
    */
   transformOrigin?: string;
+
+  /**
+   * Delay time for the animation to start
+   */
+  delayBeforeCoachmarkAnimation?: string;
 }
 
 export interface ICoachmarkStyles {
@@ -253,7 +258,8 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
     animationBorderWidth
   );
 
-  const ContinuousPulseAnimation = PulsingBeaconAnimationStyles.createDefaultAnimation(ContinuousPulse);
+  const ContinuousPulseAnimation =
+    PulsingBeaconAnimationStyles.createDefaultAnimation(ContinuousPulse, props.delayBeforeCoachmarkAnimation);
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.tsx
@@ -122,6 +122,7 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
     isCollapsed: true,
     mouseProximityOffset: 10,
     delayBeforeMouseOpen: 3600, // The approximate time the coachmark shows up
+    delayBeforeCoachmarkAnimation: 0,
     color: DefaultPalette.themePrimary,
     isPositionForced: true,
     positioningContainerProps: {
@@ -191,7 +192,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
       ariaDescribedByText,
       ariaLabelledBy,
       ariaLabelledByText,
-      ariaAlertText
+      ariaAlertText,
+      delayBeforeCoachmarkAnimation
     } = this.props;
 
     const {
@@ -218,7 +220,8 @@ export class Coachmark extends BaseComponent<ICoachmarkProps, ICoachmarkState> i
       height: `${COACHMARK_HEIGHT}px`,
       color: color,
       transformOrigin: transformOrigin,
-      isMeasured: isMeasured
+      isMeasured: isMeasured,
+      delayBeforeCoachmarkAnimation: `${delayBeforeCoachmarkAnimation}ms`
     });
 
     const finalHeight: number = isCollapsed ? COACHMARK_HEIGHT : entityInnerHostRect.height;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -90,6 +90,12 @@ export interface ICoachmarkProps extends React.Props<Coachmark> {
   delayBeforeMouseOpen?: number;
 
   /**
+   * Delay in milliseconds before Coachmark animation appears.
+   * @default 0
+   */
+  delayBeforeCoachmarkAnimation?: number;
+
+  /**
    * Callback to run when the mouse moves.
    */
   onMouseMove?: (e: MouseEvent) => void;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/docs/CoachmarkDos.md
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/docs/CoachmarkDos.md
@@ -3,3 +3,4 @@
 - Coachmarks are designed to only hold TeachingBubbles
 - Provide descriptive text in the `ariaDescribedByText` prop to let accessibility impaired users know how to open/access the Coachmark with keyboard controls. (See example in documentation)
 - The keyboard shortcut for opening the Coachmark is `Alt + C`
+- Consider when the Coachmark loads on-screen: the default value `delayBeforeCoachmarkAnimation` is set to 0, but you can increase this number to delay when the coachmark is displayed. Adding a delay can make the Coachmark stand out more, so consider scenario needs and page load times when adjusting this number. A delay that's 2-4 seconds is recommended if you choose to use one.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -1987,7 +1987,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                       className=
 
                           {
-                            animation-delay: 2s;
+                            animation-delay: 0ms;
                             animation-duration: 14s;
                             animation-iteration-count: 1;
                             animation-name: keyframes 0%{border-color:#0078d4;border-width:0px;width:35px;height:35px;}1.42%{opacity:1;border-width:10px;}3.57%{opacity:1;}7.14%{border-width:0;width:150px;height:150px;opacity:0;border-color:#71afe5;}8%{border-color:#0078d4;border-width:0px;width:35px;height:35px;opacity:0;}29.99%{border-color:#0078d4;border-width:0px;width:35px;height:35px;opacity:0;}30%{border-color:#0078d4;border-width:0px;width:35px;height:35px;}31.42%{opacity:1;border-width:10px;}33.57%{opacity:1;}37.14%{border-width:0;width:150px;height:150px;opacity:0;border-color:#71afe5;}38%{border-color:#0078d4;border-width:0px;width:35px;height:35px;opacity:0;}79.42%{border-color:#0078d4;border-width:0px;width:35px;height:35px;opacity:0;}79.43{border-color:#0078d4;border-width:0px;width:35px;height:35px;}81.85{opacity:1;border-width:10px;}83.42{opacity:1;}87%{border-width:0;width:150px;height:150px;opacity:0;border-color:#71afe5;}100%{};

--- a/packages/styling/src/styles/PulsingBeaconAnimationStyles.ts
+++ b/packages/styling/src/styles/PulsingBeaconAnimationStyles.ts
@@ -89,12 +89,12 @@ function _continuousPulseAnimationSingle(
   });
 }
 
-function _createDefaultAnimation(animationName: string): IRawStyle {
+function _createDefaultAnimation(animationName: string, delayLength?: string): IRawStyle {
   return {
     animationName,
     animationIterationCount: DEFAULT_ITERATION_COUNT,
     animationDuration: DEFAULT_DURATION,
-    animationDelay: DEFAULT_DELAY
+    animationDelay: delayLength || DEFAULT_DELAY
   };
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

- Changes default animation delay for Coachmark to 0s.
- Add `delayBeforeCoachmarkAnimation` prop for Coachmark

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6556)

