### PR TITLE
Panel scroll

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-scroll_2018-10-08-23-46.json
+++ b/common/changes/office-ui-fabric-react/panel-scroll_2018-10-08-23-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: make scrollableContent the only scrollable div",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -295,7 +295,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
 
   private _onRenderBody = (props: IPanelProps): JSX.Element => {
     return (
-      <div ref={this._content} className={this._classNames.content} /*data-is-scrollable={true}*/>
+      <div ref={this._content} className={this._classNames.content}>
         {props.children}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -13,8 +13,7 @@ import {
   elementContains,
   getId,
   getNativeProps,
-  getRTL,
-  isIOS
+  getRTL
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
@@ -174,15 +173,15 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
               elementToFocusOnDismiss={elementToFocusOnDismiss}
               isClickableOutsideFocusTrap={focusTrapZoneProps && !focusTrapZoneProps.isClickableOutsideFocusTrap ? false : true}
             >
-              <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent}>
+              <div className={_classNames.contentInner}>
                 <div className={_classNames.commands} data-is-visible={true}>
                   {onRenderNavigation(this.props, this._onRenderNavigation)}
                 </div>
-                <div className={_classNames.contentInner}>
-                  {header}
+                {header}
+                <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent} data-is-scrollable={true}>
                   {onRenderBody(this.props, this._onRenderBody)}
-                  {onRenderFooter(this.props, this._onRenderFooter)}
                 </div>
+                {onRenderFooter(this.props, this._onRenderFooter)}
               </div>
             </FocusTrapZone>
           </div>
@@ -229,9 +228,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   private _allowScrollOnPanel = (elt: HTMLDivElement | null): void => {
     if (elt) {
       allowScrollOnElement(elt, this._events);
-      if (isIOS()) {
-        elt.style.height = window.innerHeight + 'px';
-      }
     } else {
       this._events.off(this._scrollableContent);
     }
@@ -299,7 +295,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
 
   private _onRenderBody = (props: IPanelProps): JSX.Element => {
     return (
-      <div ref={this._content} className={this._classNames.content} data-is-scrollable={true}>
+      <div ref={this._content} className={this._classNames.content} /*data-is-scrollable={true}*/>
         {props.children}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
@@ -12,6 +12,7 @@ import { PanelLightDismissCustomExample } from './examples/Panel.LightDismissCus
 import { PanelMediumExample } from './examples/Panel.Medium.Example';
 import { PanelNonModalExample } from './examples/Panel.NonModal.Example';
 import { PanelPreventDefaultExample } from './examples/Panel.PreventDefault.Example';
+import { PanelScrollExample } from './examples/Panel.Scroll.Example';
 import { PanelSmallFluidExample } from './examples/Panel.SmallFluid.Example';
 import { PanelSmallLeftExample } from './examples/Panel.SmallLeft.Example';
 import { PanelSmallRightExample } from './examples/Panel.SmallRight.Example';
@@ -33,6 +34,7 @@ const PanelNonModalExampleCode = require('!raw-loader!office-ui-fabric-react/src
 const PanelFooterExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Footer.Example.tsx') as string;
 const PanelPreventDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.PreventDefault.Example.tsx') as string;
 const PanelHandleDismissTargetExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx') as string;
+const PanelScrollExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Scroll.Example.tsx') as string;
 
 export const PanelPageProps: IDocPageProps = {
   title: 'Panel',
@@ -115,6 +117,11 @@ export const PanelPageProps: IDocPageProps = {
       title: 'Panel - Handle Dismiss Target Sample',
       code: PanelHandleDismissTargetExampleCode,
       view: <PanelHandleDismissTargetExample />
+    },
+    {
+      title: 'Panel - Scrolling Content Sample',
+      code: PanelScrollExampleCode,
+      view: <PanelScrollExample />
     }
   ],
   propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Panel/Panel.types.ts')],

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -9,6 +9,7 @@ import {
   ScreenWidthMinXXLarge,
   ScreenWidthMinUhfMobile
 } from '../../Styling';
+import { isIOS } from '../../Utilities';
 // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
 // import { IStyleFunctionOrObject } from '../../Utilities';
 // import { IButtonStyles, IButtonStyleProps } from '../../Button';
@@ -103,6 +104,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const isCustomPanel = type === PanelType.custom;
+  const heightForDevice = isIOS() ? window.innerHeight : '100%';
 
   return {
     root: [
@@ -118,10 +120,10 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         bottom: 0
       },
       !isOpen &&
-        !isAnimating &&
-        isHiddenOnDismiss && {
-          visibility: 'hidden'
-        },
+      !isAnimating &&
+      isHiddenOnDismiss && {
+        visibility: 'hidden'
+      },
       isCustomPanel && classNames.custom,
       className
     ],
@@ -141,10 +143,10 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     ],
     hiddenPanel: [
       !isOpen &&
-        !isAnimating &&
-        isHiddenOnDismiss && {
-          visibility: 'hidden'
-        }
+      !isAnimating &&
+      isHiddenOnDismiss && {
+        visibility: 'hidden'
+      }
     ],
     main: [
       classNames.main,
@@ -242,30 +244,18 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       !isOpen && isAnimating && isOnRightSide && AnimationClassNames.slideRightOut40,
       focusTrapZoneClassName
     ],
-    commands: [classNames.commands],
     contentInner: [
       classNames.contentInner,
       {
         display: 'flex',
         flexDirection: 'column',
-        minHeight: '100%',
-        WebkitOverflowScrolling: 'touch',
-        /* Force hw accelleration on scrollable region */
-        transform: 'translateZ(0)'
+        maxHeight: heightForDevice,
       },
-      hasCloseButton && {
-        top: commandBarHeight,
-        minHeight: `calc(100% - ${commandBarHeight})`
+      isFooterAtBottom && {
+        height: heightForDevice
       }
     ],
-    scrollableContent: [
-      classNames.scrollableContent,
-      {
-        height: '100%',
-        overflowY: 'auto',
-        flexGrow: 1
-      }
-    ],
+    commands: [classNames.commands],
     navigation: [
       classNames.navigation,
       {
@@ -300,13 +290,19 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       },
       headerClassName
     ],
+    scrollableContent: [
+      classNames.scrollableContent,
+      {
+        overflowY: 'auto',
+        height: heightForDevice
+      }
+    ],
     content: [
       classNames.content,
       sharedPaddingStyles,
       {
         marginBottom: 0,
-        paddingBottom: '20px',
-        overflowY: 'auto'
+        paddingBottom: 20
       },
       isFooterAtBottom && {
         flexGrow: 1

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -150,11 +150,11 @@ exports[`Panel renders Panel correctly 1`] = `
         >
           <div
             className=
-                ms-Panel-scrollableContent
+                ms-Panel-contentInner
                 {
-                  flex-grow: 1;
-                  height: 100%;
-                  overflow-y: auto;
+                  display: flex;
+                  flex-direction: column;
+                  max-height: 100%;
                 }
           >
             <div
@@ -300,69 +300,65 @@ exports[`Panel renders Panel correctly 1`] = `
             </div>
             <div
               className=
-                  ms-Panel-contentInner
+                  ms-Panel-header
                   {
-                    -webkit-overflow-scrolling: touch;
-                    display: flex;
-                    flex-direction: column;
-                    min-height: calc(100% - 44px);
-                    top: 44px;
-                    transform: translateZ(0);
+                    flex-grow: 0;
+                    margin-bottom: 14px;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 14px;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                  }
+                  @media screen and (min-width: 768px){& {
+                    padding-left: 32px;
+                    padding-right: 32px;
+                  }
+                  @media screen and (min-width: 1366px){& {
+                    padding-left: 40px;
+                    padding-right: 40px;
+                  }
+                  @media (min-width: 1024px){& {
+                    margin-top: 30px;
                   }
             >
-              <div
+              <p
+                aria-level={2}
                 className=
-                    ms-Panel-header
+                    ms-Panel-headerText
                     {
-                      flex-grow: 0;
-                      margin-bottom: 14px;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 14px;
-                      padding-left: 16px;
-                      padding-right: 16px;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      line-height: 32px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
                     }
-                    @media screen and (min-width: 768px){& {
-                      padding-left: 32px;
-                      padding-right: 32px;
-                    }
-                    @media screen and (min-width: 1366px){& {
-                      padding-left: 40px;
-                      padding-right: 40px;
-                    }
-                    @media (min-width: 1024px){& {
-                      margin-top: 30px;
-                    }
+                id="Panel0-headerText"
+                role="heading"
               >
-                <p
-                  aria-level={2}
-                  className=
-                      ms-Panel-headerText
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #333333;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 21px;
-                        font-weight: 100;
-                        line-height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                      }
-                  id="Panel0-headerText"
-                  role="heading"
-                >
-                  Test Panel
-                </p>
-              </div>
+                Test Panel
+              </p>
+            </div>
+            <div
+              className=
+                  ms-Panel-scrollableContent
+                  {
+                    height: 100%;
+                    overflow-y: auto;
+                  }
+              data-is-scrollable={true}
+            >
               <div
                 className=
                     ms-Panel-content
                     {
                       margin-bottom: 0px;
-                      overflow-y: auto;
                       padding-bottom: 20px;
                       padding-left: 16px;
                       padding-right: 16px;
@@ -375,7 +371,6 @@ exports[`Panel renders Panel correctly 1`] = `
                       padding-left: 40px;
                       padding-right: 40px;
                     }
-                data-is-scrollable={true}
               >
                 <span>
                   Content goes here

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Scroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Scroll.Example.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+
+export class PanelScrollExample extends React.Component<
+  {},
+  {
+    showPanel: boolean;
+  }
+  > {
+  constructor(props: {}) {
+    super(props);
+    this.state = { showPanel: false };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <DefaultButton secondaryText="Opens the Sample Panel" onClick={this._onShowPanel} text="Open Panel" />
+        <Panel
+          isOpen={this.state.showPanel}
+          type={PanelType.smallFixedFar}
+          onDismiss={this._onClosePanel}
+          isFooterAtBottom={true}
+          headerText="Panel with scrolling content"
+          closeButtonAriaLabel="Close"
+          onRenderFooterContent={this._onRenderFooterContent}
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas lorem nulla, malesuada ut sagittis sit
+            amet, vulputate in leo. Maecenas vulputate congue sapien eu tincidunt. Etiam eu sem turpis. Fusce tempor
+            sagittis nunc, ut interdum ipsum vestibulum non. Proin dolor elit, aliquam eget tincidunt non, vestibulum
+            ut turpis. In hac habitasse platea dictumst. In a odio eget enim porttitor maximus. Aliquam nulla nibh,
+            ullamcorper aliquam placerat eu, viverra et dui. Phasellus ex lectus, maximus in mollis ac, luctus vel
+            eros. Vivamus ultrices, turpis sed malesuada gravida, eros ipsum venenatis elit, et volutpat eros dui et
+            ante. Quisque ultricies mi nec leo ultricies mollis. Vivamus egestas volutpat lacinia. Quisque pharetra
+            eleifend efficitur.{' '}
+          </p>
+          <p>
+            Mauris at nunc eget lectus lobortis facilisis et eget magna. Vestibulum venenatis augue sapien, rhoncus
+            faucibus magna semper eget. Proin rutrum libero sagittis sapien aliquet auctor. Suspendisse tristique a
+            magna at facilisis. Duis rhoncus feugiat magna in rutrum. Suspendisse semper, dolor et vestibulum lacinia,
+            nunc felis malesuada ex, nec hendrerit justo ex et massa. Quisque quis mollis nulla. Nam commodo est
+            ornare, rhoncus odio eu, pharetra tellus. Nunc sed velit mi.{' '}
+          </p>
+          <p>
+            Sed condimentum ultricies turpis convallis pharetra. Sed sagittis quam pharetra luctus porttitor. Cras vel
+            consequat lectus. Sed nec fringilla urna, a aliquet libero. Aenean sed nisl purus. Vivamus vulputate felis
+            et odio efficitur suscipit. Ut volutpat dictum lectus, ac rutrum massa accumsan at. Sed pharetra auctor
+            finibus. In augue libero, commodo vitae nisi non, sagittis convallis ante. Phasellus malesuada eleifend
+            mollis. Curabitur ultricies leo ac metus venenatis elementum.{' '}
+          </p>
+          <p>
+            Aenean egestas quam ut erat commodo blandit. Mauris ante nisl, pellentesque sed venenatis nec, aliquet sit
+            amet enim. Praesent vitae diam non diam aliquet tristique non ut arcu. Pellentesque et ultrices eros.
+            Fusce diam metus, mattis eu luctus nec, facilisis vel erat. Nam a lacus quis tellus gravida euismod. Nulla
+            sed sem eget tortor cursus interdum. Sed vehicula tristique ultricies. Aenean libero purus, mollis quis
+            massa quis, eleifend dictum massa. Fusce eu sapien sit amet odio lacinia placerat. Mauris varius risus sed
+            aliquet cursus. Aenean lectus magna, tincidunt sit amet sodales a, volutpat ac leo. Morbi nisl sapien,
+            tincidunt sit amet mauris quis, sollicitudin auctor est.{' '}
+          </p>
+          <p>
+            Nam id mi justo. Nam vehicula vulputate augue, ac pretium enim rutrum ultricies. Sed aliquet accumsan
+            varius. Quisque ac auctor ligula. Fusce fringilla, odio et dignissim iaculis, est lacus ultrices risus,
+            vitae condimentum enim urna eu nunc. In risus est, mattis non suscipit at, mattis ut ante. Maecenas
+            consectetur urna vel erat maximus, non molestie massa consequat. Duis a feugiat nibh. Sed a hendrerit
+            diam, a mattis est. In augue dolor, faucibus vel metus at, convallis rhoncus dui.
+          </p>
+        </Panel>
+      </div>
+    );
+  }
+
+  private _onClosePanel = () => {
+    this.setState({ showPanel: false });
+  };
+
+  private _onRenderFooterContent = (): JSX.Element => {
+    return (
+      <div>
+        <PrimaryButton onClick={this._onClosePanel} style={{ marginRight: '8px' }}>
+          Save
+        </PrimaryButton>
+        <DefaultButton onClick={this._onClosePanel}>Cancel</DefaultButton>
+      </div>
+    );
+  };
+
+  private _onShowPanel = () => {
+    this.setState({ showPanel: true });
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -239,11 +239,11 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
           >
             <div
               className=
-                  ms-Panel-scrollableContent
+                  ms-Panel-contentInner
                   {
-                    flex-grow: 1;
-                    height: 100%;
-                    overflow-y: auto;
+                    display: flex;
+                    flex-direction: column;
+                    max-height: 100%;
                   }
             >
               <div
@@ -389,69 +389,65 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
               </div>
               <div
                 className=
-                    ms-Panel-contentInner
+                    ms-Panel-header
                     {
-                      -webkit-overflow-scrolling: touch;
-                      display: flex;
-                      flex-direction: column;
-                      min-height: calc(100% - 44px);
-                      top: 44px;
-                      transform: translateZ(0);
+                      flex-grow: 0;
+                      margin-bottom: 14px;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 14px;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                    }
+                    @media screen and (min-width: 768px){& {
+                      padding-left: 32px;
+                      padding-right: 32px;
+                    }
+                    @media screen and (min-width: 1366px){& {
+                      padding-left: 40px;
+                      padding-right: 40px;
+                    }
+                    @media (min-width: 1024px){& {
+                      margin-top: 30px;
                     }
               >
-                <div
+                <p
+                  aria-level={2}
                   className=
-                      ms-Panel-header
+                      ms-Panel-headerText
                       {
-                        flex-grow: 0;
-                        margin-bottom: 14px;
-                        margin-left: 0;
-                        margin-right: 0;
-                        margin-top: 14px;
-                        padding-left: 16px;
-                        padding-right: 16px;
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #333333;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        line-height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
                       }
-                      @media screen and (min-width: 768px){& {
-                        padding-left: 32px;
-                        padding-right: 32px;
-                      }
-                      @media screen and (min-width: 1366px){& {
-                        padding-left: 40px;
-                        padding-right: 40px;
-                      }
-                      @media (min-width: 1024px){& {
-                        margin-top: 30px;
-                      }
+                  id="Panel3-headerText"
+                  role="heading"
                 >
-                  <p
-                    aria-level={2}
-                    className=
-                        ms-Panel-headerText
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #333333;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 21px;
-                          font-weight: 100;
-                          line-height: 32px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                        }
-                    id="Panel3-headerText"
-                    role="heading"
-                  >
-                    Hidden on Dismiss Panel
-                  </p>
-                </div>
+                  Hidden on Dismiss Panel
+                </p>
+              </div>
+              <div
+                className=
+                    ms-Panel-scrollableContent
+                    {
+                      height: 100%;
+                      overflow-y: auto;
+                    }
+                data-is-scrollable={true}
+              >
                 <div
                   className=
                       ms-Panel-content
                       {
                         margin-bottom: 0px;
-                        overflow-y: auto;
                         padding-bottom: 20px;
                         padding-left: 16px;
                         padding-right: 16px;
@@ -464,7 +460,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                         padding-left: 40px;
                         padding-right: 40px;
                       }
-                  data-is-scrollable={true}
                 >
                   <span>
                     When dismissed, this panel will be hidden instead of destroyed.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Scroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Scroll.Example.tsx.shot
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Panel.Scroll.Example.tsx correctly 1`] = `
+<div>
+  <button
+    aria-describedby="id__1"
+    aria-labelledby="id__0"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Open Panel
+        </div>
+      </div>
+    </div>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6588 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix an issue with Panel scrolling by making the scrollableContent div the only scrollable div.

Before (DetailsList within Panel - virtualization not working):
![panel-scrolling-broken](https://user-images.githubusercontent.com/6687333/46639489-2d568300-cb1b-11e8-9c43-2fda8baf1df8.gif)

After (DetailsList within Panel - virtualization working)
![panel-scrolling-fixed](https://user-images.githubusercontent.com/6687333/46639516-537c2300-cb1b-11e8-9da2-7276b0697463.gif)

#### Focus areas to test

1. Action buttons (including the "close" button) should not scroll with content
2. Header text should not scroll with content
3. Footer should not scroll with content
4. Footer should be visible on iOS Safari (not hidden behind the Safari navigation bar)
5. Footer should respect the `isFooterAtBottom` property (positioned at the bottom of the panel if true, positioned just below content otherwise)
6. On both mobile and desktop browsers, scrolling within a Panel should not scroll the content behind the Panel
