### PR TITLE
Fix ComboBox multiSelect on mouse click regression

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-multiselect-combobox_2018-11-06-19-06.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-multiselect-combobox_2018-11-06-19-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove defaultPrevented check in ComboBox item click due to multiSelect regression.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1003,7 +1003,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             (this._autofill.current &&
               this._autofill.current.isValueSelected &&
               currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-              pendingOptionText.length)) ||
+                pendingOptionText.length)) ||
             (this._autofill.current &&
               this._autofill.current.inputElement &&
               this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
@@ -1346,14 +1346,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     return (ev: any): void => {
       onItemClick && onItemClick(ev, item, index);
-      if (!ev.defaultPrevented) {
-        this._setSelectedIndex(index as number, ev);
-        if (!this.props.multiSelect) {
-          // only close the callout when it's in single-select mode
-          this.setState({
-            isOpen: false
-          });
-        }
+      this._setSelectedIndex(index as number, ev);
+      if (!this.props.multiSelect) {
+        // only close the callout when it's in single-select mode
+        this.setState({
+          isOpen: false
+        });
       }
     };
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6993
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes a regression with `ComboBox` when `multiSelect` is set due to the introduction of a `defaultPrevented` check in https://github.com/OfficeDev/office-ui-fabric-react/pull/6927

https://github.com/OfficeDev/office-ui-fabric-react/blob/1d6c20753150e5337137a492d4cde3ff9b59a7fe/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx#L1349

#### Focus areas to test

1. The `multiSelect` examples of `ComboBox` should `SELECT` an option on mouse `click`. This is the behavior that was **regressed**.
1. Existing `onItemClickMock` prop callback test should succeed https://github.com/OfficeDev/office-ui-fabric-react/blob/1d6c20753150e5337137a492d4cde3ff9b59a7fe/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx#L507

I'm currently writing unit tests for `ComboBox` which have `multiSelect` set since _none_ exist, but they can be added in a separate PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/6998)

