### PR TITLE
Async simplification

### DIFF
--- a/common/changes/@uifabric/utilities/async-simplification_2018-10-09-19-27.json
+++ b/common/changes/@uifabric/utilities/async-simplification_2018-10-09-19-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Adding `asAsync` HOC wrapper to abstract async loading for components.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/asAsync.test.tsx
+++ b/packages/utilities/src/asAsync.test.tsx
@@ -3,8 +3,8 @@ import { asAsync } from './asAsync';
 import { mount } from 'enzyme';
 
 describe('asAsync', () => {
-  it('can async load default exports', (done: () => undefined) => {
-    let _resolve: ((result: { [key: string]: React.ReactType<{}> }) => void) = () => undefined;
+  it('can async load exports', (done: () => undefined) => {
+    let _resolve: ((result: React.ReactType<{}>) => void) = () => undefined;
     let _loadCalled = false;
     // tslint:disable-next-line:no-any
     const loadThingPromise = new Promise<any>((resolve: any) => {
@@ -24,39 +24,7 @@ describe('asAsync', () => {
     expect(wrapper.text()).toEqual('placeholder');
     expect(_resolve).toBeTruthy();
 
-    _resolve({
-      default: () => <div>thing</div>
-    });
-
-    process.nextTick(() => {
-      expect(wrapper.text()).toEqual('thing');
-      done();
-    });
-  });
-
-  it('can support named exports', (done: () => void) => {
-    let _resolve: ((result: { [key: string]: React.ReactType<{}> }) => void) = () => undefined;
-    let _loadCalled = false;
-    // tslint:disable-next-line:no-any
-    const loadThingPromise = new Promise<any>((resolve: any) => {
-      _resolve = resolve;
-    });
-
-    const AsyncThing = asAsync({
-      load: () => {
-        return loadThingPromise;
-      },
-      placeholder: () => <div>placeholder</div>,
-      exportName: 'foo'
-    });
-    const wrapper = mount(<AsyncThing />);
-
-    expect(wrapper.text()).toEqual('placeholder');
-    expect(_resolve).toBeTruthy();
-
-    _resolve({
-      foo: () => <div>thing</div>
-    });
+    _resolve(() => <div>thing</div>);
 
     process.nextTick(() => {
       expect(wrapper.text()).toEqual('thing');

--- a/packages/utilities/src/asAsync.test.tsx
+++ b/packages/utilities/src/asAsync.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { asAsync } from './asAsync';
+import { mount } from 'enzyme';
+
+describe('asAsync', () => {
+  it('can async load default exports', (done: () => undefined) => {
+    let _resolve: ((result: { [key: string]: React.ReactType<{}> }) => void) = () => undefined;
+    let _loadCalled = false;
+    // tslint:disable-next-line:no-any
+    const loadThingPromise = new Promise<any>((resolve: any) => {
+      _resolve = resolve;
+    });
+
+    const AsyncThing = asAsync({
+      load: () => {
+        _loadCalled = true;
+        return loadThingPromise;
+      },
+      placeholder: () => <div>placeholder</div>
+    });
+    const wrapper = mount(<AsyncThing />);
+
+    expect(_loadCalled).toBe(true);
+    expect(wrapper.text()).toEqual('placeholder');
+    expect(_resolve).toBeTruthy();
+
+    _resolve({
+      default: () => <div>thing</div>
+    });
+
+    process.nextTick(() => {
+      expect(wrapper.text()).toEqual('thing');
+      done();
+    });
+  });
+
+  it('can support named exports', (done: () => void) => {
+    let _resolve: ((result: { [key: string]: React.ReactType<{}> }) => void) = () => undefined;
+    let _loadCalled = false;
+    // tslint:disable-next-line:no-any
+    const loadThingPromise = new Promise<any>((resolve: any) => {
+      _resolve = resolve;
+    });
+
+    const AsyncThing = asAsync({
+      load: () => {
+        return loadThingPromise;
+      },
+      placeholder: () => <div>placeholder</div>,
+      exportName: 'foo'
+    });
+    const wrapper = mount(<AsyncThing />);
+
+    expect(wrapper.text()).toEqual('placeholder');
+    expect(_resolve).toBeTruthy();
+
+    _resolve({
+      foo: () => <div>thing</div>
+    });
+
+    process.nextTick(() => {
+      expect(wrapper.text()).toEqual('thing');
+      done();
+    });
+  });
+});

--- a/packages/utilities/src/asAsync.tsx
+++ b/packages/utilities/src/asAsync.tsx
@@ -14,7 +14,7 @@
 
 import * as React from 'react';
 
-interface IAsAsyncOptions<TProps> {
+export interface IAsAsyncOptions<TProps> {
   /**
    * Callback which returns a promise resolving an object which exports the component.
    */

--- a/packages/utilities/src/asAsync.tsx
+++ b/packages/utilities/src/asAsync.tsx
@@ -1,10 +1,29 @@
 import * as React from 'react';
 
 interface IAsAsyncOptions<TProps> {
+  /**
+   * Callback which returns a promise resolving an object which exports the component.
+   */
   load: () => Promise<{ [key: string]: React.ReactType<TProps> }>;
+
+  /**
+   * The exportName to resolve from the result, defaults to "default".
+   */
   exportName?: string;
+
+  /**
+   * An optional JSX rendering for placeholder content.
+   */
   placeholder?: React.ReactType;
+
+  /**
+   * Callback executed when async loading is complete.
+   */
   onLoad?: () => void;
+
+  /**
+   * Callback when async loading fails.
+   */
   onError?: (error: Error) => void;
 }
 

--- a/packages/utilities/src/asAsync.tsx
+++ b/packages/utilities/src/asAsync.tsx
@@ -1,3 +1,17 @@
+/**
+ * asAsync - a HOC for async loading components.
+ *
+ * Usage:
+ *
+ * const AsyncDialog = asAsync({
+ *   load: () => import('Dialog'),
+ *   exportName: 'Dialog', // defaults to 'default'
+ *   placeholder: () => <div>I am a placeholder</div>
+ * });
+ *
+ * React.render(domElement, <AsyncDialog { ...dialogProps } />);
+ */
+
 import * as React from 'react';
 
 interface IAsAsyncOptions<TProps> {

--- a/packages/utilities/src/asAsync.tsx
+++ b/packages/utilities/src/asAsync.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+
+interface IAsAsyncOptions<TProps> {
+  load: () => Promise<{ [key: string]: React.ReactType<TProps> }>;
+  exportName?: string;
+  placeholder?: React.ReactType;
+  onLoad?: () => void;
+  onError?: (error: Error) => void;
+}
+
+/**
+ * If possible, use a WeakMap to maintain a cache of loaded components.
+ * This can be used to synchronously render components that have already been loaded,
+ * rather than having to wait for at least one async tick.
+ */
+const _syncModuleCache =
+  typeof WeakMap !== 'undefined'
+    ? // tslint:disable-next-line:no-any
+      new WeakMap<() => Promise<{ [key: string]: React.ReactType<any> }>, React.ReactType<any> | undefined>()
+    : undefined;
+
+/**
+ * Produces a component which internally loads the target component before first mount.
+ * The component passes all props through to the loaded component.
+ *
+ * This overload accepts a module with a default export for the component.
+ */
+export function asAsync<TProps>(options: IAsAsyncOptions<TProps>): React.ComponentType<TProps> {
+  class Async extends React.Component<TProps & { forwardedRef: React.Ref<TProps> }, { Component?: React.ReactType<TProps> }> {
+    public state = {
+      Component: _syncModuleCache ? _syncModuleCache.get(options.load) : undefined
+    };
+
+    public render(): JSX.Element | null {
+      const { forwardedRef } = this.props;
+      const { Component } = this.state;
+      const Placeholder = options.placeholder;
+
+      return Component ? <Component ref={forwardedRef} {...this.props} /> : Placeholder ? <Placeholder /> : null;
+    }
+
+    public componentDidMount(): void {
+      let { Component } = this.state;
+
+      if (!Component) {
+        options
+          .load()
+          .then((result: { [key: string]: React.ReactType<TProps> }) => {
+            Component = result[options.exportName || 'default'];
+
+            if (Component) {
+              // Cache component for future reference.
+              _syncModuleCache && _syncModuleCache.set(options.load, Component);
+
+              // Set state.
+              this.setState(
+                {
+                  Component
+                },
+                options.onLoad
+              );
+            }
+          })
+          .catch(options.onError);
+      }
+    }
+  }
+
+  return React.forwardRef((props: TProps, ref: React.Ref<TProps>) => <Async {...props} forwardedRef={ref} />);
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -21,6 +21,7 @@ export * from './KeyCodes';
 export * from './Rectangle';
 export * from './aria';
 export * from './array';
+export * from './asAsync';
 export * from './assertNever';
 export * from './autobind';
 export * from './classNamesFunction';


### PR DESCRIPTION
This change cleans up the previous `asAsync` PR:

To create async wrappers for components, you can now use this HOC as such:
```ts
const AsyncDialog = asAsync({
  load: () => import('Dialog'),
  placeholder: () => <div>I am a placeholder</div>
});

React.render(domElement, <AsyncDialog { ...dialogProps } />);
```

## Options

| param | required | desc |
| ---- | --- | --- |
| load | required | Callback which returns a promise resolving an object which exports the component. |
| exportName | optional | The exportName to resolve from the result, defaults to "default". |
| placeholder | optional | An optional JSX rendering for placeholder content. |
| onLoad | optional | Callback executed when async loading is complete. |
| onError | optional | Callback when async loading fails. |


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6629)

