### PR TITLE
Keytip: Fix TS 3.1 error by extending IBaseProps

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-keytip-fix-ts_2018-10-09-18-07.json
+++ b/common/changes/office-ui-fabric-react/jg-keytip-fix-ts_2018-10-09-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Keytip: Fix TS 3.1 error by extending IBaseProps.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/KeytipData/KeytipData.types.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/KeytipData.types.ts
@@ -1,6 +1,9 @@
+import { IBaseProps } from '../../Utilities';
 import { IKeytipProps } from '../../Keytip';
 
-export interface IKeytipDataProps {
+export interface IKeytip {}
+
+export interface IKeytipDataProps extends IBaseProps<IKeytip> {
   /**
    * IKeytipProps to create from this KeytipData
    * If no keytipProps are defined, a keytip won't be registered


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6612
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Keytip: Fix TS 3.1 error by extending IBaseProps.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6625)

