### PR TITLE
FocusTrapZone: Add/remove focus and click handlers when props change …

### DIFF
--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Panel, PanelType } from 'office-ui-fabric-react';
+import { Panel, PanelType, SearchBox } from 'office-ui-fabric-react';
 
 Panel.defaultProps = {
   isOpen: true,
@@ -12,58 +12,35 @@ Panel.defaultProps = {
 
 storiesOf('Panel', module)
   .addDecorator(FabricDecorator)
+  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default').end()}>{story()}</Screener>)
+  .add('Small left w/ close button', () => <Panel hasCloseButton type={PanelType.smallFixedNear} headerText="Small" />)
+  .add('Small fixed right w/ close button', () => (
+    <Panel hasCloseButton type={PanelType.smallFixedFar} headerText="Small fixed" />
+  ))
+  .add('Small fluid right', () => <Panel type={PanelType.smallFluid} headerText="Small fluid" />)
+  .add('Medium right', () => <Panel type={PanelType.medium} headerText="Medium" />)
+  .add('Large right', () => <Panel type={PanelType.large} headerText="Large" />)
+  .add('Large fixed right', () => <Panel type={PanelType.largeFixed} headerText="Large fixed" />)
+  .add('Extra large right', () => <Panel type={PanelType.extraLarge} headerText="Extra Large" />);
+
+storiesOf('Panel', module)
+  .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
-      steps={ new Screener.Steps()
+      steps={new Screener.Steps()
         .snapshot('default')
-        .end()
-      }
+        .click('.ms-SearchBox-field')
+        .snapshot('click')
+        .end()}
     >
-      { story() }
+      {story()}
     </Screener>
   ))
-  .add('Small left w/ close button', () => (
-    <Panel
-      hasCloseButton
-      type={ PanelType.smallFixedNear }
-      headerText='Small'
-    />
-  ))
-  .add('Small fixed right w/ close button', () => (
-    <Panel
-      hasCloseButton
-      type={ PanelType.smallFixedFar }
-      headerText='Small fixed'
-    />
-  ))
-  .add('Small fluid right', () => (
-    <Panel
-      type={ PanelType.smallFluid }
-      headerText='Small fluid'
-    />
-  ))
-  .add('Medium right', () => (
-    <Panel
-      type={ PanelType.medium }
-      headerText='Medium'
-    />
-  ))
-  .add('Large right', () => (
-    <Panel
-      type={ PanelType.large }
-      headerText='Large'
-    />
-  ))
-  .add('Large fixed right', () => (
-    <Panel
-      type={ PanelType.largeFixed }
-      headerText='Large fixed'
-    />
-  ))
-  .add('Extra large right', () => (
-    <Panel
-      type={ PanelType.extraLarge }
-      headerText='Extra Large'
-    />
-  ))
-  ;
+  .add('SearchBox and Right Panel', () => (
+    <div>
+      <SearchBox placeholder="Search" />
+      <Panel isOpen={false} type={PanelType.medium} headerClassName="" headerText={'Header'} isHiddenOnDismiss>
+        {null}
+      </Panel>
+    </div>
+  ));

--- a/common/changes/office-ui-fabric-react/focusTrapZone5_2018-10-16-01-14.json
+++ b/common/changes/office-ui-fabric-react/focusTrapZone5_2018-10-16-01-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusTrapZone: Add/remove focus and click handlers when props change",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -22,6 +22,8 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   private _previouslyFocusedElement: HTMLElement;
   private _isInFocusStack = false;
   private _isInClickStack = false;
