### PR TITLE
Carry over website pipeline improvements to homepage.htm

### DIFF
--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -79,7 +79,7 @@
 
   function getParameterByName(name, url) {
     if (!url) {
-      url = window.location.href;
+      url = window.location.search;
     }
     name = name.replace(/[\[\]]/g, "\\$&");
     var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -26,7 +26,6 @@
 
 <script type="text/javascript">
   var noCompress = getParameterByName('noCompress');
-  var devhost = getParameterByName('devhost');
   var entryPointFilename = 'fabric-sitev5';
   var appPath = '';
   var configPrefix = 'fabric-website-df';

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -32,8 +32,6 @@
   var configPrefix = 'fabric-website-df';
   var Flight = {};
 
-  // This is the production hostname.
-  // Visit https://developer.microsof-tst.com/fabric for the staging version of the site.
   if (location.hostname === 'developer.microsoft.com') {
     configPrefix = 'fabric-website-prod';
   }

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -32,6 +32,8 @@
   var configPrefix = 'fabric-website-df';
   var Flight = {};
 
+  // This is the production hostname.
+  // Visit https://developer.microsof-tst.com/fabric for the staging version of the site.
   if (location.hostname === 'developer.microsoft.com') {
     configPrefix = 'fabric-website-prod';
   }

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -1,3 +1,5 @@
+<div id="metadata" title="Home - Office UI Fabric" description="The official front-end framework for building experiences that fit seamlessly into Office and Office 365."
+  style="visibility:hidden"></div>
 <style>
   body,
   html {
@@ -17,52 +19,63 @@
 
 <div id="main">
   <div class="loading">
-    <img class="loadingImage" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/loading.gif" alt="Loading"
-      width="32" height="32" />
+    <img class="loadingImage" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/spinner.gif"
+      alt="Loading" width="32" height="32" />
   </div>
 </div>
 
 <script type="text/javascript">
-  var isProduction = false;
-  var isDogfood = false;
-  var now = Date.now();
-  var today = new Date();
-  var todaysDate = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
+  var noCompress = getParameterByName('noCompress');
+  var devhost = getParameterByName('devhost');
   var entryPointFilename = 'fabric-sitev5';
-  var baseProductionUrl = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
-  var baseDogfoodUrl = 'https://static2df.sharepointonline.com/files/fabric/fabric-website/dist/';
+  var appPath = '';
+  var configPrefix = 'fabric-website-df';
+  var Flight = {};
 
-  // Query params
-  var devUrlParam = getParameterByName('devUrl');
-  var dogfoodParam = getParameterByName('isDogfood');
-  var productionParam = getParameterByName('isProduction');
-
-  if (location.hostname == 'developer.microsoft.com' || productionParam) {
-    isProduction = true;
-  } else if (location.hostname.indexOf('devx') > -1 || dogfoodParam) {
-    isDogfood = true;
-    entryPointFilename = 'fabric-sitev5-df';
+  if (location.hostname === 'developer.microsoft.com') {
+    configPrefix = 'fabric-website-prod';
   }
 
-  var scripts = [];
+  var configScript = ['https://fabricweb.azureedge.net/fabric-website/manifests/' + configPrefix + '.js'];
 
-  if (devUrlParam) {
-    scripts.push(devUrlParam);
-  } else if (isDogfood) {
-    scripts.push(baseDogfoodUrl + entryPointFilename + '.js?date=' + now);
-  } else {
-    scripts.push(baseProductionUrl + entryPointFilename + '.min.js?date=' + todaysDate);
-  }
+  loadScripts(configScript, function () {
+    if (window.Flight) {
+      appPath += window.Flight.baseCDNUrl;
 
-  loadScript(scripts);
-
-  function loadScript(n) {
-    for (var i = 0; i < n.length; i++) {
-      var s = document.createElement('script');
-      s.src = n[i];
-      s.async = false;
-      document.body.appendChild(s);
+      loadAppScripts(appPath);
     }
+  });
+
+  // Simple synchronous script loader with callback. Adapted from https://stackoverflow.com/questions/1866717
+  function loadScripts(array, callback) {
+    var loader = function (src, handler) {
+      var script = document.createElement('script');
+      script.src = src;
+      script.onload = script.onreadystatechange = function () {
+        script.onreadystatechange = script.onload = null;
+        handler();
+      }
+      var head = document.getElementsByTagName('head')[0];
+      (head || document.body).appendChild(script);
+    };
+    (function run() {
+      if (array.length != 0) {
+        loader(array.shift(), run);
+      } else {
+        callback && callback();
+      }
+    })();
+  }
+
+  function loadAppScripts(appPath) {
+    if (noCompress) {
+      appPath += entryPointFilename + '.js';
+    } else {
+      appPath += entryPointFilename + '.min.js';
+    }
+
+    var scripts = [appPath];
+    loadScripts(scripts);
   }
 
   function getParameterByName(name, url) {
@@ -76,5 +89,4 @@
     if (!results[2]) return '';
     return decodeURIComponent(results[2].replace(/\+/g, " "));
   }
-
 </script>

--- a/common/changes/@uifabric/fabric-website/jahnp-fabric-homepage-updates_2018-10-29-20-36.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-fabric-homepage-updates_2018-10-29-20-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Carry over website pipeline improvements to prod-deployed index",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "pejahn@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Followup to #6683. The changes to `index.html` in that PR affected the following environments:
- Localhost `npm start`
- https://uifabric-tst.azurewebsites.net (non-UHF staging preview)
- https://uifabric-prod.azurewebsites.net (non-UHF production preview)

However, due to infrastructure limitations, the production environment behind https://developer.microsoft.com/fabric uses a pared-down version of the index, which is captured in `packages\apps\fabric-website\homepage.htm`. This PR carries those pipeline improvements over to that file, and distinguishes between production and dogfood manifests. I forgot to make retain these changes here when I did #6683.

When these changes are deployed, the result will be the ability to preview website changes against a UHF environment at https://developer.microsoft-tst.com/fabric.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6881)

