### PR TITLE
getGlobalClassNames now returns the correct thing even when theme mutates.

### DIFF
--- a/common/changes/@uifabric/styling/globalcn-fix_2018-10-05-03-14.json
+++ b/common/changes/@uifabric/styling/globalcn-fix_2018-10-05-03-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Fixing getGlobalClassNames to return the correct class names even when the theme object is different.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/styling/src/styles/getGlobalClassNames.test.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.test.ts
@@ -26,17 +26,20 @@ describe('getGlobalClassNames', () => {
     });
 
     it('multiple calls with the same instance of classnames return the same set of global classnames', () => {
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
-      expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
+      expect(getGlobalClassNames(globalClassnames, createTheme({ disableGlobalClassNames: true }), true)).toEqual({
+        root: 'ms-Memoized-0'
+      });
+      expect(getGlobalClassNames(globalClassnames, createTheme({ disableGlobalClassNames: true }))).toEqual({ root: 'ms-Memoized-0' });
+      expect(getGlobalClassNames(globalClassnames, createTheme({ disableGlobalClassNames: false }), true)).toEqual({
+        root: 'ms-Memoized-0'
+      });
     });
 
     it('calls with different arguments returns a different set of global classnames', () => {
       expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
-      expect(getGlobalClassNames(globalClassnames, theme, true)).toEqual({ root: 'ms-Memoized-1' });
-      expect(getGlobalClassNames({ ...globalClassnames }, theme)).toEqual({ root: 'ms-Memoized-2' });
+      expect(getGlobalClassNames({ ...globalClassnames }, theme)).toEqual({ root: 'ms-Memoized-1' });
       expect(getGlobalClassNames(globalClassnames, theme)).toEqual({ root: 'ms-Memoized-0' });
-      expect(getGlobalClassNames(globalClassnames, { ...theme })).toEqual({ root: 'ms-Memoized-3' });
+      expect(getGlobalClassNames(globalClassnames, { ...theme })).toEqual({ root: 'ms-Memoized-0' });
     });
   });
 
@@ -44,13 +47,5 @@ describe('getGlobalClassNames', () => {
     const theme = createTheme({ disableGlobalClassNames: true });
 
     expect(getGlobalClassNames({ root: 'ms-Link' }, theme, false)).toEqual({ root: 'ms-Link' });
-  });
-
-  it('works for multiple global classes', () => {
-    const theme = createTheme({ disableGlobalClassNames: false });
-
-    expect(getGlobalClassNames({ root: 'ms-Link my-other-global' }, theme)).toEqual({
-      root: 'ms-Link my-other-global'
-    });
   });
 });

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -12,7 +12,7 @@ const _getGlobalClassNames = memoizeFunction(
   <T>(classNames: GlobalClassNames<T>, disableGlobalClassNames?: boolean): Partial<GlobalClassNames<T>> => {
     const styleSheet = Stylesheet.getInstance();
 
-    if (disableGlobalClassNames || (disableGlobalClassNames === undefined && disableGlobalClassNames)) {
+    if (disableGlobalClassNames) {
       // disable global classnames
       return Object.keys(classNames).reduce((acc: {}, className: string) => {
         acc[className] = styleSheet.getClassName(classNames[className]);

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -5,23 +5,6 @@ import { memoizeFunction } from '@uifabric/utilities';
 export type GlobalClassNames<IStyles> = Record<keyof IStyles, string>;
 
 /**
- * Checks for the `disableGlobalClassNames` property on the `theme` to determine if it should return `classNames`
- * Note that calls to this function are memoized.
- *
- * @param classNames The collection of global class names that apply when the flag is false. Make sure to pass in
- * the same instance on each call to benefit from memoization.
- * @param theme The theme to check the flag on
- * @param disableGlobalClassNames Optional. Explicitly opt in/out of disabling global classnames. Defaults to false.
- */
-export function getGlobalClassNames<T>(
-  classNames: GlobalClassNames<T>,
-  theme: ITheme,
-  disableGlobalClassNames?: boolean
-): Partial<GlobalClassNames<T>> {
-  return _getGlobalClassNames(classNames, disableGlobalClassNames !== undefined ? disableGlobalClassNames : theme.disableGlobalClassNames);
-}
-
-/**
  * Internal memoized function which simply takes in the class map and the
  * disable boolean. These immutable values can be memoized.
  */
@@ -41,3 +24,20 @@ const _getGlobalClassNames = memoizeFunction(
     return classNames;
   }
 );
+
+/**
+ * Checks for the `disableGlobalClassNames` property on the `theme` to determine if it should return `classNames`
+ * Note that calls to this function are memoized.
+ *
+ * @param classNames The collection of global class names that apply when the flag is false. Make sure to pass in
+ * the same instance on each call to benefit from memoization.
+ * @param theme The theme to check the flag on
+ * @param disableGlobalClassNames Optional. Explicitly opt in/out of disabling global classnames. Defaults to false.
+ */
+export function getGlobalClassNames<T>(
+  classNames: GlobalClassNames<T>,
+  theme: ITheme,
+  disableGlobalClassNames?: boolean
+): Partial<GlobalClassNames<T>> {
+  return _getGlobalClassNames(classNames, disableGlobalClassNames !== undefined ? disableGlobalClassNames : theme.disableGlobalClassNames);
+}

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -1,5 +1,4 @@
 import { ITheme } from '../interfaces/index';
-
 import { Stylesheet } from '@uifabric/merge-styles';
 import { memoizeFunction } from '@uifabric/utilities';
 
@@ -14,19 +13,23 @@ export type GlobalClassNames<IStyles> = Record<keyof IStyles, string>;
  * @param theme The theme to check the flag on
  * @param disableGlobalClassNames Optional. Explicitly opt in/out of disabling global classnames. Defaults to false.
  */
-export const getGlobalClassNames: <T>(
+export function getGlobalClassNames<T>(
   classNames: GlobalClassNames<T>,
   theme: ITheme,
   disableGlobalClassNames?: boolean
-) => Partial<GlobalClassNames<T>> = memoizeFunction(
-  <T>(
-    classNames: GlobalClassNames<T>,
-    theme: ITheme,
-    disableGlobalClassNames?: boolean
-  ): Partial<GlobalClassNames<T>> => {
+): Partial<GlobalClassNames<T>> {
+  return _getGlobalClassNames(classNames, disableGlobalClassNames !== undefined ? disableGlobalClassNames : theme.disableGlobalClassNames);
+}
+
+/**
+ * Internal memoized function which simply takes in the class map and the
+ * disable boolean. These immutable values can be memoized.
+ */
+const _getGlobalClassNames = memoizeFunction(
+  <T>(classNames: GlobalClassNames<T>, disableGlobalClassNames?: boolean): Partial<GlobalClassNames<T>> => {
     const styleSheet = Stylesheet.getInstance();
 
-    if (disableGlobalClassNames || (disableGlobalClassNames === undefined && theme.disableGlobalClassNames)) {
+    if (disableGlobalClassNames || (disableGlobalClassNames === undefined && disableGlobalClassNames)) {
       // disable global classnames
       return Object.keys(classNames).reduce((acc: {}, className: string) => {
         acc[className] = styleSheet.getClassName(classNames[className]);


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6551
- [X] Include a change request file using `$ npm run change`

#### Description of changes

getGlobalClassNames was assuming the theme object is immutable. It isn't. But the boolean inside it is. So pull that out and pass that into a memoized function.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6577)

