### PR TITLE
BasePicker: aria role nesting

### DIFF
--- a/common/changes/office-ui-fabric-react/pickerAriaRoleNesting_2018-11-09-00-21.json
+++ b/common/changes/office-ui-fabric-react/pickerAriaRoleNesting_2018-11-09-00-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BasePicker: give selected items element role \"list\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -28,10 +28,10 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       >
         <div
           className="ms-BasePicker-text"
-          role="list"
         >
           <span
             id="selected-items-id__0"
+            role="list"
           />
           <input
             aria-autocomplete="both"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -182,10 +182,10 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       >
         <div
           className="ms-BasePicker-text"
-          role="list"
         >
           <span
             id="selected-items-id__1"
+            role="list"
           />
           <input
             aria-autocomplete="both"
@@ -242,10 +242,10 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       >
         <div
           className="ms-BasePicker-text"
-          role="list"
         >
           <span
             id="selected-items-id__3"
+            role="list"
           />
           <input
             aria-autocomplete="both"

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -199,8 +199,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
         >
           {this.getSuggestionsAlert()}
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused)} role={'list'}>
-              <span id={this._ariaMap.selectedItems} className={styles.pickerItems}>
+            <div className={css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused)}>
+              <span id={this._ariaMap.selectedItems} className={styles.pickerItems} role={'list'}>
                 {this.renderItems()}
               </span>
               {this.canAddItems() && (

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -27,10 +27,10 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
-        role="list"
       >
         <span
           id="selected-items-id__0"
+          role="list"
         />
         <input
           aria-autocomplete="both"
@@ -86,10 +86,10 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
     >
       <div
         className="ms-BasePicker-text"
-        role="list"
       >
         <span
           id="selected-items-id__69"
+          role="list"
         />
         <input
           aria-autocomplete="both"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6891 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Removes role "list" from the base picker text element and gives it to the selected items parent element. The role "list" was on the base picker text element was not really necessary and now, the element of role "combobox" is no longer contained in an element of role "list"—which is something that was not valid per the [aria-role spec](https://www.w3.org/WAI/PF/aria/roles#list).

#### Focus areas to test

(optional)
