### PR TITLE
Link: Do not pass component ref through to DOM element

### DIFF
--- a/common/changes/office-ui-fabric-react/mapol-do-not-pass-componentRef-through-to-dom-element_2018-11-08-20-06.json
+++ b/common/changes/office-ui-fabric-react/mapol-do-not-pass-componentRef-through-to-dom-element_2018-11-08-20-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Link: Fix bug where componentRef property was passed through to the dom element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
@@ -4,6 +4,7 @@ import { ILink, ILinkProps, ILinkStyleProps, ILinkStyles } from './Link.types';
 import { KeytipData } from '../../KeytipData';
 
 const getClassNames = classNamesFunction<ILinkStyleProps, ILinkStyles>();
+
 export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
   private _link = createRef<HTMLAnchorElement | HTMLButtonElement | null>();
 

--- a/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
@@ -4,7 +4,6 @@ import { ILink, ILinkProps, ILinkStyleProps, ILinkStyles } from './Link.types';
 import { KeytipData } from '../../KeytipData';
 
 const getClassNames = classNamesFunction<ILinkStyleProps, ILinkStyles>();
-
 export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
   private _link = createRef<HTMLAnchorElement | HTMLButtonElement | null>();
 
@@ -67,7 +66,7 @@ export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
     // Deconstruct the props so we remove props like `as`, `theme` and `styles`
     // as those will always be removed. We also take some props that are optional
     // based on the RootType.
-    const { children, as, disabled, target, href, theme, getStyles, styles, ...restProps } = props;
+    const { children, as, disabled, target, href, theme, getStyles, styles, componentRef, ...restProps } = props;
 
     // RootType will be a string if we're dealing with an html component
     if (typeof RootType === 'string') {

--- a/packages/office-ui-fabric-react/src/components/Link/Link.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.test.tsx
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/server';
 import * as renderer from 'react-test-renderer';
@@ -76,6 +77,7 @@ describe('Link', () => {
     const testInstance = component.root;
     expect(() => testInstance.findByType(Route)).not.toThrow();
   });
+
   it('can have the global styles for Link component be disabled', () => {
     const NoClassNamesTheme = createTheme({ disableGlobalClassNames: true });
 
@@ -88,5 +90,30 @@ describe('Link', () => {
         )
       )
     ).toBe(false);
+  });
+
+  it('does not throw a React warning when the componentRef prop is provided', () => {
+    const myRef = React.createRef<HTMLDivElement>();
+
+    const renderLinkWithComponentRef = () =>
+      mount(
+        <Link as="div" className="customClassName" componentRef={myRef}>
+          I'm a div
+        </Link>
+      );
+
+    expect(renderLinkWithComponentRef).not.toThrow();
+  });
+
+  it('does not pass the componentRef property through to the button element', () => {
+    const myRef = React.createRef<HTMLDivElement>();
+
+    const component = mount(
+      <Link className="customClassName" componentRef={myRef}>
+        I'm a div
+      </Link>
+    );
+
+    expect(Object.keys(component.find('button').props())).not.toContain('componentRef');
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Currently when passing a `componentRef` to the Link component we pass `componentRef` through to the rendered DOM Element. This results in a warning being logged when using React development mode.

This PR removes the `componentRef` prop from the props being passed through to the rendered component.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7045)

