### PR TITLE
Jg/6503 ts31 type fix

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-6503-ts31-type-fix_2018-10-06-00-05.json
+++ b/common/changes/office-ui-fabric-react/jg-6503-ts31-type-fix_2018-10-06-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Typescript 3.1 type fixes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -12,7 +12,7 @@ export interface IDropdown {
   focus: (shouldOpenOnFocus?: boolean) => void;
 }
 
-export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown> {
+export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement> {
   /**
    * Input placeholder text. Displayed until option is selected.
    */

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -4,12 +4,16 @@ import { ICalloutProps } from '../../Callout';
 import { IPanelProps } from '../../Panel';
 import { ISelectableOption } from '../../utilities/selectableOption/SelectableOption.types';
 
-export interface ISelectableDroppableTextProps<T> extends React.HTMLAttributes<T> {
+/**
+ * TComponent - Component used for reference properties, such as componentRef
+ * TListenerElement - Listener element associated with HTML event callbacks. Optional. If not provided, TComponent is assumed.
+ */
+export interface ISelectableDroppableTextProps<TComponent, TListenerElement = TComponent> extends React.HTMLAttributes<TListenerElement> {
   /**
    * Optional callback to access the ISelectableDroppableText interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
-  componentRef?: IRefObject<T>;
+  componentRef?: IRefObject<TComponent>;
 
   /**
    * Descriptive label for the ISelectableDroppableText
@@ -50,12 +54,12 @@ export interface ISelectableDroppableTextProps<T> extends React.HTMLAttributes<T
   /**
    * Optional custom renderer for the ISelectableDroppableText container
    */
-  onRenderContainer?: IRenderFunction<ISelectableDroppableTextProps<T>>;
+  onRenderContainer?: IRenderFunction<ISelectableDroppableTextProps<TComponent>>;
 
   /**
    * Optional custom renderer for the ISelectableDroppableText list
    */
-  onRenderList?: IRenderFunction<ISelectableDroppableTextProps<T>>;
+  onRenderList?: IRenderFunction<ISelectableDroppableTextProps<TComponent>>;
 
   /**
    * Optional custom renderer for the ISelectableDroppableText options


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6503
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The underlying issue of #6503 is that the Dropdown's use of `ISelectableDroppableTextProps` is inaccurate as the HTML events extended by `ISelectableDroppableTextProps` are of `HTMLDivElement` while the typing has been inaccurately enforcing them to be `IDropdown`. The TypeScript 3.1 error exposed this inconsistency.

`ISelectableDroppableTextProps` takes in only one generic type (component) but then also forces all HTML listener elements to be of that same type. This causes issues with event listeners attached to HTML elements which are not technically `IDropdown` type. 

The fix involves modifying `ISelectableDroppableText` to take in 2 generic types (the second being optional for backwards compatibility), like this:
```tsx
export interface ISelectableDroppableTextProps<TComponent, TListenerElement = TComponent> extends React.HTMLAttributes<TListenerElement> {
```

This fix allows `componentRef` and such interfaces to continue to be of type `TComponent` while all event listeners are of type `TListenerElement` (in Dropdown's case, an `HTMLDivElement`.)

#### Focus areas to test
n/a
