### PR TITLE
Rating: fix focus outline clipping plus updates to line-height and padding

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-RatingRedLinesChange_2018-10-24-20-37.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-RatingRedLinesChange_2018-10-24-20-37.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Rating: Updating padding on each star to fix clipping focus outline and adjust height to follow redlines.",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/v-vibr-RatingRedLinesChange_2018-10-24-20-37.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-RatingRedLinesChange_2018-10-24-20-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Rating: Updating padding on each star to fix clipping focus outline and adjust height to follow redlines.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
@@ -35,7 +35,8 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
 
   const ratingSmallIconSize = 16;
   const ratingLargeIconSize = 20;
-  const ratingPadding = 3;
+  const ratingVerticalPadding = 8;
+  const ratingHorizontalPadding = 2;
 
   const ratingStarUncheckedColor = palette.neutralTertiary;
   const ratingStarUncheckedHoverColor = palette.themePrimary;
@@ -62,20 +63,21 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
     rootIsSmall: [
       classNames.rootIsSmall,
       {
-        height: ratingSmallIconSize + ratingPadding * 2 + 'px'
+        height: ratingSmallIconSize + ratingVerticalPadding * 2 + 'px'
       }
     ],
     rootIsLarge: [
       classNames.rootIsLarge,
       {
-        height: ratingLargeIconSize + ratingPadding * 2 + 'px'
+        height: ratingLargeIconSize + ratingVerticalPadding * 2 + 'px'
       }
     ],
     ratingStar: [
       classNames.ratingStar,
       {
         display: 'inline-block',
-        position: 'relative'
+        position: 'relative',
+        height: 'inherit'
       }
     ],
     ratingStarBack: [
@@ -105,7 +107,8 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
       classNames.ratingButton,
       {
         backgroundColor: 'transparent',
-        padding: `${ratingPadding}px ${ratingPadding}px ${ratingPadding}px 0px`,
+        padding: `${ratingVerticalPadding}px ${ratingHorizontalPadding}px`,
+        boxSizing: 'content-box',
         margin: '0px',
         border: 'none',
         cursor: 'pointer',
@@ -148,22 +151,23 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
       classNames.ratingStarIsSmall,
       {
         fontSize: ratingSmallIconSize + 'px',
-        lineHeight: ratingSmallIconSize + 'px'
+        lineHeight: ratingSmallIconSize + 'px',
+        height: ratingSmallIconSize + 'px'
       }
     ],
     ratingStarIsLarge: [
       classNames.ratingStartIsLarge,
       {
         fontSize: ratingLargeIconSize + 'px',
-        lineHeight: ratingLargeIconSize + 'px'
+        lineHeight: ratingLargeIconSize + 'px',
+        height: ratingLargeIconSize + 'px'
       }
     ],
     labelText: [classNames.labelText, hiddenContentStyle],
     ratingFocusZone: [
       classNames.ratingFocusZone,
       {
-        display: 'inline-block',
-        paddingBottom: '1px'
+        display: 'inline-block'
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Rating Renders Rating correctly 1`] = `
         color: Highlight;
       }
       {
-        height: 22px;
+        height: 32px;
       }
   id="Rating0"
 >
@@ -32,10 +32,9 @@ exports[`Rating Renders Rating correctly 1`] = `
         ms-RatingStar-root--small
         {
           display: inline-block;
-          padding-bottom: 1px;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     data-focuszone-id="FocusZone2"
     data-is-focusable={false}
@@ -52,16 +51,17 @@ exports[`Rating Renders Rating correctly 1`] = `
           {
             background-color: transparent;
             border: none;
+            box-sizing: content-box;
             cursor: pointer;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
             outline: transparent;
-            padding-bottom: 3px;
-            padding-left: 0px;
-            padding-right: 3px;
-            padding-top: 3px;
+            padding-bottom: 8px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 8px;
             position: relative;
           }
           &::-moz-focus-inner {
@@ -104,6 +104,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
           {
             font-size: 16px;
+            height: 16px;
             line-height: 16px;
           }
       data-is-current={true}
@@ -141,6 +142,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             ms-RatingStar-container
             {
               display: inline-block;
+              height: inherit;
               position: relative;
             }
       >
@@ -207,16 +209,17 @@ exports[`Rating Renders Rating correctly 1`] = `
           {
             background-color: transparent;
             border: none;
+            box-sizing: content-box;
             cursor: pointer;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
             outline: transparent;
-            padding-bottom: 3px;
-            padding-left: 0px;
-            padding-right: 3px;
-            padding-top: 3px;
+            padding-bottom: 8px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 8px;
             position: relative;
           }
           &::-moz-focus-inner {
@@ -259,6 +262,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
           {
             font-size: 16px;
+            height: 16px;
             line-height: 16px;
           }
       disabled={false}
@@ -295,6 +299,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             ms-RatingStar-container
             {
               display: inline-block;
+              height: inherit;
               position: relative;
             }
       >
@@ -361,16 +366,17 @@ exports[`Rating Renders Rating correctly 1`] = `
           {
             background-color: transparent;
             border: none;
+            box-sizing: content-box;
             cursor: pointer;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
             outline: transparent;
-            padding-bottom: 3px;
-            padding-left: 0px;
-            padding-right: 3px;
-            padding-top: 3px;
+            padding-bottom: 8px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 8px;
             position: relative;
           }
           &::-moz-focus-inner {
@@ -413,6 +419,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
           {
             font-size: 16px;
+            height: 16px;
             line-height: 16px;
           }
       disabled={false}
@@ -449,6 +456,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             ms-RatingStar-container
             {
               display: inline-block;
+              height: inherit;
               position: relative;
             }
       >
@@ -515,16 +523,17 @@ exports[`Rating Renders Rating correctly 1`] = `
           {
             background-color: transparent;
             border: none;
+            box-sizing: content-box;
             cursor: pointer;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
             outline: transparent;
-            padding-bottom: 3px;
-            padding-left: 0px;
-            padding-right: 3px;
-            padding-top: 3px;
+            padding-bottom: 8px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 8px;
             position: relative;
           }
           &::-moz-focus-inner {
@@ -567,6 +576,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
           {
             font-size: 16px;
+            height: 16px;
             line-height: 16px;
           }
       disabled={false}
@@ -603,6 +613,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             ms-RatingStar-container
             {
               display: inline-block;
+              height: inherit;
               position: relative;
             }
       >
@@ -669,16 +680,17 @@ exports[`Rating Renders Rating correctly 1`] = `
           {
             background-color: transparent;
             border: none;
+            box-sizing: content-box;
             cursor: pointer;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
             outline: transparent;
-            padding-bottom: 3px;
-            padding-left: 0px;
-            padding-right: 3px;
-            padding-top: 3px;
+            padding-bottom: 8px;
+            padding-left: 2px;
+            padding-right: 2px;
+            padding-top: 8px;
             position: relative;
           }
           &::-moz-focus-inner {
@@ -721,6 +733,7 @@ exports[`Rating Renders Rating correctly 1`] = `
           }
           {
             font-size: 16px;
+            height: 16px;
             line-height: 16px;
           }
       disabled={false}
@@ -757,6 +770,7 @@ exports[`Rating Renders Rating correctly 1`] = `
             ms-RatingStar-container
             {
               display: inline-block;
+              height: inherit;
               position: relative;
             }
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -25,7 +25,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           color: Highlight;
         }
         {
-          height: 26px;
+          height: 36px;
         }
     id="Rating0"
   >
@@ -36,10 +36,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           ms-RatingStar-root--large
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 26px;
+            height: 36px;
           }
       data-focuszone-id="FocusZone2"
       data-is-focusable={false}
@@ -56,16 +55,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -108,6 +108,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 20px;
+              height: 20px;
               line-height: 20px;
             }
         data-is-current={true}
@@ -145,6 +146,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -211,16 +213,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -263,6 +266,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 20px;
+              height: 20px;
               line-height: 20px;
             }
         disabled={false}
@@ -299,6 +303,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -365,16 +370,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -417,6 +423,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 20px;
+              height: 20px;
               line-height: 20px;
             }
         disabled={false}
