### PR TITLE
Remove fake parameter from Picker examples

### DIFF
--- a/common/changes/office-ui-fabric-react/patch-3_2018-10-08-03-51.json
+++ b/common/changes/office-ui-fabric-react/patch-3_2018-10-08-03-51.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Remove fake parameter from examples",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/patch-3_2018-10-08-03-51.json
+++ b/common/changes/office-ui-fabric-react/patch-3_2018-10-08-03-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove fake parameter from examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tsekityam@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -69,18 +69,12 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
             return (
               <div className={styles.headerItem}>
                 Use this address:{' '}
-                {this._picker && this._picker.inputElement && this._picker.inputElement
-                  ? this._picker.inputElement.value
-                  : ''}
+                {this._picker && this._picker.inputElement && this._picker.inputElement ? this._picker.inputElement.value : ''}
               </div>
             );
           },
           shouldShow: () => {
-            return (
-              this._picker !== undefined &&
-              this._picker.inputElement !== null &&
-              this._picker.inputElement.value.indexOf('@') > -1
-            );
+            return this._picker !== undefined && this._picker.inputElement !== null && this._picker.inputElement.value.indexOf('@') > -1;
           },
           onExecute: () => {
             if (this._picker.floatingPicker.current !== null) {
@@ -239,10 +233,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
     } else {
       if (this._picker.selectedItemsList.current) {
         // tslint:disable-next-line:no-any
-        (this._picker.selectedItemsList.current as SelectedPeopleList).replaceItem(
-          item,
-          this._getExpandedGroupItems(item as any)
-        );
+        (this._picker.selectedItemsList.current as SelectedPeopleList).replaceItem(item, this._getExpandedGroupItems(item as any));
       }
     }
   };
@@ -253,9 +244,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
     const indexMostRecentlyUsed: number = mruState.indexOf(item);
 
     if (indexPeopleList >= 0) {
-      const newPeople: IPersonaProps[] = peopleList
-        .slice(0, indexPeopleList)
-        .concat(peopleList.slice(indexPeopleList + 1));
+      const newPeople: IPersonaProps[] = peopleList.slice(0, indexPeopleList).concat(peopleList.slice(indexPeopleList + 1));
       this.setState({ peopleList: newPeople });
     }
 
@@ -267,17 +256,12 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
     }
   };
 
-  private _onFilterChanged = (
-    filterText: string,
-    currentPersonas: IPersonaProps[],
-    limitResults?: number
-  ): Promise<IPersonaProps[]> | null => {
+  private _onFilterChanged = (filterText: string, currentPersonas: IPersonaProps[]): Promise<IPersonaProps[]> | null => {
     const { controlledComponent } = this.state;
     let filteredPersonas: IPersonaProps[] = [];
     if (filterText) {
       filteredPersonas = this._filterPersonasByText(filterText);
       filteredPersonas = this._removeDuplicates(filteredPersonas, currentPersonas);
-      filteredPersonas = limitResults ? filteredPersonas.splice(0, limitResults) : filteredPersonas;
     }
 
     if (controlledComponent) {
@@ -286,9 +270,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
     return controlledComponent ? null : this._convertResultsToPromise(filteredPersonas);
   };
 
-  private _returnMostRecentlyUsed = (
-    currentPersonas: IPersonaProps[]
-  ): IPersonaProps[] | Promise<IPersonaProps[]> | null => {
+  private _returnMostRecentlyUsed = (currentPersonas: IPersonaProps[]): IPersonaProps[] | Promise<IPersonaProps[]> | null => {
     const { controlledComponent } = this.state;
     let { mostRecentlyUsed } = this.state;
     mostRecentlyUsed = this._removeDuplicates(mostRecentlyUsed, this._picker.items);
@@ -331,9 +313,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
   }
 
   private _filterPersonasByText(filterText: string): IPersonaProps[] {
-    return this.state.peopleList.filter((item: IPersonaProps) =>
-      this._doesTextStartWith(item.text as string, filterText)
-    );
+    return this.state.peopleList.filter((item: IPersonaProps) => this._doesTextStartWith(item.text as string, filterText));
   }
 
   private _doesTextStartWith(text: string, filterText: string): boolean {

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
@@ -4,11 +4,7 @@ import * as React from 'react';
 import { assign } from 'office-ui-fabric-react/lib/Utilities';
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { SuggestionsStore } from '../../Suggestions/SuggestionsStore';
-import {
-  IBaseFloatingPicker,
-  IBaseFloatingPickerSuggestionProps,
-  FloatingPeoplePicker
-} from 'office-ui-fabric-react/lib/FloatingPicker';
+import { IBaseFloatingPicker, IBaseFloatingPickerSuggestionProps, FloatingPeoplePicker } from 'office-ui-fabric-react/lib/FloatingPicker';
 import { IPersonaWithMenu } from 'office-ui-fabric-react/lib/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types';
 import { people, mru } from 'office-ui-fabric-react/lib/ExtendedPicker';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
@@ -125,9 +121,7 @@ export class FloatingPeoplePickerTypesExample extends React.Component<{}, IPeopl
     const indexMostRecentlyUsed: number = mruState.indexOf(item);
 
     if (indexPeopleList >= 0) {
-      const newPeople: IPersonaProps[] = peopleList
-        .slice(0, indexPeopleList)
-        .concat(peopleList.slice(indexPeopleList + 1));
+      const newPeople: IPersonaProps[] = peopleList.slice(0, indexPeopleList).concat(peopleList.slice(indexPeopleList + 1));
       this.setState({ peopleList: newPeople });
     }
 
@@ -139,16 +133,11 @@ export class FloatingPeoplePickerTypesExample extends React.Component<{}, IPeopl
     }
   };
 
-  private _onFilterChanged = (
-    filterText: string,
-    currentPersonas: IPersonaProps[],
-    limitResults?: number
-  ): IPersonaProps[] => {
+  private _onFilterChanged = (filterText: string, currentPersonas: IPersonaProps[]): IPersonaProps[] => {
     if (filterText) {
       let filteredPersonas: IPersonaProps[] = this._filterPersonasByText(filterText);
 
       filteredPersonas = this._removeDuplicates(filteredPersonas, currentPersonas);
-      filteredPersonas = limitResults ? filteredPersonas.splice(0, limitResults) : filteredPersonas;
       return filteredPersonas;
     } else {
       return [];
@@ -167,9 +156,7 @@ export class FloatingPeoplePickerTypesExample extends React.Component<{}, IPeopl
   }
 
   private _filterPersonasByText(filterText: string): IPersonaProps[] {
-    return this.state.peopleList.filter((item: IPersonaProps) =>
-      this._doesTextStartWith(item.text as string, filterText)
-    );
+    return this.state.peopleList.filter((item: IPersonaProps) => this._doesTextStartWith(item.text as string, filterText));
   }
 
   private _doesTextStartWith(text: string, filterText: string): boolean {


### PR DESCRIPTION
`limitResults` is not a standard parameter of `onResolveSuggestions()` callback.

Remove it from the callback to avoid any misleading.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This fake parameter was first introduced in

https://github.com/OfficeDev/office-ui-fabric-react/blob/137fbcef0a2c118db0097f38075427a41c769ca0/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx#L380-L385

It is not part of the original callback of the picker. Remove them from example to avoid any misleading.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6592)

