### PR TITLE
Fix tslint attempting to run on API extractor .api files

### DIFF
--- a/scripts/lint-staged/tslint.js
+++ b/scripts/lint-staged/tslint.js
@@ -53,7 +53,14 @@ function runTsLintOnFilesGroupedPerPackage(filesGroupedByPackage) {
 
   for (let [package, files] of fileEntries) {
     const tslintConfig = path.join(path.resolve(__dirname, '..', '..'), package, 'tslint.json');
+    let filteredFiles = files.filter(f => {
+      return !f.endsWith('.api.ts');
+    });
 
-    execSync(`${tslintPath} --config ${tslintConfig} -t stylish -r ${rulesPath} ${files.join(' ')}`);
+    if (filteredFiles.length === 0) {
+      continue;
+    }
+
+    execSync(`${tslintPath} --config ${tslintConfig} -t stylish -r ${rulesPath} ${filteredFiles.join(' ')}`);
   }
 }


### PR DESCRIPTION
#### Description of changes

We should not run TSLint on API Extractor files.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6956)

