### PR TITLE
Fix persona coin initials bug

### DIFF
--- a/common/changes/office-ui-fabric-react/fixPersonaCoinInitialsBug_2018-10-05-18-21.json
+++ b/common/changes/office-ui-fabric-react/fixPersonaCoinInitialsBug_2018-10-05-18-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed initials not reappearing bug when image is removed from a PersonaCoin",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dardis.greg@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-  BaseComponent,
-  classNamesFunction,
-  divProperties,
-  getInitials,
-  getNativeProps,
-  getRTL
-} from '../../../Utilities';
+import { BaseComponent, classNamesFunction, divProperties, getInitials, getNativeProps, getRTL } from '../../../Utilities';
 import { mergeStyles } from '../../../Styling';
 import { PersonaPresence } from '../PersonaPresence/index';
 import { Icon } from '../../../Icon';
@@ -51,6 +44,14 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
     };
   }
 
+  public componentWillReceiveProps(nextProps: IPersonaCoinProps): void {
+    if (!nextProps.imageUrl) {
+      this.setState({
+        isImageLoaded: false
+      });
+    }
+  }
+
   public render(): JSX.Element | null {
     const {
       className,
@@ -88,8 +89,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
     });
 
     const shouldRenderInitials = Boolean(
-      !this.state.isImageLoaded &&
-        ((showInitialsUntilImageLoads && imageUrl) || !imageUrl || this.state.isImageError || hideImage)
+      !this.state.isImageLoaded && ((showInitialsUntilImageLoads && imageUrl) || !imageUrl || this.state.isImageError || hideImage)
     );
 
     return (
@@ -125,16 +125,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
   }
 
   private _onRenderCoin = (props: IPersonaCoinProps): JSX.Element | null => {
-    const {
-      coinSize,
-      styles,
-      imageUrl,
-      imageAlt,
-      imageShouldFadeIn,
-      imageShouldStartVisible,
-      theme,
-      showUnknownPersonaCoin
-    } = this.props;
+    const { coinSize, styles, imageUrl, imageAlt, imageShouldFadeIn, imageShouldStartVisible, theme, showUnknownPersonaCoin } = this.props;
 
     // Render the Image component only if an image URL is provided
     if (!imageUrl) {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.test.tsx
@@ -1,12 +1,13 @@
 /* tslint:disable-next-line:no-unused-variable */
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 import { setRTL } from '../../../Utilities';
 import { PersonaCoin } from './PersonaCoin';
+import { PersonaCoinBase } from './PersonaCoin.base';
 import { wrapPersona } from 'office-ui-fabric-react/lib/components/Persona/Persona.test';
 
-const testImage1x1 =
-  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
+const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 
 const coinProp = {
   text: 'Swapnil Vaibhav',
@@ -46,17 +47,13 @@ describe('PersonaCoin', () => {
   });
 
   it('renders the initials before the image is loaded', () => {
-    const component = renderer.create(
-      <PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} showInitialsUntilImageLoads={true} />
-    );
+    const component = renderer.create(<PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} showInitialsUntilImageLoads={true} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('does not render the initials when showInitialsUntilImageLoads is false', () => {
-    const component = renderer.create(
-      <PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} showInitialsUntilImageLoads={false} />
-    );
+    const component = renderer.create(<PersonaCoin text="Kat Larrson" imageUrl={testImage1x1} showInitialsUntilImageLoads={false} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -67,5 +64,13 @@ describe('PersonaCoin', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('sets isImageLoaded to false if imageUrl changes from valid to undefined', () => {
+    const component = shallow(<PersonaCoinBase imageUrl={testImage1x1} />);
+    component.setState({ isImageLoaded: true });
+    component.setProps({ imageUrl: undefined });
+    const isImageLoaded = component.state('isImageLoaded');
+    expect(isImageLoaded).toBe(false);
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6570
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Bug description: If PersonaCoin had a valid prop `imageUrl`, then had the `imageUrl` set to undefined, the image should have become initials, just like if `imageUrl` was undefined in the first place. Instead, the image simply disappeared.

Now the initials reappear if imageUrl changes from valid to undefined.

All of the code formatting changes happened automatically, I assume this is because you guys changed some prettier rules or something along those lines?

I am inexperienced but learning, feedback is appreciated for sure.
