### PR TITLE
Experiments: fixing file-type-icons example to not crash

### DIFF
--- a/common/changes/@uifabric/file-type-icons/fix-fti_2018-10-13-19-27.json
+++ b/common/changes/@uifabric/file-type-icons/fix-fti_2018-10-13-19-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Fixing enum to avoid const enum.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -5,7 +5,7 @@
  * via this enum.
  */
 
-export const enum FileIconType {
+export enum FileIconType {
   docset = 1, // Start at 1 so it will evaluate as "truthy"
   folder = 2,
   genericFile = 3,


### PR DESCRIPTION
There is a small enum in file-type-icons which is marked as const, causing problems in consumer scenarios.

Changing to a non-const enum fixes the experiments issue.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6689)

