### PR TITLE
FocusTrapZone: Add/remove focus and click handlers when props change

### DIFF
--- a/common/changes/office-ui-fabric-react/focusTrapZone_2018-10-16-01-14.json
+++ b/common/changes/office-ui-fabric-react/focusTrapZone_2018-10-16-01-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusTrapZone: Add/remove focus and click handlers when props change",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -166,11 +166,11 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
               ignoreExternalFocusing={ignoreExternalFocusing}
               forceFocusInsideTrap={isHiddenOnDismiss && !isOpen ? false : forceFocusInsideTrap}
               firstFocusableSelector={firstFocusableSelector}
+              isClickableOutsideFocusTrap={true}
               {...focusTrapZoneProps}
               className={_classNames.main}
               style={customWidthStyles}
               elementToFocusOnDismiss={elementToFocusOnDismiss}
-              isClickableOutsideFocusTrap={focusTrapZoneProps && !focusTrapZoneProps.isClickableOutsideFocusTrap ? false : true}
             >
               <div className={_classNames.commands} data-is-visible={true}>
                 {onRenderNavigation(this.props, this._onRenderNavigation)}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The `FocusTrapZone` registers a global focus handler if its prop `forceFocusInsideTrap` is true and a global click handler unless `isClickableOutsideFocusTrap` is false. However, it only set those handlers once in `componentDidMount` and didn't update them in response to prop changes. This created problems for the scenario of a panel which sets `isHiddenOnDismiss=true` (so it's hidden not destroyed on dismiss): it was impossible to make the panel capture clicks/focus while shown, but go back to not capturing clicks while hidden. 

Fix is to add/remove the event handlers as appropriate in both `componentDidMount` and `componentWillReceiveProps`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6717)

