### PR TITLE
Website: Temporary overrides for overly-specific MWF styles

### DIFF
--- a/apps/fabric-website/src/styles/_overrides.scss
+++ b/apps/fabric-website/src/styles/_overrides.scss
@@ -38,6 +38,26 @@
     }
   }
 
+  @include high-contrast {
+    // Temporary workaround for unnecessarily-specific selector from MWF, which
+    // causes colors in Breadcrumb and other components to get stomped on.
+    // These should be removed if/when MWF pushes a change to make these
+    // selectors less specific.
+    // See https://github.com/OfficeDev/office-ui-fabric-react/issues/6468 for more details.
+    [class*='m-'] button:not(.c-select-button):not(:disabled):not(.c-sequence-indicator):hover,
+    [class*='m-'] button:not(.c-select-button):not(:disabled):not(.c-sequence-indicator):active,
+    [class*='c-'] button:not(.c-select-button):not(:disabled):not(.c-sequence-indicator):hover,
+    [class*='c-'] button:not(.c-select-button):not(:disabled):not(.c-sequence-indicator):active {
+      &.ms-Breadcrumb-itemLink {
+        color: Highlight !important;
+        background-color: $ms-color-neutralLighter !important;
+      }
+    }
+  }
+
+  // @media screen and (-ms-high-contrast: active) {
+  // }
+
   // @TODO: Fix this in fabric ui core, or add prop to Panel to have user specify z-index
   // Set to 600 to place over header
   .ms-Panel {

--- a/apps/fabric-website/src/styles/_overrides.scss
+++ b/apps/fabric-website/src/styles/_overrides.scss
@@ -1,5 +1,6 @@
 @import '~office-ui-fabric-react/dist/sass/References';
 @import './variables';
+@import './mixins';
 
 //== Fabric overrides and additions
 
@@ -54,9 +55,6 @@
       }
     }
   }
-
-  // @media screen and (-ms-high-contrast: active) {
-  // }
 
   // @TODO: Fix this in fabric ui core, or add prop to Panel to have user specify z-index
   // Set to 600 to place over header

--- a/common/changes/@uifabric/example-app-base/jahnp-fix-website-css-bugs_2018-11-02-21-46.json
+++ b/common/changes/@uifabric/example-app-base/jahnp-fix-website-css-bugs_2018-11-02-21-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Fix visual bugs caused by MWF overrides on Fabric site",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "pejahn@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/jahnp-fix-website-css-bugs_2018-11-02-21-46.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-fix-website-css-bugs_2018-11-02-21-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix visual bugs caused by MWF overrides on Fabric site",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "pejahn@microsoft.com"
+}

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.scss
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.scss
@@ -1,3 +1,5 @@
+@import '~office-ui-fabric-react/dist/sass/_themeOverrides';
+
 :global {
   .FeedbackList-pivot {
     padding-top: 20px;
@@ -10,6 +12,11 @@
 
   .FeedbackList-button {
     margin-bottom: 10px;
+  }
+
+  // Temporary workaround for https://github.com/OfficeDev/office-ui-fabric-react/issues/6782.
+  a.FeedbackList-button {
+    color: $ms-color-white;
   }
 
   .FeedbackList-listElement {


### PR DESCRIPTION
#### Pull request checklist
- [x] Addresses an existing issue: #6782 and Breadcrumb HC style issue from #6468 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Some greedy selectors from MWF are stomping on Fabric component styles only on the live site. The changes in this PR are temporary workarounds until we're able to address proper fixes in MWF itself. They will *only* appear on the website, not in Fabric itself.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6960)

