### PR TITLE
Slider: fix rounded value calculation

### DIFF
--- a/apps/vr-tests/src/stories/Slider.stories.tsx
+++ b/apps/vr-tests/src/stories/Slider.stories.tsx
@@ -66,4 +66,26 @@ storiesOf('Slider', module)
         showValue={true}
       />
     </div>
+  )).addStory('Max not multiple of step', () => (
+    <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
+      <Slider
+        label='Basic example:'
+        min={18}
+        max={48}
+        step={10}
+        defaultValue={48}
+        showValue={true}
+      />
+    </div>
+  )).addStory('Step less than 1', () => (
+    <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
+      <Slider
+        label='Basic example:'
+        min={1}
+        max={3}
+        step={0.1}
+        defaultValue={1.4}
+        showValue={true}
+      />
+    </div>
   ));

--- a/common/changes/office-ui-fabric-react/sliderStepCalculation_2018-10-30-00-57.json
+++ b/common/changes/office-ui-fabric-react/sliderStepCalculation_2018-10-30-00-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Slider: fix value calculations",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -215,10 +215,15 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     return currentPosition;
   }
   private _updateValue(value: number, renderedValue: number): void {
-    const interval: number = 1.0 / this.props.step!;
-    // Make sure value has correct number of decimal places based on steps without JS's floating point issues
-    const roundedValue: number = Math.round((value * interval) / interval);
+    const { step } = this.props;
 
+    let numDec = 0;
+    if (Math.floor(step!) !== step!) {
+      numDec = step!.toString().split('.')[1].length;
+    }
+
+    // Make sure value has correct number of decimal places based on steps without JS's floating point issues
+    const roundedValue = Math.round(value * Math.pow(10, numDec)) / Math.pow(10, numDec);
     const valueChanged = roundedValue !== this.state.value;
 
     this.setState(

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -217,7 +217,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
   private _updateValue(value: number, renderedValue: number): void {
     const interval: number = 1.0 / this.props.step!;
     // Make sure value has correct number of decimal places based on steps without JS's floating point issues
-    const roundedValue: number = Math.round(value * interval) / interval;
+    const roundedValue: number = Math.round((value * interval) / interval);
 
     const valueChanged = roundedValue !== this.state.value;
 

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -224,7 +224,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
       }
     }
 
-    // Make sure value has correct number of decimal places based on steps without JS's floating point issues
+    // Make sure value has correct number of decimal places based on number of decimals in step
     const roundedValue = Number.parseFloat(value.toFixed(numDec));
     const valueChanged = roundedValue !== this.state.value;
 

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -218,12 +218,14 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     const { step } = this.props;
 
     let numDec = 0;
-    if (Math.floor(step!) !== step!) {
-      numDec = step!.toString().split('.')[1].length;
+    if (isFinite(step!)) {
+      while (Math.round(step! * Math.pow(10, numDec)) / Math.pow(10, numDec) !== step!) {
+        numDec++;
+      }
     }
 
     // Make sure value has correct number of decimal places based on steps without JS's floating point issues
-    const roundedValue = Math.round(value * Math.pow(10, numDec)) / Math.pow(10, numDec);
+    const roundedValue = Number.parseFloat(value.toFixed(numDec));
     const valueChanged = roundedValue !== this.state.value;
 
     this.setState(


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6877 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The rounded value calculation should round based on the number of decimals the step value has, not based on the step. 

Before (min = 18, max = 48, step = 10)

![sliderweirdroundedcalc3](https://user-images.githubusercontent.com/14134000/47689051-5eb7f100-dba5-11e8-8bcc-5c696a677687.gif)

After (min = 18, max = 48, step = 10)

![sliderweirdroundedcalc2](https://user-images.githubusercontent.com/14134000/47689053-5fe91e00-dba5-11e8-8167-1ee3548acf37.gif)

Note: A Slider with a fractional step still works as expected, which was the original motivation to include this rounding calculation (#3114).
![sliderwithfractionalstep](https://user-images.githubusercontent.com/14134000/47738357-36290900-dc30-11e8-8713-4c4eb087b5fc.gif)

#### Focus areas to test

I added two visual regression tests for both a Slider with a fractional step and a Slider with a min and max that are not multiples of the step. Confirm that these stories look correct.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6895)

