### PR TITLE
ExampleCard: Replace Core classes with mixins

### DIFF
--- a/common/changes/@uifabric/example-app-base/example-card-classes_2018-10-09-18-56.json
+++ b/common/changes/@uifabric/example-app-base/example-card-classes_2018-10-09-18-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "ExampleCard: Replace Fabric Core classes with mixins",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.scss
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.scss
@@ -14,11 +14,13 @@
   }
 
   .ExampleCard-title {
+    @include ms-font-l;
     margin-bottom: 10px;
     display: inline-block;
   }
 
   .ExampleCard-toggleButtons {
+    @include ms-font-l;
     display: flex;
     @include float(right);
 

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -50,8 +50,8 @@ export class ExampleCard extends React.Component<IExampleCardProps, IExampleCard
     return (
       <div className={rootClass}>
         <div className="ExampleCard-header">
-          <span className="ExampleCard-title ms-font-l">{title}</span>
-          <div className="ExampleCard-toggleButtons ms-font-l">
+          <span className="ExampleCard-title">{title}</span>
+          <div className="ExampleCard-toggleButtons">
             {codepenJS && <CodepenComponent jsContent={codepenJS} />}
             {code && (
               <CommandButton


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6618
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Removes the use of Fabric Core classes in ExampleCard, using mixins instead. I've verified that these classes aren't used anywhere else in example-app-base.

Before:
![image](https://user-images.githubusercontent.com/1382445/46684806-b9fb5280-cba8-11e8-8f57-e1225d52bac6.png)

After:
![image](https://user-images.githubusercontent.com/1382445/46684778-af40bd80-cba8-11e8-859a-7f00ced5969e.png)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6628)

