### PR TITLE
Fluent theme: Reduce Dialog padding

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-dialog-padding_2018-11-09-18-38.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-dialog-padding_2018-11-09-18-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Reduce top padding of Dialog",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -24,7 +24,7 @@ export const DialogContentStyles = (props: IDialogContentStyleProps) => {
     title: {
       fontSize: FontSizes.size20,
       fontWeight: FontWeights.semibold,
-      padding: '24px',
+      padding: '16px 24px 24px 24px',
       lineHeight: 'normal'
     },
     topButton: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #6742
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Reduces the top padding of Dialog from 24px to 16px.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7057)

