### PR TITLE
Fix Sticky sort, placeholder height, and stickyClassName

### DIFF
--- a/apps/vr-tests/src/stories/ScrollablePane.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.stories.tsx
@@ -1,0 +1,71 @@
+/*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
+import * as React from 'react';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { FabricDecorator } from '../utilities';
+import { ScrollablePane, StickyPositionType, Sticky } from 'office-ui-fabric-react';
+import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
+
+const colors = ['#eaeaea', '#dadada', '#d0d0d0', '#c8c8c8', '#a6a6a6', '#c7e0f4'];
+
+const contentAreas: JSX.Element[] = [];
+for (let i = 0; i < 5; i++) {
+  contentAreas.push(createContentArea(i));
+}
+
+function createContentArea(index: number) {
+  const color = colors[index];
+
+  return (
+    <div
+      key={index}
+      style={{
+        backgroundColor: color
+      }}
+    >
+      <Sticky stickyPosition={StickyPositionType.Both}>
+        <div
+          className="sticky"
+          style={{
+            padding: '5px 20px 5px 10px',
+            fontSize: '13px',
+            borderTop: '1px solid #000',
+            borderBottom: '1px solid #000',
+            color: '#201f1e'
+          }}>Sticky Component #{index + 1}</div>
+      </Sticky>
+      <div className="textContent">{lorem(200)}</div>
+    </div>
+  );
+}
+
+storiesOf('ScrollablePane', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .executeScript('document.getElementsByClassName(\'ms-ScrollablePane--contentContainer\')[0].scrollTop = 9999')
+        .snapshot('scrolled', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Default ScrollablePane Example', () => (
+    <div
+      style={{
+        height: '600px',
+        position: 'relative',
+        maxHeight: 'inherit',
+        width: '400px'
+      }}
+    >
+      <ScrollablePane className="scrollablePaneDefaultExample"
+        style={{ maxWidth: '400px', border: '1px solid #edebe9' }}>
+        {contentAreas.map(ele => {
+          return ele;
+        })}
+      </ScrollablePane>
+    </div>
+  ));

--- a/common/changes/office-ui-fabric-react/edwl-2018-10-fixScrollablePaneSort_2018-11-01-22-10.json
+++ b/common/changes/office-ui-fabric-react/edwl-2018-10-fixScrollablePaneSort_2018-11-01-22-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ScrollablePane and Sticky: Fix placeholder height, Sticky sorting, and stickyClassName",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -23,7 +23,7 @@ export function arraysEqual<T>(array1: T[], array2: T[]): boolean;
 
 // @public
 export function asAsync<TProps>(options: IAsAsyncOptions<TProps>): React.ComponentType<TProps & {
-    asyncPlaceholder?: React.ReactType;
+  asyncPlaceholder?: React.ReactType;
 }>;
 
 // @public
@@ -43,10 +43,10 @@ class Async {
   clearInterval(id: number): void;
   clearTimeout(id: number): void;
   debounce<T extends Function>(func: T, wait?: number, options?: {
-          leading?: boolean;
-          maxWait?: number;
-          trailing?: boolean;
-      }): ICancelable<T> & (() => void);
+    leading?: boolean;
+    maxWait?: number;
+    trailing?: boolean;
+  }): ICancelable<T> & (() => void);
   dispose(): void;
   // (undocumented)
   requestAnimationFrame(callback: () => void): number;
@@ -54,16 +54,16 @@ class Async {
   setInterval(callback: () => void, duration: number): number;
   setTimeout(callback: () => void, duration: number): number;
   throttle<T extends Function>(func: T, wait?: number, options?: {
-          leading?: boolean;
-          trailing?: boolean;
-      }): T | (() => void);
+    leading?: boolean;
+    trailing?: boolean;
+  }): T | (() => void);
 }
 
 // @public @deprecated
 export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {
-    configurable: boolean;
-    get(): T;
-    set(newValue: any): void;
+  configurable: boolean;
+  get(): T;
+  set(newValue: any): void;
 } | void;
 
 // @public (undocumented)
@@ -505,7 +505,7 @@ class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
 
 // @public
 export function buildClassMap<T>(styles: T): {
-    [key in keyof T]?: string;
+  [key in keyof T]?: string;
 };
 
 // @public (undocumented)
@@ -796,7 +796,7 @@ export function createFontStyles(localeCode: string | null): IFontStyles;
 
 // @public (undocumented)
 export function createGenericItem(name: string, currentValidationState: ValidationState, allowPhoneInitials: boolean): IGenericItem & {
-    key: React.Key;
+  key: React.Key;
 };
 
 // @public (undocumented)
@@ -1153,8 +1153,8 @@ class EventGroup {
   off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
   on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void;
   onAll(target: any, events: {
-          [key: string]: (args?: any) => void;
-      }, useCapture?: boolean): void;
+    [key: string]: (args?: any) => void;
+  }, useCapture?: boolean): void;
   static raise(target: any, eventName: string, eventArgs?: any, bubbleEvent?: boolean): boolean | undefined;
   // (undocumented)
   static stopPropagation(event: any): void;
@@ -1202,7 +1202,7 @@ class ExtendedSelectedItem extends BaseComponent<ISelectedPeopleItemProps, IPeop
 
 // @public (undocumented)
 class FabricBase extends BaseComponent<IFabricProps, {
-    isFocusVisible: boolean;
+  isFocusVisible: boolean;
 }> {
   constructor(props: IFabricProps);
   // (undocumented)
@@ -1320,7 +1320,7 @@ class FloatingPeoplePicker extends BaseFloatingPeoplePicker {
 
 // @public
 export function focusAsync(element: HTMLElement | {
-    focus: () => void;
+  focus: () => void;
 } | undefined | null): void;
 
 // @public
@@ -1447,10 +1447,10 @@ export function getChildren(parent: HTMLElement, allowVirtualChildren?: boolean)
 
 // @public (undocumented)
 export function getColorFromRGBA(rgba: {
-    r: number;
-    g: number;
-    b: number;
-    a: number;
+  r: number;
+  g: number;
+  b: number;
+  a: number;
 }): IColor;
 
 // @public (undocumented)
@@ -1657,9 +1657,9 @@ export function hsv2hex(h: number, s: number, v: number): string;
 
 // @public (undocumented)
 export function hsv2hsl(h: number, s: number, v: number): {
-    h: number;
-    s: number;
-    l: number;
+  h: number;
+  s: number;
+  l: number;
 };
 
 // @public (undocumented)
@@ -1938,8 +1938,8 @@ interface IBaseFloatingPickerProps<T> extends React.Props<any> {
   pickerSuggestionsProps?: IBaseFloatingPickerSuggestionProps;
   resolveDelay?: number;
   searchingText?: ((props: {
-          input: string;
-      }) => string) | string;
+    input: string;
+  }) => string) | string;
   selectedItems?: T[];
   showForceResolve?: () => boolean;
   suggestionItems?: T[];
@@ -2000,8 +2000,8 @@ interface IBasePickerProps<T> extends React.Props<any> {
   removeButtonAriaLabel?: string;
   resolveDelay?: number;
   searchingText?: ((props: {
-          input: string;
-      }) => string) | string;
+    input: string;
+  }) => string) | string;
   selectedItems?: T[];
 }
 
@@ -6541,9 +6541,9 @@ interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps
   onRowWillUnmount?: (item?: any, index?: number) => void;
   onShouldVirtualize?: (props: IListProps) => boolean;
   rowElementEventMap?: {
-          eventName: string;
-          callback: (context: IDragDropContext, event?: any) => void;
-      }[];
+    eventName: string;
+    callback: (context: IDragDropContext, event?: any) => void;
+  }[];
   selection?: ISelection;
   selectionMode?: SelectionMode;
   selectionPreservedOnEmptyClick?: boolean;
@@ -6604,9 +6604,9 @@ interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProp
   dragDropEvents?: IDragDropEvents;
   dragDropHelper?: IDragDropHelper;
   eventsToRegister?: {
-          eventName: string;
-          callback: (item?: any, index?: number, event?: any) => void;
-      }[];
+    eventName: string;
+    callback: (item?: any, index?: number, event?: any) => void;
+  }[];
   getRowAriaDescribedBy?: (item: any) => string;
   getRowAriaLabel?: (item: any) => string;
   item: any;
@@ -7578,9 +7578,9 @@ interface IGroupedListProps extends React.Props<GroupedListBase> {
   dragDropEvents?: IDragDropEvents;
   dragDropHelper?: IDragDropHelper;
   eventsToRegister?: {
-          eventName: string;
-          callback: (context: IDragDropContext, event?: any) => void;
-      }[];
+    eventName: string;
+    callback: (context: IDragDropContext, event?: any) => void;
+  }[];
   getGroupHeight?: (group: IGroup, groupIndex: number) => number;
   groupProps?: IGroupRenderProps;
   groups?: IGroup[];
@@ -7825,8 +7825,8 @@ interface IImageStyles {
 // @public (undocumented)
 interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   // WARNING: The name "aria-label" contains unsupported characters; API names should use only letters, numbers, and underscores
-  aria-label?: string;
-  defaultVisibleValue?: string;
+  aria - label ?: string;
+defaultVisibleValue ?: string;
 }
 
 // @public (undocumented)
@@ -9223,7 +9223,7 @@ interface IScrollablePaneContext {
     addSticky: (sticky: Sticky) => void;
     notifySubscribers: (sort?: boolean) => void;
     removeSticky: (sticky: Sticky) => void;
-    sortSticky: (sticky: Sticky) => void;
+    sortSticky: (sticky: Sticky, reSort?: boolean) => void;
     subscribe: (handler: (container: HTMLElement, stickyContainer: HTMLElement) => void) => void;
     unsubscribe: (handler: (container: HTMLElement, stickyContainer: HTMLElement) => void) => void;
     updateStickyRefHeights: () => void;
@@ -10374,8 +10374,8 @@ interface ITheme extends IScheme {
   // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
   // @internal
   schemes?: {
-          [P in ISchemeNames]?: IScheme;
-      };
+    [P in ISchemeNames]?: IScheme;
+  };
 }
 
 // @public (undocumented)
@@ -10770,7 +10770,7 @@ enum KeyCodes {
 
 // @public
 export function keyframes(timeline: {
-    [key: string]: {};
+  [key: string]: {};
 }): string;
 
 // @public
@@ -10946,8 +10946,8 @@ class MemberListPeoplePicker extends BasePickerListBelow<IPersonaProps, IPeopleP
 
 // @public
 export function memoize<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {
-    configurable: boolean;
-    get(): T;
+  configurable: boolean;
+  get(): T;
 };
 
 // @public

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9988,8 +9988,6 @@ interface IStickyProps extends React.Props<Sticky> {
 // @public (undocumented)
 interface IStickyState {
   // (undocumented)
-  distanceFromTop: number;
-  // (undocumented)
   isStickyBottom: boolean;
   // (undocumented)
   isStickyTop: boolean;
@@ -11818,6 +11816,8 @@ class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   distanceFromTop: number;
   // (undocumented)
   readonly nonStickyContent: HTMLDivElement | null;
+  // (undocumented)
+  readonly placeholder: HTMLDivElement | null;
   // (undocumented)
   render(): JSX.Element;
   // (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -23,7 +23,7 @@ export function arraysEqual<T>(array1: T[], array2: T[]): boolean;
 
 // @public
 export function asAsync<TProps>(options: IAsAsyncOptions<TProps>): React.ComponentType<TProps & {
-  asyncPlaceholder?: React.ReactType;
+    asyncPlaceholder?: React.ReactType;
 }>;
 
 // @public
@@ -43,10 +43,10 @@ class Async {
   clearInterval(id: number): void;
   clearTimeout(id: number): void;
   debounce<T extends Function>(func: T, wait?: number, options?: {
-    leading?: boolean;
-    maxWait?: number;
-    trailing?: boolean;
-  }): ICancelable<T> & (() => void);
+          leading?: boolean;
+          maxWait?: number;
+          trailing?: boolean;
+      }): ICancelable<T> & (() => void);
   dispose(): void;
   // (undocumented)
   requestAnimationFrame(callback: () => void): number;
@@ -54,16 +54,16 @@ class Async {
   setInterval(callback: () => void, duration: number): number;
   setTimeout(callback: () => void, duration: number): number;
   throttle<T extends Function>(func: T, wait?: number, options?: {
-    leading?: boolean;
-    trailing?: boolean;
-  }): T | (() => void);
+          leading?: boolean;
+          trailing?: boolean;
+      }): T | (() => void);
 }
 
 // @public @deprecated
 export function autobind<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {
-  configurable: boolean;
-  get(): T;
-  set(newValue: any): void;
+    configurable: boolean;
+    get(): T;
+    set(newValue: any): void;
 } | void;
 
 // @public (undocumented)
@@ -505,7 +505,7 @@ class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
 
 // @public
 export function buildClassMap<T>(styles: T): {
-  [key in keyof T]?: string;
+    [key in keyof T]?: string;
 };
 
 // @public (undocumented)
@@ -796,7 +796,7 @@ export function createFontStyles(localeCode: string | null): IFontStyles;
 
 // @public (undocumented)
 export function createGenericItem(name: string, currentValidationState: ValidationState, allowPhoneInitials: boolean): IGenericItem & {
-  key: React.Key;
+    key: React.Key;
 };
 
 // @public (undocumented)
@@ -1153,8 +1153,8 @@ class EventGroup {
   off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
   on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void;
   onAll(target: any, events: {
-    [key: string]: (args?: any) => void;
-  }, useCapture?: boolean): void;
+          [key: string]: (args?: any) => void;
+      }, useCapture?: boolean): void;
   static raise(target: any, eventName: string, eventArgs?: any, bubbleEvent?: boolean): boolean | undefined;
   // (undocumented)
   static stopPropagation(event: any): void;
@@ -1202,7 +1202,7 @@ class ExtendedSelectedItem extends BaseComponent<ISelectedPeopleItemProps, IPeop
 
 // @public (undocumented)
 class FabricBase extends BaseComponent<IFabricProps, {
-  isFocusVisible: boolean;
+    isFocusVisible: boolean;
 }> {
   constructor(props: IFabricProps);
   // (undocumented)
@@ -1320,7 +1320,7 @@ class FloatingPeoplePicker extends BaseFloatingPeoplePicker {
 
 // @public
 export function focusAsync(element: HTMLElement | {
-  focus: () => void;
+    focus: () => void;
 } | undefined | null): void;
 
 // @public
@@ -1447,10 +1447,10 @@ export function getChildren(parent: HTMLElement, allowVirtualChildren?: boolean)
 
 // @public (undocumented)
 export function getColorFromRGBA(rgba: {
-  r: number;
-  g: number;
-  b: number;
-  a: number;
+    r: number;
+    g: number;
+    b: number;
+    a: number;
 }): IColor;
 
 // @public (undocumented)
@@ -1657,9 +1657,9 @@ export function hsv2hex(h: number, s: number, v: number): string;
 
 // @public (undocumented)
 export function hsv2hsl(h: number, s: number, v: number): {
-  h: number;
-  s: number;
-  l: number;
+    h: number;
+    s: number;
+    l: number;
 };
 
 // @public (undocumented)
@@ -1938,8 +1938,8 @@ interface IBaseFloatingPickerProps<T> extends React.Props<any> {
   pickerSuggestionsProps?: IBaseFloatingPickerSuggestionProps;
   resolveDelay?: number;
   searchingText?: ((props: {
-    input: string;
-  }) => string) | string;
+          input: string;
+      }) => string) | string;
   selectedItems?: T[];
   showForceResolve?: () => boolean;
   suggestionItems?: T[];
@@ -2000,8 +2000,8 @@ interface IBasePickerProps<T> extends React.Props<any> {
   removeButtonAriaLabel?: string;
   resolveDelay?: number;
   searchingText?: ((props: {
-    input: string;
-  }) => string) | string;
+          input: string;
+      }) => string) | string;
   selectedItems?: T[];
 }
 
@@ -6541,9 +6541,9 @@ interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps
   onRowWillUnmount?: (item?: any, index?: number) => void;
   onShouldVirtualize?: (props: IListProps) => boolean;
   rowElementEventMap?: {
-    eventName: string;
-    callback: (context: IDragDropContext, event?: any) => void;
-  }[];
+          eventName: string;
+          callback: (context: IDragDropContext, event?: any) => void;
+      }[];
   selection?: ISelection;
   selectionMode?: SelectionMode;
   selectionPreservedOnEmptyClick?: boolean;
@@ -6604,9 +6604,9 @@ interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProp
   dragDropEvents?: IDragDropEvents;
   dragDropHelper?: IDragDropHelper;
   eventsToRegister?: {
-    eventName: string;
-    callback: (item?: any, index?: number, event?: any) => void;
-  }[];
+          eventName: string;
+          callback: (item?: any, index?: number, event?: any) => void;
+      }[];
   getRowAriaDescribedBy?: (item: any) => string;
   getRowAriaLabel?: (item: any) => string;
   item: any;
@@ -7578,9 +7578,9 @@ interface IGroupedListProps extends React.Props<GroupedListBase> {
   dragDropEvents?: IDragDropEvents;
   dragDropHelper?: IDragDropHelper;
   eventsToRegister?: {
-    eventName: string;
-    callback: (context: IDragDropContext, event?: any) => void;
-  }[];
+          eventName: string;
+          callback: (context: IDragDropContext, event?: any) => void;
+      }[];
   getGroupHeight?: (group: IGroup, groupIndex: number) => number;
   groupProps?: IGroupRenderProps;
   groups?: IGroup[];
@@ -7825,8 +7825,8 @@ interface IImageStyles {
 // @public (undocumented)
 interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   // WARNING: The name "aria-label" contains unsupported characters; API names should use only letters, numbers, and underscores
-  aria - label ?: string;
-defaultVisibleValue ?: string;
+  aria-label?: string;
+  defaultVisibleValue?: string;
 }
 
 // @public (undocumented)
@@ -9988,6 +9988,8 @@ interface IStickyProps extends React.Props<Sticky> {
 // @public (undocumented)
 interface IStickyState {
   // (undocumented)
+  distanceFromTop: number;
+  // (undocumented)
   isStickyBottom: boolean;
   // (undocumented)
   isStickyTop: boolean;
@@ -10374,8 +10376,8 @@ interface ITheme extends IScheme {
   // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
   // @internal
   schemes?: {
-    [P in ISchemeNames]?: IScheme;
-  };
+          [P in ISchemeNames]?: IScheme;
+      };
 }
 
 // @public (undocumented)
@@ -10770,7 +10772,7 @@ enum KeyCodes {
 
 // @public
 export function keyframes(timeline: {
-  [key: string]: {};
+    [key: string]: {};
 }): string;
 
 // @public
@@ -10946,8 +10948,8 @@ class MemberListPeoplePicker extends BasePickerListBelow<IPersonaProps, IPeopleP
 
 // @public
 export function memoize<T extends Function>(target: any, key: string, descriptor: TypedPropertyDescriptor<T>): {
-  configurable: boolean;
-  get(): T;
+    configurable: boolean;
+    get(): T;
 };
 
 // @public
@@ -11459,7 +11461,7 @@ class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScrollable
   // (undocumented)
   shouldComponentUpdate(nextProps: IScrollablePaneProps, nextState: IScrollablePaneState): boolean;
   // (undocumented)
-  sortSticky: (sticky: Sticky) => void;
+  sortSticky: (sticky: Sticky, reSort?: boolean | undefined) => void;
   // (undocumented)
   readonly stickyAbove: HTMLDivElement | null;
   // (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9223,7 +9223,7 @@ interface IScrollablePaneContext {
     addSticky: (sticky: Sticky) => void;
     notifySubscribers: (sort?: boolean) => void;
     removeSticky: (sticky: Sticky) => void;
-    sortSticky: (sticky: Sticky, reSort?: boolean) => void;
+    sortSticky: (sticky: Sticky, sortAgain?: boolean) => void;
     subscribe: (handler: (container: HTMLElement, stickyContainer: HTMLElement) => void) => void;
     unsubscribe: (handler: (container: HTMLElement, stickyContainer: HTMLElement) => void) => void;
     updateStickyRefHeights: () => void;
@@ -11459,7 +11459,7 @@ class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScrollable
   // (undocumented)
   shouldComponentUpdate(nextProps: IScrollablePaneProps, nextState: IScrollablePaneState): boolean;
   // (undocumented)
-  sortSticky: (sticky: Sticky, reSort?: boolean | undefined) => void;
+  sortSticky: (sticky: Sticky, sortAgain?: boolean | undefined) => void;
   // (undocumented)
   readonly stickyAbove: HTMLDivElement | null;
   // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -11,7 +11,7 @@ export interface IScrollablePaneContext {
     addSticky: (sticky: Sticky) => void;
     removeSticky: (sticky: Sticky) => void;
     updateStickyRefHeights: () => void;
-    sortSticky: (sticky: Sticky) => void;
+    sortSticky: (sticky: Sticky, reSort?: boolean) => void;
     notifySubscribers: (sort?: boolean) => void;
   };
 }
@@ -234,8 +234,11 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     this.notifySubscribers();
   };
 
-  public sortSticky = (sticky: Sticky): void => {
+  public sortSticky = (sticky: Sticky, reSort?: boolean): void => {
     if (this.stickyAbove && this.stickyBelow) {
+      if (reSort) {
+        this._removeStickyFromContainers(sticky);
+      }
       if (sticky.canStickyTop && sticky.stickyContentTop) {
         this._addToStickyContainer(sticky, this.stickyAbove, sticky.stickyContentTop);
       }

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -11,7 +11,7 @@ export interface IScrollablePaneContext {
     addSticky: (sticky: Sticky) => void;
     removeSticky: (sticky: Sticky) => void;
     updateStickyRefHeights: () => void;
-    sortSticky: (sticky: Sticky, reSort?: boolean) => void;
+    sortSticky: (sticky: Sticky, sortAgain?: boolean) => void;
     notifySubscribers: (sort?: boolean) => void;
   };
 }
@@ -234,9 +234,9 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     this.notifySubscribers();
   };
 
-  public sortSticky = (sticky: Sticky, reSort?: boolean): void => {
+  public sortSticky = (sticky: Sticky, sortAgain?: boolean): void => {
     if (this.stickyAbove && this.stickyBelow) {
-      if (reSort) {
+      if (sortAgain) {
         this._removeStickyFromContainers(sticky);
       }
       if (sticky.canStickyTop && sticky.stickyContentTop) {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -363,10 +363,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   };
 
   private _removeStickyFromContainers = (sticky: Sticky): void => {
-    if (this.stickyAbove && sticky.stickyContentTop) {
+    if (this.stickyAbove && sticky.stickyContentTop && this.stickyAbove.contains(sticky.stickyContentTop)) {
       this.stickyAbove.removeChild(sticky.stickyContentTop);
     }
-    if (this.stickyBelow && sticky.stickyContentBottom) {
+    if (this.stickyBelow && sticky.stickyContentBottom && this.stickyBelow.contains(sticky.stickyContentBottom)) {
       this.stickyBelow.removeChild(sticky.stickyContentBottom);
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -32,6 +32,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   private _stickyContentTop = createRef<HTMLDivElement>();
   private _stickyContentBottom = createRef<HTMLDivElement>();
   private _nonStickyContent = createRef<HTMLDivElement>();
+  private _placeHolder = createRef<HTMLDivElement>();
 
   constructor(props: IStickyProps) {
     super(props);
@@ -119,13 +120,21 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     }
 
     const { isStickyTop, isStickyBottom, distanceFromTop } = this.state;
-    return (
-      isStickyTop !== nextState.isStickyTop ||
-      isStickyBottom !== nextState.isStickyBottom ||
-      distanceFromTop !== nextState.distanceFromTop ||
-      this.props.stickyPosition !== nextProps.stickyPosition ||
-      this.props.children !== nextProps.children
-    );
+
+    if (this._nonStickyContent && this._nonStickyContent.current && this._placeHolder && this._placeHolder.current) {
+      const nonStickyContentHeight = this._nonStickyContent.current.offsetHeight;
+
+      return (
+        isStickyTop !== nextState.isStickyTop ||
+        isStickyBottom !== nextState.isStickyBottom ||
+        distanceFromTop !== nextState.distanceFromTop ||
+        this.props.stickyPosition !== nextProps.stickyPosition ||
+        this.props.children !== nextProps.children ||
+        nonStickyContentHeight !== this._placeHolder.current.offsetHeight
+      );
+    }
+
+    return false;
   }
 
   public render(): JSX.Element {
@@ -148,7 +157,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
-        <div style={this._getNonStickyPlaceholderHeight()} ref={this._root}>
+        <div style={this._getNonStickyPlaceholderHeight()} ref={this._placeHolder}>
           <div
             ref={this._nonStickyContent}
             className={isStickyTop || isStickyBottom ? stickyClassName : undefined}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -7,7 +7,7 @@ import { IScrollablePaneContext } from '../ScrollablePane/ScrollablePane.base';
 export interface IStickyState {
   isStickyTop: boolean;
   isStickyBottom: boolean;
-  distanceFromTop: number;
+  distanceFromTopOfPane: number;
 }
 
 export interface IStickyContext {
@@ -39,7 +39,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     this.state = {
       isStickyTop: false,
       isStickyBottom: false,
-      distanceFromTop: 0
+      distanceFromTopOfPane: 0
     };
     this.distanceFromTop = 0;
   }
@@ -109,7 +109,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       scrollablePane.updateStickyRefHeights();
     }
 
-    if (this.state.distanceFromTop !== prevState.distanceFromTop) {
+    if (this.state.distanceFromTopOfPane !== prevState.distanceFromTopOfPane) {
       scrollablePane.sortSticky(this, true);
     }
   }
@@ -119,18 +119,16 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       return true;
     }
 
-    const { isStickyTop, isStickyBottom, distanceFromTop } = this.state;
+    const { isStickyTop, isStickyBottom, distanceFromTopOfPane } = this.state;
 
     if (this._nonStickyContent && this._nonStickyContent.current && this._placeHolder && this._placeHolder.current) {
-      const nonStickyContentHeight = this._nonStickyContent.current.offsetHeight;
-
       return (
         isStickyTop !== nextState.isStickyTop ||
         isStickyBottom !== nextState.isStickyBottom ||
-        distanceFromTop !== nextState.distanceFromTop ||
+        distanceFromTopOfPane !== nextState.distanceFromTopOfPane ||
         this.props.stickyPosition !== nextProps.stickyPosition ||
         this.props.children !== nextProps.children ||
-        nonStickyContentHeight !== this._placeHolder.current.offsetHeight
+        this._nonStickyContent.current.offsetHeight !== this._placeHolder.current.offsetHeight
       );
     }
 
@@ -185,7 +183,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   public setDistanceFromTop(container: HTMLDivElement): void {
     this.distanceFromTop = this._getNonStickyDistanceFromTop(container);
     this.setState({
-      distanceFromTop: this._getNonStickyDistanceFromTop(container)
+      distanceFromTopOfPane: this._getNonStickyDistanceFromTop(container)
     });
   }
 
@@ -237,7 +235,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       this.setState({
         isStickyTop: this.canStickyTop && isStickyTop,
         isStickyBottom: isStickyBottom,
-        distanceFromTop: this.distanceFromTop
+        distanceFromTopOfPane: this.distanceFromTop
       });
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -141,30 +141,19 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     }
 
     return (
-      <div ref={this._root} data-id="root">
+      <div ref={this._root}>
         {this.canStickyTop && (
-          <div
-            data-id="stickycontenttop"
-            ref={this._stickyContentTop}
-            aria-hidden={!isStickyTop}
-            style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}
-          >
+          <div ref={this._stickyContentTop} aria-hidden={!isStickyTop} style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />
           </div>
         )}
         {this.canStickyBottom && (
-          <div
-            data-id="stickycontentbottom"
-            ref={this._stickyContentBottom}
-            aria-hidden={!isStickyBottom}
-            style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}
-          >
+          <div ref={this._stickyContentBottom} aria-hidden={!isStickyBottom} style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
-        <div style={this._getNonStickyPlaceholderHeight()} data-id="placeholder" ref={this._placeHolder}>
+        <div style={this._getNonStickyPlaceholderHeight()} ref={this._placeHolder}>
           <div
-            data-id="nonstickycontent"
             ref={this._nonStickyContent}
             className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
             style={this._getContentStyles(isStickyTop || isStickyBottom)}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -225,7 +225,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
       if (this.canStickyTop) {
         const distanceToStickTop = this.distanceFromTop - this._getStickyDistanceFromTop();
-        isStickyTop = distanceToStickTop <= container.scrollTop;
+        isStickyTop = distanceToStickTop < container.scrollTop;
       }
 
       // Can sticky bottom if the scrollablePane - total sticky footer height is smaller than the sticky's distance from the top of the pane

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -7,6 +7,7 @@ import { IScrollablePaneContext } from '../ScrollablePane/ScrollablePane.base';
 export interface IStickyState {
   isStickyTop: boolean;
   isStickyBottom: boolean;
+  distanceFromTop: number;
 }
 
 export interface IStickyContext {
@@ -36,7 +37,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     super(props);
     this.state = {
       isStickyTop: false,
-      isStickyBottom: false
+      isStickyBottom: false,
+      distanceFromTop: 0
     };
     this.distanceFromTop = 0;
   }
@@ -105,6 +107,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     if (prevState.isStickyTop !== this.state.isStickyTop || prevState.isStickyBottom !== this.state.isStickyBottom) {
       scrollablePane.updateStickyRefHeights();
     }
+
+    if (this.state.distanceFromTop !== prevState.distanceFromTop) {
+      scrollablePane.sortSticky(this, true);
+    }
   }
 
   public shouldComponentUpdate(nextProps: IStickyProps, nextState: IStickyState): boolean {
@@ -112,10 +118,11 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       return true;
     }
 
-    const { isStickyTop, isStickyBottom } = this.state;
+    const { isStickyTop, isStickyBottom, distanceFromTop } = this.state;
     return (
       isStickyTop !== nextState.isStickyTop ||
       isStickyBottom !== nextState.isStickyBottom ||
+      distanceFromTop !== nextState.distanceFromTop ||
       this.props.stickyPosition !== nextProps.stickyPosition ||
       this.props.children !== nextProps.children
     );
@@ -168,6 +175,9 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
   public setDistanceFromTop(container: HTMLDivElement): void {
     this.distanceFromTop = this._getNonStickyDistanceFromTop(container);
+    this.setState({
+      distanceFromTop: this._getNonStickyDistanceFromTop(container)
+    });
   }
 
   private _getContentStyles(isSticky: boolean): React.CSSProperties {
@@ -217,7 +227,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
       this.setState({
         isStickyTop: this.canStickyTop && isStickyTop,
-        isStickyBottom: isStickyBottom
+        isStickyBottom: isStickyBottom,
+        distanceFromTop: this.distanceFromTop
       });
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -119,17 +119,15 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
     const { isStickyTop, isStickyBottom } = this.state;
 
-    if (this._nonStickyContent && this._nonStickyContent.current && this._placeHolder && this._placeHolder.current) {
-      return (
-        isStickyTop !== nextState.isStickyTop ||
-        isStickyBottom !== nextState.isStickyBottom ||
-        this.props.stickyPosition !== nextProps.stickyPosition ||
-        this.props.children !== nextProps.children ||
-        this._nonStickyContent.current.offsetHeight !== this._placeHolder.current.offsetHeight
-      );
-    }
-
-    return false;
+    return (isStickyTop !== nextState.isStickyTop ||
+      isStickyBottom !== nextState.isStickyBottom ||
+      this.props.stickyPosition !== nextProps.stickyPosition ||
+      this.props.children !== nextProps.children ||
+      (this._nonStickyContent &&
+        this._nonStickyContent.current &&
+        this._placeHolder &&
+        this._placeHolder.current &&
+        this._nonStickyContent.current.offsetHeight !== this._placeHolder.current.offsetHeight)) as boolean;
   }
 
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -46,6 +46,10 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     return this._root.current;
   }
 
+  public get placeholder(): HTMLDivElement | null {
+    return this._placeHolder.current;
+  }
+
   public get stickyContentTop(): HTMLDivElement | null {
     return this._stickyContentTop.current;
   }
@@ -137,19 +141,30 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     }
 
     return (
-      <div ref={this._root}>
+      <div ref={this._root} data-id="root">
         {this.canStickyTop && (
-          <div ref={this._stickyContentTop} aria-hidden={!isStickyTop} style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}>
+          <div
+            data-id="stickycontenttop"
+            ref={this._stickyContentTop}
+            aria-hidden={!isStickyTop}
+            style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}
+          >
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />
           </div>
         )}
         {this.canStickyBottom && (
-          <div ref={this._stickyContentBottom} aria-hidden={!isStickyBottom} style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}>
+          <div
+            data-id="stickycontentbottom"
+            ref={this._stickyContentBottom}
+            aria-hidden={!isStickyBottom}
+            style={{ pointerEvents: isStickyBottom ? 'auto' : 'none' }}
+          >
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
-        <div style={this._getNonStickyPlaceholderHeight()} ref={this._placeHolder}>
+        <div style={this._getNonStickyPlaceholderHeight()} data-id="placeholder" ref={this._placeHolder}>
           <div
+            data-id="nonstickycontent"
             ref={this._nonStickyContent}
             className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
             style={this._getContentStyles(isStickyTop || isStickyBottom)}
@@ -168,8 +183,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   }
 
   public resetSticky(): void {
-    if (this.nonStickyContent && this.root) {
-      this.root.appendChild(this.nonStickyContent);
+    if (this.nonStickyContent && this.placeholder) {
+      this.placeholder.appendChild(this.nonStickyContent);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This is a re-do of #6870.  This PR fixes 
- Sticky component sorting order
- Placeholder heights
- When stickyClassName is applied

### **Sticky Component Sorting Order**
There are instances when the DOM isn't fully loaded, and a few `Sticky` component had the same `distanceToTop` which resulted in incorrect ordering for the `stickyAbove` container.  I've added `distanceToTop` as a state for the `Sticky` component, and if the `this.state.distanceFromTop !== prevState.distanceFromTop` then the `Sticky` element will remove itself from `stickyAbove` and `stickyBelow` and add itself again, this time in the correct position.

### **Placeholder Heights**
The two streamable links below outline the issue (please excuse jitteryness of the DetailsList, the jump is because there is no animation being used).

https://streamable.com/9mrb2

In the first video: The first row of the DetailsList is cut off due to the placeholder heights not correctly updating to match with the Sticky component's height.  

https://streamable.com/caaw5

In this second video:  The first row is correctly showing.  Once the `Item List` element Sticky, then the font size is increased, which results in the placeholder height increasing to match now.

### **When stickyClassName is applied**
Previously the check for `isStickyTop` was when the `distanceToStickTop < container.scrollTop`.  This is incorrect since if the scroll container is at the top (unscrolled) and there is a `Sticky` component that is aligned at the top as well, then it's considering the component to be `isStickyTop` when it should be when the component is 1px above the fold instead.

#6870 previously added a prop `onScrollStickyAboveClassName`, but `stickyClassName` should work with the intended purpose now.

There are a few indentation changes to the api.ts file, which I'm not sure how to get rid of.. Let me know if this is an issue and I can look into it further.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6937)

