### PR TITLE
Parser backslash backticks

### DIFF
--- a/common/changes/@uifabric/example-app-base/parser-backslash-backticks_2018-10-10-23-14.json
+++ b/common/changes/@uifabric/example-app-base/parser-backslash-backticks_2018-10-10-23-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Documentation: remove unwanted backslashes and render backticks as code blocks",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
@@ -19,6 +19,46 @@ export interface IProptertiesTableState {
   groups: IGroup[] | undefined;
 }
 
+const renderCell = (text: string) => {
+  // When the text is passed to this function, it has had newline characters removed,
+  // so this regex will match backtick sequences that span multiple lines.
+  const regex = new RegExp('`[^`]*`', 'g');
+  let regexResult: RegExpExecArray | null;
+  let codeBlocks: { index: number; text: string }[] = [];
+  while ((regexResult = regex.exec(text)) !== null) {
+    codeBlocks.push({
+      index: regexResult.index,
+      text: regexResult[0]
+    });
+  }
+
+  if (codeBlocks.length === 0) {
+    return <span>{text}</span>;
+  }
+
+  const eltChildren: JSX.Element[] = [];
+
+  let codeIndex = 0;
+  let textIndex = 0;
+  while (textIndex < text.length && codeIndex < codeBlocks.length) {
+    const codeBlock = codeBlocks[codeIndex];
+    if (textIndex < codeBlock.index) {
+      const str = text.substring(textIndex, codeBlock.index);
+      eltChildren.push(<span key={textIndex}>{str}</span>);
+      textIndex += str.length;
+    } else {
+      eltChildren.push(<code key={textIndex}>{codeBlock.text.substring(1, codeBlock.text.length - 1)}</code>);
+      codeIndex++;
+      textIndex += codeBlock.text.length;
+    }
+  }
+  if (textIndex < text.length) {
+    eltChildren.push(<span key={textIndex}>{text.substring(textIndex, text.length)}</span>);
+  }
+
+  return <span>{eltChildren}</span>;
+};
+
 const DEFAULT_COLUMNS: IColumn[] = [
   {
     key: 'name',
@@ -28,7 +68,8 @@ const DEFAULT_COLUMNS: IColumn[] = [
     maxWidth: 250,
     isCollapsable: false,
     isRowHeader: true,
-    isResizable: true
+    isResizable: true,
+    onRender: (item: IInterfaceProperty) => renderCell(item.name)
   },
   {
     key: 'type',
@@ -38,7 +79,8 @@ const DEFAULT_COLUMNS: IColumn[] = [
     maxWidth: 150,
     isCollapsable: false,
     isResizable: true,
-    isMultiline: true
+    isMultiline: true,
+    onRender: (item: IInterfaceProperty) => renderCell(item.type)
   },
   {
     key: 'defaultValue',
@@ -48,7 +90,8 @@ const DEFAULT_COLUMNS: IColumn[] = [
     maxWidth: 150,
     isCollapsable: false,
     isResizable: true,
-    isMultiline: true
+    isMultiline: true,
+    onRender: (item: IInterfaceProperty) => renderCell(item.defaultValue)
   },
   {
     key: 'description',
@@ -58,7 +101,8 @@ const DEFAULT_COLUMNS: IColumn[] = [
     maxWidth: 400,
     isCollapsable: false,
     isResizable: true,
-    isMultiline: true
+    isMultiline: true,
+    onRender: (item: IInterfaceProperty) => renderCell(item.description)
   }
 ];
 
@@ -71,7 +115,8 @@ const ENUM_COLUMNS: IColumn[] = [
     maxWidth: 250,
     isCollapsable: false,
     isRowHeader: true,
-    isResizable: true
+    isResizable: true,
+    onRender: (item: IEnumProperty) => renderCell(item.name)
   },
   {
     key: 'description',
@@ -80,7 +125,8 @@ const ENUM_COLUMNS: IColumn[] = [
     minWidth: 300,
     maxWidth: 400,
     isCollapsable: false,
-    isResizable: true
+    isResizable: true,
+    onRender: (item: IEnumProperty) => renderCell(item.description)
   }
 ];
 

--- a/packages/example-app-base/src/utilities/parser/Parse.ts
+++ b/packages/example-app-base/src/utilities/parser/Parse.ts
@@ -27,12 +27,13 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
   let propertyNameSuffix = (type: string) => (type === 'interface' ? ' interface' : ' enum');
   let propertyType = (type: string) => (type === 'interface' ? PropertyType.interface : PropertyType.enum);
 
+  // Remove all backslashes that are not immediately followed by another backslash
+  // E.g. "\text" becomes "text", "\\text" becomes "\text"
+  const escapeBackslashes = source.replace(/\\(?!\\)/g, '');
+
   if (propsInterfaceOrEnumName) {
-    regex = new RegExp(
-      `^export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`,
-      'm'
-    );
-    let regexResult = regex.exec(source);
+    regex = new RegExp(`^export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'm');
+    let regexResult = regex.exec(escapeBackslashes);
     if (regexResult && regexResult.length > 0) {
       parseInfo = _parseEnumOrInterface(regexResult);
       return [
@@ -48,7 +49,7 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
     regex = new RegExp(`^export (interface|(?:const )?enum) (\\S*?)(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'gm');
     let regexResult: RegExpExecArray | null;
     let results: Array<IProperty> = [];
-    while ((regexResult = regex.exec(source)) !== null) {
+    while ((regexResult = regex.exec(escapeBackslashes)) !== null) {
       parseInfo = _parseEnumOrInterface(regexResult);
       results.push(<IProperty>{
         name: regexResult[2],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update the documentation parser to render backslashes and backticks:

1. Replace backslashes that are not immediately followed by another backslash: "\text" is rendered as "text, "\\text" is rendered as "\text", etc.
2. Render backtick sequences as code blocks: \`myVariableName\` is rendered as \<code>myVariableName\</code>

#### Focus areas to test

(optional)
