### PR TITLE
Wrapper for donut chart in card

### DIFF
--- a/common/changes/@uifabric/dashboard/wrapperForDonutChartInCard_2018-11-04-00-11.json
+++ b/common/changes/@uifabric/dashboard/wrapperForDonutChartInCard_2018-11-04-00-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding necessary wrapper classes for charting in dashboard package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/Chart/Chart.styles.ts
+++ b/packages/dashboard/src/components/Card/Chart/Chart.styles.ts
@@ -5,6 +5,10 @@ export const getStyles = (): IChartStyles => {
     chartWrapper: {
       width: '100%',
       height: '100%'
+    },
+    donutWrapper: {
+      display: 'flex',
+      justifyContent: 'center'
     }
   };
 };

--- a/packages/dashboard/src/components/Card/Chart/Chart.tsx
+++ b/packages/dashboard/src/components/Card/Chart/Chart.tsx
@@ -69,6 +69,7 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
   }
 
   private _getChartByType = (chartType: ChartType): JSX.Element => {
+    const classNames = this.getClassNames(getStyles);
     switch (chartType) {
       case ChartType.VerticalBarChart: {
         return (
@@ -90,15 +91,19 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
       }
       case ChartType.DonutChart: {
         return (
-          <div className={mergeStyles({ width: 300, height: 250 })}>
-            <DonutChart data={this.props.chartData![0]} innerRadius={88} />
+          <div className={classNames.donutWrapper}>
+            <div className={mergeStyles({ width: 300, height: 250 })}>
+              <DonutChart data={this.props.chartData![0]} innerRadius={88} />
+            </div>
           </div>
         );
       }
       case ChartType.PieChart: {
         return (
-          <div className={mergeStyles({ width: 300, height: 250 })}>
-            <DonutChart data={this.props.chartData![0]} innerRadius={0} />
+          <div className={classNames.donutWrapper}>
+            <div className={mergeStyles({ width: 300, height: 250 })}>
+              <DonutChart data={this.props.chartData![0]} innerRadius={0} />
+            </div>
           </div>
         );
       }
@@ -201,6 +206,7 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
           tickValues.push(nextDate);
         }
       }
+      const parentElement = this._rootElem ? this._rootElem.parentElement : null;
       return (
         <div
           ref={(e: HTMLElement | null) => {
@@ -209,7 +215,7 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
           className={classNames.chartWrapper}
         >
           <LineChart
-            parentRef={this._rootElem}
+            parentRef={parentElement}
             data={this.props.chartData![0]}
             strokeWidth={this.props.strokeWidth}
             tickValues={tickValues}
@@ -218,6 +224,7 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
         </div>
       );
     } else {
+      const parentElement = this._rootElem ? this._rootElem.parentElement : null;
       return (
         <div
           ref={(e: HTMLElement | null) => {
@@ -225,7 +232,7 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
           }}
           className={classNames.chartWrapper}
         >
-          <LineChart parentRef={this._rootElem} data={this.props.chartData![0]} strokeWidth={this.props.strokeWidth} />
+          <LineChart parentRef={parentElement} data={this.props.chartData![0]} strokeWidth={this.props.strokeWidth} />
         </div>
       );
     }

--- a/packages/dashboard/src/components/Card/Chart/Chart.types.ts
+++ b/packages/dashboard/src/components/Card/Chart/Chart.types.ts
@@ -120,4 +120,9 @@ export interface IChartStyles {
    * wrapper component that sits on top of each chart
    */
   chartWrapper: IStyle;
+
+  /**
+   * wrapper for donut chart
+   */
+  donutWrapper: IStyle;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adding a wrapper to support charting in flex containers. The wrappers make sure the charting scale and center themselves appropriately.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6968)

