### PR TITLE
Update getting started docs

### DIFF
--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -178,8 +178,7 @@ export class GetStartedPage extends React.Component<any, any> {
           <ol className={styles.steps}>
             <li>
               <p>
-                Install Node.js (at least 8.x) from the
-                <a href="https://nodejs.org">Node.js website</a>.
+                Install Node.js (at least 8.x) from the <a href="https://nodejs.org">Node.js website</a>.
               </p>
             </li>
             <li>
@@ -192,9 +191,10 @@ export class GetStartedPage extends React.Component<any, any> {
               </CodeBlock>
             </li>
             <li>
-              <p>Install Fabric React:</p>
+              <p>Navigate to your project and install Fabric React:</p>
               <CodeBlock language="bash" isLightTheme={true}>
-                {`npx create-react-app my-app --typescript`}
+                {`cd my-app
+npm install office-ui-fabric-react`}
               </CodeBlock>
             </li>
             <li>

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -173,30 +173,36 @@ export class GetStartedPage extends React.Component<any, any> {
 
         <div className={styles.instructionsSection}>
           <h2 id="react">Get started with Fabric React</h2>
-          <p>
-            Use NPM to get Fabric components and core styling. All you need is{' '}
-            <a className={styles.getStartedLink} href="https://nodejs.org/en/">
-              node.js
-            </a>{' '}
-            and{' '}
-            <a className={styles.getStartedLink} href="http://gulpjs.com/">
-              gulp
-            </a>
-            .
-          </p>
+          <p>All you need to get started with Fabric is Node.js and npm.</p>
 
           <ol className={styles.steps}>
             <li>
-              <p>To install the Fabric React NPM package, from the root of your project, run:</p>
+              <p>
+                Install Node.js (at least 8.x) from the
+                <a href="https://nodejs.org">Node.js website</a>.
+              </p>
+            </li>
+            <li>
+              <p>
+                Use npm to create a React app that uses TypeScript. Consider using Facebook'
+                <a href="https://github.com/facebook/create-react-app">Create React App</a>
+                to get started quickly:
+              </p>
               <CodeBlock language="bash" isLightTheme={true}>
-                {`npm --save install office-ui-fabric-react`}
+                {`npx create-react-app my-app --typescript`}
+              </CodeBlock>
+            </li>
+            <li>
+              <p>Install Fabric React:</p>
+              <CodeBlock language="bash" isLightTheme={true}>
+                {`npx create-react-app my-app --typescript`}
               </CodeBlock>
             </li>
             <li>
               <p>
-                The library includes commonjs entry points under the lib folder. To use a control (like DefaultButton), import it along with
-                React and use it in your render method. Note that wrapping your application in the Fabric component is required to support
-                RTL, keyboard focus, and other features.
+                Import and use DefaultButton, a Fabric React control. Make sure to import controls alongside React, then use them in your
+                render method. Wrap your app in the <code>&lt;Fabric&gt;</code> component to support RTL, keyboard focus indicator, text
+                styles, and more.
               </p>
               <CodeBlock language="javascript" isLightTheme={true}>
                 {`import * as React from 'react';
@@ -226,25 +232,29 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`}
               </CodeBlock>
               <DefaultButton text="See Button" primary={true} href="#/components/button" />
               <p>
-                For more information about using components, check out the{' '}
+                Check out the
                 <a className={styles.getStartedLink} href="#/components">
                   components page
                 </a>
-                .
+                for more design and technical docs for each component.
               </p>
             </li>
             <li>
               <p>
                 If you are using Fabric React components that have icons, you can make all icons available by calling the{' '}
-                <code>initializeIcons</code> function from the <code>@uifabric/icons</code> package.
+                <code>initializeIcons</code> function from the{' '}
+                <a href="https://www.npmjs.com/package/@uifabric/icons">
+                  <code>@uifabric/icons</code>
+                </a>{' '}
+                package.
               </p>
               <CodeBlock language="javascript" isLightTheme={true}>
                 {`import { initializeIcons } from '@uifabric/icons';
 
-// Register icons and pull the fonts from the default SharePoint cdn:
+// Register icons and pull the fonts from the default SharePoint CDN:
 initializeIcons();
 
-// ...or, register icons and pull the fonts from your own cdn:
+// ...or, register icons and pull the fonts from your own CDN:
 initializeIcons('https://my.cdn.com/path/to/icons/');`}
               </CodeBlock>
               <p>
@@ -268,17 +278,18 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`}
 
           <h3>Need a component Fabric React doesn&rsquo;t have?</h3>
           <p>
-            First, check the
+            First, check the{' '}
             <a className={styles.getStartedLink} href="https://github.com/OfficeDev/office-ui-fabric-react/issues">
               Fabric React issue queue
             </a>{' '}
-            or
+            or{' '}
             <a className={styles.getStartedLink} href="https://github.com/OfficeDev/office-ui-fabric-react/projects">
-              projects
-            </a>
-             to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for
-            the component you're looking for, please
+              projects{' '}
+            </a>{' '}
+            to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for the
+            component you're looking for, please{' '}
             <a className={styles.getStartedLink} href="https://github.com/OfficeDev/office-ui-fabric-react/issues">
+              {' '}
               file an issue in the repo
             </a>
             , and we'll respond if it's being built or on our radar.
@@ -343,17 +354,18 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`}
 
           <h3>Need an icon or feature Fabric Core doesn&rsquo;t have?</h3>
           <p>
-            First, check the
+            First, check the{' '}
             <a className={styles.getStartedLink} href="https://github.com/OfficeDev/office-ui-fabric-react/issues">
-              Fabric React issue queue
+              Fabric React issue queue{' '}
             </a>{' '}
-            or
+            or{' '}
             <a className={styles.getStartedLink} href="https://github.com/OfficeDev/office-ui-fabric-react/projects">
               projects
             </a>
              to see if your component has already been requested or is being worked on. If you don't see an existing issue or project for
-            the component you're looking for, please
+            the component you're looking for, please{' '}
             <a className={styles.getStartedLink} href="https://github.com/OfficeDev/office-ui-fabric-react/issues">
+              {' '}
               file an issue in the repo
             </a>
             , and we'll respond if it's being built or on our radar.

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -200,8 +200,7 @@ npm install office-ui-fabric-react`}
             <li>
               <p>
                 Import and use DefaultButton, a Fabric React control. Make sure to import controls alongside React, then use them in your
-                render method. Wrap your app in the <code>&lt;Fabric&gt;</code> component to support RTL, keyboard focus indicator, text
-                styles, and more.
+                render method.
               </p>
               <CodeBlock language="javascript" isLightTheme={true}>
                 {`import * as React from 'react';
@@ -210,11 +209,9 @@ import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 
 const MyPage = () => (
-  <Fabric>
-    <DefaultButton>
-      I am a button.
-    </DefaultButton>
-  </Fabric>
+  <DefaultButton>
+    I am a button.
+  </DefaultButton>
 );
 
 ReactDOM.render(<MyPage />, document.body.firstChild);`}

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -184,9 +184,8 @@ export class GetStartedPage extends React.Component<any, any> {
             </li>
             <li>
               <p>
-                Use npm to create a React app that uses TypeScript. Consider using Facebook'
-                <a href="https://github.com/facebook/create-react-app">Create React App</a>
-                to get started quickly:
+                Use npm to create a React app that uses TypeScript. Consider using Facebook's{' '}
+                <a href="https://github.com/facebook/create-react-app">Create React App</a> to get started quickly:
               </p>
               <CodeBlock language="bash" isLightTheme={true}>
                 {`npx create-react-app my-app --typescript`}

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -178,13 +178,20 @@ export class GetStartedPage extends React.Component<any, any> {
           <ol className={styles.steps}>
             <li>
               <p>
-                Install Node.js (at least 8.x) from the <a href="https://nodejs.org">Node.js website</a>.
+                Install Node.js (at least 8.x) from the{' '}
+                <a href="https://nodejs.org" target="_blank">
+                  Node.js website
+                </a>
+                .
               </p>
             </li>
             <li>
               <p>
                 Use npm to create a React app that uses TypeScript. Consider using Facebook's{' '}
-                <a href="https://github.com/facebook/create-react-app">Create React App</a> to get started quickly:
+                <a href="https://github.com/facebook/create-react-app" target="_blank">
+                  Create React App
+                </a>{' '}
+                to get started quickly:
               </p>
               <CodeBlock language="bash" isLightTheme={true}>
                 {`npx create-react-app my-app --typescript`}
@@ -228,10 +235,10 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`}
               </CodeBlock>
               <DefaultButton text="See Button" primary={true} href="#/components/button" />
               <p>
-                Check out the
+                Check out the{' '}
                 <a className={styles.getStartedLink} href="#/components">
                   components page
-                </a>
+                </a>{' '}
                 for more design and technical docs for each component.
               </p>
             </li>
@@ -239,7 +246,7 @@ ReactDOM.render(<MyPage />, document.body.firstChild);`}
               <p>
                 If you are using Fabric React components that have icons, you can make all icons available by calling the{' '}
                 <code>initializeIcons</code> function from the{' '}
-                <a href="https://www.npmjs.com/package/@uifabric/icons">
+                <a href="https://www.npmjs.com/package/@uifabric/icons" target="_blank">
                   <code>@uifabric/icons</code>
                 </a>{' '}
                 package.

--- a/common/changes/@uifabric/fabric-website/jahnp-docs-updates_2018-10-31-05-29.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-docs-updates_2018-10-31-05-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Update website getting started docs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "pejahn@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The [Getting Started](https://developer.microsoft.com/en-us/fabric#/get-started) docs are getting a little stale. They include references to `gulp` and make no mention of Create React App. This PR makes a few updates and includes some formatting fixes as well.

Before (https://developer.microsoft.com/en-us/fabric#/get-started):
![image](https://user-images.githubusercontent.com/307118/47768213-4c68b080-dc94-11e8-9f11-849200437249.png)

After:
![image](https://user-images.githubusercontent.com/307118/47768188-26431080-dc94-11e8-9552-44de8a1d13f3.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6912)

