### PR TITLE
Fluent experiment: Move Customizer inside each ExampleCard

### DIFF
--- a/common/changes/@uifabric/experiments/miwhea-fluent-theme-customizers_2018-10-16-19-56.json
+++ b/common/changes/@uifabric/experiments/miwhea-fluent-theme-customizers_2018-10-16-19-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix FluentStylesPage by wrapping a Customizer around each example",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/experiments/src/components/fluent/styles/FluentStylesPage.tsx
+++ b/packages/experiments/src/components/fluent/styles/FluentStylesPage.tsx
@@ -61,55 +61,83 @@ export class FluentStylesPage extends React.Component<IComponentDemoPageProps, I
         }
         isHeaderVisible={this.props.isHeaderVisible}
         exampleCards={
-          <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
-            <div>
-              <ExampleCard title="Link - No Current Changes" code={FluentLinkExampleCode}>
+          <div>
+            <ExampleCard title="Link - No Current Changes" code={FluentLinkExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesLinkExample />
-              </ExampleCard>
-              <ExampleCard title="Breadcrumb" code={FluentBreadcrumbExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Breadcrumb" code={FluentBreadcrumbExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesBreadcrumbExample />
-              </ExampleCard>
-              <ExampleCard title="Button" code={FluentButtonExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Button" code={FluentButtonExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesButtonExample />
-              </ExampleCard>
-              <ExampleCard title="Checkbox" code={FluentCheckboxExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Checkbox" code={FluentCheckboxExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesCheckboxExample />
-              </ExampleCard>
-              <ExampleCard title="ChoiceGroup" code={FluentChoiceGroupExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="ChoiceGroup" code={FluentChoiceGroupExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesChoiceGroupExample />
-              </ExampleCard>
-              <ExampleCard title="Dropdown" code={FluentStylesDropdownExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Dropdown" code={FluentStylesDropdownExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesDropdownExample />
-              </ExampleCard>
-              <ExampleCard title="ComboBox" code={FluentStylesComboBoxExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="ComboBox" code={FluentStylesComboBoxExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesComboBoxExample />
-              </ExampleCard>
-              <ExampleCard title="ContextualMenu" code={FluentStylesContextualMenuExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="ContextualMenu" code={FluentStylesContextualMenuExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesContextualMenuExample />
-              </ExampleCard>
-              <ExampleCard title="Dialog" code={FluentDialogExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Dialog" code={FluentDialogExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesDialogExample />
-              </ExampleCard>
-              <ExampleCard title="Label" code={FluentLabelExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Label" code={FluentLabelExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesLabelExample />
-              </ExampleCard>
-              <ExampleCard title="Panel" code={FluentStylesPanelExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Panel" code={FluentStylesPanelExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesPanelExample />
-              </ExampleCard>
-              <ExampleCard title="Rating - No Current Changes" code={FluentRatingExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Rating - No Current Changes" code={FluentRatingExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesRatingExample />
-              </ExampleCard>
-              <ExampleCard title="Slider - No Current Changes" code={FluentSliderExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Slider - No Current Changes" code={FluentSliderExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesSliderExample />
-              </ExampleCard>
-              <ExampleCard title="TextField" code={FluentStylesTextFieldExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="TextField" code={FluentStylesTextFieldExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesTextFieldExample />
-              </ExampleCard>
-              <ExampleCard title="Toggle" code={FluentStylesToggleExampleCode}>
+              </Customizer>
+            </ExampleCard>
+            <ExampleCard title="Toggle" code={FluentStylesToggleExampleCode}>
+              <Customizer {...(isFluent ? FluentCustomizations : undefined)}>
                 <FluentStylesToggleExample />
-              </ExampleCard>
-            </div>
-          </Customizer>
+              </Customizer>
+            </ExampleCard>
+          </div>
         }
       />
     );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The ExampleCard was recently updated to include themes: 
![image](https://user-images.githubusercontent.com/1382445/47043662-00215a80-d143-11e8-8650-56a2916d47f8.png)

This sets a default theme, which was overriding the Fluent theme we had applied to the entire page. This PR is a quick fix to move the Customizer inside each ExampleCard, allowing it to once again set the theme as expected.

It's a quick fix to get us unblocked, while #6716 is discussing a better solution.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6715)

