### PR TITLE
Spinner no longer vibrates in place in Edge browser (Oct 2018 update).

### DIFF
--- a/common/changes/office-ui-fabric-react/issue6697_2018-10-17-01-40.json
+++ b/common/changes/office-ui-fabric-react/issue6697_2018-10-17-01-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Spinner: No longer appears to vibrate in Microsoft Edge (Oct 2018 Update).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
@@ -3,10 +3,10 @@ import { hiddenContentStyle, keyframes, HighContrastSelector } from '../../Styli
 
 const spinAnimation: string = keyframes({
   '0%': {
-    transform: 'rotateZ(0deg)'
+    transform: 'rotate(0deg)'
   },
   '100%': {
-    transform: 'rotateZ(360deg)'
+    transform: 'rotate(360deg)'
   }
 });
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
@@ -43,7 +43,7 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
           {
             animation-duration: 1.3s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-name: keyframes 0%{transform:rotate(0deg);}100%{transform:rotate(360deg);};
             animation-timing-function: cubic-bezier(.53,.21,.29,.67);
             border-radius: 50%;
             border-top-color: #0078d4;
@@ -100,7 +100,7 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
           {
             animation-duration: 1.3s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-name: keyframes 0%{transform:rotate(0deg);}100%{transform:rotate(360deg);};
             animation-timing-function: cubic-bezier(.53,.21,.29,.67);
             border-radius: 50%;
             border-top-color: #0078d4;
@@ -157,7 +157,7 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
           {
             animation-duration: 1.3s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-name: keyframes 0%{transform:rotate(0deg);}100%{transform:rotate(360deg);};
             animation-timing-function: cubic-bezier(.53,.21,.29,.67);
             border-radius: 50%;
             border-top-color: #0078d4;
@@ -214,7 +214,7 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
           {
             animation-duration: 1.3s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-name: keyframes 0%{transform:rotate(0deg);}100%{transform:rotate(360deg);};
             animation-timing-function: cubic-bezier(.53,.21,.29,.67);
             border-radius: 50%;
             border-top-color: #0078d4;
@@ -271,7 +271,7 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
           {
             animation-duration: 1.3s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-name: keyframes 0%{transform:rotate(0deg);}100%{transform:rotate(360deg);};
             animation-timing-function: cubic-bezier(.53,.21,.29,.67);
             border-radius: 50%;
             border-top-color: #0078d4;
@@ -343,7 +343,7 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
           {
             animation-duration: 1.3s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:rotateZ(0deg);}100%{transform:rotateZ(360deg);};
+            animation-name: keyframes 0%{transform:rotate(0deg);}100%{transform:rotate(360deg);};
             animation-timing-function: cubic-bezier(.53,.21,.29,.67);
             border-radius: 50%;
             border-top-color: #0078d4;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6697 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

**Before:**
![vibrating spinner](https://user-images.githubusercontent.com/1003246/47057005-b6049d00-d173-11e8-951d-18c4209a2b3e.gif)

**After:**
![fixed spinner](https://user-images.githubusercontent.com/1003246/47057010-b9982400-d173-11e8-9997-a377e0864b3d.gif)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6724)

