### PR TITLE
Added 'stretch' as valid value for justifyContent in IRawStyleBase.

### DIFF
--- a/common/changes/@uifabric/merge-styles/master_2018-10-19-18-48.json
+++ b/common/changes/@uifabric/merge-styles/master_2018-10-19-18-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Added 'stretch' as valid value for justifyContent in IRawStyleBase.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -1056,7 +1056,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * See CSS justify-content property
    * https://www.w3.org/TR/css-flexbox-1/#justify-content-property
    */
-  justifyContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
+  justifyContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch';
 
   /**
    * Justifies the box (as the alignment subject) within its containing block (as the alignment container)


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6597
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added 'stretch' as valid value for justifyContent in IRawStyleBase.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6775)

