### PR TITLE
Dropdown: remove aria-activedescendant when disabled

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdownDisabled_2018-10-30-22-43.json
+++ b/common/changes/office-ui-fabric-react/dropdownDisabled_2018-10-30-22-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: change aria attributes on listbox when disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -181,8 +181,11 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
       : // single select
         {
           role: 'listbox',
-          ariaActiveDescendant:
-            isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0 ? this._id + '-list' + selectedIndices[0] : optionId,
+          ariaActiveDescendant: disabled
+            ? undefined
+            : isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0
+              ? this._id + '-list' + selectedIndices[0]
+              : optionId,
           childRole: 'option',
           ariaSetSize: this._sizePosCache.optionSetSize,
           ariaPosInSet: this._sizePosCache.positionInSet(selectedIndices[0]),

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -169,28 +169,26 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
     const disabled = this._isDisabled();
 
     const optionId = id + '-option';
-    const ariaAttrs = multiSelect
-      ? {
-          role: undefined,
-          ariaActiveDescendant: undefined,
-          childRole: undefined,
-          ariaSetSize: undefined,
-          ariaPosInSet: undefined,
-          ariaSelected: undefined
-        }
-      : // single select
-        {
-          role: 'listbox',
-          ariaActiveDescendant: disabled
-            ? undefined
-            : isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0
-              ? this._id + '-list' + selectedIndices[0]
-              : optionId,
-          childRole: 'option',
-          ariaSetSize: this._sizePosCache.optionSetSize,
-          ariaPosInSet: this._sizePosCache.positionInSet(selectedIndices[0]),
-          ariaSelected: selectedIndices[0] === undefined ? undefined : true
-        };
+    const ariaAttrs =
+      multiSelect || disabled
+        ? {
+            role: undefined,
+            ariaActiveDescendant: undefined,
+            childRole: undefined,
+            ariaSetSize: undefined,
+            ariaPosInSet: undefined,
+            ariaSelected: undefined
+          }
+        : // single select
+          {
+            role: 'listbox',
+            ariaActiveDescendant:
+              isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0 ? this._id + '-list' + selectedIndices[0] : optionId,
+            childRole: 'option',
+            ariaSetSize: this._sizePosCache.optionSetSize,
+            ariaPosInSet: this._sizePosCache.positionInSet(selectedIndices[0]),
+            ariaSelected: selectedIndices[0] === undefined ? undefined : true
+          };
 
     this._classNames = getClassNames(propStyles, {
       theme,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -375,7 +375,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       Disabled uncontrolled example with defaultSelectedKey:
     </label>
     <div
-      aria-activedescendant="Dropdown3-option"
       aria-describedby="Dropdown3-option"
       aria-disabled={true}
       aria-expanded="false"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -460,16 +460,12 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      role="listbox"
       tabIndex={-1}
     >
       <span
         aria-atomic={true}
         aria-label="Option d"
         aria-live="off"
-        aria-posinset={4}
-        aria-selected={true}
-        aria-setsize={7}
         className=
             ms-Dropdown-title
             {
@@ -503,7 +499,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               color: GrayText;
             }
         id="Dropdown3-option"
-        role="option"
       >
         <span>
           Option d


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6605 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Currently, Narrator is not reading out `disabled` for all disabled dropdowns. I noticed that it's working properly for multi-select dropdowns, and I found that (I think) it's because we set `aria-activedescendant` to `undefined` for all multi-select dropdowns. 

https://github.com/OfficeDev/office-ui-fabric-react/blob/fc5a1f4620c93499a41abe8377ff61161cf5bd76/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx#L172-L180

For single select dropdowns, even those that are disabled, we still set an `aria-activedescendant`. By setting this to undefined when the dropdown is disabled, you can see that Narrator now reads out "disabled" on focus. My reasoning is that it doesn't really make sense to have an `aria-activedescendant` if the dropdown is disabled, because that attribute is "used [...] to inform the assistive technology about the active child which has focus" [[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-activedescendant_attribute)]. However, you aren't really focusing on the child when you focus on the disabled dropdown. 

#### Some more justification
In [Microsoft's documentation](https://docs.microsoft.com/en-us/windows/desktop/winauto/aria-container--no-active-descendants--keyboard-events), it mentions that the ARIA Container Role (without active descendant) Keyboard Accessibility Error does not apply to containers that are disabled.

> This error applies to elements that have a container role, do not have an aria-activedescendant attribute, and are not disabled.

For reference, here's the [W3C spec on aria-activedescendant](https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-activedescendant).

#### Before:

![image](https://user-images.githubusercontent.com/14134000/47755560-fc6df780-dc5b-11e8-9d07-1cd04211853e.png)

#### After:

![image](https://user-images.githubusercontent.com/14134000/47755680-5b337100-dc5c-11e8-9202-ad459405fb6b.png)

Note: One thing I'd like to bring up for discussion is whether we'd like to keep all the other information stored in the aria attributes about the selected key, such as the `aria-setsize` read out by Narrator. It seems okay as is, but just wanted to double check with you all.

#### Focus areas to test

Navigate to the Dropdown demo page and turn on Narrator. Focus on the single-select, disabled dropdown (you can click on it) and ensure that Narrator says "disabled".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6906)

