### PR TITLE
Add unit test coverage for DetailsList optional onRenderMissingItem prop

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-add-dl-render-missing-item-tests_2018-10-24-20-48.json
+++ b/common/changes/office-ui-fabric-react/keco-add-dl-render-missing-item-tests_2018-10-24-20-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add unit tests for DetailsList onRenderMissingItem prop.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -197,13 +197,22 @@ describe('DetailsList', () => {
     jest.runOnlyPendingTimers();
   });
 
-  it('invokes optional onRenderMissingItem once per missing item rendered', () => {
+  it('invokes optional onRenderMissingItem prop once per missing item rendered', () => {
     const onRenderMissingItem = jest.fn();
     const items = [...mockData(5), null, null];
 
     mount(<DetailsList items={items} skipViewportMeasures={true} onRenderMissingItem={onRenderMissingItem} />);
 
     expect(onRenderMissingItem).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not invoke optional onRenderMissingItem prop if no missing items are rendered', () => {
+    const onRenderMissingItem = jest.fn();
+    const items = mockData(5);
+
+    mount(<DetailsList items={items} skipViewportMeasures={true} onRenderMissingItem={onRenderMissingItem} />);
+
+    expect(onRenderMissingItem).toHaveBeenCalledTimes(0);
   });
 
   it('focuses into row element', () => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -197,6 +197,15 @@ describe('DetailsList', () => {
     jest.runOnlyPendingTimers();
   });
 
+  it('invokes optional onRenderMissingItem once per missing item rendered', () => {
+    const onRenderMissingItem = jest.fn();
+    const items = [...mockData(5), null, null];
+
+    mount(<DetailsList items={items} skipViewportMeasures={true} onRenderMissingItem={onRenderMissingItem} />);
+
+    expect(onRenderMissingItem).toHaveBeenCalledTimes(2);
+  });
+
   it('focuses into row element', () => {
     const onRenderColumn = (item: any, index: number, column: IColumn) => {
       let value = item && column && column.fieldName ? item[column.fieldName] : '';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6027
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In #6027, it was reported that `onRenderMissingItem` was not working. The problem seemed to be with the sample code used to test the prop and not with the library itself. However, while debugging the issue I realized we do not have _any_ test coverage for `onRenderMissingItem` ([grep](https://github.com/OfficeDev/office-ui-fabric-react/search?l=TypeScript&q=onRenderMissingItem)). 

This PR adds two unit tests for basic coverage of the optional `onRenderMissingItem` prop.

#### Focus areas to test

1. Unit test logic should make sense
2. PR build should pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6845)

