### PR TITLE
Fluent theme: Add button styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-buttons_2018-11-06-18-02.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-buttons_2018-11-06-18-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Add Fluent button styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fluent-buttons_2018-11-06-18-31.json
+++ b/common/changes/office-ui-fabric-react/fluent-buttons_2018-11-06-18-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: Update example to use PrimaryButton component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -13,6 +13,7 @@ import { RatingStyles } from './styles/Rating.styles';
 import { SliderStyles } from './styles/Slider.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
+import { IconButtonStyles } from './styles/IconButton.styles';
 
 // Roll up all style overrides in a single "Fluent theme" object
 
@@ -49,6 +50,9 @@ export const FluentStyles: any = {
   },
   Dropdown: {
     styles: DropdownStyles
+  },
+  IconButton: {
+    styles: IconButtonStyles
   },
   Label: {
     styles: LabelStyles

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -14,6 +14,7 @@ import { SliderStyles } from './styles/Slider.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
 import { IconButtonStyles } from './styles/IconButton.styles';
+import { CommandBarButtonStyles } from './styles/CommandBarButton.styles';
 
 // Roll up all style overrides in a single "Fluent theme" object
 
@@ -23,6 +24,9 @@ import { IconButtonStyles } from './styles/IconButton.styles';
 export const FluentStyles: any = {
   Breadcrumb: {
     styles: BreadcrumbStyles
+  },
+  CommandBarButton: {
+    styles: CommandBarButtonStyles
   },
   CompoundButton: {
     styles: CompoundButtonStyles

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -1,0 +1,8 @@
+import FluentTheme from '../FluentTheme';
+import { getFocusStyle } from '../../../../styling/lib';
+
+export const CommandBarButtonStyles = {
+  root: {
+    ...getFocusStyle(FluentTheme, 2)
+  }
+};

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -1,7 +1,10 @@
 import FluentTheme from '../FluentTheme';
-import { getFocusStyle } from '../../../../styling/lib';
+import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 
-export const CommandBarButtonStyles = {
+// TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
+//        this 'any' once we upgrade to TS3.1+
+// tslint:disable-next-line:no-any
+export const CommandBarButtonStyles: any = {
   root: {
     ...getFocusStyle(FluentTheme, 2)
   }

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -1,7 +1,7 @@
 import { fluentBorderRadius } from './styleConstants';
 import { NeutralColors, CommunicationColors } from '../FluentColors';
 import FluentTheme from '../FluentTheme';
-import { getFocusStyle } from '../../../../styling/lib';
+import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 
 export const CompoundButtonStyles = {
   root: {

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -1,7 +1,54 @@
 import { fluentBorderRadius } from './styleConstants';
+import { NeutralColors, CommunicationColors } from '../FluentColors';
+import FluentTheme from '../FluentTheme';
+import { getFocusStyle } from '../../../../styling/lib';
 
 export const CompoundButtonStyles = {
   root: {
-    borderRadius: fluentBorderRadius
+    ...getFocusStyle(FluentTheme, 2),
+    backgroundColor: NeutralColors.white,
+    border: `1px solid ${NeutralColors.gray110}`,
+    borderRadius: fluentBorderRadius,
+    padding: '16px 12px',
+
+    // Primary styles require targeting a selector for now.
+    // @todo: These selectors override the focus style above. Need to fix this.
+    selectors: {
+      '&.ms-Button--compoundPrimary': {
+        backgroundColor: CommunicationColors.primary,
+        borderColor: CommunicationColors.primary
+      }
+    }
+  },
+  rootPressed: {
+    backgroundColor: NeutralColors.gray40,
+
+    // Primary styles require targeting a selector for now.
+    selectors: {
+      '&.ms-Button--compoundPrimary:active': {
+        backgroundColor: CommunicationColors.shade20
+      }
+    }
+  },
+  rootChecked: {
+    backgroundColor: NeutralColors.gray40,
+
+    // Primary styles require targeting a selector for now.
+    selectors: {
+      '&.ms-Button--compoundPrimary': {
+        backgroundColor: CommunicationColors.shade20,
+        borderColor: CommunicationColors.shade20
+      }
+    }
+  },
+  rootDisabled: {
+    borderColor: NeutralColors.gray20,
+
+    selectors: {
+      '&.ms-Button--compoundPrimary': {
+        backgroundColor: NeutralColors.gray20,
+        borderColor: NeutralColors.gray20
+      }
+    }
   }
 };

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,21 +1,23 @@
-import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { fluentBorderRadius } from './styleConstants';
+import { getFocusStyle } from '../../../../styling/lib';
+import FluentTheme from '../FluentTheme';
 import { NeutralColors } from '../FluentColors';
 
-export const DefaultButtonStyles = (props: IButtonProps) => {
-  const { primary, theme } = props;
-  const { palette, semanticColors } = theme!;
-
-  return {
-    root: {
-      borderRadius: fluentBorderRadius,
-      backgroundColor: primary ? semanticColors.primaryButtonBackground : palette.white,
-      border: primary ? '' : `1px solid ${NeutralColors.gray110}`,
-      color: primary ? semanticColors.buttonText : palette.white
-    },
-    rootHovered: {
-      backgroundColor: primary ? palette.themeDarkAlt : NeutralColors.gray20,
-      border: primary ? '' : `1px solid ${NeutralColors.gray110}`
-    }
-  };
+export const DefaultButtonStyles = {
+  root: {
+    borderRadius: fluentBorderRadius,
+    backgroundColor: NeutralColors.white,
+    border: `1px solid ${NeutralColors.gray110}`,
+    ...getFocusStyle(FluentTheme, 1)
+  },
+  rootHovered: {
+    backgroundColor: NeutralColors.gray20
+  },
+  rootPressed: {
+    backgroundColor: NeutralColors.gray30
+  },
+  rootDisabled: {
+    backgroundColor: NeutralColors.gray20,
+    borderColor: NeutralColors.gray20
+  }
 };

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,9 +1,12 @@
 import { fluentBorderRadius } from './styleConstants';
-import { getFocusStyle } from '../../../../styling/lib';
+import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import FluentTheme from '../FluentTheme';
 import { NeutralColors, CommunicationColors } from '../FluentColors';
 
-export const DefaultButtonStyles = {
+// TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
+//        this 'any' once we upgrade to TS3.1+
+// tslint:disable-next-line:no-any
+export const DefaultButtonStyles: any = {
   root: {
     borderRadius: fluentBorderRadius,
     backgroundColor: NeutralColors.white,

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,7 +1,7 @@
 import { fluentBorderRadius } from './styleConstants';
 import { getFocusStyle } from '../../../../styling/lib';
 import FluentTheme from '../FluentTheme';
-import { NeutralColors } from '../FluentColors';
+import { NeutralColors, CommunicationColors } from '../FluentColors';
 
 export const DefaultButtonStyles = {
   root: {
@@ -11,7 +11,11 @@ export const DefaultButtonStyles = {
     ...getFocusStyle(FluentTheme, 1)
   },
   rootHovered: {
-    backgroundColor: NeutralColors.gray20
+    selectors: {
+      '.ms-Button--primary': {
+        backgroundColor: CommunicationColors.shade10
+      }
+    }
   },
   rootPressed: {
     backgroundColor: NeutralColors.gray30
@@ -22,5 +26,38 @@ export const DefaultButtonStyles = {
   rootDisabled: {
     backgroundColor: NeutralColors.gray20,
     borderColor: NeutralColors.gray20
+  },
+
+  splitButtonMenuButton: {
+    background: 'transparent',
+    borderTopRightRadius: fluentBorderRadius,
+    borderBottomRightRadius: fluentBorderRadius,
+    border: `1px solid ${NeutralColors.gray110}`,
+    borderLeft: 'none'
+  },
+
+  splitButtonContainer: {
+    selectors: {
+      '.ms-Button--default': {
+        borderRight: 'none',
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0
+      },
+      '.ms-Button--primary': {
+        border: 'none',
+        backgroundColor: CommunicationColors.primary
+      },
+      '.ms-Button--primary + .ms-Button': {
+        backgroundColor: CommunicationColors.primary,
+        border: 'none'
+      },
+      '.ms-Button.is-disabled': {
+        backgroundColor: NeutralColors.gray20
+      },
+      '.ms-Button.is-disabled + .ms-Button': {
+        backgroundColor: NeutralColors.gray20,
+        border: 'none'
+      }
+    }
   }
 };

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -16,6 +16,9 @@ export const DefaultButtonStyles = {
   rootPressed: {
     backgroundColor: NeutralColors.gray30
   },
+  rootChecked: {
+    backgroundColor: NeutralColors.gray30
+  },
   rootDisabled: {
     backgroundColor: NeutralColors.gray20,
     borderColor: NeutralColors.gray20

--- a/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
@@ -1,0 +1,24 @@
+import { CommunicationColors, NeutralColors } from '../FluentColors';
+
+export const IconButtonStyles = {
+  root: {
+    backgroundColor: NeutralColors.white,
+    color: CommunicationColors.primary
+  },
+  rootHovered: {
+    backgroundColor: NeutralColors.gray20,
+    color: CommunicationColors.shade10
+  },
+  rootPressed: {
+    backgroundColor: NeutralColors.gray30,
+    color: CommunicationColors.shade20
+  },
+  rootChecked: {
+    backgroundColor: NeutralColors.gray30,
+    color: CommunicationColors.shade20
+  },
+  rootDisabled: {
+    backgroundColor: NeutralColors.white,
+    color: NeutralColors.gray90
+  }
+};

--- a/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
@@ -13,5 +13,8 @@ export const PrimaryButtonStyles = {
   },
   rootPressed: {
     backgroundColor: CommunicationColors.shade20
+  },
+  rootChecked: {
+    backgroundColor: CommunicationColors.shade20
   }
 };

--- a/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
@@ -1,7 +1,17 @@
 import { fluentBorderRadius } from './styleConstants';
+import { CommunicationColors, NeutralColors } from '../FluentColors';
 
 export const PrimaryButtonStyles = {
   root: {
-    borderRadius: fluentBorderRadius
+    borderRadius: fluentBorderRadius,
+    border: 'none',
+    backgroundColor: CommunicationColors.primary,
+    color: NeutralColors.white
+  },
+  rootHovered: {
+    backgroundColor: CommunicationColors.shade10
+  },
+  rootPressed: {
+    backgroundColor: CommunicationColors.shade20
   }
 };

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Default.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css, classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { getStyles, IButtonBasicExampleStyleProps, IButtonBasicExampleStyles } from './Button.Basic.Example.styles';
-import { DefaultButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton, PrimaryButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 
 export class ButtonDefaultExample extends React.Component<IButtonProps, {}> {
@@ -26,8 +26,7 @@ export class ButtonDefaultExample extends React.Component<IButtonProps, {}> {
         </div>
         <div>
           <Label>Primary</Label>
-          <DefaultButton
-            primary={true}
+          <PrimaryButton
             data-automation-id="test"
             disabled={disabled}
             checked={checked}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #6813
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds styles for button components to the Fluent theme.

#### Before
![image](https://user-images.githubusercontent.com/1382445/48084324-3e42f480-e1ac-11e8-9143-29932bcc92cc.png)

#### After
![image](https://user-images.githubusercontent.com/1382445/48084348-4e5ad400-e1ac-11e8-863a-0ee4e3537b30.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6995)

