### PR TITLE
Fixes #5849: get rid of explicit loader syntax inside component file

### DIFF
--- a/common/changes/@uifabric/dashboard/dashboard_2018-11-05-16-50.json
+++ b/common/changes/@uifabric/dashboard/dashboard_2018-11-05-16-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Fixes #5849: get rid of explicit loader syntax inside component file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
@@ -10,9 +10,10 @@ import { getStyles } from './DashboardGridLayout.styles';
 import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { CardSizeToWidthHeight, updateLayoutsFromLayout } from '../../utilities/DashboardGridLayoutUtils';
 
-require('style-loader!css-loader!react-grid-layout/css/styles.css');
-require('style-loader!css-loader!react-resizable/css/styles.css');
-require('style-loader!css-loader!./DashboardGridLayout.css');
+// These require the style-loader and css-loader rules from webpack
+require('react-grid-layout/css/styles.css');
+require('react-resizable/css/styles.css');
+require('./DashboardGridLayout.css');
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
 

--- a/packages/dashboard/webpack.config.js
+++ b/packages/dashboard/webpack.config.js
@@ -24,12 +24,7 @@ module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
             loader: '@microsoft/loader-load-themed-styles' // creates style nodes from JS strings
           },
           {
-            loader: 'css-loader', // translates CSS into CommonJS
-            options: {
-              modules: true,
-              importLoaders: 2,
-              minimize: false
-            }
+            loader: 'css-loader' // translates CSS into CommonJS
           }
         ]
       }

--- a/packages/dashboard/webpack.config.js
+++ b/packages/dashboard/webpack.config.js
@@ -14,6 +14,28 @@ module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
     library: 'FabricDashboardGridLayout'
   },
 
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        enforce: 'pre',
+        use: [
+          {
+            loader: '@microsoft/loader-load-themed-styles' // creates style nodes from JS strings
+          },
+          {
+            loader: 'css-loader', // translates CSS into CommonJS
+            options: {
+              modules: true,
+              importLoaders: 2,
+              minimize: false
+            }
+          }
+        ]
+      }
+    ]
+  },
+
   externals: [{ react: 'React' }, { 'react-dom': 'ReactDOM' }],
 
   resolve: {

--- a/packages/dashboard/webpack.serve.config.js
+++ b/packages/dashboard/webpack.serve.config.js
@@ -16,6 +16,29 @@ module.exports = resources.createServeConfig({
     'react-dom': 'ReactDOM'
   },
 
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        enforce: 'pre',
+        use: [
+          {
+            loader: '@microsoft/loader-load-themed-styles' // creates style nodes from JS strings
+          },
+          {
+            loader: 'css-loader', // translates CSS into CommonJS
+            options: {
+              modules: true,
+              importLoaders: 2,
+              localIdentName: '[name]_[local]_[hash:base64:5]',
+              minimize: false
+            }
+          }
+        ]
+      }
+    ]
+  },
+
   resolve: {
     alias: {
       '@uifabric/dashboard/src': path.join(__dirname, 'src'),

--- a/packages/dashboard/webpack.serve.config.js
+++ b/packages/dashboard/webpack.serve.config.js
@@ -26,13 +26,7 @@ module.exports = resources.createServeConfig({
             loader: '@microsoft/loader-load-themed-styles' // creates style nodes from JS strings
           },
           {
-            loader: 'css-loader', // translates CSS into CommonJS
-            options: {
-              modules: true,
-              importLoaders: 2,
-              localIdentName: '[name]_[local]_[hash:base64:5]',
-              minimize: false
-            }
+            loader: 'css-loader' // translates CSS into CommonJS
           }
         ]
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5849
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The source code inside dashboard grid layout component explicitly includes loader rules. Following this [recommendation](https://webpack.js.org/concepts/loaders/#inline), we should get rid of having these inline loader code inside our codebase.

> Use module.rules whenever possible, as this will reduce boilerplate in your source code and allow you to debug or locate a loader faster if something goes south.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6974)

