### PR TITLE
Auto resolve multiple in PeoplePicker 5.0

### DIFF
--- a/common/changes/@uifabric/experiments/5.0_2018-10-13-00-21.json
+++ b/common/changes/@uifabric/experiments/5.0_2018-10-13-00-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "ferasd@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/5.0_2018-10-13-00-21.json
+++ b/common/changes/@uifabric/utilities/5.0_2018-10-13-00-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "ferasd@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/5.0_2018-10-13-00-21.json
+++ b/common/changes/office-ui-fabric-react/5.0_2018-10-13-00-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "People picker support for auto resolving multiple entries",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "ferasd@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -142,6 +142,11 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * @default false
    */
   enableSelectedSuggestionAlert?: boolean;
+  /**
+   * Flag for auto resolving multiple items.
+   * @default false
+   */
+  autoResolveMultiple?: boolean;
 }
 
 export interface IBasePickerSuggestionsProps {

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.scss
@@ -3,6 +3,9 @@
     width: 200px;
   }
 
+  .toggle-div {
+    display: flex;
+  }
   .ms-PeoplePicker {
     width: 100%;
   }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -26,6 +26,7 @@ import './PeoplePicker.Types.Example.scss';
 export interface IPeoplePickerExampleState {
   currentPicker?: number | string;
   delayResults?: boolean;
+  autoResolveMultiple?: boolean;
   peopleList: IPersonaProps[];
   mostRecentlyUsed: IPersonaProps[];
   currentSelectedItems?: IPersonaProps[];
@@ -65,6 +66,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
     this.state = {
       currentPicker: 1,
       delayResults: false,
+      autoResolveMultiple: false,
       peopleList: peopleList,
       mostRecentlyUsed: mru,
       currentSelectedItems: []
@@ -116,11 +118,18 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
             selectedKey={ this.state.currentPicker }
             onChanged={ this._dropDownSelected }
           />
-          <Toggle
-            label='Delay Suggestion Results'
-            defaultChecked={ false }
-            onChanged={ this._toggleDelayResultsChange }
-          />
+          <div className={ 'toggle-div' }>
+            <Toggle
+              label='Delay Suggestion Results'
+              defaultChecked={ false }
+              onChanged={ this._toggleDelayResultsChange }
+            />
+            <Toggle
+              label='Auto Resolve Multiple Suggestions'
+              defaultChecked={ false }
+              onChanged={ this._toggleAutoResolveMultipleChange }
+            />
+          </div>
         </div>
         <PrimaryButton
           text='Set focus'
@@ -175,6 +184,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         componentRef={ this._resolveRef('_picker') }
         onInputChange={ this._onInputChange }
         resolveDelay={ 300 }
+        autoResolveMultiple={ this.state.autoResolveMultiple }
       />
     );
   }
@@ -196,6 +206,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         } }
         componentRef={ this._resolveRef('_picker') }
         resolveDelay={ 300 }
+        autoResolveMultiple={ this.state.autoResolveMultiple }
       />
     );
   }
@@ -219,6 +230,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         } }
         componentRef={ this._resolveRef('_picker') }
         resolveDelay={ 300 }
+        autoResolveMultiple={ this.state.autoResolveMultiple }
       />
     );
   }
@@ -242,6 +254,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         } }
         componentRef={ this._resolveRef('_picker') }
         resolveDelay={ 300 }
+        autoResolveMultiple={ this.state.autoResolveMultiple }
       />
     );
   }
@@ -412,6 +425,10 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
 
   private _toggleDelayResultsChange = (toggleState: boolean): void => {
     this.setState({ delayResults: toggleState });
+  }
+
+  private _toggleAutoResolveMultipleChange = (toggleState: boolean): void => {
+    this.setState({ autoResolveMultiple: toggleState });
   }
 
   private _dropDownSelected = (option: IDropdownOption): void => {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6280
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Added support for auto resolving multiple entries separated by a character ( ';' by default). The resolver automatically picks the first suggestion returned.

#### Focus areas to test

Added a toggle to test the feature in People Picker example page.


This change is needed to support copy/paste from outlook.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6686)

