### PR TITLE
ContextualMenu: fixing subComponentStyles not working with mergeStyleSets when used directly.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-ContextualMenuFix_2018-11-01-22-05.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ContextualMenuFix_2018-11-01-22-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Add fix for subComponentStyles being optional in a deprecated prop.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/v-vibr-ContextualMenuFix_2018-11-01-22-05.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ContextualMenuFix_2018-11-01-22-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "ContextualMenu: Add fix for subComponentStyles being optional in a deprecated prop.",
+      "comment": "ContextualMenu: Add fix for subComponentStyles. It is now optional in the `IContextualMenuClassNames` interface.",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -286,9 +286,10 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
         }
       }
 
-      const calloutStyles = !getMenuClassNames
-        ? (this._classNames.subComponentStyles.callout as IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>)
-        : undefined;
+      const calloutStyles =
+        !getMenuClassNames && this._classNames.subComponentStyles
+          ? (this._classNames.subComponentStyles.callout as IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>)
+          : undefined;
 
       return (
         <Callout

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -15,7 +15,7 @@ export interface IContextualMenuClassNames {
   list: string;
   header: string;
   title: string;
-  subComponentStyles: IContextualMenuSubComponentStyles;
+  subComponentStyles?: IContextualMenuSubComponentStyles;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6922 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Make the `subComponentStyles` optional in the `IContextualMenuClassNames` interface for backward compatibility for partners still using the deprecated `getMenuClassNames` prop.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6936)

