### PR TITLE
ContextualMenu SubMenu Example accessibility fixes

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-ctx-menu-a11y-fixes_2018-10-09-20-43.json
+++ b/common/changes/office-ui-fabric-react/keco-ctx-menu-a11y-fixes_2018-10-09-20-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes missing label in ContextualMenu.Submenu example and invalid non-numeric input in hover delay  field.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -129,6 +129,7 @@ export class ContextualMenuCustomizationExample extends React.Component<{}, {}> 
               key: 'categories',
               text: 'Categorize',
               subMenuProps: {
+                ariaLabel: 'Categories',
                 items: [
                   {
                     key: 'categories',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -138,6 +138,7 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
               key: 'categories',
               text: 'Categorize',
               subMenuProps: {
+                ariaLabel: 'Categories',
                 items: [
                   {
                     key: 'categories',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -19,7 +19,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
   public render(): JSX.Element {
     return (
       <div>
-        <TextField value={String(this.state.hoverDelay)} label="Hover delay (ms)" onChange={this._onHoverDelayChanged} />
+        <TextField value={String(this.state.hoverDelay)} label="Hover delay (ms)" type="number" onChange={this._onHoverDelayChanged} />
         <DefaultButton
           id="ContextualMenuButton2"
           text="Click for ContextualMenu"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -124,7 +124,7 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
           onChange={[Function]}
           onFocus={[Function]}
           onInput={[Function]}
-          type="text"
+          type="number"
           value="250"
         />
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Still working my way thru the issues in #6360. Here are two minor a11y fixes for the `ContextualMenu` examples.

**Fixes:**

- Bug 15 : [Accessibility][Usable]: Header/Label should be define for 'Categories group' in 'Categorize submenu'. (https://github.com/OfficeDev/office-ui-fabric-react/commit/b89cfd23da63875b43fb4c9d5e55b8cd1a9bc88f)
- Bug 18 : [Accessibility][Keyboard]: User is not able to delete 'NAN' value from 'Hover delay' edit box under 'ContextualMenu with submenus' after entering invalid values. (https://github.com/OfficeDev/office-ui-fabric-react/commit/3d60edd6d1dbbef009b70637290f50d40030d568)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6631)

