### PR TITLE
Breadcrumb examples aria labels

### DIFF
--- a/common/changes/office-ui-fabric-react/breadcrumbA11y_2018-10-29-22-40.json
+++ b/common/changes/office-ui-fabric-react/breadcrumbA11y_2018-10-29-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Breadcrumb Example: distinct aria labels",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/breadcrumbA11y_2018-10-29-22-40.json
+++ b/common/changes/office-ui-fabric-react/breadcrumbA11y_2018-10-29-22-40.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Breadcrumb Example: distinct aria labels",
-      "type": "patch"
+      "type": "none"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -23,7 +23,7 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
             { text: 'This is folder 4', key: 'f4', onClick: this._onBreadcrumbItemClicked },
             { text: 'This is folder 5', key: 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true }
           ]}
-          ariaLabel={'Website breadcrumb'}
+          ariaLabel={'Breadcrumb with no maxDisplayedItems'}
         />
 
         <Label className={exampleStyles.exampleLabel} style={{ marginTop: '24px' }}>
@@ -39,7 +39,7 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
             { text: 'This is folder 5', key: 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true }
           ]}
           dividerAs={this._getCustomDivider}
-          ariaLabel={'Website breadcrumb'}
+          ariaLabel={'Breadcrumb with custom divider icon'}
         />
 
         <Label className={exampleStyles.exampleLabel} style={{ marginTop: '24px' }}>
@@ -81,7 +81,7 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
             }
           ]}
           maxDisplayedItems={3}
-          ariaLabel={'Website breadcrumb'}
+          ariaLabel={'Breadcrumb with maxDisplayedItems set to three'}
           overflowAriaLabel={'More links'}
         />
 
@@ -98,6 +98,7 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
           maxDisplayedItems={2}
           overflowIndex={1}
           overflowAriaLabel={'More items'}
+          ariaLabel={'Breadcrumb with maxDisplayedItems set to two and overflowIndex set to 1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx
@@ -18,7 +18,7 @@ export class BreadcrumbStaticExample extends React.Component {
           // Returning undefined to OnReduceData tells the breadcrumb not to shrink
           onReduceData={this._returnUndefined}
           maxDisplayedItems={3}
-          ariaLabel={'Website breadcrumb'}
+          ariaLabel={'Breadcrumb with static width'}
           overflowAriaLabel={'More items'}
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -47,7 +47,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Website breadcrumb"
+          aria-label="Breadcrumb with no maxDisplayedItems"
           className=
               ms-Breadcrumb
               {
@@ -1087,7 +1087,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Website breadcrumb"
+          aria-label="Breadcrumb with custom divider icon"
           className=
               ms-Breadcrumb
               {
@@ -2082,7 +2082,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Website breadcrumb"
+          aria-label="Breadcrumb with maxDisplayedItems set to three"
           className=
               ms-Breadcrumb
               {
@@ -2756,6 +2756,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
+          aria-label="Breadcrumb with maxDisplayedItems set to two and overflowIndex set to 1"
           className=
               ms-Breadcrumb
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -26,7 +26,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
         }
       >
         <div
-          aria-label="Website breadcrumb"
+          aria-label="Breadcrumb with static width"
           className=
               ms-Breadcrumb
               {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #6468 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Give each breadcrumb on the example page a unique aria label. This fixes bug 2 on the issue linked above.

#### Focus areas to test

Open the Breadcrumb example page, inspect the DOM, and verify that the aria labels are all distinct.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6885)

