### PR TITLE
FacepileButton styles

### DIFF
--- a/common/changes/office-ui-fabric-react/facepilebutton-styles_2018-10-04-04-01.json
+++ b/common/changes/office-ui-fabric-react/facepilebutton-styles_2018-10-04-04-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Facepile: allow FacepileButton to render custom styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.styles.ts
@@ -24,20 +24,14 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
     padding: 0,
     borderRadius: '50%',
     verticalAlign: 'top',
+    display: 'inline',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    border: 'none',
     selectors: {
-      'button&': {
-        display: 'inline',
-        background: 'none',
-        backgroundColor: 'transparent',
+      '&::-moz-focus-inner': {
         padding: 0,
-        cursor: 'pointer',
-        border: 'none',
-        selectors: {
-          '&::-moz-focus-inner': {
-            padding: 0,
-            border: 0
-          }
-        }
+        border: 0
       }
     }
   };
@@ -56,26 +50,22 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
       getFocusStyle(theme, -1),
       ItemButtonStyles,
       {
+        fontSize: fonts.medium.fontSize,
+        color: palette.white,
+        backgroundColor: palette.themePrimary,
+        marginRight: spacingAroundItemButton * 2 + 'px',
         selectors: {
-          'button&': {
-            fontSize: fonts.medium.fontSize,
-            color: palette.white,
-            backgroundColor: palette.themePrimary,
-            marginRight: spacingAroundItemButton * 2 + 'px',
-            selectors: {
-              '&:hover': {
-                backgroundColor: palette.themeDark
-              },
-              '&:focus': {
-                backgroundColor: palette.themeDark
-              },
-              '&:active': {
-                backgroundColor: palette.themeDarker
-              },
-              '&:disabled': {
-                backgroundColor: palette.neutralTertiaryAlt
-              }
-            }
+          '&:hover': {
+            backgroundColor: palette.themeDark
+          },
+          '&:focus': {
+            backgroundColor: palette.themeDark
+          },
+          '&:active': {
+            backgroundColor: palette.themeDarker
+          },
+          '&:disabled': {
+            backgroundColor: palette.neutralTertiaryAlt
           }
         }
       }
@@ -86,14 +76,10 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
       getFocusStyle(theme, -1),
       ItemButtonStyles,
       {
-        selectors: {
-          'button&': {
-            fontSize: fonts.small.fontSize,
-            color: palette.neutralSecondary,
-            backgroundColor: palette.neutralLight,
-            marginLeft: `${spacingAroundItemButton * 2}px`
-          }
-        }
+        fontSize: fonts.small.fontSize,
+        color: palette.neutralSecondary,
+        backgroundColor: palette.neutralLight,
+        marginLeft: `${spacingAroundItemButton * 2}px`
       }
     ],
 
@@ -131,14 +117,10 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
       getFocusStyle(theme, -1),
       ItemButtonStyles,
       {
-        selectors: {
-          'button&': {
-            fontSize: fonts.medium.fontSize,
-            color: palette.neutralSecondary,
-            backgroundColor: palette.neutralLight,
-            marginLeft: `${spacingAroundItemButton * 2}px`
-          }
-        }
+        fontSize: fonts.medium.fontSize,
+        color: palette.neutralSecondary,
+        backgroundColor: palette.neutralLight,
+        marginLeft: `${spacingAroundItemButton * 2}px`
       }
     ],
 

