### PR TITLE
Throttle icon duplicate registration warnings

### DIFF
--- a/common/changes/@uifabric/styling/throttle-icons_2018-11-09-00-17.json
+++ b/common/changes/@uifabric/styling/throttle-icons_2018-11-09-00-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Icon: warnings from duplicate registrations are now throttled into a single message.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -215,6 +215,8 @@ let _missingIconsTimer: number | undefined = undefined;
 
 function _warnDuplicateIcon(iconName: string): void {
   const options = _iconSettings.__options;
+  const warningDelay = 2000;
+  const maxIconsInMessage = 10;
 
   if (!options.disableWarnings) {
     _missingIcons.push(iconName);
@@ -224,12 +226,12 @@ function _warnDuplicateIcon(iconName: string): void {
           `Some icons were re-registered. Applications should only call registerIcons for any given ` +
             `icon once. Redefining what an icon is may have unintended consequences. Duplicates ` +
             `include: \n` +
-            _missingIcons.slice(0, 10).join(', ') +
-            (_missingIcons.length > 10 ? ` (+ ${_missingIcons.length - 10} more)` : '')
+            _missingIcons.slice(0, maxIconsInMessage).join(', ') +
+            (_missingIcons.length > maxIconsInMessage ? ` (+ ${_missingIcons.length - maxIconsInMessage} more)` : '')
         );
         _missingIconsTimer = undefined;
         _missingIcons = [];
-      }, 2000);
+      }, warningDelay);
     }
   }
 }

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -104,9 +104,7 @@ export function registerIcons(iconSubset: IIconSubset, options?: Partial<IIconOp
       const normalizedIconName = normalizeIconName(iconName);
 
       if (_iconSettings[normalizedIconName]) {
-        if (!options.disableWarnings) {
-          warn(`Icon '${iconName} being re-registered. Ignoring duplicate registration.`);
-        }
+        _warnDuplicateIcon(iconName);
       } else {
         _iconSettings[normalizedIconName] = {
           code,
@@ -210,4 +208,28 @@ export function setIconOptions(options: Partial<IIconOptions>): void {
     ..._iconSettings.__options,
     ...options
   };
+}
+
+let _missingIcons: string[] = [];
+let _missingIconsTimer: number | undefined = undefined;
+
+function _warnDuplicateIcon(iconName: string): void {
+  const options = _iconSettings.__options;
+
+  if (!options.disableWarnings) {
+    _missingIcons.push(iconName);
+    if (_missingIconsTimer === undefined) {
+      _missingIconsTimer = setTimeout(() => {
+        warn(
+          `Some icons were re-registered. Applications should only call registerIcons for any given ` +
+            `icon once. Redefining what an icon is may have unintended consequences. Duplicates ` +
+            `include: \n` +
+            _missingIcons.slice(0, 10).join(', ') +
+            (_missingIcons.length > 10 ? ` (+ ${_missingIcons.length - 10} more)` : '')
+        );
+        _missingIconsTimer = undefined;
+        _missingIcons = [];
+      }, 2000);
+    }
+  }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7040
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Before:

When `initializeIcons` in `@uifabric/icons` was called more than once (perhaps due to duplicate packages in a bundle), the console would be spammed with ~1500 warnings.

After:

Warnings are throttled into a single message that reads like this:

"Some icons were re-registered. Applications should only call registerIcons for any given icon once. Redefining what an icon is may have unintended consequences. Duplicates include: Add, Upload, Delete, Foo, Bar, Baz (+1434 more)"


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7047)

