### PR TITLE
Fix Styling API Warning

### DIFF
--- a/common/changes/@uifabric/styling/jg-missed-api-commit_2018-10-31-04-05.json
+++ b/common/changes/@uifabric/styling/jg-missed-api-commit_2018-10-31-04-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Update missed API change from PR #6854.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/styling/etc/styling.api.ts
+++ b/packages/styling/etc/styling.api.ts
@@ -98,7 +98,8 @@ export function getScreenSelector(min: number, max: number): string;
 // @public
 export function getTheme(depComments?: boolean): ITheme;
 
-// @public
+// WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
+// @internal
 export function getThemedContext(context: ICustomizerContext, scheme?: ISchemeNames, theme?: ITheme): ICustomizerContext;
 
 // @public


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Somehow in #6854 an update to styling API was missed even though it's reflected in OUFR's API. I suspect it was missed since it only generates a build warning for the styling package, not a build error. 

@kkjeer Should API changes like this be failing the styling package? (This API change did cause an error for OUFR that I had to fix as part of #6854.)

#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6911)

