### PR TITLE
Panel: fix box-shadow

### DIFF
--- a/common/changes/office-ui-fabric-react/panelBoxShadow_2018-11-01-23-44.json
+++ b/common/changes/office-ui-fabric-react/panelBoxShadow_2018-11-01-23-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: fix box-shadow value",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -166,7 +166,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
             borderRight: `1px solid ${palette.neutralLight}`,
             pointerEvents: 'auto',
             width: panelSize.width.sm,
-            boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)',
+            boxShadow: '0px 0px 30px 0px rgba(0,0,0,0.2)',
             left: 'auto'
           },
           '$root &': [
@@ -180,7 +180,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
               right: 'auto',
               left: 0,
               width: panelSize.width.xs,
-              boxShadow: '30px 0px 30px -30px rgba(0,0,0,0.2)'
+              boxShadow: '0px 0px 30px 0px rgba(0,0,0,0.2)'
             },
             type === PanelType.smallFixedFar && {
               width: panelSize.width.xs,

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`Panel renders Panel correctly 1`] = `
               @media (min-width: 480px){& {
                 border-left: 1px solid #eaeaea;
                 border-right: 1px solid #eaeaea;
-                box-shadow: -30px 0px 30px -30px rgba(0,0,0,0.2);
+                box-shadow: 0px 0px 30px 0px rgba(0,0,0,0.2);
                 left: auto;
                 pointer-events: auto;
                 width: 340px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -230,7 +230,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                 @media (min-width: 480px){& {
                   border-left: 1px solid #eaeaea;
                   border-right: 1px solid #eaeaea;
-                  box-shadow: -30px 0px 30px -30px rgba(0,0,0,0.2);
+                  box-shadow: 0px 0px 30px 0px rgba(0,0,0,0.2);
                   left: auto;
                   pointer-events: auto;
                   width: 340px;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6888
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Changes the box-shadow value for Panels so that the shadow extends all the way from the top to the bottom of the Panel. Before, it was too short.

Before:

![image](https://user-images.githubusercontent.com/14134000/47886661-aaaea400-ddf8-11e8-8ce3-59e364fecc6c.png)

After:

![image](https://user-images.githubusercontent.com/14134000/47886669-b1d5b200-ddf8-11e8-9eb3-d7a7ccee64aa.png)

#### Focus areas to test

Open the Panel demo page and ensure that the shadows now reach from the top to the bottom of the panel. 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6941)

