### PR TITLE
Resolve Console Errors for horizontal bar chart

### DIFF
--- a/common/changes/@uifabric/charting/resolveConsoleErrors_2018-10-08-12-49.json
+++ b/common/changes/@uifabric/charting/resolveConsoleErrors_2018-10-08-12-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "resolve console errors for horizontal bar chart",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "gorigarajesh@gmail.com"
+}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -46,9 +46,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                     </div>
                   )}
                   <div>
-                    <strong>
-                      {points!.chartData![0].horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                    </strong>
+                    <strong>{points!.chartData![0].horizontalBarChartdata!.x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}</strong>
                   </div>
                 </div>
                 <svg className={this._classNames.chart}>
@@ -78,8 +76,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
     // calculating starting point of each bar and it's range
     const startingPoint: number[] = [];
     const total = data.chartData!.reduce(
-      (acc: number, point: IChartDataPoint) =>
-        acc + (point.horizontalBarChartdata!.x ? point.horizontalBarChartdata!.x : 0),
+      (acc: number, point: IChartDataPoint) => acc + (point.horizontalBarChartdata!.x ? point.horizontalBarChartdata!.x : 0),
       0
     );
     let prevPosition = 0;
@@ -91,17 +88,9 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
         prevPosition += value;
       }
       value = (pointData / total) * 100;
+      value >= 0 ? (value = value) : (value = 0);
       startingPoint.push(prevPosition);
-      return (
-        <rect
-          key={index}
-          x={startingPoint[index] + '%'}
-          y={0}
-          width={value + '%'}
-          height={this._barHeight}
-          fill={color}
-        />
-      );
+      return <rect key={index} x={startingPoint[index] + '%'} y={0} width={value + '%'} height={this._barHeight} fill={color} />;
     });
     return bars;
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Resolve Console Errors for horizontal bar chart

** resolved Error is : <Rect>  width can not take negative values.


(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6599)

