### PR TITLE
PR: fix zero slider value

### DIFF
--- a/common/changes/office-ui-fabric-react/reli-fix-slider-zero-value_2018-10-06-13-27.json
+++ b/common/changes/office-ui-fabric-react/reli-fix-slider-zero-value_2018-10-06-13-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Sliders' support for zero values.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "reli@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -42,7 +42,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 
     this._id = getId('Slider');
 
-    const value = props.value || props.defaultValue || props.min;
+    const value = props.value != null ? props.value : props.defaultValue != null ? props.defaultValue : props.min; 
 
     this.state = {
       value: value,

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -42,7 +42,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 
     this._id = getId('Slider');
 
-    const value = props.value != null ? props.value : props.defaultValue != null ? props.defaultValue : props.min; 
+    const value = props.value !== undefined ? props.value : props.defaultValue !== undefined ? props.defaultValue : props.min;
 
     this.state = {
       value: value,

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -66,6 +66,20 @@ describe('Slider', () => {
     expect(slider.current!.value).toEqual(12);
   });
 
+  it('should be able to handler zero default value', () => {
+    const slider = React.createRef<ISlider>();
+
+    mount(<Slider label="slider" defaultValue={0} min={-100} max={100} componentRef={slider} />);
+    expect(slider.current!.value).toEqual(0);
+  });
+  
+  it('should be able to handler zero value', () => {
+    const slider = React.createRef<ISlider>();
+
+    mount(<Slider label="slider" value={0} min={-100} max={100} componentRef={slider} />);
+    expect(slider.current!.value).toEqual(0);
+  });
+  
   it('renders correct aria-valuetext', () => {
     let component = mount(<Slider />);
 

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -72,14 +72,14 @@ describe('Slider', () => {
     mount(<Slider label="slider" defaultValue={0} min={-100} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(0);
   });
-  
+
   it('should be able to handler zero value', () => {
     const slider = React.createRef<ISlider>();
 
     mount(<Slider label="slider" value={0} min={-100} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(0);
   });
-  
+
   it('renders correct aria-valuetext', () => {
     let component = mount(<Slider />);
 


### PR DESCRIPTION
This PR fixes #4886 by allowing zero being `defaultValue`/`value`.
I am surprised that **nobody ever** set `min` to negative numbers. This bug is very easy to reproduce.

#### Pull request checklist

- [X] Addresses an existing issue: Fixes #4886
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Allow zero to be sliders' value or default value.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6589)

