### PR TITLE
Enable website to load dynamic scripts from manifest JS file

### DIFF
--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -6,8 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" user-scalable="no" />
   <title>Office UI Fabric</title>
-  <link href="https://devofficecdn.azureedge.net/themes/DevOffice/Content/favicon.ico" rel="shortcut icon" type="image/x-icon"
-  />
+  <link href="https://devofficecdn.azureedge.net/themes/DevOffice/Content/favicon.ico" rel="shortcut icon" type="image/x-icon" />
   <script src="https://cdn.optimizely.com/js/5703250400.js"></script>
   <style>
     body,
@@ -29,32 +28,107 @@
 <body>
   <div id="main">
     <div class="loading">
-      <img class="loadingImage" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/spinner.gif" alt="Loading"
-        width="32" height="32" />
+      <img class="loadingImage" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/spinner.gif"
+        alt="Loading" width="32" height="32" />
     </div>
   </div>
 
   <script type="text/javascript">
-    function loadScript(n) {
-      for (var i = 0; i < n.length; i++) {
-        var s = document.createElement('script');
-        s.src = n[i];
-        s.async = false;
-        document.body.appendChild(s);
-      }
+    var isLocal = window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
+    var isDogfood = false;
+    var isProduction = false;
+
+    // Query params
+    var dogfoodParam = getParameterByName('isDogfood');
+    var productionParam = getParameterByName('isProduction');
+    var noCompress = isLocal || getParameterByName('noCompress');
+    var devhost = getParameterByName('devhost');
+
+    var entryPointFilename = 'fabric-sitev5';
+    var appPath = '';
+    var Flight = {};
+
+    // Determine production or staging/dogfood
+    if (location.hostname === 'developer.microsoft.com' || productionParam) {
+      isProduction = true;
+    } else if (location.hostname === 'uifabric-tst.azurewebsites.net' || dogfoodParam) {
+      isDogfood = true;
     }
 
-    var isLocal = window.location.hostname === 'localhost';
-    // This path allows minified files to be served locally for testing purposes.
-    var appPath = isLocal ? '' : '';
+    // If the site is hosted, load the flight config script for production or dogfood
+    if (!isLocal) {
+      var configPrefix = isProduction ? 'fabric-website-prod' : 'fabric-website-df';
+      var configScript = ['https://fabricweb.azureedge.net/fabric-website/manifests/' + configPrefix + '.js'];
 
-    var scripts = [
-      '//cdnjs.cloudflare.com/ajax/libs/react/16.3.1/umd/react.production.min.js',
-      '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.1/umd/react-dom.production.min.js',
-      appPath + '/fabric-sitev5.js'
-    ];
+      loadScripts(configScript, function () {
+        if (window.Flight) {
+          appPath += window.Flight.baseCDNUrl;
 
-    loadScript(scripts);
+          loadAppScripts(appPath);
+        }
+      });
+    }
+
+    else {
+      loadAppScripts(appPath);
+    }
+
+    // Simple synchronous script loader with callback. Adapted from https://stackoverflow.com/questions/1866717
+    function loadScripts(array, callback) {
+      var loader = function (src, handler) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.onload = script.onreadystatechange = function () {
+          script.onreadystatechange = script.onload = null;
+          handler();
+        }
+        var head = document.getElementsByTagName('head')[0];
+        (head || document.body).appendChild(script);
+      };
+      (function run() {
+        if (array.length != 0) {
+          loader(array.shift(), run);
+        } else {
+          callback && callback();
+        }
+      })();
+    }
+
+    function loadAppScripts(appPath) {
+      var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.3.2/umd/react';
+      var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.2/umd/react-dom';
+
+      if (noCompress) {
+        reactPath = reactPath + '.development.js';
+        reactDomPath = reactDomPath + '.development.js'
+        appPath += entryPointFilename + '.js';
+      } else {
+        reactPath = reactPath + '.production.min.js';
+        reactDomPath = reactDomPath + '.production.min.js'
+        appPath += entryPointFilename + '.min.js';
+      }
+
+      var scripts = [
+        reactPath,
+        reactDomPath,
+        appPath
+      ];
+
+      // Load React and app scripts
+      loadScripts(scripts);
+    }
+
+    function getParameterByName(name, url) {
+      if (!url) {
+        url = window.location.href;
+      }
+      name = name.replace(/[\[\]]/g, "\\$&");
+      var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+      if (!results) return null;
+      if (!results[2]) return '';
+      return decodeURIComponent(results[2].replace(/\+/g, " "));
+    }
   </script>
 </body>
 

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -100,11 +100,11 @@
 
       if (noCompress) {
         reactPath = reactPath + '.development.js';
-        reactDomPath = reactDomPath + '.development.js'
+        reactDomPath = reactDomPath + '.development.js';
         appPath += entryPointFilename + '.js';
       } else {
         reactPath = reactPath + '.production.min.js';
-        reactDomPath = reactDomPath + '.production.min.js'
+        reactDomPath = reactDomPath + '.production.min.js';
         appPath += entryPointFilename + '.min.js';
       }
 

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -25,10 +25,20 @@ initializeIcons();
 
 let isProduction = process.argv.indexOf('--production') > -1;
 
+let isLocal = window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
+declare let Flight; // Contains flight & CDN configuration loaded by manifest
+declare let __webpack_public_path__;
+
+// Final bundle location can be dynamic, so we need to update the public path
+// at runtime to point to the right CDN URL
+if (!isLocal && Flight.baseCDNUrl) {
+  __webpack_public_path__ = Flight.baseCDNUrl;
+}
+
 if (!isProduction) {
   setBaseUrl('./dist/');
 } else {
-  setBaseUrl('https://static2.sharepointonline.com/files/fabric/fabric-website/dist/');
+  setBaseUrl(__webpack_public_path__);
 }
 
 let rootElement;

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -29,8 +29,7 @@ let isLocal = window.location.hostname === 'localhost' || window.location.hostna
 declare let Flight; // Contains flight & CDN configuration loaded by manifest
 declare let __webpack_public_path__;
 
-// Final bundle location can be dynamic, so we need to update the public path
-// at runtime to point to the right CDN URL
+// Final bundle location can be dynamic, so we need to update the public path at runtime to point to the right CDN URL
 if (!isLocal && Flight.baseCDNUrl) {
   __webpack_public_path__ = Flight.baseCDNUrl;
 }

--- a/common/changes/@uifabric/fabric-website/jahnp-website-updates_2018-10-12-21-18.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-website-updates_2018-10-12-21-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Enable website to load bundle scripts from manifest JS file",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "pejahn@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: N/A (enables better site deployment management)
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Today, the website loads all of its app scripts from a single, static entry point file. Pushing updates to the site means that we need to continuously update that single entry point and add 70+ bundle chunks. 

The changes in this PR enable us to load the website entry point and chunks from a dynamic location, determined by a simple manifest JS file. It is one part of a set of infrastructure updates we're undertaking to allow the site to be updated with every release of Fabric, and roll back faulty changes quickly and predictably.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6683)

