### PR TITLE
Add ComboBox tests for multi-select item selection via mouse click and onItemClicked callback

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-add-combobox-multiselect-tests_2018-11-07-04-57.json
+++ b/common/changes/office-ui-fabric-react/keco-add-combobox-multiselect-tests_2018-11-07-04-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add unit tests for ComboBox multiSelect onItemClicked callback and on select via mouse click.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -504,6 +504,22 @@ describe('ComboBox', () => {
     expect(updatedText).toEqual('');
   });
 
+  it('in multiSelect mode, selectedIndices are correct after performing multiple selections using mouse click', () => {
+    const comboBoxRef = React.createRef<any>();
+    wrapper = mount(<ComboBox multiSelect options={DEFAULT_OPTIONS} componentRef={comboBoxRef} />);
+
+    const comboBoxRoot = wrapper.find('.ms-ComboBox');
+    const inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    const buttons = document.querySelectorAll('.ms-ComboBox-option');
+
+    ReactTestUtils.Simulate.click(buttons[0]);
+    ReactTestUtils.Simulate.click(buttons[1]);
+    ReactTestUtils.Simulate.click(buttons[2]);
+
+    expect((comboBoxRef.current as ComboBox).state.selectedIndices).toEqual([0, 1, 2]);
+  });
+
   it('invokes optional onItemClick callback on option select', () => {
     const onItemClickMock = jest.fn();
     wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} onItemClick={onItemClickMock} />);

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -520,6 +520,19 @@ describe('ComboBox', () => {
     expect((comboBoxRef.current as ComboBox).state.selectedIndices).toEqual([0, 1, 2]);
   });
 
+  it('in multiSelect mode, optional onItemClick callback invoked per option select', () => {
+    const onItemClickMock = jest.fn();
+    wrapper = mount(<ComboBox multiSelect options={DEFAULT_OPTIONS} onItemClick={onItemClickMock} />);
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
+    const buttons = document.querySelectorAll('.ms-ComboBox-option');
+
+    ReactTestUtils.Simulate.click(buttons[0]);
+    ReactTestUtils.Simulate.click(buttons[1]);
+    ReactTestUtils.Simulate.click(buttons[2]);
+
+    expect(onItemClickMock).toHaveBeenCalledTimes(3);
+  });
+
   it('invokes optional onItemClick callback on option select', () => {
     const onItemClickMock = jest.fn();
     wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} onItemClick={onItemClickMock} />);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There was a regression introduced in #6927 and fixed in #6998 which could have been caught had a test for multi-select enabled `ComboBox` existed.

This PR adds that test and a test for the `onItemClicked` _optional_ callback introduced in #6927. Previously, `onItemClicked` was only tested for single-selection `ComboBox` scenarios.

#### Focus areas to test

- Unit tests should succeed locally and on CI.
- Locally, I reverted 6f3e3aab25958dbe40ad064ef8e59bb72c03dc05 to confirm the unit test fails since that commit contains the regression.

The unit test failure _with_ the regression present:

```shell
 FAIL  src/components/ComboBox/ComboBox.test.tsx
  ● ComboBox › in multiSelect mode, selectedIndices are correct after performing multiple selections using mouse click

    expect(received).toEqual(expected)

    Expected value to equal:
      [0, 1, 2]
    Received:
      []

    Difference:

    - Expected
    + Received

    - Array [
    -   0,
    -   1,
    -   2,
    - ]
    + Array []

      518 |     ReactTestUtils.Simulate.click(buttons[2]);
      519 |
    > 520 |     expect((comboBoxRef.current as ComboBox).state.selectedIndices).toEqual([0, 1, 2]);
          |                                                                     ^
      521 |   });
      522 |
      523 |   it('in multiSelect mode, optional onItemClick callback invoked per option select', () => {
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7015)

