### PR TITLE
Fix ContextualMenu Examples: broken "charm" icons & incorrect input type

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-ctx-menu-a11y-fixes_2018-10-10-00-12.json
+++ b/common/changes/office-ui-fabric-react/keco-ctx-menu-a11y-fixes_2018-10-10-00-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix ContextualMenu example broken charm icons and specify hover delay input as type=\"number\".",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -195,7 +195,7 @@ export class ContextualMenuCustomizationWithNoWrapExample extends React.Componen
     return (
       <IconButton
         {...item}
-        iconProps={{ iconName: item.name }}
+        iconProps={{ iconName: item.text }}
         className="ms-ContextualMenu-customizationExample-icon ms-ContextualMenu-link"
         data-is-focusable={true}
         onClick={dismissMenu}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -19,7 +19,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
   public render(): JSX.Element {
     return (
       <div>
-        <TextField value={String(this.state.hoverDelay)} label="Hover delay (ms)" onChange={this._onHoverDelayChanged} />
+        <TextField value={String(this.state.hoverDelay)} label="Hover delay (ms)" type="number" onChange={this._onHoverDelayChanged} />
         <DefaultButton
           id="ContextualMenuButton2"
           text="Click for ContextualMenu"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -124,7 +124,7 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
           onChange={[Function]}
           onFocus={[Function]}
           onInput={[Function]}
-          type="text"
+          type="number"
           value="250"
         />
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5943
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Still working my way thru the issues in #6360. Here are two minor a11y related fixes for the `ContextualMenu` examples.

**Fixes:**

- Bug 14 : [Functional]: Some controls are not implemented properly in 'Charm' submenu window. (https://github.com/OfficeDev/office-ui-fabric-react/commit/9a1f9c96ea7a884ec33a0e4d2ae110f189bf3e9d)
- Bug 18 : [Accessibility][Keyboard]: User is not able to delete 'NAN' value from 'Hover delay' edit box under 'ContextualMenu with submenus' after entering invalid values. (https://github.com/OfficeDev/office-ui-fabric-react/commit/3d60edd6d1dbbef009b70637290f50d40030d568)


#### Focus areas to test

**Bug 14**

**Before**

![image](https://user-images.githubusercontent.com/706967/46705729-b803b480-cbe5-11e8-907e-8696f2663e9e.png)

**After**

![image](https://user-images.githubusercontent.com/706967/46705712-a15d5d80-cbe5-11e8-9b70-4b38bd4227fb.png)

**Bug 18**

**Before**

I'm entering "zzzz" here, which results in `NaN` that I cannot clear.

![ctxmenu_invalid_input_master](https://user-images.githubusercontent.com/706967/46705855-41b38200-cbe6-11e8-9276-f7553b82027b.gif)

**After**

I'm entering "zzzz" here, which results in `0` not `NaN`.

![ctxmenu_invalid_input](https://user-images.githubusercontent.com/706967/46705807-087b1200-cbe6-11e8-9a61-b124bc4eb3d8.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6635)

