### PR TITLE
Fluent theme: Export all styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-theme-exports_2018-11-05-22-28.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-theme-exports_2018-11-05-22-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Export all Fluent styles",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -28,6 +28,7 @@
     "@uifabric/tslint-rules": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "@uifabric/merge-styles": "^6.11.0",
     "@uifabric/set-version": ">=1.1.3 <2.0.0",
     "@uifabric/variants": ">=6.12.0 <7.0.0",
     "office-ui-fabric-react": ">=6.99.0 <7.0.0",

--- a/packages/fluent-theme/src/fluent/index.ts
+++ b/packages/fluent-theme/src/fluent/index.ts
@@ -1,0 +1,6 @@
+export * from './FluentColors';
+export * from './FluentDepths';
+export * from './FluentMotion';
+export * from './FluentStyles';
+export * from './FluentTheme';
+export * from './FluentType';

--- a/packages/fluent-theme/src/index.ts
+++ b/packages/fluent-theme/src/index.ts
@@ -1,1 +1,2 @@
 export * from './FluentCustomizations';
+export * from './fluent/index';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Exports the various Fluent style objects (colors, depth, motion, etc.) from the `fluent-theme` package. These are useful when building custom components that need to match the Fluent design language.

This PR is a clean attempt at #6919, which had build issues and a messy merge from master.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6982)

