### PR TITLE
TextField: set overflow to hidden when multiline and autoAdjustHeight are true

### DIFF
--- a/common/changes/office-ui-fabric-react/textFieldScrollBar_2018-10-31-21-03.json
+++ b/common/changes/office-ui-fabric-react/textFieldScrollBar_2018-10-31-21-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: set overflow to hidden when autoAdjustHeight is set to avoid flashing scrollbar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/textFieldScrollBar_2018-10-31-21-03.json
+++ b/common/changes/office-ui-fabric-react/textFieldScrollBar_2018-10-31-21-03.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "TextField: set overflow to hidden when autoAdjustHeight is set to avoid flashing scrollbar",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -521,8 +521,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     if (this._textElement.current && this.props.autoAdjustHeight && this.props.multiline) {
       const textField = this._textElement.current;
       textField.style.height = '';
-      const scrollHeight = textField.scrollHeight + 2; // +2 to avoid vertical scroll bars
-      textField.style.height = scrollHeight + 'px';
+      textField.style.height = textField.scrollHeight + 'px';
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -174,6 +174,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       suffix,
       theme,
       styles,
+      autoAdjustHeight,
       onRenderAddon = this._onRenderAddon, // @deprecated
       onRenderPrefix = this._onRenderPrefix,
       onRenderSuffix = this._onRenderSuffix,
@@ -197,7 +198,8 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       hasIcon: !!iconProps,
       underlined,
       iconClass,
-      inputClassName
+      inputClassName,
+      autoAdjustHeight
     });
 
     // If a custom description render function is supplied then treat description as always available.

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -58,7 +58,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     resizable,
     hasErrorMessage,
     iconClass,
-    inputClassName
+    inputClassName,
+    autoAdjustHeight
   } = props;
 
   const { semanticColors, palette } = theme;
@@ -296,6 +297,10 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         overflow: 'auto',
         width: '100%'
       },
+      multiline &&
+        autoAdjustHeight && {
+          overflow: 'hidden'
+        },
       hasIcon && {
         paddingRight: 24
       },

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -290,7 +290,16 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> &
   Pick<
     ITextFieldProps,
-    'className' | 'disabled' | 'inputClassName' | 'required' | 'multiline' | 'borderless' | 'resizable' | 'underlined' | 'iconClass'
+    | 'className'
+    | 'disabled'
+    | 'inputClassName'
+    | 'required'
+    | 'multiline'
+    | 'borderless'
+    | 'resizable'
+    | 'underlined'
+    | 'iconClass'
+    | 'autoAdjustHeight'
   > & {
     /** Element has an error message. */
     hasErrorMessage?: boolean;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -833,7 +833,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 min-height: inherit;
                 min-width: 0px;
                 outline: 0px;
-                overflow: auto;
+                overflow: hidden;
                 padding-bottom: 0;
                 padding-left: 12px;
                 padding-right: 12px;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6506
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes get rid of the flickering scrollbar issue for auto adjust height TextFields. The original change in `_adjustInputHeight` wasn't working in IE11

      const scrollHeight = textField.scrollHeight + 2; // +2 to avoid vertical scroll bars

and increasing the number enough to prevent the scrollbar from flickering showed up as an obvious space at the bottom of the text field. Setting `overflow` to hidden for multiline, autoAdjustHeight text fields seemed like the right approach.

Before:

![textfieldautoadjustheightscrollbar](https://user-images.githubusercontent.com/14134000/47820504-ec691d00-dd1a-11e8-9c6a-7891e50d3eaa.gif)

After:

![textfieldautoadjustheight](https://user-images.githubusercontent.com/14134000/47820508-f0953a80-dd1a-11e8-8cb2-8b8c1119da66.gif)

**Note:** I didn't remove the original line called out above, even though we don't need it anymore, because I noticed that it does add 2px of padding at the bottom of the text field. We currently have paddingTop set to 6 for multiline text fields, but nothing set at the bottom. Would we like to keep this, or set paddingBottom to a defined value elsewhere?

#### Focus areas to test

Open the TextField demo page in IE11. Scroll down to the auto adjust height TextField example and type in it until the text overflows, causing the height of the field to increase. You should notice no flickering scrollbar. Test in Chrome and Edge as well.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6924)

