### PR TITLE
Use IGroup.key instead of IGroup.name for GroupedList inner List page key prop value

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-groupedlist-uniq-key_2018-11-05-21-19.json
+++ b/common/changes/office-ui-fabric-react/keco-groupedlist-uniq-key_2018-11-05-21-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Set GroupedList List page key to IGroup key instead of name for uniqueness.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -280,7 +280,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     const groups = this.state.groups;
     const pageGroup = groups && groups[itemIndex];
     return {
-      key: pageGroup && pageGroup.name
+      key: pageGroup && (pageGroup.key || pageGroup.name)
     };
   };
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -280,7 +280,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     const groups = this.state.groups;
     const pageGroup = groups && groups[itemIndex];
     return {
-      key: pageGroup && (pageGroup.key || pageGroup.name)
+      key: pageGroup && pageGroup.key
     };
   };
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { SelectionMode, Selection } from '../../utilities/selection/index';
+import { GroupedList } from './GroupedList';
+import { DetailsRow } from '../DetailsList/DetailsRow';
+import { IGroup } from './GroupedList.types';
+import { IColumn } from '../DetailsList/DetailsList.types';
+import { List } from '../List/List';
+
+describe('GroupedList', () => {
+  it("sets inner List page key to IGroup's key attribute for uniqueness", () => {
+    const _selection = new Selection();
+    const _items: Array<any> = [];
+    const _groups: Array<IGroup> = [
+      {
+        count: 1,
+        key: 'group0',
+        name: 'group 0',
+        startIndex: 0,
+        level: 0,
+        children: []
+      }
+    ];
+
+    function _onRenderCell(nestingDepth: number, item: any, itemIndex: number): JSX.Element {
+      return (
+        <DetailsRow
+          columns={Object.keys(item)
+            .slice(0, 2)
+            .map(
+              (value): IColumn => {
+                return {
+                  key: value,
+                  name: value,
+                  fieldName: value,
+                  minWidth: 300
+                };
+              }
+            )}
+          groupNestingDepth={nestingDepth}
+          item={item}
+          itemIndex={itemIndex}
+          selection={_selection}
+          selectionMode={SelectionMode.multiple}
+        />
+      );
+    }
+
+    const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
+    const listPage = wrapper
+      .find(List)
+      .find('.ms-List-page')
+      .first();
+
+    expect(listPage.key()).toBe('group0');
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6940
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Modifies `GroupedList` so that the `key` of its inner `List` components used per group is equal to the value of its `IGroup.key` **not** `IGroup.name`. 

#### Justification for this change

React documentation specifies:

>Keys used within arrays should be unique among their siblings.
>https://reactjs.org/docs/lists-and-keys.html#keys-must-only-be-unique-among-siblings

OUIFR's documentation for `IGroup` encourages developers to use a _unique identifier_ for each group as the value of `IGroup.key`:

```ts
export interface IGroup {
  /**
   * Unique identifier for the group.
   */
  key: string;

  /**
   * Display name for the group, rendered on the header.
   */
  name: string;
  ...
```

Therefore, we should use `IGroup.key` as the unique `key` prop per `List` page.

I chose not to default to `IGroup.name` in the absence of `key` since it is not guaranteed to be unique and `key` is a required field.

#### Backwards Compatibility

As far as I'm aware this change should not break backwards compatibility as it _does not_ modify our public API surface.

#### Focus areas to test

Added a unit test to ensure that `IGroup.key` is used as the value of the `GroupedList`'s inner `List`'s `key` prop.
