### PR TITLE
Qqli1209/add aria label for ChoiceGroupOptions

### DIFF
--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -125,8 +125,8 @@ export class ChoiceGroupOptionBase extends BaseComponent<IChoiceGroupOptionProps
             {onRenderLabel!(props)}
           </div>
         ) : (
-            onRenderLabel!(props)
-          )}
+          onRenderLabel!(props)
+        )}
       </label>
     );
   };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -21,6 +21,7 @@ export class ChoiceGroupOptionBase extends BaseComponent<IChoiceGroupOptionProps
 
   public render(): JSX.Element {
     const {
+      ariaLabel,
       focused,
       required,
       theme,
@@ -49,6 +50,7 @@ export class ChoiceGroupOptionBase extends BaseComponent<IChoiceGroupOptionProps
       <div className={this._classNames.root}>
         <div className={this._classNames.choiceFieldWrapper}>
           <input
+            aria-label={ariaLabel || this.props.text}
             ref={this._inputElement}
             id={id}
             className={this._classNames.input}
@@ -123,8 +125,8 @@ export class ChoiceGroupOptionBase extends BaseComponent<IChoiceGroupOptionProps
             {onRenderLabel!(props)}
           </div>
         ) : (
-          onRenderLabel!(props)
-        )}
+            onRenderLabel!(props)
+          )}
       </label>
     );
   };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -58,6 +58,11 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
    * This value is used to group each ChoiceGroupOption into the same logical ChoiceGroup
    */
   name?: string;
+
+  /**
+   * Accessible label for the ChoiceGroupOption.
+   */
+  ariaLabel?: string;
 }
 
 export interface IChoiceGroupOptionStyleProps {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6726
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Add aria-label for ChoiceGroupOptions so that user can specify their own aria-label.

#### Focus areas to test



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6784)

