### PR TITLE
IStyleSet: Now uses a form that works better in TS 2.8 and does not require TS 3.0 to work.

### DIFF
--- a/common/changes/@uifabric/merge-styles/issue6615_2018-10-10-22-15.json
+++ b/common/changes/@uifabric/merge-styles/issue6615_2018-10-10-22-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "IStyleSet: Now uses a form that works better in TS 2.8 and does not require TS 3.0 to work. Thanks [Nimelrian](https://github.com/Nimelrian)!",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -11,12 +11,9 @@ export type __ReduceToFunction<T> = T extends (...args: any[]) => any ? T : neve
  * Helper function whose role is supposed to express that regardless if T is a style object or style function,
  * it will always map to a style function.
  *
- * Note: the commmented segment is the right expression but it is buggy in 2.8.2. Once Fabric upgrades to Typescript 3,
- *  we should uncomment the commented segmment below as well as uncomment the test in mergeStyleSets.test.ts.
- *
- * See https://github.com/OfficeDev/office-ui-fabric-react/issues/6124.
+ * @author [Nimelrian](https://github.com/Nimelrian) in https://github.com/OfficeDev/office-ui-fabric-react/issues/6615
  */
-export type __MapToFunctionType<T> = /*[T] extends [IStyleSet<any>] ? (...args: any[]) => T :*/ __ReduceToFunction<T>;
+export type __MapToFunctionType<T> = Extract<T, Function> extends never ? (...args: any[]) => Partial<T> : Extract<T, Function>;
 
 /**
  * A style set is a dictionary of display areas to IStyle objects.

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -8,8 +8,6 @@ export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 /**
  * Helper function whose role is supposed to express that regardless if T is a style object or style function,
  * it will always map to a style function.
- *
- * @author [Nimelrian](https://github.com/Nimelrian) in https://github.com/OfficeDev/office-ui-fabric-react/issues/6615
  */
 export type __MapToFunctionType<T> = Extract<T, Function> extends never ? (...args: any[]) => Partial<T> : Extract<T, Function>;
 

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -5,8 +5,6 @@ export type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } & 
 
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
-export type __ReduceToFunction<T> = T extends (...args: any[]) => any ? T : never;
-
 /**
  * Helper function whose role is supposed to express that regardless if T is a style object or style function,
  * it will always map to a style function.

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -295,11 +295,9 @@ describe('mergeStyleSets', () => {
         expect.assertions(0);
       });
 
-      // NOTE: The following test should be enabled when Fabric is upgraded to Typescript 3.
       it('IStyleSet/IProcessedStyleSet should work with legacy sub components that only take IStyleFunctions', () => {
         const classNames = mergeStyleSets<IStylesWithStyleObjectAsSubCommponent>(getStyles2());
 
-        // NOTE: The following line should be uncommented when Fabric is upgraded to Typescript 3.
         LegacySubComponent({ styles: classNames.subComponentStyles.button({ isCollapsed: false }) });
 
         // this test primarily tests that the lines above do not result in a Typescript error.

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -296,11 +296,11 @@ describe('mergeStyleSets', () => {
       });
 
       // NOTE: The following test should be enabled when Fabric is upgraded to Typescript 3.
-      it.skip('IStyleSet/IProcessedStyleSet should work with legacy sub components that only take IStyleFunctions', () => {
+      it('IStyleSet/IProcessedStyleSet should work with legacy sub components that only take IStyleFunctions', () => {
         const classNames = mergeStyleSets<IStylesWithStyleObjectAsSubCommponent>(getStyles2());
 
         // NOTE: The following line should be uncommented when Fabric is upgraded to Typescript 3.
-        // LegacySubComponent({ styles: classNames.subComponentStyles.button({ isCollapsed: false }) });
+        LegacySubComponent({ styles: classNames.subComponentStyles.button({ isCollapsed: false }) });
 
         // this test primarily tests that the lines above do not result in a Typescript error.
         expect.assertions(0);

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -44,11 +44,11 @@ export function mergeStyleSets<
   TStyleSet1 extends IStyleSet<TStyleSet1>,
   TStyleSet2 extends IStyleSet<TStyleSet2>,
   TStyleSet3 extends IStyleSet<TStyleSet3>
-  >(
-    styleSet1: TStyleSet1 | false | null | undefined,
-    styleSet2: TStyleSet2 | false | null | undefined,
-    styleSet3: TStyleSet3 | false | null | undefined
-  ): IProcessedStyleSet<TStyleSet1 & TStyleSet2 & TStyleSet3>;
+>(
+  styleSet1: TStyleSet1 | false | null | undefined,
+  styleSet2: TStyleSet2 | false | null | undefined,
+  styleSet3: TStyleSet3 | false | null | undefined
+): IProcessedStyleSet<TStyleSet1 & TStyleSet2 & TStyleSet3>;
 
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,
@@ -66,12 +66,12 @@ export function mergeStyleSets<
   TStyleSet2 extends IStyleSet<TStyleSet2>,
   TStyleSet3 extends IStyleSet<TStyleSet3>,
   TStyleSet4 extends IStyleSet<TStyleSet4>
-  >(
-    styleSet1: TStyleSet1 | false | null | undefined,
-    styleSet2: TStyleSet2 | false | null | undefined,
-    styleSet3: TStyleSet3 | false | null | undefined,
-    styleSet4: TStyleSet4 | false | null | undefined
-  ): IProcessedStyleSet<TStyleSet1 & TStyleSet2 & TStyleSet3 & TStyleSet4>;
+>(
+  styleSet1: TStyleSet1 | false | null | undefined,
+  styleSet2: TStyleSet2 | false | null | undefined,
+  styleSet3: TStyleSet3 | false | null | undefined,
+  styleSet4: TStyleSet4 | false | null | undefined
+): IProcessedStyleSet<TStyleSet1 & TStyleSet2 & TStyleSet3 & TStyleSet4>;
 
 /**
  * Takes in one or more style set objects, each consisting of a set of areas,
@@ -91,9 +91,7 @@ export function mergeStyleSets(...styleSets: Array<IStyleSet<any> | undefined | 
  *
  * @param styleSets - One or more style sets to be merged.
  */
-export function mergeStyleSets(
-  ...styleSets: Array<IStyleSet<any> | undefined | false | null>
-): IProcessedStyleSet<any> {
+export function mergeStyleSets(...styleSets: Array<IStyleSet<any> | undefined | false | null>): IProcessedStyleSet<any> {
   // tslint:disable-next-line:no-any
   const classNameSet: IProcessedStyleSet<any> = { subComponentStyles: {} };
   const classMap: { [key: string]: string } = {};
@@ -108,9 +106,7 @@ export function mergeStyleSets(
     // we have guarded against falsey values just above.
     styleSet!;
 
-  if (styleSets.length > 1) {
-    concatenatedStyleSet = concatStyleSets(...styleSets);
-  }
+  concatenatedStyleSet = concatStyleSets(...styleSets);
 
   const registrations = [];
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6615 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Addresses the issue in #6615 and fix the runtime bug where subComponentStyles were not processed when only 1 argument is passed into mergeStyleSets because we do not call concatStyleSets.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6649)

