### PR TITLE
[DetailsList] Adding tooltips to columns.

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-11-05-07-31.json
+++ b/common/changes/office-ui-fabric-react/master_2018-11-05-07-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: add ability to specify column tooltip",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nerios@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2856,6 +2856,7 @@ interface IColumn {
   onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
   sortAscendingAriaLabel?: string;
   sortDescendingAriaLabel?: string;
+  title?: string;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -77,6 +77,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
               children: (
                 <span
                   id={`${parentId}-${column.key}`}
+                  title={column.title}
                   aria-label={column.isIconOnly ? column.name : undefined}
                   aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name `}
                   className={classNames.cellTitle}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -125,4 +125,30 @@ describe('DetailsColumn', () => {
 
     expect(mockOnColumnClick.mock.calls.length).toBe(0);
   });
+
+  it('renders tooltip when title prop is provided', () => {
+    const title = 'tooltip';
+    const column = assign({}, baseColumn, { title });
+    const columns = [column];
+    let component: any;
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    const columnHeader = component.find(DetailsColumn);
+    const columnHeaderTitle = columnHeader.find(`.ms-DetailsHeader-cellTitle[title="${title}"]`);
+
+    expect(columnHeaderTitle).toHaveLength(1);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -308,6 +308,11 @@ export interface IColumn {
   name: string;
 
   /**
+   * Tooltip to render on the column header.
+   */
+  title?: string;
+
+  /**
    * The field to pull the text value from for the column. This can be null if a custom
    * onRender method is provided.
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ x] Include a change request file using `$ npm run change`

#### Description of changes

There is no easy way to show a tooltip in a DetailsList column. This PR adds a that ability.

#### Focus areas to test

A new prop "title" in the IColumn interface can now be used to add a tooltip.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6971)

