### PR TITLE
Fix DetailsHeader IColumn invoking onColumnClick when disabled

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-disabled-col-click_2018-10-04-18-11.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-disabled-col-click_2018-10-04-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes DetailsHeader disabled columns invoking onColumnClick callbacks",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react';
 import { Icon } from '../../Icon';
-import {
-  BaseComponent,
-  IRenderFunction,
-  createRef,
-  IDisposable,
-  classNamesFunction,
-  IClassNames
-} from '../../Utilities';
+import { BaseComponent, IRenderFunction, createRef, IDisposable, classNamesFunction, IClassNames } from '../../Utilities';
 import { IColumn, ColumnActionsMode } from './DetailsList.types';
 
 import { ITooltipHostProps } from '../../Tooltip';
@@ -36,15 +29,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   }
 
   public render(): JSX.Element {
-    const {
-      column,
-      columnIndex,
-      parentId,
-      isDraggable,
-      styles,
-      theme,
-      cellStyleProps = DEFAULT_CELL_STYLE_PROPS
-    } = this.props;
+    const { column, columnIndex, parentId, isDraggable, styles, theme, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = this.props;
     const { onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip } = this.props;
 
     this._classNames = getClassNames(styles, {
@@ -103,41 +88,26 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                       : undefined
                   }
                   aria-describedby={
-                    this.props.onRenderColumnHeaderTooltip || this._hasAccessibleLabel()
-                      ? `${parentId}-${column.key}-tooltip`
-                      : undefined
+                    this.props.onRenderColumnHeaderTooltip || this._hasAccessibleLabel() ? `${parentId}-${column.key}-tooltip` : undefined
                   }
                   onContextMenu={this._onColumnContextMenu.bind(this, column)}
                   onClick={this._onColumnClick.bind(this, column)}
                   aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
                 >
                   <span id={`${parentId}-${column.key}-name`} className={classNames.cellName}>
-                    {(column.iconName || column.iconClassName) && (
-                      <Icon className={classNames.iconClassName} iconName={column.iconName} />
-                    )}
+                    {(column.iconName || column.iconClassName) && <Icon className={classNames.iconClassName} iconName={column.iconName} />}
 
-                    {column.isIconOnly ? (
-                      <span className={classNames.accessibleLabel}>{column.name}</span>
-                    ) : (
-                      column.name
-                    )}
+                    {column.isIconOnly ? <span className={classNames.accessibleLabel}>{column.name}</span> : column.name}
                   </span>
 
                   {column.isFiltered && <Icon className={classNames.nearIcon} iconName={'Filter'} />}
 
-                  {column.isSorted && (
-                    <Icon
-                      className={classNames.sortIcon}
-                      iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'}
-                    />
-                  )}
+                  {column.isSorted && <Icon className={classNames.sortIcon} iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'} />}
 
                   {column.isGrouped && <Icon className={classNames.nearIcon} iconName={'GroupedDescending'} />}
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
-                    !column.isIconOnly && (
-                      <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />
-                    )}
+                    !column.isIconOnly && <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />}
                 </span>
               )
             },
@@ -213,10 +183,16 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   };
 
   private _onColumnClick(column: IColumn, ev: React.MouseEvent<HTMLElement>): void {
+    if (column.columnActionsMode === ColumnActionsMode.disabled) {
+      return;
+    }
+
     const { onColumnClick } = this.props;
+
     if (column.onColumnClick) {
       column.onColumnClick(ev, column);
     }
+
     if (onColumnClick) {
       onColumnClick(ev, column);
     }
@@ -254,16 +230,10 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     const classNames = this._classNames;
 
     return this._hasAccessibleLabel() && !this.props.onRenderColumnHeaderTooltip ? (
-      <label
-        key={`${column.key}_label`}
-        id={`${parentId}-${column.key}-tooltip`}
-        className={classNames.accessibleLabel}
-      >
+      <label key={`${column.key}_label`} id={`${parentId}-${column.key}-tooltip`} className={classNames.accessibleLabel}>
         {column.ariaLabel}
         {(column.isFiltered && column.filterAriaLabel) || null}
-        {(column.isSorted &&
-          (column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel)) ||
-          null}
+        {(column.isSorted && (column.isSortedDescending ? column.sortDescendingAriaLabel : column.sortAscendingAriaLabel)) || null}
         {(column.isGrouped && column.groupAriaLabel) || null}
       </label>
     ) : null;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { DetailsColumn } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
+import { IColumn, ColumnActionsMode } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList.types';
+import { mount } from 'enzyme';
+import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
+import { assign } from '@uifabric/utilities';
+
+let mockOnColumnClick: jest.Mock<{}>;
+let baseColumn: IColumn;
+
+describe('DetailsColumn', () => {
+  beforeEach(() => {
+    mockOnColumnClick = jest.fn();
+    baseColumn = {
+      key: '1',
+      name: 'Foo',
+      minWidth: 20,
+      onColumnClick: mockOnColumnClick
+    };
+  });
+
+  it('invokes IColumn#onColumnClick when columnActionMode omitted', () => {
+    const columns = [baseColumn];
+    let component: any;
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    const columnHeader = component.find(DetailsColumn);
+    const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
+
+    columnHeaderTitle.simulate('click');
+
+    expect(mockOnColumnClick.mock.calls.length).toBe(1);
+  });
+
+  it('invokes IColumn#onColumnClick when columnActionMode is ColumnActionsMode.clickable', () => {
+    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.clickable });
+    const columns = [column];
+    let component: any;
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    const columnHeader = component.find(DetailsColumn);
+    const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
+
+    columnHeaderTitle.simulate('click');
+
+    expect(mockOnColumnClick.mock.calls.length).toBe(1);
+  });
+
+  it('invokes IColumn#onColumnClick when columnActionMode is ColumnActionsMode.hasDropdown', () => {
+    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.hasDropdown });
+    const columns = [column];
+    let component: any;
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    const columnHeader = component.find(DetailsColumn);
+    const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
+
+    columnHeaderTitle.simulate('click');
+
+    expect(mockOnColumnClick.mock.calls.length).toBe(1);
+  });
+
+  it('does not invoke IColumn#onColumnClick when columnActionMode is ColumnActionMode.disabled', () => {
+    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.disabled });
+    const columns = [column];
+    let component: any;
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    const columnHeader = component.find(DetailsColumn);
+    const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
+
+    columnHeaderTitle.simulate('click');
+
+    expect(mockOnColumnClick.mock.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6445
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Early returns if the `IColumn` clicked has `columnAction === ColumnActionsMode.disabled` to not invoke `onColumnClick` callbacks (one on props and the other on IColumn)
- Adds unit tests for the various `ColumnActionsMode` values

#### Focus areas to test

1. Set a DetailsList column's `columnAction: ColumnActionsMode.disabled`
1. Set a `onColumnClick` callback on that same column
1. Click the column. `onColumnClick` callbacks shouldn't be invoked
1. Columns that have other `columnAction` values or none (default) should invoke their `onColumnClick` callback as they do in `master`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6569)

