### PR TITLE
Fixes #6975: add support for comma'ed selectors in mergestyles

### DIFF
--- a/common/changes/@uifabric/merge-styles/6975-comma-mergestyles_2018-11-05-19-06.json
+++ b/common/changes/@uifabric/merge-styles/6975-comma-mergestyles_2018-11-05-19-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Fixes #6975: adds ability for mergestyles to handle commas in selectors",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -39,6 +39,16 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0 .foo{background:red;}');
   });
 
+  it('can have child selectors with comma', () => {
+    styleToClassName({
+      selectors: {
+        '.foo, .bar': { background: 'red' }
+      }
+    });
+
+    expect(_stylesheet.getRules()).toEqual('.css-0 .foo, .css-0 .bar{background:red;}');
+  });
+
   it('can have same element class selectors', () => {
     styleToClassName({
       selectors: {

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -50,6 +50,16 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0 .foo, .css-0 .bar{background:red;}');
   });
 
+  it('can have child selectors with comma with pseudo selectors', () => {
+    styleToClassName({
+      selectors: {
+        ':hover, :active': { background: 'red' }
+      }
+    });
+
+    expect(_stylesheet.getRules()).toEqual('.css-0:hover, .css-0:active{background:red;}');
+  });
+
   it('can have child selectors with comma with @media query', () => {
     styleToClassName({
       selectors: {

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -2,6 +2,7 @@ import { InjectionMode, Stylesheet } from './Stylesheet';
 
 import { setRTL } from './transforms/rtlifyRules';
 import { styleToClassName } from './styleToClassName';
+import { renderStatic } from './server';
 
 const _stylesheet: Stylesheet = Stylesheet.getInstance();
 
@@ -47,6 +48,20 @@ describe('styleToClassName', () => {
     });
 
     expect(_stylesheet.getRules()).toEqual('.css-0 .foo, .css-0 .bar{background:red;}');
+  });
+
+  it('can have child selectors with comma with @media query', () => {
+    styleToClassName({
+      selectors: {
+        '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)': {
+          background: 'red'
+        }
+      }
+    });
+
+    expect(_stylesheet.getRules()).toEqual(
+      '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){.css-0{background:red;}}'
+    );
   });
 
   it('can have same element class selectors', () => {

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -25,8 +25,6 @@ function getDisplayName(rules?: { [key: string]: IRawStyle }): string | undefine
 function expandSelector(newSelector: string, currentSelector: string): string {
   if (newSelector.indexOf(':global(') === 0) {
     return newSelector.replace(/:global\(|\)$/g, '');
-  } else if (newSelector.indexOf('@') === 0) {
-    return newSelector + '{' + currentSelector;
   } else if (newSelector.indexOf(':') === 0) {
     return currentSelector + newSelector;
   } else if (newSelector.indexOf('&') < 0) {
@@ -64,11 +62,14 @@ function extractRules(args: IStyle[], rules: IRuleSet = { __order: [] }, current
           // tslint:disable-next-line:no-any
           const selectors: { [key: string]: IStyle } = (arg as any).selectors;
 
-          for (const newSelector in selectors) {
+          for (let newSelector in selectors) {
             if (selectors.hasOwnProperty(newSelector)) {
               const selectorValue = selectors[newSelector];
 
-              if (newSelector.indexOf(',') > -1) {
+              if (newSelector.indexOf('@') === 0) {
+                newSelector = newSelector + '{' + currentSelector;
+                extractRules([selectorValue], rules, newSelector);
+              } else if (newSelector.indexOf(',') > -1) {
                 const commaSeparatedSelectors = newSelector.split(/,/g).map((s: string) => s.trim());
                 extractRules(
                   [selectorValue],

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -22,6 +22,20 @@ function getDisplayName(rules?: { [key: string]: IRawStyle }): string | undefine
   return rootStyle ? (rootStyle as IRawStyle).displayName : undefined;
 }
 
+function expandSelector(newSelector: string, currentSelector: string): string {
+  if (newSelector.indexOf(':global(') === 0) {
+    return newSelector.replace(/:global\(|\)$/g, '');
+  } else if (newSelector.indexOf('@') === 0) {
+    return newSelector + '{' + currentSelector;
+  } else if (newSelector.indexOf(':') === 0) {
+    return currentSelector + newSelector;
+  } else if (newSelector.indexOf('&') < 0) {
+    return currentSelector + ' ' + newSelector;
+  }
+
+  return newSelector;
+}
+
 function extractRules(args: IStyle[], rules: IRuleSet = { __order: [] }, currentSelector: string = '&'): IRuleSet {
   const stylesheet = Stylesheet.getInstance();
   let currentRules: IDictionary | undefined = rules[currentSelector] as IDictionary;
@@ -50,21 +64,22 @@ function extractRules(args: IStyle[], rules: IRuleSet = { __order: [] }, current
           // tslint:disable-next-line:no-any
           const selectors: { [key: string]: IStyle } = (arg as any).selectors;
 
-          for (let newSelector in selectors) {
+          for (const newSelector in selectors) {
             if (selectors.hasOwnProperty(newSelector)) {
               const selectorValue = selectors[newSelector];
 
-              if (newSelector.indexOf(':global(') === 0) {
-                newSelector = newSelector.replace(/:global\(|\)$/g, '');
-              } else if (newSelector.indexOf('@') === 0) {
-                newSelector = newSelector + '{' + currentSelector;
-              } else if (newSelector.indexOf(':') === 0) {
-                newSelector = currentSelector + newSelector;
-              } else if (newSelector.indexOf('&') < 0) {
-                newSelector = currentSelector + ' ' + newSelector;
+              if (newSelector.indexOf(',') > -1) {
+                const commaSeparatedSelectors = newSelector.split(/,/g).map((s: string) => s.trim());
+                extractRules(
+                  [selectorValue],
+                  rules,
+                  commaSeparatedSelectors
+                    .map((commaSeparatedSelector: string) => expandSelector(commaSeparatedSelector, currentSelector))
+                    .join(', ')
+                );
+              } else {
+                extractRules([selectorValue], rules, expandSelector(newSelector, currentSelector));
               }
-
-              extractRules([selectorValue], rules, newSelector);
             }
           }
         } else {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6975
- [x] Include a change request file using `$ npm run change`

#### Description of changes

See #6975 for details. Basically selectors with commas will not produce the correct results.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6977)

