### PR TITLE
ContextualMenu: Fix Narrator Separator Announcement

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-6848-hide-separator_2018-10-26-22-48.json
+++ b/common/changes/office-ui-fabric-react/jg-6848-hide-separator_2018-10-26-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Fix separator announcement in Narrator scan mode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -545,6 +545,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
           role="separator"
           key={'separator-' + index + (top === undefined ? '' : top ? '-top' : '-bottom')}
           className={classNames.divider}
+          aria-hidden="true"
         />
       );
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6848, #6360
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add `aria-hidden` attribute to separator to prevent announcement in Narrator's scan mode.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6876)

