### PR TITLE
ContextualMenu: add subComponentStyles for menu items.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-ContextualMenu_menuItem_2018-11-06-18-59.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ContextualMenu_menuItem_2018-11-06-18-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Add menuItem subComponentStyles to enable each item styling from the ContextualMenu styles.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6270,6 +6270,7 @@ interface IContextualMenuStyles {
 // @public (undocumented)
 interface IContextualMenuSubComponentStyles {
   callout: IStyleFunctionOrObject<ICalloutContentStyleProps, any>;
+  menuItem: IStyleFunctionOrObject<IContextualMenuItemStyleProps, any>;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -457,10 +457,15 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
         primaryDisabled: item.primaryDisabled
       };
 
+      const menuItemStyles = this._classNames.subComponentStyles
+        ? (this._classNames.subComponentStyles.menuItem as IStyleFunctionOrObject<IContextualMenuItemStyleProps, IContextualMenuItemStyles>)
+        : undefined;
+
       // We need to generate default styles then override if styles are provided
       // since the ContextualMenu currently handles item classNames.
       itemClassNames = mergeStyleSets(
         getContextualMenuItemClassNames(getItemStyles, itemStyleProps),
+        getContextualMenuItemClassNames(menuItemStyles, itemStyleProps),
         getContextualMenuItemClassNames(styles, itemStyleProps)
       );
     }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.deprecated.test.tsx
@@ -73,7 +73,7 @@ describe('ContextualMenu', () => {
         list: 'listFoo',
         header: 'headerFoo',
         title: 'titleFoo',
-        subComponentStyles: { callout: { root: ['calloutFoo'] } }
+        subComponentStyles: { callout: { root: ['calloutFoo'] }, menuItem: { root: ['itemFoo'] } }
       };
     };
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -73,6 +73,6 @@ export const getStyles = (props: IContextualMenuStyleProps): IContextualMenuStyl
         backgroundColor: palette.neutralLight
       }
     ],
-    subComponentStyles: { callout: {} }
+    subComponentStyles: { callout: {}, menuItem: {} }
   };
 };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1166,7 +1166,7 @@ describe('ContextualMenu', () => {
         list: 'listFoo',
         header: 'headerFoo',
         title: 'titleFoo',
-        subComponentStyles: { callout: { root: ['calloutFoo'] } }
+        subComponentStyles: { callout: { root: ['calloutFoo'] }, menuItem: { root: ['itemFoo'] } }
       };
     };
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -10,7 +10,7 @@ import { IWithResponsiveModeState } from '../../utilities/decorators/withRespons
 import { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';
 export { DirectionalHint } from '../../common/DirectionalHint';
 import { IVerticalDividerClassNames } from '../Divider/VerticalDivider.types';
-import { IContextualMenuItemProps, IContextualMenuRenderItem } from './ContextualMenuItem.types';
+import { IContextualMenuItemProps, IContextualMenuRenderItem, IContextualMenuItemStyleProps } from './ContextualMenuItem.types';
 import { IKeytipProps } from '../../Keytip';
 
 export enum ContextualMenuItemType {
@@ -597,4 +597,7 @@ export interface IContextualMenuStyles {
 export interface IContextualMenuSubComponentStyles {
   /** Refers to the callout that hosts the ContextualMenu options */
   callout: IStyleFunctionOrObject<ICalloutContentStyleProps, any>;
+
+  /** Refers to the item in the list */
+  menuItem: IStyleFunctionOrObject<IContextualMenuItemStyleProps, any>;
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
Adding `subComponentStyles` for menu items from within the `ContextualMenu` styles. With this change it allows me to style the items from the fluent theme by passing a style function or object as opposed to target the global classNames.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6997)