@@ -453,6 +460,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -519,16 +527,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -571,6 +580,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 20px;
+              height: 20px;
               line-height: 20px;
             }
         disabled={false}
@@ -607,6 +617,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -673,16 +684,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -725,6 +737,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 20px;
+              height: 20px;
               line-height: 20px;
             }
         disabled={false}
@@ -761,6 +774,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -843,7 +857,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           color: Highlight;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     id="Rating3"
   >
@@ -854,10 +868,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           ms-RatingStar-root--small
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 22px;
+            height: 32px;
           }
       data-focuszone-id="FocusZone5"
       data-is-focusable={false}
@@ -874,16 +887,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -926,6 +940,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -962,6 +977,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -1028,16 +1044,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -1080,6 +1097,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -1116,6 +1134,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -1182,16 +1201,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -1234,6 +1254,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         data-is-current={true}
@@ -1271,6 +1292,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -1337,16 +1359,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -1389,6 +1412,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -1425,6 +1449,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -1491,16 +1516,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -1543,6 +1569,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -1579,6 +1606,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -1661,7 +1689,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           color: Highlight;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     id="Rating6"
   >
@@ -1672,10 +1700,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           ms-RatingStar-root--small
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 22px;
+            height: 32px;
           }
       data-focuszone-id="FocusZone8"
       data-is-focusable={false}
