### PR TITLE
Calendar and DatePicker: allow native div props on container.

### DIFF
--- a/common/changes/office-ui-fabric-react/calendar-fix_2018-10-09-16-27.json
+++ b/common/changes/office-ui-fabric-react/calendar-fix_2018-10-09-16-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker and Calendar: allowing native div props to be forwarded to container div.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
@@ -8,23 +8,11 @@ import { mount } from 'enzyme';
 import { Calendar } from './Calendar';
 import { DateRangeType, DayOfWeek } from './Calendar.types';
 import { addDays, compareDates } from '../../utilities/dateMath/DateMath';
+import { resetIds } from '../../Utilities';
 
 describe('Calendar', () => {
   const dayPickerStrings = {
-    months: [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December'
-    ],
+    months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
 
     shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
 
@@ -35,15 +23,23 @@ describe('Calendar', () => {
     goToToday: 'Go to today'
   };
 
+  beforeEach(() => {
+    resetIds();
+  });
+
+  it('can append div attributes to container', () => {
+    const renderedComponent = mount(<Calendar strings={dayPickerStrings} id="foo" />);
+
+    expect(renderedComponent.getElement().props.id).toEqual('foo');
+  });
+
   it('can handle invalid starting dates', () => {
     // Arrange
     const defaultDate = new Date('invalid');
 
     // Act
 
-    const renderedComponent = mount(
-      <Calendar strings={dayPickerStrings} isMonthPickerVisible={true} value={defaultDate} />
-    );
+    const renderedComponent = mount(<Calendar strings={dayPickerStrings} isMonthPickerVisible={true} value={defaultDate} />);
 
     const today = renderedComponent.find('.ms-DatePicker-day--today');
     expect(+today.text()).toEqual(new Date().getDate());
@@ -70,10 +66,7 @@ describe('Calendar', () => {
       const today = new Date();
       const monthName = dayPickerStrings.months[today.getMonth()];
       const year = today.getFullYear();
-      const dayPickerMonth = ReactTestUtils.findRenderedDOMComponentWithClass(
-        renderedComponent,
-        'ms-DatePicker-monthAndYear'
-      );
+      const dayPickerMonth = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-monthAndYear');
       expect(dayPickerMonth).toBeDefined();
       expect(dayPickerMonth.textContent).toEqual(monthName + ' ' + year.toString());
     });
@@ -141,10 +134,7 @@ describe('Calendar', () => {
 
     it('Verify day picker header', () => {
       const monthName = dayPickerStrings.months[defaultDate.getMonth()];
-      const dayPickerMonth = ReactTestUtils.findRenderedDOMComponentWithClass(
-        renderedComponent,
-        'ms-DatePicker-monthAndYear'
-      );
+      const dayPickerMonth = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-monthAndYear');
       expect(dayPickerMonth).toBeDefined();
       expect(dayPickerMonth.textContent).toEqual(monthName + ' ' + defaultDate.getFullYear().toString());
     });
@@ -167,19 +157,13 @@ describe('Calendar', () => {
     });
 
     it('Verify month picker seen', () => {
-      const monthPicker = ReactTestUtils.findRenderedDOMComponentWithClass(
-        renderedComponent,
-        'ms-DatePicker-monthPicker'
-      ) as HTMLElement;
+      const monthPicker = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-monthPicker') as HTMLElement;
       expect(monthPicker).toBeDefined();
       expect(monthPicker.style.display).not.toEqual('none');
     });
 
     it('Verify month picker header', () => {
-      const currentYear = ReactTestUtils.findRenderedDOMComponentWithClass(
-        renderedComponent,
-        'ms-DatePicker-currentYear'
-      );
+      const currentYear = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-currentYear');
       expect(currentYear).toBeDefined();
       expect(currentYear.textContent).toEqual(defaultDate.getFullYear().toString());
     });

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -4,7 +4,7 @@ import { DayOfWeek, FirstWeekOfYear, DateRangeType } from '../../utilities/dateV
 import { CalendarDay, ICalendarDay } from './CalendarDay';
 import { CalendarMonth, ICalendarMonth } from './CalendarMonth';
 import { compareDates, getDateRangeArray } from '../../utilities/dateMath/DateMath';
-import { css, BaseComponent, KeyCodes, createRef } from '../../Utilities';
+import { css, BaseComponent, KeyCodes, createRef, getNativeProps, divProperties } from '../../Utilities';
 import * as stylesImport from './Calendar.scss';
 const styles: any = stylesImport;
 
@@ -135,6 +135,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
       showCloseButton,
       allFocusable
     } = this.props;
+    const nativeProps = getNativeProps(this.props, divProperties, ['value']);
+
     const { selectedDate, navigatedDayDate, navigatedMonthDate, isMonthPickerVisible, isDayPickerVisible } = this.state;
     const onHeaderSelect = showMonthPickerAsOverlay ? this._onHeaderSelect : undefined;
     const monthPickerOnly = !showMonthPickerAsOverlay && !isDayPickerVisible;
@@ -143,6 +145,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
     return (
       <div className={css(rootClass, styles.root, className)} role="application">
         <div
+          {...nativeProps}
           className={css(
             'ms-DatePicker-picker ms-DatePicker-picker--opened ms-DatePicker-picker--focused',
             styles.picker,

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -7,7 +7,7 @@ export interface ICalendar {
   focus: () => void;
 }
 
-export interface ICalendarProps extends IBaseProps<ICalendar> {
+export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the ICalendar interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
         >
           <div
             className="ms-DatePicker-dayPicker"
-            id="DatePickerDay-dayPicker10"
+            id="DatePickerDay-dayPicker1"
           >
             <div
               className="ms-DatePicker-header"
@@ -29,7 +29,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                 aria-atomic="true"
                 aria-live="polite"
                 aria-relevant="text"
-                id="DatePickerDay-monthAndYear11"
+                id="DatePickerDay-monthAndYear2"
               >
                 <div
                   className="ms-DatePicker-monthAndYear"
@@ -44,7 +44,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                   className="ms-DatePicker-navContainer"
                 >
                   <button
-                    aria-controls="DatePickerDay-dayPicker10"
+                    aria-controls="DatePickerDay-dayPicker1"
                     aria-disabled={false}
                     className="ms-DatePicker-prevMonth js-prevMonth"
                     disabled={false}
@@ -72,7 +72,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     </i>
                   </button>
                   <button
-                    aria-controls="DatePickerDay-dayPicker10"
+                    aria-controls="DatePickerDay-dayPicker1"
                     aria-disabled={false}
                     className="ms-DatePicker-nextMonth js-nextMonth"
                     disabled={false}
@@ -104,15 +104,15 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
             </div>
             <div
               className="ms-FocusZone"
-              data-focuszone-id="FocusZone12"
+              data-focuszone-id="FocusZone3"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
               role="presentation"
             >
               <table
-                aria-activedescendant="DatePickerDay-active9"
-                aria-labelledby="DatePickerDay-monthAndYear11"
+                aria-activedescendant="DatePickerDay-active0"
+                aria-labelledby="DatePickerDay-monthAndYear2"
                 aria-multiselectable="false"
                 aria-readonly="true"
                 className="ms-DatePicker-table"
@@ -242,7 +242,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
                         disabled={false}
-                        id="DatePickerDay-active9"
+                        id="DatePickerDay-active0"
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="button"
@@ -1046,7 +1046,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
             </div>
             <div
               className="ms-FocusZone"
-              data-focuszone-id="FocusZone13"
+              data-focuszone-id="FocusZone4"
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IDatePicker, IDatePickerProps, IDatePickerStrings, IDatePickerStyleProps, IDatePickerStyles } from './DatePicker.types';
-import { BaseComponent, KeyCodes, createRef, classNamesFunction, getId } from '../../Utilities';
+import { BaseComponent, KeyCodes, createRef, classNamesFunction, getId, getNativeProps, divProperties } from '../../Utilities';
 import { Calendar, ICalendar, DayOfWeek } from '../../Calendar';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { Callout } from '../../Callout';
@@ -170,9 +170,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     });
 
     const calloutId = getId('DatePicker-Callout');
+    const nativeProps = getNativeProps(this.props, divProperties, ['value']);
 
     return (
-      <div className={classNames.root}>
+      <div {...nativeProps} className={classNames.root}>
         <div ref={this._datePickerDiv} role="combobox" aria-expanded={isDatePickerShown} aria-haspopup="true" aria-owns={calloutId}>
           <TextField
             label={label}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -6,13 +6,24 @@ import { DatePickerBase } from './DatePicker.base';
 import { IDatePickerStrings } from './DatePicker.types';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { shallow, mount, ReactWrapper } from 'enzyme';
+import { resetIds } from '../../Utilities';
 
 describe('DatePicker', () => {
+  beforeEach(() => {
+    resetIds();
+  });
+
   it('renders default DatePicker correctly', () => {
     // This will only render the input. Calendar component has its own snapshot.
     const component = renderer.create(<DatePicker />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('can add an id to the container', () => {
+    const wrapper = mount(<DatePickerBase id="foo" />);
+
+    expect(wrapper.getElement().props.id).toEqual('foo');
   });
 
   it('should not open DatePicker when disabled, no label', () => {
@@ -132,20 +143,7 @@ describe('DatePicker', () => {
     const minDate = new Date('Jan 1 2017');
     const maxDate = new Date('Dec 31 2017');
     const strings: IDatePickerStrings = {
-      months: [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December'
-      ],
+      months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
       shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
       days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
       shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
@@ -156,13 +154,7 @@ describe('DatePicker', () => {
 
     beforeEach(() => {
       datePicker = mount(
-        <DatePickerBase
-          allowTextInput={true}
-          minDate={minDate}
-          maxDate={maxDate}
-          value={defaultDate}
-          strings={strings}
-        />
+        <DatePickerBase allowTextInput={true} minDate={minDate} maxDate={maxDate} value={defaultDate} strings={strings} />
       );
     });
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -12,7 +12,7 @@ export interface IDatePicker {
   reset(): void;
 }
 
-export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAttributes<HTMLDivElement> {
+export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the IDatePicker interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -12,7 +12,7 @@ export interface IDatePicker {
   reset(): void;
 }
 
-export interface IDatePickerProps extends IBaseProps<IDatePicker> {
+export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IDatePicker interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
   <div
     aria-expanded={false}
     aria-haspopup="true"
-    aria-owns="DatePicker-Callout4"
+    aria-owns="DatePicker-Callout0"
     role="combobox"
   >
     <div
@@ -117,7 +117,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   color: #666666;
                   opacity: 1;
                 }
-            id="TextField5"
+            id="TextField1"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -19,6 +19,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
           padding-right: 0px;
           padding-top: 0px;
         }
+    placeholder="Select a date..."
   >
     <div
       aria-expanded={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -24,6 +24,7 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
           padding-right: 0px;
           padding-top: 0px;
         }
+    placeholder="Select a date..."
   >
     <div
       aria-expanded={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -22,6 +22,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
           padding-right: 0px;
           padding-top: 0px;
         }
+    placeholder="Select a date..."
   >
     <div
       aria-expanded={false}
@@ -214,6 +215,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
           padding-right: 0px;
           padding-top: 0px;
         }
+    placeholder="Date required with no label..."
   >
     <div
       aria-expanded={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -19,6 +19,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
           padding-right: 0px;
           padding-top: 0px;
         }
+    placeholder="Select a date..."
   >
     <div
       aria-expanded={false}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6601
- [X] Include a change request file using `$ npm run change`

#### Description of changes

`id` and other native div props can now be pushed to the container for `Calendar` and `DatePicker`.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6619)

