### PR TITLE
Add support for blur to ITextField similar to existing focus

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-textfield-blur_2018-10-25-22-39.json
+++ b/common/changes/office-ui-fabric-react/keco-textfield-blur_2018-10-25-22-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add blur to ITextField and implement to support programmatic blur.\"",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2396,6 +2396,7 @@ interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
   hidden?: boolean;
   hideOverflow?: boolean;
   isBeakVisible?: boolean;
+  layerProps?: ILayerProps;
   minPagePadding?: number;
   onDismiss?: (ev?: any) => void;
   onLayerMounted?: () => void;
@@ -10267,6 +10268,7 @@ interface ITeachingBubbleStyles {
 
 // @public (undocumented)
 interface ITextField {
+  blur: () => void;
   focus: () => void;
   select: () => void;
   selectionEnd: number | null;
@@ -10898,6 +10900,8 @@ export function mapEnumByName<T>(theEnum: any, callback: (name?: string, value?:
 class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextFieldState>, implements ITextField {
   constructor(props: ITextFieldProps);
   protected _skipComponentRefResolution: boolean;
+  // (undocumented)
+  blur(): void;
   // (undocumented)
   componentDidUpdate(): void;
   // (undocumented)
@@ -12136,6 +12140,7 @@ class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProps, ITea
 // @public (undocumented)
 class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldState>, implements ITextField {
   constructor(props: ITextFieldProps);
+  blur(): void;
   // (undocumented)
   componentDidMount(): void;
   // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -168,6 +168,10 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
     this._textField && this._textField.focus();
   }
 
+  public blur(): void {
+    this._textField && this._textField.blur();
+  }
+
   public select(): void {
     this._textField && this._textField.select();
   }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -250,6 +250,15 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
   }
 
   /**
+   * Blurs the text field.
+   */
+  public blur() {
+    if (this._textElement.current) {
+      this._textElement.current.blur();
+    }
+  }
+
+  /**
    * Selects the text field
    */
   public select() {
@@ -408,9 +417,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
   }
 
   private _renderInput(): React.ReactElement<React.HTMLAttributes<HTMLInputElement>> {
-    const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, [
-      'defaultValue'
-    ]);
+    const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
     return (
       <input
@@ -478,9 +485,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     }
 
     this._latestValidateValue = value;
-    const onGetErrorMessage = this.props.onGetErrorMessage as (
-      value: string
-    ) => string | PromiseLike<string> | undefined;
+    const onGetErrorMessage = this.props.onGetErrorMessage as (value: string) => string | PromiseLike<string> | undefined;
     const result = onGetErrorMessage(value || '');
 
     if (result !== undefined) {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -9,7 +9,7 @@ import { createRef, resetIds } from '../../Utilities';
 
 import { TextField } from './TextField';
 import { TextFieldBase } from './TextField.base';
-import { ITextFieldStyles } from './TextField.types';
+import { ITextFieldStyles, ITextField } from './TextField.types';
 
 describe('TextField', () => {
   const textFieldRef = createRef<TextFieldBase>();
@@ -42,9 +42,7 @@ describe('TextField', () => {
   it('renders TextField correctly', () => {
     const className = 'testClassName';
     const inputClassName = 'testInputClassName';
-    const component = renderer.create(
-      <TextField label="Label" className={className} inputClassName={inputClassName} />
-    );
+    const component = renderer.create(<TextField label="Label" className={className} inputClassName={inputClassName} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -63,13 +61,7 @@ describe('TextField', () => {
 
   it('renders multiline TextField correctly with props affecting styling', () => {
     const component = renderer.create(
-      <TextField
-        label="Label"
-        errorMessage={'test message'}
-        underlined={true}
-        prefix={'test prefix'}
-        suffix={'test suffix'}
-      />
+      <TextField label="Label" errorMessage={'test message'} underlined={true} prefix={'test prefix'} suffix={'test suffix'} />
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
@@ -77,13 +69,7 @@ describe('TextField', () => {
 
   it('renders multiline TextField correctly with errorMessage', () => {
     const component = renderer.create(
-      <TextField
-        label="Label"
-        errorMessage={'test message'}
-        underlined={true}
-        prefix={'test prefix'}
-        suffix={'test suffix'}
-      />
+      <TextField label="Label" errorMessage={'test message'} underlined={true} prefix={'test prefix'} suffix={'test suffix'} />
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
@@ -239,9 +225,7 @@ describe('TextField', () => {
         return value.length > 3 ? errorMessage : '';
       }
 
-      const textField = mount(
-        <TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} />
-      );
+      const textField = mount(<TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} />);
 
       const inputDOM = textField.getDOMNode().querySelector('input');
       ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
@@ -255,9 +239,7 @@ describe('TextField', () => {
         return Promise.resolve(value.length > 3 ? errorMessage : '');
       }
 
-      const textField = mount(
-        <TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} />
-      );
+      const textField = mount(<TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} />);
 
       const inputDOM = textField.getDOMNode().querySelector('input');
       ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
@@ -447,9 +429,7 @@ describe('TextField', () => {
         return value.length > 3 ? errorMessage : '';
       };
 
-      const textField = mount(
-        <TextField value="initial value" onGetErrorMessage={validatorSpy} validateOnFocusOut validateOnFocusIn />
-      );
+      const textField = mount(<TextField value="initial value" onGetErrorMessage={validatorSpy} validateOnFocusOut validateOnFocusIn />);
 
       const inputDOM = textField.getDOMNode().querySelector('input') as Element;
       ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before focus'));
@@ -630,5 +610,27 @@ describe('TextField', () => {
     renderIntoDocument(<TextField componentRef={textFieldRef} defaultValue={initialValue} onSelect={onSelect} />);
 
     textFieldRef.current!.setSelectionRange(0, initialValue.length);
+  });
+
+  it('sets focus to the input via ITextField focus', () => {
+    const wrapper = mount(<TextField componentRef={textFieldRef} />);
+    const textField = textFieldRef.current as ITextField;
+    const inputEl = wrapper.find('input').getDOMNode();
+
+    textField.focus();
+
+    expect(inputEl).toBe(document.activeElement);
+  });
+
+  it('blurs the input via ITextField blur', () => {
+    const wrapper = mount(<TextField componentRef={textFieldRef} />);
+    const textField = textFieldRef.current as ITextField;
+    const inputEl = wrapper.find('input').getDOMNode();
+
+    textField.focus();
+    expect(inputEl).toBe(document.activeElement);
+
+    textField.blur();
+    expect(document.activeElement).toBe(document.body);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -9,6 +9,9 @@ export interface ITextField {
   /** Sets focus to the input. */
   focus: () => void;
 
+  /** Blurs the input */
+  blur: () => void;
+
   /** Select the value of the text field. */
   select: () => void;
 
@@ -286,16 +289,8 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 
 export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> &
   Pick<
-  ITextFieldProps,
-  | 'className'
-  | 'disabled'
-  | 'inputClassName'
-  | 'required'
-  | 'multiline'
-  | 'borderless'
-  | 'resizable'
-  | 'underlined'
-  | 'iconClass'
+    ITextFieldProps,
+    'className' | 'disabled' | 'inputClassName' | 'required' | 'multiline' | 'borderless' | 'resizable' | 'underlined' | 'iconClass'
   > & {
     /** Element has an error message. */
     hasErrorMessage?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6713
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In #6713, there is an ask to support programmatic `blur` of `TextField` similar to how we currently support programmatic `focus`. This adds support for that. This issue was left-over from my shield rotation.

#### Focus areas to test

1. Focus the `TextField` input either programmatically or manually
1. Invoke `blur` on `TextField` using a timer or user action which in turn invokes `TextField#blur`.
1. The input should no longer be focused.

Will try to add a unit test later today, had some difficulty casting the `ReactWrapper`.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6856)