+  private _hasFocusHandler: boolean;
+  private _hasClickHandler: boolean;
 
   public componentWillMount(): void {
     const { isClickableOutsideFocusTrap = false, forceFocusInsideTrap = true } = this.props;
@@ -36,27 +38,23 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   }
 
   public componentDidMount(): void {
-    const { isClickableOutsideFocusTrap = false, forceFocusInsideTrap = true, elementToFocusOnDismiss, disableFirstFocus = false } = this.props;
+    const { elementToFocusOnDismiss, disableFirstFocus = false } = this.props;
 
     this._previouslyFocusedElement = elementToFocusOnDismiss ? elementToFocusOnDismiss : document.activeElement as HTMLElement;
     if (!elementContains(this._root.current, this._previouslyFocusedElement) && !disableFirstFocus) {
       this.focus();
     }
 
-    if (forceFocusInsideTrap) {
-      this._events.on(window, 'focus', this._forceFocusInTrap, true);
+    this._updateEventHandlers(this.props);
     }
-
-    if (!isClickableOutsideFocusTrap) {
-      this._events.on(window, 'click', this._forceClickInTrap, true);
-    }
-  }
 
   public componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void {
     const { elementToFocusOnDismiss } = nextProps;
     if (elementToFocusOnDismiss && this._previouslyFocusedElement !== elementToFocusOnDismiss) {
       this._previouslyFocusedElement = elementToFocusOnDismiss;
     }
+
+    this._updateEventHandlers(nextProps);
   }
 
   public componentWillUnmount(): void {
@@ -122,6 +120,24 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
     if (_firstFocusableChild) {
       focusAsync(_firstFocusableChild);
     }
+  }
+
+  private _updateEventHandlers(newProps: IFocusTrapZoneProps): void {
+    const { isClickableOutsideFocusTrap = false, forceFocusInsideTrap = true } = newProps;
+
+    if (forceFocusInsideTrap && !this._hasFocusHandler) {
+      this._events.on(window, 'focus', this._forceFocusInTrap, true);
+    } else if (!forceFocusInsideTrap && this._hasFocusHandler) {
+      this._events.off(window, 'focus', this._forceFocusInTrap, true);
+    }
+    this._hasFocusHandler = forceFocusInsideTrap;
+
+    if (!isClickableOutsideFocusTrap && !this._hasClickHandler) {
+      this._events.on(window, 'click', this._forceClickInTrap, true);
+    } else if (isClickableOutsideFocusTrap && this._hasClickHandler) {
+      this._events.off(window, 'click', this._forceClickInTrap, true);
+    }
+    this._hasClickHandler = !isClickableOutsideFocusTrap;
   }
 
   private _onKeyboardHandler = (ev: React.KeyboardEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -180,8 +180,9 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
             { overlay }
             <FocusTrapZone
               ignoreExternalFocusing={ ignoreExternalFocusing }
-              forceFocusInsideTrap={ forceFocusInsideTrap }
+              forceFocusInsideTrap={ isHiddenOnDismiss && !isOpen ? false : forceFocusInsideTrap }
               firstFocusableSelector={ firstFocusableSelector }
+              isClickableOutsideFocusTrap={ true }
               { ...focusTrapZoneProps }
               className={
                 css(
@@ -195,7 +196,6 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
                 ) }
               style={ customWidthStyles }
               elementToFocusOnDismiss={ elementToFocusOnDismiss }
-              isClickableOutsideFocusTrap={ focusTrapZoneProps && !focusTrapZoneProps.isClickableOutsideFocusTrap ? false : true }
             >
               <div className={ css('ms-Panel-commands') } data-is-visible={ true } >
                 { onRenderNavigation(this.props, this._onRenderNavigation) }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -41,9 +41,10 @@ export interface IPanelProps extends React.Props<Panel> {
   isLightDismiss?: boolean;
 
   /**
-  * Whether the panel is hidden on dismiss, instead of destroyed in the DOM.
-  * @default false
-  */
+   * Whether the panel is hidden on dismiss, instead of destroyed in the DOM.
+   * Protects the contents from being destroyed when the panel is dismissed.
+   * @default false
+   */
   isHiddenOnDismiss?: boolean;
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This is a port of #6717 to Fabric 5 (description pasted below). Also includes @natalieethell's fix for #5704, so that panels which set `isHiddenOnDismiss` to true will not continue to trap focus while hidden.

The `FocusTrapZone` registers a global focus handler if its prop `forceFocusInsideTrap` is true and a global click handler unless `isClickableOutsideFocusTrap` is false. However, it only set those handlers once in `componentDidMount` and didn't update them in response to prop changes. This created problems for the scenario of a panel which sets `isHiddenOnDismiss=true` (so it's hidden not destroyed on dismiss): it was impossible to make the panel capture clicks/focus while shown, but go back to not capturing clicks while hidden.

Fix is to add/remove the event handlers as appropriate in both `componentDidMount` and `componentWillReceiveProps`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6741)