### PR TITLE
Fix DetailsList onRenderColumnHeaderTooltip not rendering >= 6.18.0

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-dl-onRenderColumnTooltip_2018-11-08-21-24.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-dl-onRenderColumnTooltip_2018-11-08-21-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsHeader: Support optional tooltip rendering for column headers.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -289,6 +289,8 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
               dragDropHelper={this._dragDropHelper}
               onColumnClick={onColumnClick}
               onColumnContextMenu={onColumnContextMenu}
+              // Do not render tooltips by default, but allow for override via props.
+              onRenderColumnHeaderTooltip={this.props.onRenderColumnHeaderTooltip}
               isDropped={this._onDropIndexInfo.targetIndex === columnIndex}
               cellStyleProps={this.props.cellStyleProps}
             />,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -175,6 +175,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
       viewport,
       onColumnClick,
       onColumnContextMenu,
+      onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip,
       styles,
       theme
     } = this.props;
@@ -182,7 +183,6 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     const showCheckbox = selectAllVisibility !== SelectAllVisibility.none;
     const isCheckboxHidden = selectAllVisibility === SelectAllVisibility.hidden;
 
-    const { onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip } = this.props;
     if (!this._dragDropHelper && columnReorderProps) {
       this._dragDropHelper = new DragDropHelper({
         selection: {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -6,6 +6,8 @@ import { DetailsList } from './DetailsList';
 
 import { IDetailsList, IColumn, DetailsListLayoutMode, CheckboxVisibility } from './DetailsList.types';
 import { IDetailsColumnProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
+import { IDetailsHeaderProps, DetailsHeader } from './DetailsHeader';
+import { IRenderFunction } from '../../Utilities';
 
 // Populate mock data for testing
 function mockData(count: number, isColumn: boolean = false, customDivider: boolean = false): any {
@@ -329,5 +331,21 @@ describe('DetailsList', () => {
 
     expect(columns[0].onColumnResize).toHaveBeenCalledTimes(1);
     expect(columns[1].onColumnResize).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes optional onRenderDetailsHeader prop to customize DetailsHeader rendering when provided', () => {
+    const onRenderDetailsHeaderMock = jest.fn();
+
+    mount(
+      <DetailsList
+        items={mockData(2)}
+        skipViewportMeasures={true}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+        onRenderDetailsHeader={onRenderDetailsHeaderMock}
+      />
+    );
+
+    expect(onRenderDetailsHeaderMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -348,4 +348,24 @@ describe('DetailsList', () => {
 
     expect(onRenderDetailsHeaderMock).toHaveBeenCalledTimes(1);
   });
+
+  it('invokes optional onRenderColumnHeaderTooltip prop to customize DetailsColumn tooltip rendering when provided', () => {
+    const NUM_COLUMNS = 2;
+    const onRenderColumnHeaderTooltipMock = jest.fn();
+    const onRenderDetailsHeader = (props: IDetailsHeaderProps, defaultRenderer?: IRenderFunction<IDetailsHeaderProps>) => {
+      return <DetailsHeader {...props} onRenderColumnHeaderTooltip={onRenderColumnHeaderTooltipMock} />;
+    };
+
+    mount(
+      <DetailsList
+        items={mockData(NUM_COLUMNS)}
+        skipViewportMeasures={true}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+        onRenderDetailsHeader={onRenderDetailsHeader}
+      />
+    );
+
+    expect(onRenderColumnHeaderTooltipMock).toHaveBeenCalledTimes(NUM_COLUMNS);
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5703
- [x] Include a change request file using `$ npm run change`

### Description of changes

As noted in #5703, `onRenderColumnHeaderTooltip` has not worked in OUIFR versions `>= 6.18.0`.  This PR fixes that regression by allowing for developers to supply a `onRenderColumnHeaderTooltip` via `onRenderDetailsHeader`. By default, we do not render column header tooltips _by design_.

If the default props are used when providing `renderAs` overrides, then the `IColumn`'s `ariaLabel` will be used as the tooltip's contents on `mouseenter`.

### Focus areas to test

- By default `DetailsList` should not render tooltips for column headers (existing behavior).
- If `onRenderDetailsHeader` is provided, which in-turn passes a render function for the `onRenderColumnHeaderTooltip` prop, then column header tooltips should render on `mouseenter`.

#### Screengrabs

**Before**

![dl_tooltip_basic_before](https://user-images.githubusercontent.com/706967/48103385-af51ce80-e1e3-11e8-8740-583595334ce6.gif)

**After**

![dl_tooltip_basic_after](https://user-images.githubusercontent.com/706967/48103474-17a0b000-e1e4-11e8-9174-37c870d5835c.gif)

#### Testing Locally

Here is a diff that can be applied to the "Basic DetailsList" example which exhibits the above behavior. I've also added unit tests to ensure that the render functions are invoked if provided.

```diff
diff --git a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
index a4f13c48d..0242d530f 100644
--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -3,7 +3,10 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { DetailsList, DetailsListLayoutMode, Selection, IColumn, IDetailsList } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { createRef } from 'office-ui-fabric-react/lib/Utilities';
+import { createRef, IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { IDetailsHeaderProps } from '../DetailsHeader.types';
+import { DetailsHeader } from '../DetailsHeader';
+import { ITooltipHostProps, TooltipHost } from '../../Tooltip';
 
 const _items: any[] = [];
 
@@ -84,6 +87,7 @@ export class DetailsListBasicExample extends React.Component<
             items={items}
             columns={_columns}
             setKey="set"
+            onRenderDetailsHeader={this._onRenderDetailsHeader}
             layoutMode={DetailsListLayoutMode.fixedColumns}
             selection={this._selection}
             selectionPreservedOnEmptyClick={true}
@@ -103,6 +107,17 @@ export class DetailsListBasicExample extends React.Component<
     }
   }
 
+  private _onRenderDetailsHeader(props: IDetailsHeaderProps, defaultRender?: IRenderFunction<IDetailsHeaderProps>): JSX.Element | null {
+    return (
+      <DetailsHeader
+        {...props}
+        onRenderColumnHeaderTooltip={(props: ITooltipHostProps, defaultRender?: IRenderFunction<ITooltipHostProps>) => (
+          <TooltipHost {...props} />
+        )}
+      />
+    );
+  }
+
   private _getSelectionDetails(): string {
     const selectionCount = this._selection.getSelectedCount();
 ```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7013)

