### PR TITLE
Callout: Add layer props

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-layerProps_2018-10-25-16-55.json
+++ b/common/changes/office-ui-fabric-react/callout-layerProps_2018-10-25-16-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Callout: Added layerProps to interface",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.tsx
@@ -12,7 +12,8 @@ export class Callout extends BaseComponent<ICalloutProps, ICalloutState> {
   }
 
   public render(): JSX.Element {
-    const content = <CalloutContent {...this.props} />;
-    return this.props.doNotLayer ? content : <Layer>{content}</Layer>;
+    const { layerProps, ...rest } = this.props;
+    const content = <CalloutContent {...rest} />;
+    return this.props.doNotLayer ? content : <Layer {...layerProps}>{content}</Layer>;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -2,6 +2,7 @@ import { IStyle, ITheme } from '../../Styling';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { IRefObject, IPoint, IRectangle, IStyleFunctionOrObject } from '../../Utilities';
 import { ICalloutPositionedInfo } from '../../utilities/positioning';
+import { ILayerProps } from '../../Layer';
 
 export interface ICallout {}
 
@@ -132,6 +133,11 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional callback when the layer content has mounted.
    */
   onLayerMounted?: () => void;
+
+  /**
+   * Optional props to pass to the Layer component hosting the panel.
+   */
+  layerProps?: ILayerProps;
 
   /**
    * Optional callback that is called once the callout has been correctly positioned.


### PR DESCRIPTION
Panel and other components built on top of layers provide way to add layer props. Adding this will open up the ability to use hostId and place the callout layer within a given element on the page. This allows the callout to resize with the given parent. 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6850)

