### PR TITLE
Fix typo in the aria-label of DatePicker's inner Callout

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-dt-aria-spelling_2018-11-02-18-35.json
+++ b/common/changes/office-ui-fabric-react/keco-dt-aria-spelling_2018-11-02-18-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix typo with DatePicker Callout aria-label.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -62,7 +62,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     highlightCurrentMonth: false,
     highlightSelectedMonth: false,
     borderless: false,
-    pickerAriaLabel: 'Calender',
+    pickerAriaLabel: 'Calendar',
     showWeekNumbers: false,
     firstWeekOfYear: FirstWeekOfYear.FirstDay,
     showGoToToday: true,

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -7,6 +7,7 @@ import { IDatePickerStrings } from './DatePicker.types';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { shallow, mount, ReactWrapper } from 'enzyme';
 import { resetIds } from '../../Utilities';
+import { Callout } from '../Callout/Callout';
 
 describe('DatePicker', () => {
   beforeEach(() => {
@@ -37,6 +38,14 @@ describe('DatePicker', () => {
     const wrapper = mount(<DatePickerBase disabled label="label" />);
     wrapper.find('i').simulate('click');
     expect(wrapper.state('isDatePickerShown')).toBe(false);
+  });
+
+  it('should set "Calendar" as the Callout\'s aria-label', () => {
+    const datePicker = shallow(<DatePickerBase />);
+    datePicker.setState({ isDatePickerShown: true });
+    const calloutProps = datePicker.find(Callout).props();
+
+    expect(calloutProps.ariaLabel).toBe('Calendar');
   });
 
   describe('when Calendar properties are not specified', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6910
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes a typo with the `aria-label` of `DatePicker`'s inner `Callout` element. Changes "Calender" to "Calendar". Added a unit test to ensure correct spelling as this is set by the library and not configurable. Nice catch @martellaj.

#### Focus areas to test

Check that `DatePicker`'s inner `Callout` has an `aria-label` with the value "Calendar" not "Calender". I've also added a unit test for this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6954)