--- a/packages/office-ui-fabric-react/src/components/Facepile/FacepileButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/FacepileButton.styles.ts
@@ -1,0 +1,12 @@
+import { ITheme, concatStyleSets } from '../../Styling';
+import { memoizeFunction } from '../../Utilities';
+import { IButtonStyles } from '../../Button';
+import { getStyles as getBaseButtonStyles } from '../Button/BaseButton.styles';
+
+export const getStyles = memoizeFunction(
+  (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
+    const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
+
+    return concatStyleSets(baseButtonStyles, customStyles)!;
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Facepile/FacepileButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/FacepileButton.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
-import { BaseComponent } from '../../Utilities';
 import { BaseButton, IButtonProps } from '../../Button';
-import { getTheme } from '../../Styling';
-import { getStyles } from '../Button/BaseButton.styles';
+import { BaseComponent, customizable, nullRender } from '../../Utilities';
+import { getStyles } from './FacepileButton.styles';
 
+@customizable('FacepileButton', ['theme', 'styles'], true)
 export class FacepileButton extends BaseComponent<IButtonProps, {}> {
-  public render(): JSX.Element {
-    const baseButtonStyles = getStyles(getTheme());
+  /**
+   * Tell BaseComponent to bypass resolution of componentRef.
+   */
+  protected _skipComponentRefResolution = true;
 
-    return <BaseButton {...this.props} styles={baseButtonStyles} />;
+  public render(): JSX.Element {
+    const { theme, styles, className } = this.props;
+
+    return <BaseButton {...this.props} variantClassName={className} styles={getStyles(theme!, styles)} onRenderDescription={nullRender} />;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -57,17 +57,8 @@ exports[`Facepile renders Facepile correctly 1`] = `
                 ms-Facepile-itemButton
                 ms-Facepile-person
                 {
-                  border-radius: 50%;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  text-align: center;
-                  vertical-align: top;
-                }
-                button& {
                   background-color: transparent;
-                  background: none;
+                  border-radius: 50%;
                   border: none;
                   cursor: pointer;
                   display: inline;
@@ -75,6 +66,8 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   padding-left: 0px;
                   padding-right: 0px;
                   padding-top: 0px;
+                  text-align: center;
+                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0px;
@@ -181,17 +174,8 @@ exports[`Facepile renders Facepile correctly 1`] = `
                 ms-Facepile-itemButton
                 ms-Facepile-person
                 {
-                  border-radius: 50%;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  text-align: center;
-                  vertical-align: top;
-                }
-                button& {
                   background-color: transparent;
-                  background: none;
+                  border-radius: 50%;
                   border: none;
                   cursor: pointer;
                   display: inline;
@@ -199,6 +183,8 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   padding-left: 0px;
                   padding-right: 0px;
                   padding-top: 0px;
+                  text-align: center;
+                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0px;
@@ -308,11 +294,12 @@ exports[`Facepile renders Facepile correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
                   border-radius: 50%;
-                  border: 1px solid transparent;
+                  border: none;
                   box-sizing: border-box;
                   cursor: pointer;
-                  display: inline-block;
+                  display: inline;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
@@ -357,17 +344,6 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   left: 0px;
                   position: relative;
                   top: 0px;
-                }
-                button& {
-                  background-color: transparent;
-                  background: none;
-                  border: none;
-                  cursor: pointer;
-                  display: inline;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
                 }
             data="75%"
             data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
@@ -46,14 +46,17 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            background-color: #0078d4;
             border-radius: 50%;
-            border: 1px solid transparent;
+            border: none;
             box-sizing: border-box;
+            color: #ffffff;
             cursor: pointer;
-            display: inline-block;
+            display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
+            margin-right: 4px;
             outline: transparent;
             padding-bottom: 0px;
             padding-left: 0px;
@@ -104,20 +107,6 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
           }
           &:active {
             background-color: #004578;
-          }
-          button& {
-            background-color: #0078d4;
-            background: none;
-            border: none;
-            color: #ffffff;
-            cursor: pointer;
-            display: inline;
-            font-size: 14px;
-            margin-right: 4px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
           }
           &:disabled {
             background-color: #c8c8c8;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -83,17 +83,8 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                   ms-Facepile-itemButton
                   ms-Facepile-person
                   {
-                    border-radius: 50%;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    text-align: center;
-                    vertical-align: top;
-                  }
-                  button& {
                     background-color: transparent;
-                    background: none;
+                    border-radius: 50%;
                     border: none;
                     cursor: pointer;
                     display: inline;
@@ -101,6 +92,8 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                    text-align: center;
+                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0px;
@@ -207,17 +200,8 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                   ms-Facepile-itemButton
                   ms-Facepile-person
                   {
-                    border-radius: 50%;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    text-align: center;
-                    vertical-align: top;
-                  }
-                  button& {
                     background-color: transparent;
-                    background: none;
+                    border-radius: 50%;
                     border: none;
                     cursor: pointer;
                     display: inline;
@@ -225,6 +209,8 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                    text-align: center;
+                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0px;
@@ -334,11 +320,12 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
                     border-radius: 50%;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     cursor: pointer;
-                    display: inline-block;
+                    display: inline;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
@@ -383,17 +370,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     left: 0px;
                     position: relative;
                     top: 0px;
-                  }
-                  button& {
-                    background-color: transparent;
-                    background: none;
-                    border: none;
-                    cursor: pointer;
-                    display: inline;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
                   }
               data="75%"
               data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -83,17 +83,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   ms-Facepile-itemButton
                   ms-Facepile-person
                   {
-                    border-radius: 50%;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    text-align: center;
-                    vertical-align: top;
-                  }
-                  button& {
                     background-color: transparent;
-                    background: none;
+                    border-radius: 50%;
                     border: none;
                     cursor: pointer;
                     display: inline;
@@ -101,6 +92,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                    text-align: center;
+                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0px;
@@ -207,17 +200,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   ms-Facepile-itemButton
                   ms-Facepile-person
                   {
-                    border-radius: 50%;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    text-align: center;
-                    vertical-align: top;
-                  }
-                  button& {
                     background-color: transparent;
-                    background: none;
+                    border-radius: 50%;
                     border: none;
                     cursor: pointer;
                     display: inline;
@@ -225,6 +209,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                    text-align: center;
+                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0px;
@@ -334,11 +320,12 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
                     border-radius: 50%;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     cursor: pointer;
-                    display: inline-block;
+                    display: inline;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
@@ -383,17 +370,6 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     left: 0px;
                     position: relative;
                     top: 0px;
-                  }
-                  button& {
-                    background-color: transparent;
-                    background: none;
-                    border: none;
-                    cursor: pointer;
-                    display: inline;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
                   }
               data="75%"
               data-is-focusable={true}
@@ -491,17 +467,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   ms-Facepile-itemButton
                   ms-Facepile-person
                   {
-                    border-radius: 50%;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    text-align: center;
-                    vertical-align: top;
-                  }
-                  button& {
                     background-color: transparent;
-                    background: none;
+                    border-radius: 50%;
                     border: none;
                     cursor: pointer;
                     display: inline;
@@ -509,6 +476,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                    text-align: center;
+                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0px;
@@ -594,17 +563,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   ms-Facepile-itemButton
                   ms-Facepile-person
                   {
-                    border-radius: 50%;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    text-align: center;
-                    vertical-align: top;
-                  }
-                  button& {
                     background-color: transparent;
-                    background: none;
+                    border-radius: 50%;
                     border: none;
                     cursor: pointer;
                     display: inline;
@@ -612,6 +572,8 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     padding-left: 0px;
                     padding-right: 0px;
                     padding-top: 0px;
+                    text-align: center;
+                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6537 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1. Rewrite FacepileButton to use a getStyles function (similar to other Button variants such as DefaultButton)
2. Remove button& selectors from Facepile styles. These selectors were overriding any custom styles passed in to FacepileButton.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6561)

