### PR TITLE
Image: Add ImageFit.centerCover

### DIFF
--- a/apps/vr-tests/src/stories/Image.stories.tsx
+++ b/apps/vr-tests/src/stories/Image.stories.tsx
@@ -1,9 +1,9 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
-import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
 import { Image, ImageFit, Label, Layer } from 'office-ui-fabric-react';
+import * as React from 'react';
+import Screener from 'screener-storybook/src/screener';
+import { FabricDecorator } from '../utilities';
 
 const img350x150 = 'http://placehold.it/350x150';
 
@@ -31,6 +31,11 @@ let imagePropsFitCover = {
   imageFit: ImageFit.cover
 };
 
+let imagePropsFitCenterCover = {
+  src: 'http://placehold.it/400x400',
+  imageFit: ImageFit.centerCover
+};
+
 let imagePropsMaximizeFrame = {
   src: 'http://placehold.it/500x500',
   imageFit: ImageFit.cover,
@@ -41,16 +46,7 @@ let imagePropsMaximizeFrame = {
 
 storiesOf('Image', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
-    <Screener
-      steps={new Screener.Steps()
-        .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
-    >
-      {story()}
-    </Screener>
-  ))
+  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
   .addStory('No fit, no w/h', () => (
     <div>
       <Label>Without a width or height specified, the frame remains at its natural size and the image will not be scaled.</Label>
@@ -59,70 +55,108 @@ storiesOf('Image', module)
   ))
   .addStory('No fit, only width', () => (
     <div>
-      <Label>If only a width is provided, the frame will be set to that width.
-      The image will scale proportionally to fill the available width.</Label>
+      <Label>
+        If only a width is provided, the frame will be set to that width. The image will scale proportionally to fill the available width.
+      </Label>
       <Image src={img350x150} width={600} />
     </div>
   ))
   .addStory('No fit, only height', () => (
     <div>
-      <Label>If only a height is provided, the frame will be set to that height.
-        The image will scale proportionally to fill the available height.</Label>
+      <Label>
+        If only a height is provided, the frame will be set to that height. The image will scale proportionally to fill the available
+        height.
+      </Label>
       <Image src={img350x150} width={100} />
     </div>
   ))
   .addStory('Fit: none, image larger', () => (
     <div>
       <Label>The image is larger than the frame, so it is cropped to fit. The image is positioned at the upper left of the frame.</Label>
-      <Image  {...imagePropsFitNone} />
+      <Image {...imagePropsFitNone} />
     </div>
   ))
   .addStory('Fit: none, image smaller', () => (
     <div>
-      <Label>The image is smaller than the frame, so there is empty space within the frame.
-        The image is positioned at the upper left of the frame.</Label>
-      <Image  {...imagePropsFitNone} src='http://placehold.it/100x100' />
+      <Label>
+        The image is smaller than the frame, so there is empty space within the frame. The image is positioned at the upper left of the
+        frame.
+      </Label>
+      <Image {...imagePropsFitNone} src="http://placehold.it/100x100" />
     </div>
   ))
   .addStory('Fit: center, image larger', () => (
     <div>
       <Label>The image is larger than the frame, so all sides are cropped to center the image.</Label>
-      <Image  {...imagePropsFitCenter} src='http://placehold.it/800x300' />
+      <Image {...imagePropsFitCenter} src="http://placehold.it/800x300" />
     </div>
   ))
   .addStory('Fit: center, image smaller', () => (
     <div>
-      <Label>The image is smaller than the frame, so there is empty space within the frame.
-            The image is centered in the available space.</Label>
-      <Image  {...imagePropsFitCenter} src='http://placehold.it/100x100' />
+      <Label>
+        The image is smaller than the frame, so there is empty space within the frame. The image is centered in the available space.
+      </Label>
+      <Image {...imagePropsFitCenter} src="http://placehold.it/100x100" />
     </div>
   ))
   .addStory('Fit: contain, image wider', () => (
     <div>
-      <Label>The image has a wider aspect ratio (more landscape) than the frame,
-              so the image is scaled to fit the width and centered in the available vertical space.</Label>
+      <Label>
+        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the width and centered in the
+        available vertical space.
+      </Label>
       <Image {...imagePropsFitContain} width={200} height={200} />
     </div>
   ))
   .addStory('Fit: contain, image taller', () => (
     <div>
-      <Label>The image has a taller aspect ratio (more portrait) than the frame,
-                so the image is scaled to fit the height and centered in the available horizontal space.</Label>
+      <Label>
+        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the height and centered in the
+        available horizontal space.
+      </Label>
       <Image {...imagePropsFitContain} width={300} height={50} />
     </div>
   ))
   .addStory('Fit: cover, image wider', () => (
     <div>
-      <Label>The image has a wider aspect ratio (more landscape) than the frame,
-          so the image is scaled to fit the height and the sides are cropped evenly.</Label>
+      <Label>
+        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the height and the sides are
+        cropped evenly.
+      </Label>
       <Image {...imagePropsFitCover} width={150} height={250} />
     </div>
   ))
   .addStory('Fit: cover, image taller', () => (
     <div>
-      <Label>The image has a taller aspect ratio (more portrait) than the frame,
-            so the image is scaled to fit the width and the top and bottom are cropped evenly.</Label>
+      <Label>
+        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the width and the top and bottom
+        are cropped evenly.
+      </Label>
       <Image {...imagePropsFitCover} width={250} height={150} />
+    </div>
+  ))
+  .addStory('Fit: centerCover, image smaller', () => (
+    <div>
+      <Label>The image is smaller than the frame, so the image is centered with empty space within the frame.</Label>
+      <Image {...imagePropsFitCenterCover} width={500} height={500} />
+    </div>
+  ))
+  .addStory('Fit: centerCover, image larger', () => (
+    <div>
+      <Label>The image is larger than the frame, so the image behaves as "cover".</Label>
+      <Image {...imagePropsFitCenterCover} width={350} height={250} />
+    </div>
+  ))
+  .addStory('Fit: centerCover, image wider', () => (
+    <div>
+      <Label>The image has a wider aspect ratio (more landscape) than the frame, so the sides are cropped evenly.</Label>
+      <Image {...imagePropsFitCenterCover} width={300} height={500} />
+    </div>
+  ))
+  .addStory('Fit: centerCover, image taller', () => (
+    <div>
+      <Label>The image has a taller aspect ratio (more portrait) than the frame, so the top and bottom are cropped evenly.</Label>
+      <Image {...imagePropsFitCenterCover} width={500} height={300} />
     </div>
   ))
   .addStory('Maximize frame, landscape container', () => (
@@ -133,7 +167,4 @@ storiesOf('Image', module)
       </div>
     </div>
   ))
-  .addStory('Maximize frame, portrait container', () => (
-    <Layer>sdfsfdsf</Layer>
-  ))
-  ;
+  .addStory('Maximize frame, portrait container', () => <Layer>sdfsfdsf</Layer>);

--- a/common/changes/office-ui-fabric-react/swese44-imagescaling_2018-10-11-15-37.json
+++ b/common/changes/office-ui-fabric-react/swese44-imagescaling_2018-10-11-15-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Implement ImageFit.centerCover",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pjsw@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, getNativeProps, imageProperties, createRef } from '../../Utilities';
-import { IImageProps, IImageStyles, IImageStyleProps, ImageCoverStyle, ImageFit, ImageLoadState } from './Image.types';
+import { BaseComponent, classNamesFunction, createRef, getNativeProps, imageProperties } from '../../Utilities';
+import { IImageProps, IImageStyleProps, IImageStyles, ImageCoverStyle, ImageFit, ImageLoadState } from './Image.types';
 
 const getClassNames = classNamesFunction<IImageStyleProps, IImageStyles>();
 
@@ -75,11 +75,10 @@ export class ImageBase extends BaseComponent<IImageProps, IImageState> {
       maximizeFrame,
       shouldFadeIn,
       shouldStartVisible,
-      isLoaded:
-        loadState === ImageLoadState.loaded ||
-        (loadState === ImageLoadState.notLoaded && this.props.shouldStartVisible),
+      isLoaded: loadState === ImageLoadState.loaded || (loadState === ImageLoadState.notLoaded && this.props.shouldStartVisible),
       isLandscape: coverStyle === ImageCoverStyle.landscape,
       isCenter: imageFit === ImageFit.center,
+      isCenterCover: imageFit === ImageFit.centerCover,
       isContain: imageFit === ImageFit.contain,
       isCover: imageFit === ImageFit.cover,
       isNone: imageFit === ImageFit.none,
@@ -148,7 +147,7 @@ export class ImageBase extends BaseComponent<IImageProps, IImageState> {
 
     // Do not compute cover style if it was already specified in props
     if (
-      (imageFit === ImageFit.cover || imageFit === ImageFit.contain) &&
+      (imageFit === ImageFit.cover || imageFit === ImageFit.contain || imageFit === ImageFit.centerCover) &&
       this.props.coverStyle === undefined &&
       this._imageElement.current &&
       this._frameElement.current
@@ -156,7 +155,7 @@ export class ImageBase extends BaseComponent<IImageProps, IImageState> {
       // Determine the desired ratio using the width and height props.
       // If those props aren't available, measure measure the frame.
       let desiredRatio;
-      if (!!width && !!height) {
+      if (!!width && !!height && imageFit !== ImageFit.centerCover) {
         desiredRatio = (width as number) / (height as number);
       } else {
         desiredRatio = this._frameElement.current.clientWidth / this._frameElement.current.clientHeight;

--- a/packages/office-ui-fabric-react/src/components/Image/Image.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.doc.tsx
@@ -1,27 +1,27 @@
 import * as React from 'react';
-import './ImagePage.global.scss';
-
 import { IDocPageProps } from '../../common/DocPage.types';
-import { ImageDefaultExample } from './examples/Image.Default.Example';
 import { ImageCenterExample } from './examples/Image.Center.Example';
+import { ImageCenterCoverExample } from './examples/Image.CenterCover.Example';
 import { ImageContainExample } from './examples/Image.Contain.Example';
 import { ImageCoverExample } from './examples/Image.Cover.Example';
-import { ImageNoneExample } from './examples/Image.None.Example';
+import { ImageDefaultExample } from './examples/Image.Default.Example';
 import { ImageMaximizeFrameExample } from './examples/Image.MaximizeFrame.Example';
+import { ImageNoneExample } from './examples/Image.None.Example';
 import { ImageStatus } from './Image.checklist';
+import './ImagePage.global.scss';
 
 const ImageDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Default.Example.tsx') as string;
 const ImageCenterExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Center.Example.tsx') as string;
 const ImageContainExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Contain.Example.tsx') as string;
 const ImageCoverExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.Cover.Example.tsx') as string;
+const ImageCenterCoverExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.CenterCover.Example.tsx') as string;
 const ImageNoneExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.None.Example.tsx') as string;
 const ImageMaximizeFrameExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Image/examples/Image.MaximizeFrame.Example.tsx') as string;
 
 export const ImagePageProps: IDocPageProps = {
   title: 'Image',
   componentName: 'Image',
-  componentUrl:
-    'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Image',
+  componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Image',
   componentStatus: ImageStatus,
   examples: [
     {
@@ -48,6 +48,11 @@ export const ImagePageProps: IDocPageProps = {
       title: 'ImageFit: Cover',
       code: ImageCoverExampleCode,
       view: <ImageCoverExample />
+    },
+    {
+      title: 'ImageFit: CenterCover',
+      code: ImageCenterCoverExampleCode,
+      view: <ImageCenterCoverExample />
     },
     {
       title: 'Maximizing the image frame',

--- a/packages/office-ui-fabric-react/src/components/Image/Image.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.styles.ts
@@ -1,5 +1,5 @@
+import { AnimationClassNames, getGlobalClassNames, IStyle } from '../../Styling';
 import { IImageStyleProps, IImageStyles } from './Image.types';
-import { AnimationClassNames, IStyle, getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-Image',
@@ -8,6 +8,7 @@ const GlobalClassNames = {
   imageCenter: 'ms-Image-image--center',
   imageContain: 'ms-Image-image--contain',
   imageCover: 'ms-Image-image--cover',
+  imageCenterCover: 'ms-Image-image--centerCover',
   imageNone: 'ms-Image-image--none',
   imageLandscape: 'ms-Image-image--landscape',
   imagePortrait: 'ms-Image-image--portrait'
@@ -26,6 +27,7 @@ export const getStyles = (props: IImageStyleProps): IImageStyles => {
     isCenter,
     isContain,
     isCover,
+    isCenterCover,
     isNone,
     isError,
     isNotImageFit,
@@ -54,7 +56,7 @@ export const getStyles = (props: IImageStyleProps): IImageStyles => {
           width: '100%'
         }
       ],
-      (isCenter || isContain || isCover) && {
+      (isCenter || isContain || isCover || isCenterCover) && {
         position: 'relative'
       },
       className
@@ -93,6 +95,16 @@ export const getStyles = (props: IImageStyleProps): IImageStyles => {
         !isLandscape && {
           width: '100%',
           height: 'auto'
+        },
+        ImageFitStyles
+      ],
+      isCenterCover && [
+        classNames.imageCenterCover,
+        isLandscape && {
+          maxHeight: '100%'
+        },
+        !isLandscape && {
+          maxWidth: '100%'
         },
         ImageFitStyles
       ],

--- a/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.test.tsx
@@ -1,15 +1,13 @@
+import { mount } from 'enzyme';
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
-
 import { Image } from './Image';
 import { ImageBase } from './Image.base';
 import { ImageFit } from './Image.types';
 
 /* tslint:disable:no-unused-variable */
-const testImage1x1 =
-  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
+const testImage1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 const brokenImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII=';
 
 describe('Image', () => {
@@ -87,6 +85,11 @@ describe('Image', () => {
 
     component.find('img').simulate('load');
     expect(component.update().find('.ms-Image-image--landscape')).toHaveLength(1);
+  });
+
+  it('renders ImageFit.centerCover correctly', () => {
+    const component = renderer.create(<Image src={testImage1x1} imageFit={ImageFit.centerCover} width={50} height={100} />);
+    expect(component.toJSON()).toMatchSnapshot();
   });
 
   it('allows onError events to be attached', done => {

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -104,8 +104,8 @@ export enum ImageFit {
 
   /**
    * The image will be centered horizontally and vertically within the frame and maintains its aspect ratio. It will
-   * behave as ImageFit.center if the height or width is less than the Image frame's height or width, but if image is
-   * fully larger than the frame it will behave as ImageFit.cover.
+   * behave as ImageFit.center if the image's natural height or width is less than the Image frame's height or width,
+   * but if both natural height and width are larger than the frame it will behave as ImageFit.cover.
    */
   centerCover = 4
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -100,7 +100,14 @@ export enum ImageFit {
    * Neither the image nor the frame are scaled. If their sizes do not match, the image will either be cropped or the
    * frame will have empty space.
    */
-  none = 3
+  none = 3,
+
+  /**
+   * The image will be centered horizontally and vertically within the frame and maintains its aspect ratio. It will
+   * behave as ImageFit.center if the height or width is less than the Image frame's height or width, but if image is
+   * fully larger than the frame it will behave as ImageFit.cover.
+   */
+  centerCover = 4
 }
 
 /**
@@ -182,11 +189,12 @@ export interface IImageStyleProps {
   isLandscape?: boolean;
 
   /**
-   * ImageFit booleans for center, cover, contain, none
+   * ImageFit booleans for center, cover, contain, centerCover, none
    */
   isCenter?: boolean;
   isContain?: boolean;
   isCover?: boolean;
+  isCenterCover?: boolean;
   isNone?: boolean;
 
   /**

--- a/packages/office-ui-fabric-react/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -30,3 +30,41 @@ exports[`Image renders Image correctly 1`] = `
   />
 </div>
 `;
+
+exports[`Image renders ImageFit.centerCover correctly 1`] = `
+<div
+  className=
+      ms-Image
+      {
+        overflow: hidden;
+        position: relative;
+      }
+  style={
+    Object {
+      "height": 100,
+      "width": 50,
+    }
+  }
+>
+  <img
+    className=
+        ms-Image-image
+        ms-Image-image--centerCover
+        ms-Image-image--portrait
+        is-notLoaded
+        is-fadeIn
+        {
+          display: block;
+          left: 50% /* @noflip */;
+          max-width: 100%;
+          opacity: 0;
+          position: absolute;
+          top: 50%;
+          transform: translate(-50%,-50%);
+        }
+    onError={[Function]}
+    onLoad={[Function]}
+    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQImWP4DwQACfsD/eNV8pwAAAAASUVORK5CYII="
+  />
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/Image/examples/Image.CenterCover.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/examples/Image.CenterCover.Example.tsx
@@ -1,0 +1,62 @@
+import { IImageProps, Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
+import { Label } from 'office-ui-fabric-react/lib/Label';
+import * as React from 'react';
+
+export class ImageCenterCoverExample extends React.Component<any, any> {
+  public render(): JSX.Element {
+    const imageProps: Partial<IImageProps> = {
+      imageFit: ImageFit.centerCover,
+      width: 200,
+      height: 200
+    };
+
+    return (
+      <div>
+        <p>
+          Setting the imageFit property to "centerCover" will cause the image to scale up or down proportionally. Images smaller than their
+          frame will be rendered as "ImageFit.center", while images larger than both the frame's height and width will render as
+          "ImageFit.cover".
+        </p>
+        <Label>The image is smaller than the frame, so it's centered and rendered at its natural size.</Label>
+        <Image
+          {...imageProps}
+          src="http://placehold.it/100x150"
+          alt="Example implementation of the property image fit using the centerCover value on an image smaller than the frame."
+        />
+        <br />
+        <Label>
+          The image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's rendered at its
+          natural size while cropping the sides.
+        </Label>
+        <Image
+          {...imageProps}
+          src="http://placehold.it/300x100"
+          alt="Example implementation of the property image fit using the centerCover value on an image wider than the frame."
+        />
+        <br />
+        <Label>
+          The image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's rendered at its
+          natural size while cropping the top and bottom.
+        </Label>
+        <Image
+          {...imageProps}
+          src="http://placehold.it/100x300"
+          alt="Example implementation of the property image fit using the centerCover value on an image taller than the frame."
+        />
+        <br />
+        <Label>These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.</Label>
+        <Image
+          {...imageProps}
+          src="http://placehold.it/400x500"
+          alt="Example implementation of the property image fit using the centerCover value on an image taller and wider than the frame."
+        />
+        <br />
+        <Image
+          {...imageProps}
+          src="http://placehold.it/500x400"
+          alt="Example implementation of the property image fit using the centerCover value on an image taller and wider than the frame."
+        />
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.CenterCover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.CenterCover.Example.tsx.shot
@@ -1,0 +1,281 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] = `
+<div>
+  <p>
+    Setting the imageFit property to "centerCover" will cause the image to scale up or down proportionally. Images smaller than their frame will be rendered as "ImageFit.center", while images larger than both the frame's height and width will render as "ImageFit.cover".
+  </p>
+  <label
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    The image is smaller than the frame, so it's centered and rendered at its natural size.
+  </label>
+  <div
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
+    style={
+      Object {
+        "height": 200,
+        "width": 200,
+      }
+    }
+  >
+    <img
+      alt="Example implementation of the property image fit using the centerCover value on an image smaller than the frame."
+      className=
+          ms-Image-image
+          ms-Image-image--centerCover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            max-width: 100%;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      src="http://placehold.it/100x150"
+    />
+  </div>
+  <br />
+  <label
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    The image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's rendered at its natural size while cropping the sides.
+  </label>
+  <div
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
+    style={
+      Object {
+        "height": 200,
+        "width": 200,
+      }
+    }
+  >
+    <img
+      alt="Example implementation of the property image fit using the centerCover value on an image wider than the frame."
+      className=
+          ms-Image-image
+          ms-Image-image--centerCover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            max-width: 100%;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      src="http://placehold.it/300x100"
+    />
+  </div>
+  <br />
+  <label
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    The image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's rendered at its natural size while cropping the top and bottom.
+  </label>
+  <div
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
+    style={
+      Object {
+        "height": 200,
+        "width": 200,
+      }
+    }
+  >
+    <img
+      alt="Example implementation of the property image fit using the centerCover value on an image taller than the frame."
+      className=
+          ms-Image-image
+          ms-Image-image--centerCover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            max-width: 100%;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      src="http://placehold.it/100x300"
+    />
+  </div>
+  <br />
+  <label
+    className=
+        ms-Label
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+  >
+    These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.
+  </label>
+  <div
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
+    style={
+      Object {
+        "height": 200,
+        "width": 200,
+      }
+    }
+  >
+    <img
+      alt="Example implementation of the property image fit using the centerCover value on an image taller and wider than the frame."
+      className=
+          ms-Image-image
+          ms-Image-image--centerCover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            max-width: 100%;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      src="http://placehold.it/400x500"
+    />
+  </div>
+  <br />
+  <div
+    className=
+        ms-Image
+        {
+          overflow: hidden;
+          position: relative;
+        }
+    style={
+      Object {
+        "height": 200,
+        "width": 200,
+      }
+    }
+  >
+    <img
+      alt="Example implementation of the property image fit using the centerCover value on an image taller and wider than the frame."
+      className=
+          ms-Image-image
+          ms-Image-image--centerCover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            left: 50% /* @noflip */;
+            max-width: 100%;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      src="http://placehold.it/500x400"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6661 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Center the image within its frame; if it's both wider and taller than the frame then it should "cover" the frame.

#### Focus areas to test

Image image diffs

Screenshots from the living examples (orange background added to the image frame just for these screenshots):

<img width="284" alt="screen shot 2018-10-11 at 8 46 20 am" src="https://user-images.githubusercontent.com/471731/46816770-85b39d80-cd32-11e8-9c1e-efd41d4e21e7.png">

<img width="292" alt="screen shot 2018-10-11 at 8 46 47 am" src="https://user-images.githubusercontent.com/471731/46816773-89472480-cd32-11e8-9236-7dd9a2bcd9b7.png">

<img width="328" alt="screen shot 2018-10-11 at 8 46 59 am" src="https://user-images.githubusercontent.com/471731/46816788-8c421500-cd32-11e8-943e-1d53c024316a.png">

<img width="294" alt="screen shot 2018-10-11 at 8 47 08 am" src="https://user-images.githubusercontent.com/471731/46816793-8ea46f00-cd32-11e8-9beb-ded352839245.png">

<img width="264" alt="screen shot 2018-10-11 at 8 47 27 am" src="https://user-images.githubusercontent.com/471731/46816798-9106c900-cd32-11e8-9b81-0e30d8d7c40f.png">

<img width="268" alt="screen shot 2018-10-11 at 8 47 41 am" src="https://user-images.githubusercontent.com/471731/46816803-9401b980-cd32-11e8-87a3-11813cdbce8f.png">

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6662)

