### PR TITLE
Fluent theme: Update Dialog styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-dialog-updates_2018-11-08-18-36.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-dialog-updates_2018-11-08-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Update Dialog styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -1,5 +1,5 @@
 import { IDialogContentStyleProps } from 'office-ui-fabric-react/lib/Dialog';
-import { DefaultPalette, FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -32,6 +32,10 @@ export const DialogContentStyles = (props: IDialogContentStyleProps) => {
       selectors: {
         '.ms-Dialog-button': {
           color: palette.neutralSecondary
+        },
+        '.ms-Dialog-button:hover': {
+          color: palette.neutralDark,
+          borderRadius: fluentBorderRadius
         }
       }
     },

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -1,6 +1,8 @@
-import { FontSizes } from '../FluentType';
-import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { IDialogContentStyleProps } from 'office-ui-fabric-react/lib/Dialog';
+import { DefaultPalette, FontWeights } from 'office-ui-fabric-react/lib/Styling';
+
 import { Depths } from '../FluentDepths';
+import { FontSizes } from '../FluentType';
 import { fluentBorderRadius } from './styleConstants';
 
 export const DialogStyles = {
@@ -14,22 +16,32 @@ export const DialogStyles = {
   }
 };
 
-export const DialogContentStyles = {
-  title: {
-    fontSize: FontSizes.size20,
-    fontWeight: FontWeights.semibold,
-    padding: '16px',
-    lineHeight: 'normal'
-  },
-  topButton: {
-    padding: '16px 10px 0 0'
-  },
-  inner: {
-    padding: '0 16px 16px'
-  },
-  subText: {
-    fontWeight: FontWeights.regular
-  }
+export const DialogContentStyles = (props: IDialogContentStyleProps) => {
+  const { theme } = props;
+  const { palette } = theme;
+
+  return {
+    title: {
+      fontSize: FontSizes.size20,
+      fontWeight: FontWeights.semibold,
+      padding: '24px',
+      lineHeight: 'normal'
+    },
+    topButton: {
+      padding: '14px 14px 0 0',
+      selectors: {
+        '.ms-Dialog-button': {
+          color: palette.neutralSecondary
+        }
+      }
+    },
+    inner: {
+      padding: '0 24px 24px 24px'
+    },
+    subText: {
+      fontWeight: FontWeights.regular
+    }
+  };
 };
 
 export const DialogFooterStyles = {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #6742
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates the Dialog styles in the Fluent theme. Increases the padding around the Dialog and updates the close button styles.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7034)

