### PR TITLE
ComboBox/Autofill: Prevent text from being selected when focus is not on the input box in IE11

### DIFF
--- a/common/changes/office-ui-fabric-react/chiechan-comboboxFixIE11_2018-10-29-06-57.json
+++ b/common/changes/office-ui-fabric-react/chiechan-comboboxFixIE11_2018-10-29-06-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox/Autofill: prevent text from being selected when focus is not on the input box",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1829,8 +1829,8 @@ interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputElement | Au
   enableAutofillOnKeyPress?: KeyCodes[];
   onInputChange?: (value: string) => string;
   onInputValueChange?: (newValue?: string) => void;
+  preventValueSelection?: boolean;
   shouldSelectFullInputValueInComponentDidUpdate?: () => boolean;
-  shouldSelectValueInComponentDidUpdate?: () => boolean;
   suggestedDisplayValue?: string;
   updateValueInWillReceiveProps?: () => string | null;
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1830,6 +1830,7 @@ interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputElement | Au
   onInputChange?: (value: string) => string;
   onInputValueChange?: (newValue?: string) => void;
   shouldSelectFullInputValueInComponentDidUpdate?: () => boolean;
+  shouldSelectValueInComponentDidUpdate?: () => boolean;
   suggestedDisplayValue?: string;
   updateValueInWillReceiveProps?: () => string | null;
 }

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -75,12 +75,10 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
 
   public componentDidUpdate() {
     const value = this._value;
-    const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, shouldSelectValueInComponentDidUpdate } = this.props;
+    const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, preventValueSelection } = this.props;
     let differenceIndex = 0;
 
-    // We need to explicitly not select the text in the autofill if we are no longer focused. In IE11, selecting
-    // a input will also focus the input, causing other element's focus to be stolen.
-    if (shouldSelectValueInComponentDidUpdate && !shouldSelectValueInComponentDidUpdate()) {
+    if (preventValueSelection) {
       return;
     }
 

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -80,7 +80,7 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
 
     // We need to explicitly not select the text in the autofill if we are no longer focused. In IE11, selecting
     // a input will also focus the input, causing other element's focus to be stolen.
-    if (shouldSelectValueInComponentDidUpdate !== undefined && !shouldSelectValueInComponentDidUpdate()) {
+    if (shouldSelectValueInComponentDidUpdate && !shouldSelectValueInComponentDidUpdate()) {
       return;
     }
 

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -78,6 +78,8 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, shouldSelectValueInComponentDidUpdate } = this.props;
     let differenceIndex = 0;
 
+    // We need to explicitly not select the text in the autofill if we are no longer focused. In IE11, selecting
+    // a input will also focus the input, causing other element's focus to be stolen.
     if (shouldSelectValueInComponentDidUpdate !== undefined && !shouldSelectValueInComponentDidUpdate()) {
       return;
     }

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -75,8 +75,12 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
 
   public componentDidUpdate() {
     const value = this._value;
-    const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate } = this.props;
+    const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, shouldSelectValueInComponentDidUpdate } = this.props;
     let differenceIndex = 0;
