### PR TITLE
Fix SearchBox autoFocus bug

### DIFF
--- a/common/changes/office-ui-fabric-react/fixAutoFocusBug_2018-10-04-17-27.json
+++ b/common/changes/office-ui-fabric-react/fixAutoFocusBug_2018-10-04-17-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed null ref error when autoFocus prop is used in SearchBox",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dardis.greg@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -77,6 +77,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
     });
 
     const nativeProps = getNativeProps(this.props, inputProperties, ['id', 'className', 'placeholder', 'onFocus', 'onBlur', 'value']);
+
     return (
       <div ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -4,6 +4,7 @@ import { BaseComponent, getId, KeyCodes, classNamesFunction, createRef, getNativ
 
 import { IconButton } from '../../Button';
 import { Icon } from '../../Icon';
+import { log } from 'util';
 
 const getClassNames = classNamesFunction<ISearchBoxStyleProps, ISearchBoxStyles>();
 
@@ -77,7 +78,6 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
     });
 
     const nativeProps = getNativeProps(this.props, inputProperties, ['id', 'className', 'placeholder', 'onFocus', 'onBlur', 'value']);
-
     return (
       <div ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
@@ -154,7 +154,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
       hasFocus: true
     });
 
-    this._events.on(this._rootElement.current, 'blur', this._onBlur, true);
+    this._events.on(ev.currentTarget, 'blur', this._onBlur, true);
 
     if (this.props.onFocus) {
       this.props.onFocus(ev as React.FocusEvent<HTMLInputElement>);

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -4,7 +4,6 @@ import { BaseComponent, getId, KeyCodes, classNamesFunction, createRef, getNativ
 
 import { IconButton } from '../../Button';
 import { Icon } from '../../Icon';
-import { log } from 'util';
 
 const getClassNames = classNamesFunction<ISearchBoxStyleProps, ISearchBoxStyles>();
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6562 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

If `autoFocus={true}` for the SearchBox component, `onFocusCapture` for the root div [(here)](https://github.com/OfficeDev/office-ui-fabric-react/blob/c61c1ca08a7c66101006165001e9193419704af2/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx#L82) is called before the ref is set to `this._rootElement` on the same line.

This results in `this._rootElement.current` being null in `this._onFocusCapture`. This seems to be an issue with React, shown [here](https://github.com/facebook/react/issues/7769), and I got the workaround from the very same [issue](https://github.com/facebook/react/issues/7769#issuecomment-337344644).
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6566)

