### PR TITLE
cherry pick Huaxi/bookmark signal (#6886) into v5.79.1

### DIFF
--- a/common/changes/@uifabric/experiments/huaxi-bookmark-signal_2018-10-29-22-56.json
+++ b/common/changes/@uifabric/experiments/huaxi-bookmark-signal_2018-10-29-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "added bookmark signal icons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "huaxi@microsoft.com"
+}

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -169,3 +169,11 @@ i.emailed {
 .liveEdit {
   display: none; // Not implemented.
 }
+
+.bookmarkOutline {
+  color: $ms-color-black;
+}
+
+.bookmarkFilled {
+  color: $ms-color-black;
+}

--- a/packages/experiments/src/components/signals/Signals.scss
+++ b/packages/experiments/src/components/signals/Signals.scss
@@ -170,10 +170,10 @@ i.emailed {
   display: none; // Not implemented.
 }
 
-.bookmarkOutline {
+.follow {
   color: $ms-color-black;
 }
 
-.bookmarkFilled {
+.unfollow {
   color: $ms-color-black;
 }

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -250,11 +250,11 @@ export const ExternalSignal: Signal = (props: ISignalProps): JSX.Element => {
 };
 
 export const NotFollowedSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal { ...props } signalClass={ SignalsStyles.unfollow } iconName="SingleBookmark" />;
+  return <IconSignal { ...props } signalClass={ SignalsStyles.unfollow } iconName='SingleBookmark' />;
 };
 
 export const FollowedSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal { ...props } signalClass={ SignalsStyles.follow } iconName="SingleBookmarkSolid" />;
+  return <IconSignal { ...props } signalClass={ SignalsStyles.follow } iconName='SingleBookmarkSolid' />;
 };
 
 type IIconSignalProps = ISignalProps &

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -249,7 +249,16 @@ export const ExternalSignal: Signal = (props: ISignalProps): JSX.Element => {
   );
 };
 
-type IIconSignalProps = ISignalProps & Pick<IIconProps, 'iconName'> & {
+export const NotFollowedSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return <IconSignal { ...props } signalClass={ SignalsStyles.bookmarkOutline } iconName="SingleBookmark" />;
+};
+
+export const FollowedSignal: Signal = (props: ISignalProps): JSX.Element => {
+  return <IconSignal { ...props } signalClass={ SignalsStyles.bookmarkFilled } iconName="SingleBookmarkSolid" />;
+};
+
+type IIconSignalProps = ISignalProps &
+  Pick<IIconProps, 'iconName'> & {
   /**
    * The class name to use for the Signal type.
    */

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -250,11 +250,11 @@ export const ExternalSignal: Signal = (props: ISignalProps): JSX.Element => {
 };
 
 export const NotFollowedSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal { ...props } signalClass={ SignalsStyles.bookmarkOutline } iconName="SingleBookmark" />;
+  return <IconSignal { ...props } signalClass={ SignalsStyles.unfollow } iconName="SingleBookmark" />;
 };
 
 export const FollowedSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal { ...props } signalClass={ SignalsStyles.bookmarkFilled } iconName="SingleBookmarkSolid" />;
+  return <IconSignal { ...props } signalClass={ SignalsStyles.follow } iconName="SingleBookmarkSolid" />;
 };
 
 type IIconSignalProps = ISignalProps &


### PR DESCRIPTION
* added bookmark signals

* rush change

* renamed signalicons

#### Pull request checklist

- [x ] Addresses an existing issue: Added additional signal icons
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added bookmark signal icons

#### Focus areas to test

 bookmark signal icons

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7049)