@@ -1692,16 +1719,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -1744,6 +1772,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         data-is-current={true}
@@ -1781,6 +1810,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -1847,16 +1877,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -1899,6 +1930,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -1935,6 +1967,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2001,16 +2034,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2053,6 +2087,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -2089,6 +2124,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2155,16 +2191,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2207,6 +2244,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -2243,6 +2281,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2309,16 +2348,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2361,6 +2401,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -2397,6 +2438,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2463,16 +2505,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2515,6 +2558,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -2551,6 +2595,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2617,16 +2662,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2669,6 +2715,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -2705,6 +2752,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2771,16 +2819,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2823,6 +2872,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -2859,6 +2909,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -2925,16 +2976,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -2977,6 +3029,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -3013,6 +3066,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3079,16 +3133,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3131,6 +3186,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -3167,6 +3223,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3243,7 +3300,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           font-weight: 400;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     id="Rating9"
   >
@@ -3254,10 +3311,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           ms-RatingStar-root--small
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 22px;
+            height: 32px;
           }
       data-focuszone-id="FocusZone11"
       data-is-focusable={false}
@@ -3274,16 +3330,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: default;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3308,6 +3365,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         data-is-current={true}
@@ -3345,6 +3403,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3380,16 +3439,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: default;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3414,6 +3474,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -3450,6 +3511,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3485,16 +3547,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: default;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3519,6 +3582,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -3555,6 +3619,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3590,16 +3655,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: default;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3624,6 +3690,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -3660,6 +3727,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3695,16 +3763,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: default;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3729,6 +3798,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -3765,6 +3835,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3810,7 +3881,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           font-weight: 400;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     id="Rating12"
   >
@@ -3821,10 +3892,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           ms-RatingStar-root--small
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 22px;
+            height: 32px;
           }
       data-focuszone-id="FocusZone14"
       data-is-focusable={true}
@@ -3841,16 +3911,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -3875,6 +3946,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -3911,6 +3983,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -3977,16 +4050,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4011,6 +4085,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -4047,6 +4122,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -4113,16 +4189,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4147,6 +4224,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         data-is-current={true}
@@ -4184,6 +4262,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -4250,16 +4329,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4284,6 +4364,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -4320,6 +4401,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -4386,16 +4468,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4420,6 +4503,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -4456,6 +4540,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -4538,7 +4623,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           color: Highlight;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     id="Rating15"
   >
@@ -4549,10 +4634,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           ms-RatingStar-root--small
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 22px;
+            height: 32px;
           }
       data-focuszone-id="FocusZone17"
       data-is-focusable={false}
@@ -4569,16 +4653,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4621,6 +4706,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         data-is-current={true}
@@ -4658,6 +4744,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -4724,16 +4811,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4776,6 +4864,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -4812,6 +4901,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -4878,16 +4968,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -4930,6 +5021,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -4966,6 +5058,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -5032,16 +5125,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -5084,6 +5178,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -5120,6 +5215,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -5186,16 +5282,17 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -5238,6 +5335,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={false}
@@ -5274,6 +5372,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -18,7 +18,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           font-weight: 400;
         }
         {
-          height: 22px;
+          height: 32px;
         }
     id="Rating0"
   >
@@ -29,10 +29,9 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           ms-RatingStar-root--small
           {
             display: inline-block;
-            padding-bottom: 1px;
           }
           {
-            height: 22px;
+            height: 32px;
           }
       data-focuszone-id="FocusZone2"
       data-is-focusable={true}
@@ -49,16 +48,17 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -83,6 +83,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -119,6 +120,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -185,16 +187,17 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -219,6 +222,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -255,6 +259,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -321,16 +326,17 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -355,6 +361,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -391,6 +398,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -457,16 +465,17 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -491,6 +500,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -527,6 +537,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >
@@ -593,16 +604,17 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             {
               background-color: transparent;
               border: none;
+              box-sizing: content-box;
               cursor: pointer;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
               outline: transparent;
-              padding-bottom: 3px;
-              padding-left: 0px;
-              padding-right: 3px;
-              padding-top: 3px;
+              padding-bottom: 8px;
+              padding-left: 2px;
+              padding-right: 2px;
+              padding-top: 8px;
               position: relative;
             }
             &::-moz-focus-inner {
@@ -627,6 +639,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
             }
             {
               font-size: 16px;
+              height: 16px;
               line-height: 16px;
             }
         disabled={true}
@@ -663,6 +676,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               ms-RatingStar-container
               {
                 display: inline-block;
+                height: inherit;
                 position: relative;
               }
         >


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6835 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Changing the line-height and padding on each star to fix focus outline clipping issue as described in the issue addressed in this PR.

The line height matches to fluent redlines after discussing it with design (@betrue-final-final )

#### Focus areas to test

Would this count as minor or patch???

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6841)

