### PR TITLE
Scrollablepane detailslist bug

### DIFF
--- a/common/changes/office-ui-fabric-react/scrollablepane-detailslist-bug_2018-10-11-18-57.json
+++ b/common/changes/office-ui-fabric-react/scrollablepane-detailslist-bug_2018-10-11-18-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ScrollablePane: Update DetailsList example to fix bug where footer overlapped scroll bar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { BaseComponent, classNamesFunction, divProperties, getNativeProps, createRef, getRTL } from '../../Utilities';
-import {
-  IScrollablePane,
-  IScrollablePaneProps,
-  IScrollablePaneStyles,
-  IScrollablePaneStyleProps
-} from './ScrollablePane.types';
+import { IScrollablePane, IScrollablePaneProps, IScrollablePaneStyles, IScrollablePaneStyleProps } from './ScrollablePane.types';
 import { Sticky } from '../../Sticky';
 
 export interface IScrollablePaneContext {
@@ -30,8 +25,7 @@ export interface IScrollablePaneState {
 
 const getClassNames = classNamesFunction<IScrollablePaneStyleProps, IScrollablePaneStyles>();
 
-export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScrollablePaneState>
-  implements IScrollablePane {
+export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScrollablePaneState> implements IScrollablePane {
   public static childContextTypes: React.ValidationMap<IScrollablePaneContext> = {
     scrollablePane: PropTypes.object
   };
@@ -169,19 +163,12 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
   public componentDidUpdate(prevProps: IScrollablePaneProps, prevState: IScrollablePaneState) {
     const initialScrollPosition = this.props.initialScrollPosition;
-    if (
-      this.contentContainer &&
-      typeof initialScrollPosition === 'number' &&
-      prevProps.initialScrollPosition !== initialScrollPosition
-    ) {
+    if (this.contentContainer && typeof initialScrollPosition === 'number' && prevProps.initialScrollPosition !== initialScrollPosition) {
       this.contentContainer.scrollTop = initialScrollPosition;
     }
 
     // Update subscribers when stickyTopHeight/stickyBottomHeight changes
-    if (
-      prevState.stickyTopHeight !== this.state.stickyTopHeight ||
-      prevState.stickyBottomHeight !== this.state.stickyBottomHeight
-    ) {
+    if (prevState.stickyTopHeight !== this.state.stickyTopHeight || prevState.stickyBottomHeight !== this.state.stickyBottomHeight) {
       this.notifySubscribers();
     }
 
@@ -189,6 +176,8 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   }
 
   public render(): JSX.Element {
+    console.log('ScrollablePaneBase -> render');
+
     const { className, theme, styles } = this.props;
     const { stickyTopHeight, stickyBottomHeight } = this.state;
     const classNames = getClassNames(styles!, {
@@ -202,11 +191,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
         <div ref={this._contentContainer} className={classNames.contentContainer} data-is-scrollable={true}>
           {this.props.children}
         </div>
-        <div
-          ref={this._stickyAboveRef}
-          className={classNames.stickyAbove}
-          style={this._getStickyContainerStyle(stickyTopHeight, true)}
-        />
+        <div ref={this._stickyAboveRef} className={classNames.stickyAbove} style={this._getStickyContainerStyle(stickyTopHeight, true)} />
         <div className={classNames.stickyBelow} style={this._getStickyContainerStyle(stickyBottomHeight, false)}>
           <div ref={this._stickyBelowRef} className={classNames.stickyBelowItems} />
         </div>
@@ -309,19 +294,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     if (this.stickyAbove && this.stickyBelow && this.contentContainer && sticky.nonStickyContent) {
       // If sticky is sticky, then append content to appropriate container
       if (sticky.state.isStickyTop || sticky.state.isStickyBottom) {
-        if (
-          sticky.state.isStickyTop &&
-          !this.stickyAbove.contains(sticky.nonStickyContent) &&
-          sticky.stickyContentTop
-        ) {
+        if (sticky.state.isStickyTop && !this.stickyAbove.contains(sticky.nonStickyContent) && sticky.stickyContentTop) {
           sticky.addSticky(sticky.stickyContentTop);
         }
 
-        if (
-          sticky.state.isStickyBottom &&
-          !this.stickyBelow.contains(sticky.nonStickyContent) &&
-          sticky.stickyContentBottom
-        ) {
+        if (sticky.state.isStickyBottom && !this.stickyBelow.contains(sticky.nonStickyContent) && sticky.stickyContentBottom) {
           sticky.addSticky(sticky.stickyContentBottom);
         }
       } else if (!this.contentContainer.contains(sticky.nonStickyContent)) {
@@ -331,11 +308,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     }
   }
 
-  private _addToStickyContainer = (
-    sticky: Sticky,
-    stickyContainer: HTMLDivElement,
-    stickyContentToAdd: HTMLDivElement
-  ): void => {
+  private _addToStickyContainer = (sticky: Sticky, stickyContainer: HTMLDivElement, stickyContentToAdd: HTMLDivElement): void => {
     // If there's no children, append child to list, otherwise, sort though array and append at correct position
     if (!stickyContainer.children.length) {
       stickyContainer.appendChild(stickyContentToAdd);
@@ -360,8 +333,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
             return a.distanceFromTop - b.distanceFromTop;
           })
           .filter(item => {
-            const stickyContent =
-              stickyContainer === this.stickyAbove ? item.stickyContentTop : item.stickyContentBottom;
+            const stickyContent = stickyContainer === this.stickyAbove ? item.stickyContentTop : item.stickyContentBottom;
             if (stickyContent) {
               return stickyChildrenElements.indexOf(stickyContent) > -1;
             }
@@ -411,6 +383,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   };
 
   private _getStickyContainerStyle = (height: number, isTop: boolean): React.CSSProperties => {
+    console.log('ScrollablePaneBase -> _getStickyContainerStyle()');
     return {
       height: height,
       ...(getRTL()

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -176,8 +176,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   }
 
   public render(): JSX.Element {
-    console.log('ScrollablePaneBase -> render');
-
     const { className, theme, styles } = this.props;
     const { stickyTopHeight, stickyBottomHeight } = this.state;
     const classNames = getClassNames(styles!, {
@@ -383,7 +381,6 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   };
 
   private _getStickyContainerStyle = (height: number, isTop: boolean): React.CSSProperties => {
-    console.log('ScrollablePaneBase -> _getStickyContainerStyle()');
     return {
       height: height,
       ...(getRTL()

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -68,7 +68,7 @@ export interface IScrollablePaneStyles {
    */
   stickyAbove: IStyle;
   /**
-   * Style set for the stickyAbove element.
+   * Style set for the stickyBelow element.
    */
   stickyBelow: IStyle;
   /**

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -124,6 +124,8 @@ export class ScrollablePaneDetailsListExample extends React.Component<
       items: items,
       selectionDetails: this._getSelectionDetails()
     };
+
+    this._onDetailsListColumnResized = this._onDetailsListColumnResized.bind(this);
   }
 
   public render(): JSX.Element {
@@ -152,6 +154,7 @@ export class ScrollablePaneDetailsListExample extends React.Component<
           </Sticky>
           <MarqueeSelection selection={this._selection}>
             <DetailsList
+              onColumnResize={this._onDetailsListColumnResized}
               items={items}
               columns={_columns}
               setKey="set"
@@ -184,12 +187,13 @@ export class ScrollablePaneDetailsListExample extends React.Component<
         return `${selectionCount} items selected`;
     }
   }
+
+  private _onDetailsListColumnResized() {
+    this.forceUpdate();
+  }
 }
 
-function onRenderDetailsHeader(
-  props: IDetailsHeaderProps,
-  defaultRender?: IRenderFunction<IDetailsHeaderProps>
-): JSX.Element {
+function onRenderDetailsHeader(props: IDetailsHeaderProps, defaultRender?: IRenderFunction<IDetailsHeaderProps>): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>
       {defaultRender!({
@@ -200,10 +204,7 @@ function onRenderDetailsHeader(
   );
 }
 
-function onRenderDetailsFooter(
-  props: IDetailsFooterProps,
-  defaultRender?: IRenderFunction<IDetailsFooterProps>
-): JSX.Element {
+function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRenderFunction<IDetailsFooterProps>): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Footer} isScrollSynced={true}>
       <DetailsRow

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -188,6 +188,9 @@ export class ScrollablePaneDetailsListExample extends React.Component<
     }
   }
 
+  // When the DetailsList columns are resized, this may cause a horizontal scroll bar to appear or
+  // disappear within ScrollablePane. This rerenders the component to ensure that the floating
+  // footer does not overlap with the scroll bar.
   private _onDetailsListColumnResized() {
     this.forceUpdate();
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6339
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates the DetailsList example for ScrollablePane to re-render whenever a column is adjusted. This fixes a bug where the footer was positioned correctly on the initial render, but then would either overlap with the scroll bar or sit too high above it if the DetailsList width changed.

Before:
![image](https://user-images.githubusercontent.com/1382445/46827464-79890980-cd4d-11e8-9314-20ba2af728f0.png)
When the scroll bar appears, the footer is covering it.

After:
![image](https://user-images.githubusercontent.com/1382445/46827495-8c034300-cd4d-11e8-87e8-f0a691128a27.png)
When the scroll bar appears, the footer is repositioned above it.

Before:
![image](https://user-images.githubusercontent.com/1382445/46827570-c4a31c80-cd4d-11e8-8700-a3495d2d264d.png)
When the scroll bar disappears, the footer is positioned too high.

After:
![image](https://user-images.githubusercontent.com/1382445/46827679-1fd50f00-cd4e-11e8-952b-81d2f593cb52.png)
When the scroll bar disappears, the footer moves down to the bottom.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6666)

