### PR TITLE
Website: Update TypeScript usage in Get Started tutorial

### DIFF
--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -187,14 +187,18 @@ export class GetStartedPage extends React.Component<any, any> {
             </li>
             <li>
               <p>
-                Use npm to create a React app. Consider using Facebook's{' '}
+                Use npm to create a React app that uses TypeScript. Consider using Facebook's{' '}
                 <a href="https://github.com/facebook/create-react-app" target="_blank">
                   Create React App
+                </a>{' '}
+                along with{' '}
+                <a href="https://github.com/wmonk/create-react-app-typescript">
+                  <code>react-scripts-ts</code>
                 </a>{' '}
                 to get started quickly:
               </p>
               <CodeBlock language="bash" isLightTheme={true}>
-                {`npx create-react-app my-app`}
+                {`npx create-react-app my-app --scripts-version=react-scripts-ts`}
               </CodeBlock>
             </li>
             <li>
@@ -206,21 +210,27 @@ npm install office-ui-fabric-react`}
             </li>
             <li>
               <p>
-                Import and use DefaultButton, a Fabric React control. Make sure to import controls alongside React, then use them in your
-                render method.
+                In <code>src/App.tsx</code>, import and use <code>DefaultButton</code>, a Fabric React control. Make sure to import controls
+                alongside React, then use them in your <code>render</code> method. It will should look something like this:
               </p>
               <CodeBlock language="javascript" isLightTheme={true}>
                 {`import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 
-const MyPage = () => (
-  <DefaultButton>
-    I am a button.
-  </DefaultButton>
-);
+class App extends React.Component {
+  public render() {
+    return (
+      <div className="App">
+        <DefaultButton>
+          I am a button.
+        </DefaultButton>
+      </div>
+    );
+  }
+}
 
-ReactDOM.render(<MyPage />, document.body.firstChild);`}
+export default App;`}
               </CodeBlock>
             </li>
             <li>

--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -187,14 +187,14 @@ export class GetStartedPage extends React.Component<any, any> {
             </li>
             <li>
               <p>
-                Use npm to create a React app that uses TypeScript. Consider using Facebook's{' '}
+                Use npm to create a React app. Consider using Facebook's{' '}
                 <a href="https://github.com/facebook/create-react-app" target="_blank">
                   Create React App
                 </a>{' '}
                 to get started quickly:
               </p>
               <CodeBlock language="bash" isLightTheme={true}>
-                {`npx create-react-app my-app --typescript`}
+                {`npx create-react-app my-app`}
               </CodeBlock>
             </li>
             <li>
@@ -212,7 +212,6 @@ npm install office-ui-fabric-react`}
               <CodeBlock language="javascript" isLightTheme={true}>
                 {`import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 
 const MyPage = () => (

--- a/common/changes/@uifabric/fabric-website/jahnp-fix-tutorial_2018-11-03-20-51.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-fix-tutorial_2018-11-03-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Remove TypeScript from get started tutorial",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "pejahn@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/jahnp-fix-tutorial_2018-11-03-20-51.json
+++ b/common/changes/@uifabric/fabric-website/jahnp-fix-tutorial_2018-11-03-20-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/fabric-website",
-      "comment": "Remove TypeScript from get started tutorial",
+      "comment": "Update TypeScript instructions in getting started tutorial",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
#### Pull request checklist
- [x] Addresses an existing issue: Fixes #6965, sort of
- [x] Include a change request file using `$ npm run change`

#### Description of changes
In #6912, we introduced the recommendation to use Create React App's new `--typescript` option. However, its configuration does not play nice with Fabric, as it doesn't support `const enum`s (which Fabric uses & exports a fair bit). See #6965 for more details.

While we discuss the future of `const enum`s in #6386 , this PR updates the TypeScript + Create React App recommendation to use [`react-scripts-ts`](https://github.com/wmonk/create-react-app-typescript) instead. 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6967)

