### PR TITLE
Add min height to multiline text field

### DIFF
--- a/common/changes/office-ui-fabric-react/addMinHeightToMultilineTextField_2018-10-08-15-47.json
+++ b/common/changes/office-ui-fabric-react/addMinHeightToMultilineTextField_2018-10-08-15-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField can no longer be resized to below its minimum height",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dardis.greg@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -289,6 +289,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           }
         ],
       multiline && {
+        minHeight: 'inherit',
         lineHeight: 17,
         flexGrow: 1,
         paddingTop: 6,

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -232,6 +232,7 @@ exports[`TextField renders TextField multiline resizable correctly 1`] = `
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
+              min-height: inherit;
               min-width: 0px;
               outline: 0px;
               overflow: auto;
@@ -368,6 +369,7 @@ exports[`TextField renders TextField multiline unresizable correctly 1`] = `
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
+              min-height: inherit;
               min-width: 0px;
               outline: 0px;
               overflow: auto;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AllErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AllErrorMessage.Example.tsx.shot
@@ -552,6 +552,7 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -105,6 +105,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -102,6 +102,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;
@@ -236,6 +237,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;
@@ -377,6 +379,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;
@@ -521,6 +524,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;
@@ -662,6 +666,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;
@@ -795,6 +800,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 margin-left: 0px;
                 margin-right: 0px;
                 margin-top: 0px;
+                min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
                 overflow: auto;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6586
- [x] Include a change request file using `$ npm run change`

#### Description of changes

TextField resizing icon could be dragged past the minimum height of the TextField. Added `minHeight: 'inherit'` to fix that bug.

before: 
![multiline_before](https://user-images.githubusercontent.com/26682451/46619568-43425480-cad7-11e8-8747-31a67eb42380.PNG)

after: 
![multiline_after](https://user-images.githubusercontent.com/26682451/46619571-463d4500-cad7-11e8-826a-17fa52b90a6f.PNG)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6602)

