### PR TITLE
Add opitional switch for Dashboard Chart -- stack bar chart to not apply default style while data points count is less two

### DIFF
--- a/common/changes/@uifabric/dashboard/timto-dashboard_2018-10-31-17-34.json
+++ b/common/changes/@uifabric/dashboard/timto-dashboard_2018-10-31-17-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Add opitional switch for Dashboard Chart -- stack bar chart to not apply default style while data points count is less two",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "timto@corp.microsoft.com"
+}

--- a/packages/dashboard/src/components/Card/Chart/Chart.tsx
+++ b/packages/dashboard/src/components/Card/Chart/Chart.tsx
@@ -136,7 +136,13 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
       return <MultiStackedBarChart data={this.props.chartData!} barHeight={this.props.barHeight} hideRatio={this.props.hideRatio} />;
     }
 
-    return <StackedBarChart data={this.props.chartData![0]} barHeight={this.props.barHeight} />;
+    return (
+      <StackedBarChart
+        data={this.props.chartData![0]}
+        barHeight={this.props.barHeight}
+        ignoreFixStyle={this.props.ignoreStackBarChartDefaultStyle}
+      />
+    );
   };
 
   private _getLineChart = (): JSX.Element => {

--- a/packages/dashboard/src/components/Card/Chart/Chart.types.ts
+++ b/packages/dashboard/src/components/Card/Chart/Chart.types.ts
@@ -103,6 +103,11 @@ export interface IChartProps {
    * One of the timeRange must be specified to line chart when Date type data is selected for line chart. The default is 180Days format
    */
   timeRange?: '7Days' | '30Days' | '90Days' | '180Days';
+
+  /**
+   * Ignore stack bar chart default style when data points count is less than two
+   */
+  ignoreStackBarChartDefaultStyle?: boolean;
 }
 
 export interface IChartInternalProps extends IChartProps {

--- a/packages/dashboard/src/components/Card/Layout/Layout.tsx
+++ b/packages/dashboard/src/components/Card/Layout/Layout.tsx
@@ -108,7 +108,8 @@ export class Layout extends React.Component<ILayoutProps> {
                   dataPoints,
                   compactChartWidth,
                   chartUpdatedOn,
-                  timeRange
+                  timeRange,
+                  ignoreStackBarChartDefaultStyle
                 } = cardContent.content as IChartProps;
                 contentArea.push(
                   <React.Fragment>
@@ -127,6 +128,7 @@ export class Layout extends React.Component<ILayoutProps> {
                       timeRange={timeRange}
                       width={this._getChartWidth(cardContentList.length)}
                       height={this._getChartHeight(cardContentList.length)}
+                      ignoreStackBarChartDefaultStyle={ignoreStackBarChartDefaultStyle}
                     />
                   </React.Fragment>
                 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Add opitional switch for Dashboard Chart -- stack bar chart to not apply default style while data points count is less two

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6917)

