### PR TITLE
Dropdown: allow onChanged to be called when an item has been reselected

### DIFF
--- a/common/changes/office-ui-fabric-react/janormanms-dropdown-reselect_2018-10-22-17-24.json
+++ b/common/changes/office-ui-fabric-react/janormanms-dropdown-reselect_2018-10-22-17-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add an optional parameter to allow Dropdown to call onChanged when an item is clicked, even if that item was already selected",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "janorman@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -276,13 +276,13 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
   }
 
   public setSelectedIndex(event: React.FormEvent<HTMLDivElement>, index: number): void {
-    const { onChange, onChanged, options, selectedKey, selectedKeys, multiSelect } = this.props;
+    const { onChange, onChanged, options, selectedKey, selectedKeys, multiSelect, notifyOnReselect } = this.props;
     const { selectedIndices = [] } = this.state;
     const checked: boolean = selectedIndices ? selectedIndices.indexOf(index) > -1 : false;
 
     index = Math.max(0, Math.min(options.length - 1, index));
 
-    if (!multiSelect && index === selectedIndices[0]) {
+    if (!multiSelect && !notifyOnReselect && index === selectedIndices[0]) {
       return;
     } else if (!multiSelect && selectedKey === undefined) {
       // Set the selected option if this is an uncontrolled component

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -161,6 +161,30 @@ describe('Dropdown', () => {
       }
     });
 
+    it('issues the onChange callback when the selected item is the same if notifyOnReselect is true', () => {
+      const container = document.createElement('div');
+      let dropdownRoot: HTMLElement | undefined;
+
+      document.body.appendChild(container);
+
+      const onChangeSpy = jasmine.createSpy('onChange');
+
+      try {
+        ReactDOM.render(
+          <Dropdown label="testgroup" defaultSelectedKey="3" onChange={onChangeSpy} options={DEFAULT_OPTIONS} notifyOnReselect={true} />,
+          container
+        );
+        dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
+
+        ReactTestUtils.Simulate.click(dropdownRoot);
+
+        const secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="3"]') as HTMLElement;
+        ReactTestUtils.Simulate.click(secondItemElement);
+      } finally {
+        expect(onChangeSpy).toHaveBeenCalledWith(expect.anything(), DEFAULT_OPTIONS[3], 3);
+      }
+    });
+
     it('issues the onDismiss callback when dismissing options callout', () => {
       const container = document.createElement('div');
       let dropdownRoot: HTMLElement | undefined;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -146,7 +146,7 @@ describe('Dropdown', () => {
 
       document.body.appendChild(container);
 
-      const onChangeSpy = jasmine.createSpy('onChange');
+      const onChangeSpy = jest.fn();
 
       try {
         ReactDOM.render(<Dropdown label="testgroup" defaultSelectedKey="1" onChange={onChangeSpy} options={DEFAULT_OPTIONS} />, container);
@@ -167,7 +167,7 @@ describe('Dropdown', () => {
 
       document.body.appendChild(container);
 
-      const onChangeSpy = jasmine.createSpy('onChange');
+      const onChangeSpy = jest.fn();
 
       try {
         ReactDOM.render(
@@ -191,7 +191,7 @@ describe('Dropdown', () => {
 
       document.body.appendChild(container);
 
-      const onDismissSpy = jasmine.createSpy('onDismiss');
+      const onDismissSpy = jest.fn();
 
       try {
         ReactDOM.render(
@@ -232,7 +232,7 @@ describe('Dropdown', () => {
 
       document.body.appendChild(container);
 
-      const onChangeSpy = jasmine.createSpy('onChange');
+      const onChangeSpy = jest.fn();
 
       try {
         ReactDOM.render(<Dropdown label="testgroup" defaultSelectedKey="1" onChange={onChangeSpy} options={DEFAULT_OPTIONS} />, container);
@@ -496,7 +496,7 @@ describe('Dropdown', () => {
 
       document.body.appendChild(container);
 
-      const onChangedSpy = jasmine.createSpy('onChanged');
+      const onChangedSpy = jest.fn();
 
       try {
         ReactDOM.render(
@@ -526,7 +526,7 @@ describe('Dropdown', () => {
 
       document.body.appendChild(container);
 
-      const onChangedSpy = jasmine.createSpy('onChanged');
+      const onChangedSpy = jest.fn();
 
       try {
         ReactDOM.render(

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -87,6 +87,12 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   multiSelectDelimiter?: string;
 
   /**
+   * Optional preference to have onChanged still be called when an already selected item is
+   * clicked in single select mode.  Default to false
+   */
+  notifyOnReselect?: boolean;
+
+  /**
    * Deprecated at v0.52.0, use 'disabled' instead.
    * @deprecated
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6759 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Dropdown only notifies when an item is clicked if the selection has actually changed. Adding a parameter to allow onChanged to be called when an item is reselected in single select mode

#### Focus areas to test

Dropdown

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6789)

