### PR TITLE
Fluent theme: Update color of disabled Label

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-label_2018-10-22-15-58.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-label_2018-10-22-15-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Fluent experiment: Change the color of disabled Labels",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Label.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Label.styles.ts
@@ -1,7 +1,18 @@
+import { ILabelStyleProps } from 'office-ui-fabric-react/lib/Label';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
-export const LabelStyles = {
-  root: {
-    fontWeight: FontWeights.semibold
-  }
+export const LabelStyles = (props: ILabelStyleProps) => {
+  const { theme, disabled } = props;
+  const { palette } = theme;
+
+  return {
+    root: [
+      {
+        fontWeight: FontWeights.semibold
+      },
+      disabled && {
+        color: palette.neutralTertiary
+      }
+    ]
+  };
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #6711
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates the color of disabled Labels in the Fluent theme.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6787)

