### PR TITLE
DatePicker A11y Pass

### DIFF
--- a/common/changes/office-ui-fabric-react/datePickerAccessibility_2018-10-11-17-23.json
+++ b/common/changes/office-ui-fabric-react/datePickerAccessibility_2018-10-11-17-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Calendar: accessibility fixes for month option grid",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -82,11 +82,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
         <div className={css('ms-DatePicker-header', styles.header)}>
           {this.props.onHeaderSelect ? (
             <div
-              className={css(
-                'ms-DatePicker-currentYear js-showYearPicker',
-                styles.currentYear,
-                styles.headerToggleView
-              )}
+              className={css('ms-DatePicker-currentYear js-showYearPicker', styles.currentYear, styles.headerToggleView)}
               onClick={this._onHeaderSelect}
               onKeyDown={this._onHeaderKeyDown}
               aria-label={dateTimeFormatter.formatYear(navigatedDate)}
@@ -138,40 +134,41 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, {}> {
           </div>
         </div>
         <FocusZone>
-          <div className={css('ms-DatePicker-optionGrid', styles.optionGrid)} role="grid">
-            {strings.shortMonths.map((month, index) => {
-              const indexedMonth = setMonth(navigatedDate, index);
-              const isCurrentMonth = this._isCurrentMonth(index, navigatedDate.getFullYear(), today!);
-              const isNavigatedMonth = navigatedDate.getMonth() === index;
-              const isSelectedMonth = selectedDate.getMonth() === index;
-              const isSelectedYear = selectedDate.getFullYear() === navigatedDate.getFullYear();
-              const isInBounds =
-                (minDate ? compareDatePart(minDate, getMonthEnd(indexedMonth)) < 1 : true) &&
-                (maxDate ? compareDatePart(getMonthStart(indexedMonth), maxDate) < 1 : true);
+          <div className={css('ms-DatePicker-optionGrid', styles.optionGrid)} role="grid" aria-readonly="true">
+            <div role="row">
+              {strings.shortMonths.map((month, index) => {
+                const indexedMonth = setMonth(navigatedDate, index);
+                const isCurrentMonth = this._isCurrentMonth(index, navigatedDate.getFullYear(), today!);
+                const isNavigatedMonth = navigatedDate.getMonth() === index;
+                const isSelectedMonth = selectedDate.getMonth() === index;
+                const isSelectedYear = selectedDate.getFullYear() === navigatedDate.getFullYear();
+                const isInBounds =
+                  (minDate ? compareDatePart(minDate, getMonthEnd(indexedMonth)) < 1 : true) &&
+                  (maxDate ? compareDatePart(getMonthStart(indexedMonth), maxDate) < 1 : true);
 
-              return (
-                <button
-                  role={'gridcell'}
-                  className={css('ms-DatePicker-monthOption', styles.monthOption, {
-                    ['ms-DatePicker-day--today ' + styles.monthIsCurrentMonth]:
-                      highlightCurrentMonth && isCurrentMonth!,
-                    ['ms-DatePicker-day--highlighted ' + styles.monthIsHighlighted]:
-                      (highlightCurrentMonth || highlightSelectedMonth) && isSelectedMonth && isSelectedYear,
-                    ['ms-DatePicker-monthOption--disabled ' + styles.monthOptionIsDisabled]: !isInBounds
-                  })}
-                  disabled={!isInBounds}
-                  key={index}
-                  onClick={isInBounds ? this._selectMonthCallbacks[index] : undefined}
-                  onKeyDown={isInBounds ? this._onSelectMonthKeyDown(index) : undefined}
-                  aria-label={dateTimeFormatter.formatMonthYear(indexedMonth, strings)}
-                  aria-selected={isCurrentMonth || isNavigatedMonth}
-                  data-is-focusable={isInBounds ? true : undefined}
-                  ref={isNavigatedMonth ? 'navigatedMonth' : undefined}
-                >
-                  {month}
-                </button>
-              );
-            })}
+                return (
+                  <button
+                    role={'gridcell'}
+                    className={css('ms-DatePicker-monthOption', styles.monthOption, {
+                      ['ms-DatePicker-day--today ' + styles.monthIsCurrentMonth]: highlightCurrentMonth && isCurrentMonth!,
+                      ['ms-DatePicker-day--highlighted ' + styles.monthIsHighlighted]:
+                        (highlightCurrentMonth || highlightSelectedMonth) && isSelectedMonth && isSelectedYear,
+                      ['ms-DatePicker-monthOption--disabled ' + styles.monthOptionIsDisabled]: !isInBounds
+                    })}
+                    disabled={!isInBounds}
+                    key={index}
+                    onClick={isInBounds ? this._selectMonthCallbacks[index] : undefined}
+                    onKeyDown={isInBounds ? this._onSelectMonthKeyDown(index) : undefined}
+                    aria-label={dateTimeFormatter.formatMonthYear(indexedMonth, strings)}
+                    aria-selected={isCurrentMonth || isNavigatedMonth}
+                    data-is-focusable={isInBounds ? true : undefined}
+                    ref={isNavigatedMonth ? 'navigatedMonth' : undefined}
+                  >
+                    {month}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </FocusZone>
       </div>

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -1053,153 +1053,158 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
               role="presentation"
             >
               <div
+                aria-readonly="true"
                 className="ms-DatePicker-optionGrid"
                 role="grid"
               >
-                <button
-                  aria-label="January 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
+                <div
+                  role="row"
                 >
-                  Jan
-                </button>
-                <button
-                  aria-label="February 2000"
-                  aria-selected={true}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Feb
-                </button>
-                <button
-                  aria-label="March 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Mar
-                </button>
-                <button
-                  aria-label="April 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Apr
-                </button>
-                <button
-                  aria-label="May 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  May
-                </button>
-                <button
-                  aria-label="June 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Jun
-                </button>
-                <button
-                  aria-label="July 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Jul
-                </button>
-                <button
-                  aria-label="August 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Aug
-                </button>
-                <button
-                  aria-label="September 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Sep
-                </button>
-                <button
-                  aria-label="October 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Oct
-                </button>
-                <button
-                  aria-label="November 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Nov
-                </button>
-                <button
-                  aria-label="December 2000"
-                  aria-selected={false}
-                  className="ms-DatePicker-monthOption"
-                  data-is-focusable={true}
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="gridcell"
-                >
-                  Dec
-                </button>
+                  <button
+                    aria-label="January 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Jan
+                  </button>
+                  <button
+                    aria-label="February 2000"
+                    aria-selected={true}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Feb
+                  </button>
+                  <button
+                    aria-label="March 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Mar
+                  </button>
+                  <button
+                    aria-label="April 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Apr
+                  </button>
+                  <button
+                    aria-label="May 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    May
+                  </button>
+                  <button
+                    aria-label="June 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Jun
+                  </button>
+                  <button
+                    aria-label="July 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Jul
+                  </button>
+                  <button
+                    aria-label="August 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Aug
+                  </button>
+                  <button
+                    aria-label="September 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Sep
+                  </button>
+                  <button
+                    aria-label="October 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Oct
+                  </button>
+                  <button
+                    aria-label="November 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Nov
+                  </button>
+                  <button
+                    aria-label="December 2000"
+                    aria-selected={false}
+                    className="ms-DatePicker-monthOption"
+                    data-is-focusable={true}
+                    disabled={false}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="gridcell"
+                  >
+                    Dec
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -5,20 +5,7 @@ import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-reac
 import './DatePicker.Examples.scss';
 
 const DayPickerStrings: IDatePickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
 
   shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
 
@@ -56,6 +43,7 @@ export class DatePickerBasicExample extends React.Component<{}, IDatePickerBasic
           firstDayOfWeek={firstDayOfWeek}
           strings={DayPickerStrings}
           placeholder="Select a date..."
+          ariaLabel="Select a date"
           // tslint:disable:jsx-no-lambda
           onAfterMenuDismiss={() => console.log('onAfterMenuDismiss called')}
           // tslint:enable:jsx-no-lambda

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -57,6 +57,7 @@ export class DatePickerBoundedExample extends React.Component<{}, IDatePickerReq
           firstDayOfWeek={firstDayOfWeek}
           strings={DayPickerStrings}
           placeholder="Select a date..."
+          ariaLabel="Select a date"
           minDate={minDate}
           maxDate={maxDate}
           allowTextInput={true}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -3,20 +3,7 @@ import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-reac
 import './DatePicker.Examples.scss';
 
 const DayPickerStrings: IDatePickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
 
   shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
 
@@ -61,12 +48,14 @@ export class DatePickerRequiredExample extends React.Component<{}, IDatePickerRe
           firstDayOfWeek={firstDayOfWeek}
           strings={DayPickerStrings}
           placeholder="Select a date..."
+          ariaLabel="Select a date"
         />
         <DatePicker
           isRequired={true}
           firstDayOfWeek={firstDayOfWeek}
           strings={DayPickerStrings}
           placeholder="Date required with no label..."
+          ariaLabel="Select a date"
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -4,20 +4,7 @@ import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-reac
 import './DatePicker.Examples.scss';
 
 const DayPickerStrings: IDatePickerStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
-  ],
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
 
   shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
 
@@ -58,6 +45,7 @@ export class DatePickerWeekNumbersExample extends React.Component<{}, IDatePicke
           firstWeekOfYear={1}
           showMonthPickerAsOverlay={true}
           placeholder="Select a date..."
+          ariaLabel="Select a date"
         />
         <Dropdown
           label="Select the first day of the week"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -83,6 +83,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
           >
             <input
               aria-invalid={false}
+              aria-label="Select a date"
               className=
                   ms-TextField-field
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -88,6 +88,7 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
           >
             <input
               aria-invalid={false}
+              aria-label="Select a date"
               className=
                   ms-TextField-field
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -116,6 +116,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
           >
             <input
               aria-invalid={false}
+              aria-label="Select a date"
               className=
                   ms-TextField-field
                   {
@@ -287,6 +288,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
           >
             <input
               aria-invalid={false}
+              aria-label="Select a date"
               className=
                   ms-TextField-field
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -83,6 +83,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
           >
             <input
               aria-invalid={false}
+              aria-label="Select a date"
               className=
                   ms-TextField-field
                   {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #0000 (Fixes issue 6362, but don't want to link it in this PR since that would close it and we still have some boxes to check)
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes cover the following accessibility issues for DatePicker:

* Bug 1 : [Accessibility][Programmatic access]: Buttons must have discernible text.

This is in reference to the "Select a date" control not having a name. These changes add an aria-label to the examples on the demo page.

* Bug 3 : [Accessibility][Usable]: Narrator speaks 'Editable' on 'Date and month controls' on calendar.

This bug required a change to CalendarMonth. While digging into this issue, I discovered that CalendarMonth was not following the W3C standards for `grid` and `gridcell`. The site states the following requirements:

> Authors MUST ensure that elements with role gridcell are owned by elements with role row, which in turn are owned by an element with role rowgroup, grid or treegrid.

We had the element with role `grid`, but were missing the element in between with role `row`. I also added an `aria-readonly` attribute to ensure that the calendar months are not read out by Narrator as "editable", as elements with role `gridcell` seem to be editable by default. I decided to put the `aria-readonly` attribute on the element with role `grid` after reading the following from the W3C standards:

> A grid is considered editable unless otherwise specified. To make a grid read-only, set the aria-readonly attribute of the grid to true. The value of the grid element's aria-readonly attribute is implicitly propagated to all of its owned gridcell elements, and will be exposed through the accessibility API.

Although the diff looks like a lot, I only have changes/additions on lines 137, 138, and 171 in CalendarMonth.

#### Focus areas to test

Bug 1: With Narrator on, tab down to the first example of the DatePicker demo page. Note that there is now an aria label on it. There should be an aria label on the other examples as well.

Bug 3: With Narrator on, tab down to the first example of the DatePicker demo page. Open the first DatePicker and tab to a month name, such as Jan. Ensure that Narrator reads out "read only" for the `gridcell`, not editable.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6664)

