### PR TITLE
Add props for stacked chart in card

### DIFF
--- a/common/changes/@uifabric/charting/addPropsForStackedChartInCard_2018-11-08-18-16.json
+++ b/common/changes/@uifabric/charting/addPropsForStackedChartInCard_2018-11-08-18-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Make change to multistacked bar chart's hideDenominator prop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "v-kanuli@microsoft.com"
+}

--- a/common/changes/@uifabric/dashboard/addPropsForStackedChartInCard_2018-11-08-18-16.json
+++ b/common/changes/@uifabric/dashboard/addPropsForStackedChartInCard_2018-11-08-18-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding props for card to send props to dataviz in charting package",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "v-kanuli@microsoft.com"
+}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -33,7 +33,8 @@ export interface IMultiStackedBarChartState {
 export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarChartProps, IMultiStackedBarChartState> {
   public static defaultProps: Partial<IMultiStackedBarChartProps> = {
     barHeight: 16,
-    hideRatio: []
+    hideRatio: [],
+    hideDenominator: []
   };
 
   private _classNames: IProcessedStyleSet<IMultiStackedBarChartStyles>;
@@ -61,7 +62,14 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     const legends = this._getLegendData(data!, hideRatio!, palette);
     const bars: JSX.Element[] = [];
     data!.map((singleChartData: IChartProps, index: number) => {
-      const singleChartBars = this._createBarsAndLegends(singleChartData!, barHeight!, palette, hideRatio![index], href, hideDenominator);
+      const singleChartBars = this._createBarsAndLegends(
+        singleChartData!,
+        barHeight!,
+        palette,
+        hideRatio![index],
+        hideDenominator![index],
+        href
+      );
       bars.push(<div key={index}>{singleChartBars}</div>);
     });
     this._classNames = getClassNames(styles!, {
@@ -96,8 +104,8 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     barHeight: number,
     palette: IPalette,
     hideRatio: boolean,
-    href?: string,
-    hideDenominator?: boolean
+    hideDenominator: boolean,
+    href?: string
   ): JSX.Element {
     const defaultPalette: string[] = [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     // calculating starting point of each bar and it's range

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -47,7 +47,7 @@ export interface IMultiStackedBarChartProps {
   /**
    * If this value is set to true the denominator will not be shown for the ratio above the chart
    */
-  hideDenominator?: boolean;
+  hideDenominator?: boolean[];
 }
 
 export interface IMultiStackedBarChartStyleProps {

--- a/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChart.Example.tsx
+++ b/packages/charting/src/components/StackedBarChart/examples/MultiStackedBarChart.Example.tsx
@@ -13,11 +13,12 @@ export const MultiStackedBarChartExample: React.SFC<{}> = () => {
 
   const secondChartPoints: IChartDataPoint[] = [
     { legend: 'Phone Numbers', data: 40, color: DefaultPalette.blue },
-    { legend: 'Credit card Numbers', data: 23, color: DefaultPalette.green },
-    { legend: 'Asset Numbers', data: 35, color: DefaultPalette.yellow }
+    { legend: 'Credit card Numbers', data: 23, color: DefaultPalette.green }
   ];
 
   const hideRatio: boolean[] = [true, false];
+
+  const hideDenominator: boolean[] = [true, true];
 
   const data: IChartProps[] = [
     {
@@ -30,5 +31,13 @@ export const MultiStackedBarChartExample: React.SFC<{}> = () => {
     }
   ];
 
-  return <MultiStackedBarChart data={data} hideRatio={hideRatio} width={600} href={'https://developer.microsoft.com/en-us/'} />;
+  return (
+    <MultiStackedBarChart
+      data={data}
+      hideDenominator={hideDenominator}
+      hideRatio={hideRatio}
+      width={600}
+      href={'https://developer.microsoft.com/en-us/'}
+    />
+  );
 };

--- a/packages/dashboard/src/components/Card/Chart/Chart.tsx
+++ b/packages/dashboard/src/components/Card/Chart/Chart.tsx
@@ -137,11 +137,19 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
 
   private _getStackedBarChart = (): JSX.Element => {
     if (this.props.chartData!.length > 1) {
-      return <MultiStackedBarChart data={this.props.chartData!} barHeight={this.props.barHeight} hideRatio={this.props.hideRatio} />;
+      return (
+        <MultiStackedBarChart
+          data={this.props.chartData!}
+          barHeight={this.props.barHeight}
+          hideRatio={this.props.hideRatio}
+          hideDenominator={this.props.hideDenominator}
+        />
+      );
     }
 
     return (
       <StackedBarChart
+        hideDenominator={this.props.hideDenominator ? this.props.hideDenominator[0] : false}
         data={this.props.chartData![0]}
         barHeight={this.props.barHeight}
         ignoreFixStyle={this.props.ignoreStackBarChartDefaultStyle}

--- a/packages/dashboard/src/components/Card/Chart/Chart.types.ts
+++ b/packages/dashboard/src/components/Card/Chart/Chart.types.ts
@@ -76,6 +76,11 @@ export interface IChartProps {
   hideRatio?: boolean[];
 
   /**
+   * This property tells whether to show denominator for ratio on top of stacked bar chart or not.
+   */
+  hideDenominator?: boolean[];
+
+  /**
    * Type of chart to render
    */
   chartType: ChartType;

--- a/packages/dashboard/src/components/Card/Layout/Layout.tsx
+++ b/packages/dashboard/src/components/Card/Layout/Layout.tsx
@@ -126,6 +126,7 @@ export class Layout extends React.Component<ILayoutProps, { _width: number; _hei
                   barHeight,
                   chartData,
                   hideRatio,
+                  hideDenominator,
                   data,
                   chartType,
                   dataPoints,
@@ -153,6 +154,7 @@ export class Layout extends React.Component<ILayoutProps, { _width: number; _hei
                           legendColors={legendColors}
                           chartData={chartData}
                           hideRatio={hideRatio}
+                          hideDenominator={hideDenominator}
                           barWidth={barWidth}
                           barHeight={barHeight}
                           data={data}

--- a/packages/dashboard/src/components/Card/examples/Card.Chart.MultiStackedBar.Example.tsx
+++ b/packages/dashboard/src/components/Card/examples/Card.Chart.MultiStackedBar.Example.tsx
@@ -36,8 +36,7 @@ export class MultiStackedBarChartExample extends React.Component<{}, { loading: 
 
     const secondChartPoints: IChartDataPoint[] = [
       { legend: 'Phone Numbers', data: 40, color: DefaultPalette.blue },
-      { legend: 'Credit card Numbers', data: 23, color: DefaultPalette.green },
-      { legend: 'Asset Numbers', data: 35, color: DefaultPalette.yellow }
+      { legend: 'Credit card Numbers', data: 23, color: DefaultPalette.green }
     ];
 
     const data: IChartingProps[] = [
@@ -60,7 +59,8 @@ export class MultiStackedBarChartExample extends React.Component<{}, { loading: 
     const chartContent2: IChartProps = {
       chartType: ChartType.StackedBarChart,
       chartData: data,
-      chartUpdatedOn: 'Updated 6:20 pm today'
+      chartUpdatedOn: 'Updated 6:20 pm today',
+      hideDenominator: [true, false]
     };
 
     const contentAreaList: ICardContentDetails[] = [

--- a/packages/dashboard/src/components/Card/examples/Card.Chart.StackedBar.Example.tsx
+++ b/packages/dashboard/src/components/Card/examples/Card.Chart.StackedBar.Example.tsx
@@ -31,9 +31,7 @@ export class StackedBarChartExample extends React.Component<{}, { loading: boole
         chartTitle: 'Monitored',
         chartData: [
           { legend: 'Legend 1 text', data: 40, color: DefaultPalette.accent },
-          { legend: 'Legend 2 text', data: 23, color: DefaultPalette.green },
-          { legend: 'Legend 3 text', data: 35, color: DefaultPalette.orange },
-          { legend: 'Legend 4 text', data: 87, color: DefaultPalette.blue }
+          { legend: 'Legend 2 text', data: 23, color: DefaultPalette.green }
         ]
       }
     ];
@@ -57,7 +55,8 @@ export class StackedBarChartExample extends React.Component<{}, { loading: boole
     const chartContent1: IChartProps = {
       chartType: ChartType.StackedBarChart,
       chartData: firstChartData,
-      chartUpdatedOn: 'Updated 6:20 pm today'
+      chartUpdatedOn: 'Updated 6:20 pm today',
+      hideDenominator: [true]
     };
 
     const chartContent2: IChartProps = {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Add props for the dashboard card to support hideDenominator props for stacked bar chart. Make changes to props in MultiStacked bar chart of charting package.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7033)

