### PR TITLE
Add placeholder mode to MultiStackBardChart data point in order to render the bar chart with a progress gray color(default) area

### DIFF
--- a/common/changes/@uifabric/charting/timto-empty_2018-10-26-21-36.json
+++ b/common/changes/@uifabric/charting/timto-empty_2018-10-26-21-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Add placeholder mode to MultiStackBardChart data point in order to render the bar chart with a progress gray color(default)  area",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "timto@corp.microsoft.com"
+}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -99,7 +99,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     let prevPosition = 0;
     let value = 0;
     const bars = data.chartData!.map((point: IChartDataPoint, index: number) => {
-      const color: string = point.color ? point.color : defaultPalette[Math.floor(Math.random() * 4 + 1)];
+      const color: string = point.color
+        ? point.color
+        : point.placeHolder
+          ? palette.neutralTertiaryAlt
+          : defaultPalette[Math.floor(Math.random() * 4 + 1)];
       const pointData = point.data ? point.data : 0;
       if (index > 0) {
         prevPosition += value;
@@ -119,14 +123,14 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
       return (
         <g
           key={index}
-          className={this._classNames.opacityChangeOnHover}
+          className={point.placeHolder ? this._classNames.placeHolderOnHover : this._classNames.opacityChangeOnHover}
           ref={(e: SVGGElement) => {
             this._refCallback(e, point.legend!);
           }}
-          onMouseOver={this._onBarHover.bind(this, point.legend!, pointData, color)}
-          onMouseMove={this._onBarHover.bind(this, point.legend!, pointData, color)}
-          onMouseLeave={this._onBarLeave}
-          onClick={this._redirectToUrl.bind(this, href)}
+          onMouseOver={point.placeHolder ? undefined : this._onBarHover.bind(this, point.legend!, pointData, color)}
+          onMouseMove={point.placeHolder ? undefined : this._onBarHover.bind(this, point.legend!, pointData, color)}
+          onMouseLeave={point.placeHolder ? undefined : this._onBarLeave}
+          onClick={point.placeHolder ? undefined : this._redirectToUrl.bind(this, href)}
         >
           <rect key={index} x={startingPoint[index] + '%'} y={0} width={value + '%'} height={barHeight} fill={color} />
         </g>
@@ -194,10 +198,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     const defaultPalette: string[] = [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     const actions: ILegend[] = [];
     data.map((singleChartData: IChartProps, index: number) => {
-      if (singleChartData.chartData!.length < 3) {
+      const validChartData = singleChartData.chartData!.filter((_: IChartDataPoint) => !_.placeHolder);
+      if (validChartData!.length < 3) {
         const hideNumber = hideRatio[index] === undefined ? false : hideRatio[index];
         if (hideNumber) {
-          singleChartData.chartData!.map((point: IChartDataPoint) => {
+          validChartData!.map((point: IChartDataPoint) => {
             const color: string = point.color ? point.color : defaultPalette[Math.floor(Math.random() * 4 + 1)];
             const legend: ILegend = {
               title: point.legend!,
@@ -216,7 +221,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           });
         }
       } else {
-        singleChartData.chartData!.map((point: IChartDataPoint) => {
+        validChartData!.map((point: IChartDataPoint) => {
           const color: string = point.color ? point.color : defaultPalette[Math.floor(Math.random() * 4 + 1)];
           const legend: ILegend = {
             title: point.legend!,

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -56,6 +56,10 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
       opacity: shouldHighlight ? '' : '0.1',
       cursor: href ? 'pointer' : 'default'
     },
+    placeHolderOnHover: {
+      opacity: shouldHighlight ? '' : '0.1',
+      cursor: 'default'
+    },
     legendContainer: {
       marginTop: '5px'
     },

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -129,6 +129,11 @@ export interface IMultiStackedBarChartStyles {
   opacityChangeOnHover: IStyle;
 
   /**
+   * Style to change the opacity of placeholder data point when we hover a single bar or legend
+   */
+  placeHolderOnHover: IStyle;
+
+  /**
    * Style for the legends container
    */
   legendContainer: IStyle;

--- a/packages/charting/src/components/StackedBarChart/StackedBarChartPage.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChartPage.tsx
@@ -7,12 +7,14 @@ import { StackedBarChartMultipleExample } from './examples/StackedBarChart.Multi
 import { StackedBarChartDynamicExample } from './examples/StackedBarChart.Dynamic.Example';
 import { MultiStackedBarChartExample } from './examples/MultiStackedBarChart.Example';
 import { StackedBarChartBaseBarExample } from './examples/StackedBarChart.BaseBar.Example';
+import { MultiStackedBarChartWithPlaceholderExample } from './examples/MultiStackedBarChartWithPlaceHolder.Example';
 
 const StackedBarChartBasicExampleCode = require('!raw-loader!@uifabric/charting/src/components/StackedBarChart/examples/StackedBarChart.Basic.Example.tsx') as string;
 const StackedBarChartMultipleExampleCode = require('!raw-loader!@uifabric/charting/src/components/StackedBarChart/examples/StackedBarChart.Multiple.Example.tsx') as string;
 const StackedBarChartDynamicExampleCode = require('!raw-loader!@uifabric/charting/src/components/StackedBarChart/examples/StackedBarChart.Dynamic.Example.tsx') as string;
 const MultiStackedBarChartExampleCode = require('!raw-loader!@uifabric/charting/src/components/StackedBarChart/examples/MultiStackedBarChart.Example.tsx') as string;
 const StackedBarChartBaseBarExampleCode = require('!raw-loader!@uifabric/charting/src/components/StackedBarChart/examples/StackedBarChart.BaseBar.Example.tsx') as string;
+const MultiStackedBarChartWithPlaceholderExampleCode = require('!raw-loader!@uifabric/charting/src/components/StackedBarChart/examples/MultiStackedBarChartWithPlaceHolder.Example.tsx') as string;
 
 export class StackedBarChartPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -36,6 +38,9 @@ export class StackedBarChartPage extends React.Component<IComponentDemoPageProps
             </ExampleCard>
             <ExampleCard title="Multiple StackedBarCharts" code={MultiStackedBarChartExampleCode}>
               <MultiStackedBarChartExample />
+            </ExampleCard>
+            <ExampleCard title="Multiple StackedBarCharts with placeholder" code={MultiStackedBarChartWithPlaceholderExampleCode}>
+              <MultiStackedBarChartWithPlaceholderExample />
             </ExampleCard>
           </div>
         }

--- a/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChartWithPlaceHolder.Example.tsx
+++ b/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChartWithPlaceHolder.Example.tsx
@@ -15,7 +15,7 @@ export const MultiStackedBarChartWithPlaceholderExample: React.SFC<{}> = () => {
     { data: 106, placeHolder: true }
   ];
 
-  const hideRatio: boolean[] = [true, false];
+  const hideRatio: boolean[] = [true, true];
 
   const data: IChartProps[] = [
     {

--- a/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChartWithPlaceHolder.Example.tsx
+++ b/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChartWithPlaceHolder.Example.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { IChartDataPoint, MultiStackedBarChart, IChartProps } from '@uifabric/charting';
+
+export const MultiStackedBarChartWithPlaceholderExample: React.SFC<{}> = () => {
+  const firstChartPoints: IChartDataPoint[] = [
+    { legend: 'Malware', data: 40, color: '#00AE56' },
+    { legend: 'Phishing', data: 23, color: '#662D91' },
+    { legend: 'Spam and bulk', data: 35, color: '#0078D4' },
+    { data: 87, placeHolder: true }
+  ];
+
+  const secondChartPoints: IChartDataPoint[] = [
+    { legend: 'Malicious links', data: 40, color: '#FFAA44' },
+    { legend: 'Malicious attachments', data: 23, color: '#038387' },
+    { data: 106, placeHolder: true }
+  ];
+
+  const hideRatio: boolean[] = [true, false];
+
+  const data: IChartProps[] = [
+    {
+      chartTitle: 'Currently blocked',
+      chartData: firstChartPoints
+    },
+    {
+      chartTitle: 'Increased protection needed against detected threats',
+      chartData: secondChartPoints
+    }
+  ];
+
+  return <MultiStackedBarChart data={data} hideRatio={hideRatio} width={600} href={'https://developer.microsoft.com/en-us/'} />;
+};

--- a/packages/charting/src/types/IDataPoint.ts
+++ b/packages/charting/src/types/IDataPoint.ts
@@ -51,6 +51,11 @@ export interface IChartDataPoint {
    * color for the legend in the chart
    */
   color?: string;
+
+  /**
+   * placeholder data point
+   */
+  placeHolder?: boolean;
 }
 
 export interface ILineChartDataPoint {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Add placeholder mode to MultiStackBardChart data point in order to render the bar chart with a progress gray color(default)  area

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6874)

