### PR TITLE
Panel: Fixed double scroll bar and reenabled isFooterSticky style prop that adds divider when content is scrolling

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-flex-fixes_2018-10-12-19-21.json
+++ b/common/changes/office-ui-fabric-react/panel-flex-fixes_2018-10-12-19-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Fixed second scroll bar when content taller than panel",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -37,7 +37,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   };
 
   private _panel = createRef<HTMLDivElement>();
-  private _content = createRef<HTMLDivElement>();
   private _classNames: IProcessedStyleSet<IPanelStyles>;
   private _scrollableContent: HTMLDivElement | null;
 
@@ -294,11 +293,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   };
 
   private _onRenderBody = (props: IPanelProps): JSX.Element => {
-    return (
-      <div ref={this._content} className={this._classNames.content}>
-        {props.children}
-      </div>
-    );
+    return <div className={this._classNames.content}>{props.children}</div>;
   };
 
   private _onRenderFooter = (props: IPanelProps): JSX.Element | null => {
@@ -314,10 +309,10 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   };
 
   private _updateFooterPosition(): void {
-    const _content = this._content.current;
-    if (_content) {
-      const height = _content.clientHeight;
-      const innerHeight = _content.scrollHeight;
+    const scrollableContent = this._scrollableContent;
+    if (scrollableContent) {
+      const height = scrollableContent.clientHeight;
+      const innerHeight = scrollableContent.scrollHeight;
 
       this.setState({
         isFooterSticky: height < innerHeight ? true : false
@@ -344,6 +339,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   };
 
   private _onTransitionComplete = (): void => {
+    this._updateFooterPosition();
     this.setState({
       isAnimating: false
     });

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -278,6 +278,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         display: 'flex',
         flexDirection: 'column',
         maxHeight: '100%',
+        overflowY: 'hidden',
         selectors: {
           ['@supports (-webkit-overflow-scrolling: touch)']: {
             maxHeight: windowHeight
@@ -335,9 +336,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       {
         marginBottom: 0,
         paddingBottom: 20
-      },
-      isFooterAtBottom && {
-        flexGrow: 1
       }
     ],
     footer: [

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -302,6 +302,7 @@ exports[`Panel renders Panel correctly 1`] = `
                   display: flex;
                   flex-direction: column;
                   max-height: 100%;
+                  overflow-y: hidden;
                 }
                 @supports (-webkit-overflow-scrolling: touch){& {
                   max-height: 768px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -391,6 +391,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                     display: flex;
                     flex-direction: column;
                     max-height: 100%;
+                    overflow-y: hidden;
                   }
                   @supports (-webkit-overflow-scrolling: touch){& {
                     max-height: 768px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6679
- [x] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

#### Focus areas to test
Footer behavior and scrolling with lots of content.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6680)