+
+    if (shouldSelectValueInComponentDidUpdate !== undefined && !shouldSelectValueInComponentDidUpdate()) {
+      return;
+    }
 
     if (this._autoFillEnabled && value && suggestedDisplayValue && this._doesTextStartWith(suggestedDisplayValue, value)) {
       let shouldSelectFullRange = false;
@@ -292,4 +296,4 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
 /**
  *  @deprecated do not use.
  */
-export class BaseAutoFill extends Autofill {}
+export class BaseAutoFill extends Autofill { }

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
@@ -84,6 +84,14 @@ export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputEleme
   updateValueInWillReceiveProps?: () => string | null;
 
   /**
+   * componentDidUpdate handler for selecting auto fill range
+   *
+   * @return { boolean } - should the value of the input be selected?
+   * True if we're focused on our input, false otherwise.
+   */
+  shouldSelectValueInComponentDidUpdate?: () => boolean;
+
+  /**
    * Handler for checking if the full value of the input should
    * be seleced in componentDidUpdate
    *
@@ -101,10 +109,10 @@ export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputEleme
  * Deprecated, do not use.
  * @deprecated do not use, will be removed in 6.0
  */
-export interface IBaseAutoFill extends IAutofill {}
+export interface IBaseAutoFill extends IAutofill { }
 
 /**
  * Deprecated, do not use.
  * @deprecated do not use, will be removed in 6.0
  */
-export interface IBaseAutoFillProps extends IAutofillProps {}
+export interface IBaseAutoFillProps extends IAutofillProps { }

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
@@ -86,7 +86,7 @@ export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputEleme
   /**
    * componentDidUpdate handler for selecting auto fill range
    *
-   * @return { boolean } - should the value of the input be selected?
+   * @returns - should the value of the input be selected?
    * True if we're focused on our input, false otherwise.
    */
   shouldSelectValueInComponentDidUpdate?: () => boolean;

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
@@ -84,14 +84,6 @@ export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputEleme
   updateValueInWillReceiveProps?: () => string | null;
 
   /**
-   * componentDidUpdate handler for selecting auto fill range
-   *
-   * @returns - should the value of the input be selected?
-   * True if we're focused on our input, false otherwise.
-   */
-  shouldSelectValueInComponentDidUpdate?: () => boolean;
-
-  /**
    * Handler for checking if the full value of the input should
    * be seleced in componentDidUpdate
    *
@@ -103,6 +95,13 @@ export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputEleme
    * A callback used to modify the input string.
    */
   onInputChange?: (value: string) => string;
+
+  /**
+   * Should the value of the input be selected? True if we're focused on our input, false otherwise.
+   * We need to explicitly not select the text in the autofill if we are no longer focused.
+   * In IE11, selecting a input will also focus the input, causing other element's focus to be stolen.
+   */
+  preventValueSelection?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -327,15 +327,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._classNames = this.props.getClassNames
       ? this.props.getClassNames(theme!, !!isOpen, !!disabled, !!required, !!focused, !!allowFreeform, !!hasErrorMessage, className)
       : getClassNames(
-          getStyles(theme!, customStyles),
-          className!,
-          !!isOpen,
-          !!disabled,
-          !!required,
-          !!focused,
-          !!allowFreeform,
-          !!hasErrorMessage
-        );
+        getStyles(theme!, customStyles),
+        className!,
+        !!isOpen,
+        !!disabled,
+        !!required,
+        !!focused,
+        !!allowFreeform,
+        !!hasErrorMessage
+      );
 
     return (
       <div {...divProps} ref={this._root} className={this._classNames.container}>
@@ -380,6 +380,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 defaultVisibleValue={this._currentVisibleValue}
                 suggestedDisplayValue={suggestedDisplayValue}
                 updateValueInWillReceiveProps={this._onUpdateValueInAutofillWillReceiveProps}
+                shouldSelectValueInComponentDidUpdate={this._shouldSelectValueInComponentDidUpdate}
                 shouldSelectFullInputValueInComponentDidUpdate={this._onShouldSelectFullInputValueInAutofillComponentDidUpdate}
                 title={title}
               />
@@ -480,6 +481,16 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    */
   private _onShouldSelectFullInputValueInAutofillComponentDidUpdate = (): boolean => {
     return this._currentVisibleValue === this.state.suggestedDisplayValue;
+  };
+
+  /**
+   * componentDidUpdate handler for selecting auto fill range
+   *
+   * @return { boolean } - should the value of the input be selected?
+   * True if we're focused on our input, false otherwise.
+   */
+  private _shouldSelectValueInComponentDidUpdate = (): boolean => {
+    return !!this.state.focused;
   };
 
   /**
@@ -1002,7 +1013,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             (this._autofill.current &&
               this._autofill.current.isValueSelected &&
               currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-                pendingOptionText.length)) ||
+              pendingOptionText.length)) ||
             (this._autofill.current &&
               this._autofill.current.inputElement &&
               this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
@@ -1187,24 +1198,24 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         </CommandButton>
       ) : (
-        <Checkbox
-          id={id + '-list' + item.index}
-          ariaLabel={this._getPreviewText(item)}
-          key={item.key}
-          data-index={item.index}
-          styles={checkboxStyles}
-          className={'ms-ComboBox-option'}
-          data-is-focusable={true}
-          onChange={this._onItemClick(item.index!)}
-          label={item.text}
-          role="option"
-          aria-selected={isSelected ? 'true' : 'false'}
-          checked={isSelected}
-          title={title}
-        >
-          {onRenderOption(item, this._onRenderOptionContent)}
-        </Checkbox>
-      );
+          <Checkbox
+            id={id + '-list' + item.index}
+            ariaLabel={this._getPreviewText(item)}
+            key={item.key}
+            data-index={item.index}
+            styles={checkboxStyles}
+            className={'ms-ComboBox-option'}
+            data-is-focusable={true}
+            onChange={this._onItemClick(item.index!)}
+            label={item.text}
+            role="option"
+            aria-selected={isSelected ? 'true' : 'false'}
+            checked={isSelected}
+            title={title}
+          >
+            {onRenderOption(item, this._onRenderOptionContent)}
+          </Checkbox>
+        );
     };
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -327,15 +327,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._classNames = this.props.getClassNames
       ? this.props.getClassNames(theme!, !!isOpen, !!disabled, !!required, !!focused, !!allowFreeform, !!hasErrorMessage, className)
       : getClassNames(
-        getStyles(theme!, customStyles),
-        className!,
-        !!isOpen,
-        !!disabled,
-        !!required,
-        !!focused,
-        !!allowFreeform,
-        !!hasErrorMessage
-      );
+          getStyles(theme!, customStyles),
+          className!,
+          !!isOpen,
+          !!disabled,
+          !!required,
+          !!focused,
+          !!allowFreeform,
+          !!hasErrorMessage
+        );
 
     return (
       <div {...divProps} ref={this._root} className={this._classNames.container}>
@@ -1198,24 +1198,24 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         </CommandButton>
       ) : (
-          <Checkbox
-            id={id + '-list' + item.index}
-            ariaLabel={this._getPreviewText(item)}
-            key={item.key}
-            data-index={item.index}
-            styles={checkboxStyles}
-            className={'ms-ComboBox-option'}
-            data-is-focusable={true}
-            onChange={this._onItemClick(item.index!)}
-            label={item.text}
-            role="option"
-            aria-selected={isSelected ? 'true' : 'false'}
-            checked={isSelected}
-            title={title}
-          >
-            {onRenderOption(item, this._onRenderOptionContent)}
-          </Checkbox>
-        );
+        <Checkbox
+          id={id + '-list' + item.index}
+          ariaLabel={this._getPreviewText(item)}
+          key={item.key}
+          data-index={item.index}
+          styles={checkboxStyles}
+          className={'ms-ComboBox-option'}
+          data-is-focusable={true}
+          onChange={this._onItemClick(item.index!)}
+          label={item.text}
+          role="option"
+          aria-selected={isSelected ? 'true' : 'false'}
+          checked={isSelected}
+          title={title}
+        >
+          {onRenderOption(item, this._onRenderOptionContent)}
+        </Checkbox>
+      );
     };
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -380,9 +380,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 defaultVisibleValue={this._currentVisibleValue}
                 suggestedDisplayValue={suggestedDisplayValue}
                 updateValueInWillReceiveProps={this._onUpdateValueInAutofillWillReceiveProps}
-                shouldSelectValueInComponentDidUpdate={this._shouldSelectValueInComponentDidUpdate}
                 shouldSelectFullInputValueInComponentDidUpdate={this._onShouldSelectFullInputValueInAutofillComponentDidUpdate}
                 title={title}
+                preventValueSelection={!focused}
               />
               <IconButton
                 className={'ms-ComboBox-CaretDown-button'}
@@ -481,16 +481,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    */
   private _onShouldSelectFullInputValueInAutofillComponentDidUpdate = (): boolean => {
     return this._currentVisibleValue === this.state.suggestedDisplayValue;
-  };
-
-  /**
-   * componentDidUpdate handler for selecting auto fill range
-   *
-   * @return { boolean } - should the value of the input be selected?
-   * True if we're focused on our input, false otherwise.
-   */
-  private _shouldSelectValueInComponentDidUpdate = (): boolean => {
-    return !!this.state.focused;
   };
 
   /**

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -327,15 +327,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._classNames = this.props.getClassNames
       ? this.props.getClassNames(theme!, !!isOpen, !!disabled, !!required, !!focused, !!allowFreeform, !!hasErrorMessage, className)
       : getClassNames(
-        getStyles(theme!, customStyles),
-        className!,
-        !!isOpen,
-        !!disabled,
-        !!required,
-        !!focused,
-        !!allowFreeform,
-        !!hasErrorMessage
-      );
+          getStyles(theme!, customStyles),
+          className!,
+          !!isOpen,
+          !!disabled,
+          !!required,
+          !!focused,
+          !!allowFreeform,
+          !!hasErrorMessage
+        );
 
     return (
       <div {...divProps} ref={this._root} className={this._classNames.container}>
@@ -380,7 +380,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 defaultVisibleValue={this._currentVisibleValue}
                 suggestedDisplayValue={suggestedDisplayValue}
                 updateValueInWillReceiveProps={this._onUpdateValueInAutofillWillReceiveProps}
-                shouldSelectValueInComponentDidUpdate={this._shouldSelectValueInComponentDidUpdate}
                 shouldSelectFullInputValueInComponentDidUpdate={this._onShouldSelectFullInputValueInAutofillComponentDidUpdate}
                 title={title}
               />
@@ -481,16 +480,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    */
   private _onShouldSelectFullInputValueInAutofillComponentDidUpdate = (): boolean => {
     return this._currentVisibleValue === this.state.suggestedDisplayValue;
-  };
-
-  /**
-   * componentDidUpdate handler for selecting auto fill range
-   *
-   * @return { boolean } - should the value of the input be selected?
-   * True if we're focused on our input, false otherwise.
-   */
-  private _shouldSelectValueInComponentDidUpdate = (): boolean => {
-    return !!this.state.focused;
   };
 
   /**
@@ -1013,7 +1002,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             (this._autofill.current &&
               this._autofill.current.isValueSelected &&
               currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-              pendingOptionText.length)) ||
+                pendingOptionText.length)) ||
             (this._autofill.current &&
               this._autofill.current.inputElement &&
               this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
@@ -1198,24 +1187,24 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         </CommandButton>
       ) : (
-          <Checkbox
-            id={id + '-list' + item.index}
-            ariaLabel={this._getPreviewText(item)}
-            key={item.key}
-            data-index={item.index}
-            styles={checkboxStyles}
-            className={'ms-ComboBox-option'}
-            data-is-focusable={true}
-            onChange={this._onItemClick(item.index!)}
-            label={item.text}
-            role="option"
-            aria-selected={isSelected ? 'true' : 'false'}
-            checked={isSelected}
-            title={title}
-          >
-            {onRenderOption(item, this._onRenderOptionContent)}
-          </Checkbox>
-        );
+        <Checkbox
+          id={id + '-list' + item.index}
+          ariaLabel={this._getPreviewText(item)}
+          key={item.key}
+          data-index={item.index}
+          styles={checkboxStyles}
+          className={'ms-ComboBox-option'}
+          data-is-focusable={true}
+          onChange={this._onItemClick(item.index!)}
+          label={item.text}
+          role="option"
+          aria-selected={isSelected ? 'true' : 'false'}
+          checked={isSelected}
+          title={title}
+        >
+          {onRenderOption(item, this._onRenderOptionContent)}
+        </Checkbox>
+      );
     };
 
     return (


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

In IE11, there is a specific problem with ComboBoxes that cause them to steal focus from everything.

The specific case is when you open a combo box and then dismiss the menu by clicking outside of the ComboBox. When we do that, in componentDidUpdate inside Autofill will make the text inside the input box to be selected.

This is fine in most browser, except for IE11 and earlier versions of Edge. In IE11, when you select a range of text in an input, it'll cause the input to be focused, resulting in a ComboBox that will steal focus from everything.

This problem can be seen in the ComboBox demo page in office ui fabric and in this [codepen](https://codepen.io/JoshChang47/pen/oaVRrW)

The debug mode for [IE11](https://s.codepen.io/JoshChang47/debug/oaVRrW/PNrvYGmKgXVM) (look in the console for the logs)

The fix to this problem is that we shouldn't select the text if the ComboBox is being dismissed and we are no longer focusing on it

#### Focus areas to test

With my change, focus in the ComboBox will no longer get stolen when you open a ComboBox and is more like the behavior in what we see in other Browsers like Chrome.

I also validated that all other behaviors remain consistent with previous behaviors:
* typing in a value
* selecting a value from a list
* using auto suggest for a value
* selecting a value with enter/tab
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6879)

Current Problem:
![combobox stall broken](https://user-images.githubusercontent.com/5695630/47680153-4a62fc80-db83-11e8-8983-1a2135c41741.gif)

Fixed Solution:
![combobox stall fix](https://user-images.githubusercontent.com/5695630/47680171-53ec6480-db83-11e8-9849-93c8a4c8202f.gif)
