### PR TITLE
Added break in PeoplePicker switch

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-10-19-00-05.json
+++ b/common/changes/office-ui-fabric-react/master_2018-10-19-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added 'break' statement in PeoplePicker component example. Without it, changing picker type to 'Process Selection' was rendering 'Controlled Picker' instead.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -89,6 +89,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
         break;
       case 6:
         currentPicker = this._renderProcessSelectionPicker();
+        break;
       case 7:
         currentPicker = this._renderControlledPicker();
         break;
@@ -326,9 +327,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
     const indexMostRecentlyUsed: number = mruState.indexOf(item);
 
     if (indexPeopleList >= 0) {
-      const newPeople: IPersonaProps[] = peopleList
-        .slice(0, indexPeopleList)
-        .concat(peopleList.slice(indexPeopleList + 1));
+      const newPeople: IPersonaProps[] = peopleList.slice(0, indexPeopleList).concat(peopleList.slice(indexPeopleList + 1));
       this.setState({ peopleList: newPeople });
     }
 
@@ -368,9 +367,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
     return this._filterPromise(mostRecentlyUsed);
   };
 
-  private _returnMostRecentlyUsedWithLimit = (
-    currentPersonas: IPersonaProps[]
-  ): IPersonaProps[] | Promise<IPersonaProps[]> => {
+  private _returnMostRecentlyUsedWithLimit = (currentPersonas: IPersonaProps[]): IPersonaProps[] | Promise<IPersonaProps[]> => {
     let { mostRecentlyUsed } = this.state;
     mostRecentlyUsed = this._removeDuplicates(mostRecentlyUsed, currentPersonas);
     mostRecentlyUsed = mostRecentlyUsed.splice(0, 3);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6737
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added 'break' statement in PeoplePicker component example. Without it, chan
ging picker type to 'Process Selection' was rendering 'Controlled Picker' instead.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6763)

