### PR TITLE
Add prop for card header color

### DIFF
--- a/common/changes/@uifabric/dashboard/AddPropForCardHeaderColor_2018-11-09-07-58.json
+++ b/common/changes/@uifabric/dashboard/AddPropForCardHeaderColor_2018-11-09-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Add Prop for to allow user to change card header color accordingly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "gorigarajesh@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/CardHeader/CardHeader.styles.ts
+++ b/packages/dashboard/src/components/Card/CardHeader/CardHeader.styles.ts
@@ -2,7 +2,7 @@ import { ICardHeaderProps, ICardHeaderStyles } from './CardHeader.types';
 import { FontSize } from './CardHeader.types';
 
 export const getStyles = (props: ICardHeaderProps): ICardHeaderStyles => {
-  const { fontSize } = props;
+  const { fontSize, fontColor } = props;
 
   return {
     root: {
@@ -17,7 +17,7 @@ export const getStyles = (props: ICardHeaderProps): ICardHeaderStyles => {
       lineHeight: '38px',
       fontFamily: 'Segoe UI',
       marginRight: '16px',
-      color: '#000000',
+      color: fontColor ? fontColor : '#000000',
       fontWeight: 'bold'
     },
     annotationText: {

--- a/packages/dashboard/src/components/Card/CardHeader/CardHeader.tsx
+++ b/packages/dashboard/src/components/Card/CardHeader/CardHeader.tsx
@@ -11,10 +11,8 @@ export class CardHeader extends React.Component<ICardHeaderProps, {}> {
 
   public render(): JSX.Element {
     const getClassNames = classNamesFunction<ICardHeaderProps, ICardHeaderStyles>();
-    const fontSize = this.props.fontSize;
-    const headerText = this.props.headerText;
-    const annotationText = this.props.annotationText;
-    const classNames = getClassNames(getStyles, { fontSize });
+    const { fontSize, headerText, annotationText, fontColor } = this.props;
+    const classNames = getClassNames(getStyles, { fontSize, fontColor });
 
     let fontSizeMapping = [{ fontSize: 28, lineHeight: '36px' }, { fontSize: 16, lineHeight: '21px' }];
     if (fontSize === FontSize.medium) {

--- a/packages/dashboard/src/components/Card/CardHeader/CardHeader.types.ts
+++ b/packages/dashboard/src/components/Card/CardHeader/CardHeader.types.ts
@@ -12,6 +12,11 @@ export interface ICardHeaderProps {
   fontSize?: FontSize;
 
   /**
+   * The font color for the card header
+   */
+  fontColor?: string;
+
+  /**
    * The header text
    */
   headerText?: string;

--- a/packages/dashboard/src/components/Card/Layout/Layout.tsx
+++ b/packages/dashboard/src/components/Card/Layout/Layout.tsx
@@ -162,7 +162,14 @@ export class Layout extends React.Component<ILayoutProps> {
     if (header === null || header === undefined) {
       return null;
     }
-    return <CardHeader headerText={header.headerText} annotationText={header.annotationText} fontSize={header.fontSize} />;
+    return (
+      <CardHeader
+        headerText={header.headerText}
+        annotationText={header.annotationText}
+        fontSize={header.fontSize}
+        fontColor={header.fontColor}
+      />
+    );
   }
 
   private _generateFooter(actions: IAction[], className: string): JSX.Element | null {

--- a/packages/dashboard/src/components/Card/examples/Card.Chart.Donut.Example.tsx
+++ b/packages/dashboard/src/components/Card/examples/Card.Chart.Donut.Example.tsx
@@ -73,7 +73,8 @@ export class DonutChartExample extends React.Component<{}, {}> {
     ];
 
     const header = {
-      headerText: 'Donut Chart and Pie chart '
+      headerText: 'Donut Chart and Pie chart ',
+      fontColor: '#C50F1F'
     };
 
     return <Card cardFrameContent={cardFrameContent} header={header} cardContentList={contentAreaList} cardSize={CardSize.large} />;


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Add prop for card header color to allow user to apply colors card header

#### Focus areas to test

(optional)


#### screenshot

![Uploading card header color prop.png…]()
