### PR TITLE
5.x - Fix Coachmark focus when tabbing

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-09-2018-CoachmarkFocusTab_2018-09-05-19-35.json
+++ b/common/changes/office-ui-fabric-react/edwl-09-2018-CoachmarkFocusTab_2018-09-05-19-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark: Fix tabbing when Coachmark is mounted (backport from PR 6240)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/v5-coachmark-focus-fix_2018-10-17-21-25.json
+++ b/common/changes/office-ui-fabric-react/v5-coachmark-focus-fix_2018-10-17-21-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Coachmark: Fix tabbing when Coachmark is mounted (backport from PR 6240)",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -32,6 +32,11 @@ export interface ICoachmarkStyleProps {
   isMeasuring: boolean;
 
   /**
+   * Is the Coachmark finished measuring the dimensions of innerHostElement
+   */
+  isMeasured: boolean;
+
+  /**
    * The height measured before the component has been mounted
    * in pixels
    */
@@ -80,8 +85,7 @@ export interface ICoachmarkStyles {
   root?: IStyle;
 
   /**
-   * The pulsing beacon that animates when the coachmark
-   * is collapsed.
+   * The pulsing beacon that animates when the Coachmark is collapsed.
    */
   pulsingBeacon?: IStyle;
 
@@ -113,7 +117,12 @@ export interface ICoachmarkStyles {
   entityInnerHost: IStyle;
 
   /**
-   * The styles applied when the coachmark has collapsed.
+   * The layer that directly contains the TeachingBubbleContent
+   */
+  childrenContainer: IStyle;
+
+  /**
+   * The styles applied when the Coachmark has collapsed.
    */
   collapsed?: IStyle;
 
@@ -364,6 +373,11 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
       },
       (!props.isMeasuring) && {
         visibility: 'visible',
+      }
+    ],
+    childrenContainer: [
+      {
+        display: props.isMeasured && props.isCollapsed ? 'none' : 'block'
       }
     ],
     ariaContainer: {


### PR DESCRIPTION
Applies PR #6240 to the 5.x branch. Tested on the development site and verified that tabbing throughout the page works, even with the CoachMark opened.

Another attempt at #6734, this time with a different branch name.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6736)

