### PR TITLE
DetailsList: select all button should not have aria-describedby if no label is present

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListSelectAll_2018-10-12-18-03.json
+++ b/common/changes/office-ui-fabric-react/detailsListSelectAll_2018-10-12-18-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: do not set select all button aria-describedby unless id it references exists",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -237,7 +237,9 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
                       <DetailsRowCheck
                         id={`${this._id}-check`}
                         aria-label={ariaLabelForSelectionColumn}
-                        aria-describedby={`${this._id}-checkTooltip`}
+                        aria-describedby={
+                          ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip ? `${this._id}-checkTooltip` : undefined
+                        }
                         data-is-focusable={!isCheckboxHidden}
                         isHeader={true}
                         selected={isAllSelected}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -334,8 +334,8 @@ describe('DetailsHeader', () => {
         .find(`#${selectAllCheckBoxAriaLabelledBy}`)
         .first()
         .getDOMNode()
-        .getAttribute('aria-describedby')
-    ).toBeNull();
+        .hasAttribute('aria-describedby')
+    ).toBe(false);
 
     expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(0);
   });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -312,6 +312,64 @@ describe('DetailsHeader', () => {
     expect(component.toJSON()).toMatchSnapshot();
   });
 
+  // if ariaLabelForSelectAllCheckbox is not provided, the select all checkbox label should not
+  // be rendered and therefore aria-describedby should not exist on the select all checkbox
+  it('does not accessible label for select all checkbox or aria-describedby', () => {
+    const component = mount(
+      <DetailsHeader
+        selection={_selection}
+        selectionMode={SelectionMode.multiple}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        columns={columns}
+      />
+    );
+
+    const selectAllCheckBoxAriaLabelledBy = component
+      .find('[aria-colindex=1]')
+      .getDOMNode()
+      .getAttribute('aria-labelledby');
+
+    expect(
+      component
+        .find(`#${selectAllCheckBoxAriaLabelledBy}`)
+        .first()
+        .getDOMNode()
+        .getAttribute('aria-describedby')
+    ).toBeNull();
+
+    expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(0);
+  });
+
+  // if ariaLabelForSelectAllCheckbox is passed in and onRenderColumnHeaderTooltip is not,
+  // the select all checkbox label should be rendered and aria-describedby on select all
+  // checkbox should exist with a valid id
+  it('renders accessible label for select all checkbox and valid aria-describedby', () => {
+    const component = mount(
+      <DetailsHeader
+        selection={_selection}
+        selectionMode={SelectionMode.multiple}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        columns={columns}
+        ariaLabelForSelectAllCheckbox={'Toggle selection for all items'}
+      />
+    );
+
+    const selectAllCheckBoxAriaLabelledBy = component
+      .find('[aria-colindex=1]')
+      .getDOMNode()
+      .getAttribute('aria-labelledby');
+
+    expect(
+      component
+        .find(`#${selectAllCheckBoxAriaLabelledBy}`)
+        .first()
+        .getDOMNode()
+        .getAttribute('aria-describedby')!
+    ).toEqual(`${selectAllCheckBoxAriaLabelledBy}Tooltip`);
+
+    expect(component.find(`#${selectAllCheckBoxAriaLabelledBy}Tooltip`).length).toEqual(1);
+  });
+
   it('should mark the columns as draggable', () => {
     const headerRef = createRef<IDetailsHeader>();
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -96,7 +96,6 @@ exports[`DetailsHeader can render 1`] = `
 
     >
       <div
-        aria-describedby="header0-checkTooltip"
         className=
             ms-DetailsRow-check
             ms-DetailsRow-check--isHeader
@@ -944,7 +943,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
 
     >
       <div
-        aria-describedby="header4-checkTooltip"
         className=
             ms-DetailsRow-check
             ms-DetailsRow-check--isHeader

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -135,7 +135,6 @@ exports[`DetailsList renders List correctly 1`] = `
 
             >
               <div
-                aria-describedby="header6-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -693,7 +692,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
 
             >
               <div
-                aria-describedby="header0-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -1823,7 +1821,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
 
             >
               <div
-                aria-describedby="header12-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -2382,7 +2379,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
 
             >
               <div
-                aria-describedby="header9-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -3308,7 +3304,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
 
             >
               <div
-                aria-describedby="header3-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -135,7 +135,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
 
             >
               <div
-                aria-describedby="header0-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -913,7 +912,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
 
             >
               <div
-                aria-describedby="header9-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -2210,7 +2208,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
 
             >
               <div
-                aria-describedby="header3-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader
@@ -2988,7 +2985,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
 
             >
               <div
-                aria-describedby="header6-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -135,7 +135,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
 
             >
               <div
-                aria-describedby="header0-checkTooltip"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsRow-check--isHeader

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
@@ -78,6 +78,8 @@ export class DetailsListCompactExample extends React.Component<
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             compact={true}
+            ariaLabelForSelectionColumn="Toggle selection"
+            ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomColumns.Example.tsx
@@ -35,6 +35,8 @@ export class DetailsListCustomColumnsExample extends React.Component<{}, IDetail
         onColumnHeaderClick={this._onColumnClick}
         onItemInvoked={this._onItemInvoked}
         onColumnHeaderContextMenu={this._onColumnHeaderContextMenu}
+        ariaLabelForSelectionColumn="Toggle selection"
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -27,9 +27,7 @@ export class DetailsListCustomGroupHeadersExample extends React.Component {
           groupProps={{
             onRenderHeader: props => (
               <div className="DetailsListExample-customHeader">
-                <div className="DetailsListExample-customHeaderTitle">{`I am a custom header for: ${
-                  props!.group!.name
-                }`}</div>
+                <div className="DetailsListExample-customHeaderTitle">{`I am a custom header for: ${props!.group!.name}`}</div>
                 <div className="DetailsListExample-customHeaderLinkSet">
                   <Link className="DetailsListExample-customHeaderLink" onClick={this._onToggleSelectGroup(props!)}>
                     {props!.isSelected ? 'Remove selection' : 'Select group'}
@@ -42,12 +40,12 @@ export class DetailsListCustomGroupHeadersExample extends React.Component {
             ),
             onRenderFooter: props => (
               <div className="DetailsListExample-customHeader">
-                <div className="DetailsListExample-customHeaderTitle">{`I'm a custom footer for: ${
-                  props!.group!.name
-                }`}</div>
+                <div className="DetailsListExample-customHeaderTitle">{`I'm a custom footer for: ${props!.group!.name}`}</div>
               </div>
             )
           }}
+          ariaLabelForSelectionColumn="Toggle selection"
+          ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
-import {
-  DetailsList,
-  DetailsListLayoutMode,
-  Selection,
-  SelectionMode,
-  IColumn
-} from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 import './DetailsListExample.scss';
@@ -224,6 +218,8 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             enterModalSelectionOnTouch={true}
+            ariaLabelForSelectionColumn="Toggle selection"
+            ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           />
         </MarqueeSelection>
       </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -52,14 +52,7 @@ export class DetailsListDragDropExample extends React.Component<
   }
 
   public render(): JSX.Element {
-    const {
-      items,
-      selectionDetails,
-      columns,
-      isColumnReorderEnabled,
-      frozenColumnCountFromStart,
-      frozenColumnCountFromEnd
-    } = this.state;
+    const { items, selectionDetails, columns, isColumnReorderEnabled, frozenColumnCountFromStart, frozenColumnCountFromEnd } = this.state;
 
     return (
       <div className={'detailsListDragDropExample'}>
@@ -94,6 +87,8 @@ export class DetailsListDragDropExample extends React.Component<
             onRenderItemColumn={this._onRenderItemColumn}
             dragDropEvents={this._getDragDropEvents()}
             columnReorderOptions={this.state.isColumnReorderEnabled ? this._getColumnReorderOptions() : undefined}
+            ariaLabelForSelectionColumn="Toggle selection"
+            ariaLabelForSelectAllCheckbox="Toggle selection for all items"
           />
         </MarqueeSelection>
       </div>
@@ -122,17 +117,11 @@ export class DetailsListDragDropExample extends React.Component<
     return isNaN(Number(value)) ? `The value should be a number, actual is ${value}.` : '';
   }
 
-  private _onChangeStartCountText = (
-    event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
-    text: string
-  ): void => {
+  private _onChangeStartCountText = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     this.setState({ frozenColumnCountFromStart: text });
   };
 
-  private _onChangeEndCountText = (
-    event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
-    text: string
-  ): void => {
+  private _onChangeEndCountText = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, text: string): void => {
     this.setState({ frozenColumnCountFromEnd: text });
   };
 
@@ -183,9 +172,7 @@ export class DetailsListDragDropExample extends React.Component<
   }
 
   private _insertBeforeItem(item: any): void {
-    const draggedItems = this._selection.isIndexSelected(_draggedIndex)
-      ? this._selection.getSelection()
-      : [_draggedItem];
+    const draggedItems = this._selection.isIndexSelected(_draggedIndex) ? this._selection.getSelection() : [_draggedItem];
 
     const items: any[] = this.state.items.filter((i: number) => draggedItems.indexOf(i) === -1);
     let insertIndex = items.indexOf(item);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.NavigatingFocus.Example.tsx
@@ -37,6 +37,8 @@ export class DetailsListNavigatingFocusExample extends React.Component<{}, IDeta
         items={this.state.items}
         columns={this._columns}
         initialFocusedIndex={this.state.initialFocusedIndex}
+        ariaLabelForSelectionColumn="Toggle selection"
+        ariaLabelForSelectAllCheckbox="Toggle selection for all items"
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6638 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The `aria-describedby` attribute of the select all button in DetailsList should only be set to `{this._id}-checkTooltip` if the label with that id exists. I added the same conditional used for adding the label with id `{this._id}-checkTooltip` to adding `aria-describedby` with id `{this._id}-checkTooltip`.

These changes also add aria labels to select all checkboxes in all DetailsList examples.

#### Focus areas to test

Added two tests in DetailsHeader.test.tsx to verify the following two scenarios:

1. Ensure that `aria-describedby` does not exist on the select all button when an `ariaLabelForSelectAllCheckbox` prop is not passed in.
2. Ensure that `aria-describedby` exists on the select all button when an `ariaLabelForSelectAllCheckbox` prop is passed in and an `onRenderColumnHeaderTooltip` is not passed in.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6682)

