### PR TITLE
horizontal scroll bar with sticky footer bug fix [ ScrollablePane ]

### DIFF
--- a/common/changes/office-ui-fabric-react/arkgupta-horizontalScrollBarStickyFooterFix_2018-10-23-10-55.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-horizontalScrollBarStickyFooterFix_2018-10-23-10-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "update to fix bug when footer covered horizontal scroll bar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "arkgupta@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -109,11 +109,12 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
           return false;
         }
 
+        // Compute the scrollbar height which might have changed due to some action like a column resize which might cause overflow
         const scrollbarHeight = this._getScrollbarHeight();
-        // check if the scroll bar height has changed and update the state to re-render it
+        // check if the scroll bar height has changed and update the state so that it's postioned correctly below sticky footer
         if (scrollbarHeight !== this.state.scrollbarHeight) {
           this.setState({
-            scrollbarHeight
+            scrollbarHeight: scrollbarHeight
           });
         }
 
@@ -393,20 +394,20 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
       height: height,
       ...(getRTL()
         ? {
-          right: '0',
-          left: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
-        }
+            right: '0',
+            left: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
+          }
         : {
-          left: '0',
-          right: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
-        }),
+            left: '0',
+            right: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
+          }),
       ...(isTop
         ? {
-          top: '0'
-        }
+            top: '0'
+          }
         : {
-          bottom: `${this.state.scrollbarHeight || this._getScrollbarHeight() || 0}px`
-        })
+            bottom: `${this.state.scrollbarHeight || this._getScrollbarHeight() || 0}px`
+          })
     };
   };
 

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -110,6 +110,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
         }
 
         const scrollbarHeight = this._getScrollbarHeight();
+        // check if the scroll bar height has changed and update the state to re-render it
         if (scrollbarHeight !== this.state.scrollbarHeight) {
           this.setState({
             scrollbarHeight

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -109,7 +109,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
           return false;
         }
 
-        // Compute the scrollbar height which might have changed due to some action like a column resize which might cause overflow
+        // Compute the scrollbar height which might have changed due to change in width of the content which might cause overflow
         const scrollbarHeight = this._getScrollbarHeight();
         // check if the scroll bar height has changed and update the state so that it's postioned correctly below sticky footer
         if (scrollbarHeight !== this.state.scrollbarHeight) {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -109,6 +109,13 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
           return false;
         }
 
+        const scrollbarHeight = this._getScrollbarHeight();
+        if (scrollbarHeight !== this.state.scrollbarHeight) {
+          this.setState({
+            scrollbarHeight
+          });
+        }
+
         // Notify subscribers again to re-check whether Sticky should be Sticky'd or not
         this.notifySubscribers();
 
@@ -385,20 +392,20 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
       height: height,
       ...(getRTL()
         ? {
-            right: '0',
-            left: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
-          }
+          right: '0',
+          left: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
+        }
         : {
-            left: '0',
-            right: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
-          }),
+          left: '0',
+          right: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`
+        }),
       ...(isTop
         ? {
-            top: '0'
-          }
+          top: '0'
+        }
         : {
-            bottom: `${this.state.scrollbarHeight || this._getScrollbarHeight() || 0}px`
-          })
+          bottom: `${this.state.scrollbarHeight || this._getScrollbarHeight() || 0}px`
+        })
     };
   };
 

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -124,8 +124,6 @@ export class ScrollablePaneDetailsListExample extends React.Component<
       items: items,
       selectionDetails: this._getSelectionDetails()
     };
-
-    this._onDetailsListColumnResized = this._onDetailsListColumnResized.bind(this);
   }
 
   public render(): JSX.Element {
@@ -154,7 +152,6 @@ export class ScrollablePaneDetailsListExample extends React.Component<
           </Sticky>
           <MarqueeSelection selection={this._selection}>
             <DetailsList
-              onColumnResize={this._onDetailsListColumnResized}
               items={items}
               columns={_columns}
               setKey="set"
@@ -186,13 +183,6 @@ export class ScrollablePaneDetailsListExample extends React.Component<
       default:
         return `${selectionCount} items selected`;
     }
-  }
-
-  // When the DetailsList columns are resized, this may cause a horizontal scroll bar to appear or
-  // disappear within ScrollablePane. This rerenders the component to ensure that the floating
-  // footer does not overlap with the scroll bar.
-  private _onDetailsListColumnResized() {
-    this.forceUpdate();
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6339 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Updates ScrollablePaneBase component by making changes to the componentDidMount lifecycle hook. The MutationObserver has been modified by adding a check which compares the current computed scroll bar height and comparing it with the height in the current state. If the height has changed we explicitly update the state. This re-renders the scroll bar and hence it is positioned correctly below the footer.

This fix, as compared to the [previous one ](https://github.com/OfficeDev/office-ui-fabric-react/pull/6666) by @mikewheaton seems to be more efficient as it doesn't involve re-rendering the scrollablePane( and hence all it's children ) on each column-resize operation. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6802)

