### PR TITLE
TextField: fix multiline bug, update docs

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield_2018-11-09-20-41.json
+++ b/common/changes/office-ui-fabric-react/textfield_2018-11-09-20-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: fix multiline bug, update docs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10302,7 +10302,7 @@ interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElement | HTM
   autoComplete?: 'on' | 'off';
   borderless?: boolean;
   className?: string;
-  // @deprecated
+  // @deprecated (undocumented)
   componentId?: string;
   componentRef?: IRefObject<ITextField>;
   defaultValue?: string;
@@ -12160,6 +12160,8 @@ class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldState>, imp
   blur(): void;
   // (undocumented)
   componentDidMount(): void;
+  // (undocumented)
+  componentDidUpdate(): void;
   // (undocumented)
   componentWillReceiveProps(newProps: ITextFieldProps): void;
   // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -17,24 +17,7 @@ import {
 } from './inputMask';
 
 /**
- * props.mask:
- *  The string containing the prompt and format characters.
- * @example
- *  `Phone Number: (999) 9999`
- *
- * _maskCharData
- *  An array of data containing information regarding the format characters,
- *  their indices inside the display text, and their corresponding values.
- * @example
- * ```
- *  [
- *    { value: '1', displayIndex: 16, format: /[0-9]/ },
- *    { value: '2', displayIndex: 17, format: /[0-9]/ },
- *    { displayIndex: 18, format: /[0-9]/ },
- *    { value: '4', displayIndex: 22, format: /[0-9]/ },
- *    ...
- *  ]
- * ```
+ * State for the MaskedTextField component.
  */
 export interface IMaskedTextFieldState {
   /**
@@ -50,12 +33,7 @@ export interface IMaskedTextFieldState {
 
 export const DEFAULT_MASK_CHAR = '_';
 
-enum inputChangeType {
-  default,
-  backspace,
-  delete,
-  textPasted
-}
+type InputChangeType = 'default' | 'backspace' | 'delete' | 'textPasted';
 
 export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextFieldState> implements ITextField {
   public static defaultProps: ITextFieldProps = {
@@ -68,15 +46,29 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
   protected _skipComponentRefResolution = true;
 
   private _textField: ITextField;
+  /**
+   *  An array of data containing information regarding the format characters,
+   *  their indices inside the display text, and their corresponding values.
+   * @example
+   * ```
+   *  [
+   *    { value: '1', displayIndex: 16, format: /[0-9]/ },
+   *    { value: '2', displayIndex: 17, format: /[0-9]/ },
+   *    { displayIndex: 18, format: /[0-9]/ },
+   *    { value: '4', displayIndex: 22, format: /[0-9]/ },
+   *    ...
+   *  ]
+   * ```
+   */
   private _maskCharData: IMaskValue[];
-  // True if the TextField is focused
+  /** True if the TextField is focused */
   private _isFocused: boolean;
-  // True if the TextField was not focused and it was clicked into
+  /** True if the TextField was not focused and it was clicked into */
   private _moveCursorOnMouseUp: boolean;
 
-  // The stored selection data prior to input change events.
+  /** The stored selection data prior to input change events. */
   private _changeSelectionData: {
-    changeType: inputChangeType;
+    changeType: InputChangeType;
     selectionStart: number;
     selectionEnd: number;
   } | null;
@@ -258,14 +250,14 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
   }
 
   @autobind
-  private _onBeforeChange(value: String) {
+  private _onBeforeChange(value: string) {
     if (this.props.onBeforeChange) {
       this.props.onBeforeChange(value);
     }
 
     if (this._changeSelectionData === null) {
       this._changeSelectionData = {
-        changeType: inputChangeType.default,
+        changeType: 'default',
         selectionStart: this._textField.selectionStart !== null ? this._textField.selectionStart : -1,
         selectionEnd: this._textField.selectionEnd !== null ? this._textField.selectionEnd : -1
       };
@@ -284,7 +276,7 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
     let cursorPos = 0;
     const { changeType, selectionStart, selectionEnd } = this._changeSelectionData;
 
-    if (changeType === inputChangeType.textPasted) {
+    if (changeType === 'textPasted') {
       const charsSelected = selectionEnd - selectionStart,
         charCount = value.length + charsSelected - displayValue.length,
         startPos = selectionStart,
@@ -295,9 +287,9 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
         this._maskCharData = clearRange(this._maskCharData, selectionStart, charsSelected);
       }
       cursorPos = insertString(this._maskCharData, startPos, pastedString);
-    } else if (changeType === inputChangeType.delete || changeType === inputChangeType.backspace) {
+    } else if (changeType === 'delete' || changeType === 'backspace') {
       // isDel is true If the characters are removed LTR, otherwise RTL
-      const isDel = changeType === inputChangeType.delete,
+      const isDel = changeType === 'delete',
         charCount = selectionEnd - selectionStart;
 
       if (charCount) {
@@ -385,7 +377,7 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
         }
 
         this._changeSelectionData = {
-          changeType: keyCode === KeyCodes.backspace ? inputChangeType.backspace : inputChangeType.delete,
+          changeType: keyCode === KeyCodes.backspace ? 'backspace' : 'delete',
           selectionStart: selectionStart !== null ? selectionStart : -1,
           selectionEnd: selectionEnd !== null ? selectionEnd : -1
         };
@@ -403,7 +395,7 @@ export class MaskedTextField extends BaseComponent<ITextFieldProps, IMaskedTextF
       selectionEnd = (event.target as HTMLInputElement).selectionEnd;
     // Store the paste selection range
     this._changeSelectionData = {
-      changeType: inputChangeType.textPasted,
+      changeType: 'textPasted',
       selectionStart: selectionStart !== null ? selectionStart : -1,
       selectionEnd: selectionEnd !== null ? selectionEnd : -1
     };

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { IProcessedStyleSet } from '../../Styling';
-import { IStyleFunctionOrObject } from '../../Utilities';
-import { ITextField, ITextFieldProps } from './TextField.types';
 import { Label, ILabelStyleProps, ILabelStyles } from '../../Label';
 import { Icon } from '../../Icon';
 import {
@@ -12,9 +10,10 @@ import {
   inputProperties,
   textAreaProperties,
   createRef,
-  classNamesFunction
+  classNamesFunction,
+  IStyleFunctionOrObject
 } from '../../Utilities';
-import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
+import { ITextField, ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
 
 const getClassNames = classNamesFunction<ITextFieldStyleProps, ITextFieldStyles>();
 
@@ -66,9 +65,18 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
   private _lastValidation: number;
   private _latestValue: string | undefined;
   private _latestValidateValue: string | undefined;
-  private _isDescriptionAvailable: boolean;
   private _textElement = createRef<HTMLTextAreaElement | HTMLInputElement | null>();
   private _classNames: IProcessedStyleSet<ITextFieldStyles>;
+  /**
+   * If true, the text field is changing between single- and multi-line, so we'll need to reset
+   * focus after the change completes.
+   */
+  private _shouldResetFocusAfterRender: boolean | undefined;
+  /**
+   * If set, the text field is changing between single- and multi-line, so we'll need to reset
+   * selection/cursor after the change completes.
+   */
+  private _selectionBeforeInputTypeChange: [number | null, number | null] | undefined;
 
   public constructor(props: ITextFieldProps) {
     super(props);
@@ -101,13 +109,8 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       errorMessage: ''
     };
 
-    this._onInputChange = this._onInputChange.bind(this);
-    this._onFocus = this._onFocus.bind(this);
-    this._onBlur = this._onBlur.bind(this);
-
     this._delayedValidate = this._async.debounce(this._validate, this.props.deferredValidationTime);
     this._lastValidation = 0;
-    this._isDescriptionAvailable = false;
   }
 
   /**
@@ -149,6 +152,28 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     if (newProps.defaultValue !== this.props.defaultValue && newProps.value === undefined) {
       this._setValue(newProps.defaultValue);
     }
+
+    // Text field is changing between single- and multi-line. After the change is complete,
+    // we'll need to reset focus and selection/cursor.
+    if (!!newProps.multiline !== !!this.props.multiline && this.state.isFocused) {
+      this._shouldResetFocusAfterRender = true;
+      this._selectionBeforeInputTypeChange = [this.selectionStart, this.selectionEnd];
+    }
+  }
+
+  public componentDidUpdate(): void {
+    if (this._shouldResetFocusAfterRender) {
+      // The text field has just changed between single- and multi-line, so we need to reset focus
+      // and selection/cursor.
+      this._shouldResetFocusAfterRender = false;
+      this.focus();
+      if (this._selectionBeforeInputTypeChange) {
+        const [start, end] = this._selectionBeforeInputTypeChange;
+        if (start !== null && end !== null) {
+          this.setSelectionRange(start, end);
+        }
+      }
+    }
   }
 
   public componentWillUnmount(): void {
@@ -159,7 +184,6 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     const {
       borderless,
       className,
-      description,
       disabled,
       iconClass,
       iconProps,
@@ -201,10 +225,6 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       inputClassName,
       autoAdjustHeight
     });
-
-    // If a custom description render function is supplied then treat description as always available.
-    // Otherwise defer to the presence of description or error message text.
-    this._isDescriptionAvailable = Boolean(this.props.onRenderDescription || description || errorMessage);
 
     return (
       <div className={this._classNames.root}>
@@ -325,7 +345,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     );
   }
 
-  private _onFocus(ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void {
+  private _onFocus = (ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
     if (this.props.onFocus) {
       this.props.onFocus(ev);
     }
@@ -334,9 +354,9 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     if (this.props.validateOnFocusIn) {
       this._validate(this.state.value);
     }
-  }
+  };
 
-  private _onBlur(ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void {
+  private _onBlur = (ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
     if (this.props.onBlur) {
       this.props.onBlur(ev);
     }
@@ -345,7 +365,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     if (this.props.validateOnFocusOut) {
       this._validate(this.state.value);
     }
-  }
+  };
 
   private _onRenderLabel = (props: ITextFieldProps): JSX.Element | null => {
     const { label, required } = props;
@@ -396,6 +416,15 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     return errorMessage;
   }
 
+  /**
+   * If a custom description render function is supplied then treat description as always available.
+   * Otherwise defer to the presence of description or error message text.
+   */
+  private get _isDescriptionAvailable(): boolean {
+    const props = this.props;
+    return !!(props.onRenderDescription || props.description || this._errorMessage);
+  }
+
   private _renderTextArea(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
     const textAreaProps = getNativeProps(this.props, textAreaProperties, ['defaultValue']);
 
@@ -441,7 +470,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     );
   }
 
-  private _onInputChange(event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void {
+  private _onInputChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
     event.persist();
     const element: HTMLInputElement = event.target as HTMLInputElement;
     const value: string = element.value;
@@ -452,31 +481,27 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     }
     this._latestValue = value;
 
-    this.setState(
-      {
-        value: value
-      } as ITextFieldState,
-      () => {
-        this._adjustInputHeight();
+    this.setState({ value: value } as ITextFieldState, () => {
+      this._adjustInputHeight();
 
-        if (this.props.onChange) {
-          this.props.onChange(event, value);
-        }
-
-        if (this.props.onChanged) {
-          this.props.onChanged(value);
-        }
+      if (this.props.onChange) {
+        this.props.onChange(event, value);
       }
-    );
+
+      if (this.props.onChanged) {
+        this.props.onChanged(value);
+      }
+    });
 
     const { validateOnFocusIn, validateOnFocusOut } = this.props;
     if (!(validateOnFocusIn || validateOnFocusOut)) {
       this._delayedValidate(value);
     }
 
-    const onBeforeChange = this.props.onBeforeChange as (newValue: any) => void;
-    onBeforeChange(value);
-  }
+    if (this.props.onBeforeChange) {
+      this.props.onBeforeChange(value);
+    }
+  };
 
   private _validate(value: string | undefined): void {
     const { validateOnFocusIn, validateOnFocusOut } = this.props;
@@ -492,9 +517,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
 
     if (result !== undefined) {
       if (typeof result === 'string') {
-        this.setState({
-          errorMessage: result
-        } as ITextFieldState);
+        this.setState({ errorMessage: result } as ITextFieldState);
         this._notifyAfterValidate(value, result);
       } else {
         const currentValidation: number = ++this._lastValidation;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -619,7 +619,7 @@ describe('TextField', () => {
 
     textField.focus();
 
-    expect(inputEl).toBe(document.activeElement);
+    expect(document.activeElement).toBe(inputEl);
   });
 
   it('blurs the input via ITextField blur', () => {
@@ -628,9 +628,31 @@ describe('TextField', () => {
     const inputEl = wrapper.find('input').getDOMNode();
 
     textField.focus();
-    expect(inputEl).toBe(document.activeElement);
+    expect(document.activeElement).toBe(inputEl);
 
     textField.blur();
     expect(document.activeElement).toBe(document.body);
+  });
+
+  it('can switch from single to multi line and back', () => {
+    // start as single line
+    const wrapper = mount(<TextField componentRef={textFieldRef} />);
+    let input = wrapper.getDOMNode().querySelector('input');
+    expect(input).toBeTruthy();
+
+    // switch to multiline
+    wrapper.setProps({ multiline: true });
+    const textarea = wrapper.getDOMNode().querySelector('textarea');
+    expect(textarea).toBeTruthy();
+
+    // switch back
+    wrapper.setProps({ multiline: false });
+    input = wrapper.getDOMNode().querySelector('input');
+    expect(input).toBeTruthy();
+
+    // Also tried writing tests to verify that focus is maintained after the field type switch
+    // (textFieldRef.current.focus() after initial render, switch to multiline, then verify the
+    // new textarea is document.activeElement), but the tests kept failing even though it works
+    // properly in the browser. Not sure why.
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -28,6 +28,16 @@ describe('TextField', () => {
     return renderedDOM as HTMLElement;
   }
 
+  /**
+   * Mounts the element attached to a child of document.body. This is primarily for tests involving
+   * event handlers (which don't work right unless the element is attached).
+   */
+  function mountAttached(element: React.ReactElement<any>) {
+    const parent = document.createElement('div');
+    document.body.appendChild(parent);
+    return mount(element, { attachTo: parent });
+  }
+
   function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
     const target: EventTarget = { value: targetValue } as HTMLInputElement;
     const event: ReactTestUtils.SyntheticEventData = { target };
@@ -225,13 +235,15 @@ describe('TextField', () => {
         return value.length > 3 ? errorMessage : '';
       }
 
-      const textField = mount(<TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} />);
+      const textField = mount(
+        <TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />
+      );
 
       const inputDOM = textField.getDOMNode().querySelector('input');
       ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
 
       // The value is delayed to validate, so it must to query error message after a while.
-      return delay(250).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
+      return delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
     });
 
     it('should render error message when onGetErrorMessage returns a Promise<string>', () => {
@@ -239,13 +251,15 @@ describe('TextField', () => {
         return Promise.resolve(value.length > 3 ? errorMessage : '');
       }
 
-      const textField = mount(<TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} />);
+      const textField = mount(
+        <TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />
+      );
 
       const inputDOM = textField.getDOMNode().querySelector('input');
       ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
 
       // The value is delayed to validate, so it must to query error message after a while.
-      return delay(250).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
+      return delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
     });
 
     it('should render error message on first render when onGetErrorMessage returns a string', () => {
@@ -649,10 +663,50 @@ describe('TextField', () => {
     wrapper.setProps({ multiline: false });
     input = wrapper.getDOMNode().querySelector('input');
     expect(input).toBeTruthy();
+  });
 
-    // Also tried writing tests to verify that focus is maintained after the field type switch
-    // (textFieldRef.current.focus() after initial render, switch to multiline, then verify the
-    // new textarea is document.activeElement), but the tests kept failing even though it works
-    // properly in the browser. Not sure why.
+  it('maintains focus when switching single to multi line and back', () => {
+    const wrapper = mountAttached(<TextField componentRef={textFieldRef} />);
+    const textField = textFieldRef.current as ITextField;
+    // focus input
+    textField.focus();
+    let input = wrapper.find('input').getDOMNode();
+    expect(document.activeElement).toBe(input);
+
+    // switch to multiline
+    wrapper.setProps({ multiline: true });
+    // verify still focused
+    const textarea = wrapper.find('textarea').getDOMNode();
+    expect(document.activeElement).toBe(textarea);
+
+    // back to single line
+    wrapper.setProps({ multiline: false });
+    // verify still focused
+    input = wrapper.find('input').getDOMNode();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('maintains selection when switching single to multi line and back', () => {
+    const start = 1;
+    const end = 3;
+    const wrapper = mountAttached(<TextField componentRef={textFieldRef} defaultValue="some text" />);
+    const textField = textFieldRef.current as ITextField;
+    // select
+    textField.focus();
+    textField.setSelectionRange(start, end);
+    expect(textField.selectionStart).toBe(start);
+    expect(textField.selectionEnd).toBe(end);
+
+    // switch to multiline
+    wrapper.setProps({ multiline: true });
+    // verify still selected
+    expect(textField.selectionStart).toBe(start);
+    expect(textField.selectionEnd).toBe(end);
+
+    // back to single line
+    wrapper.setProps({ multiline: false });
+    // verify still selected
+    expect(textField.selectionStart).toBe(start);
+    expect(textField.selectionEnd).toBe(end);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -23,6 +23,7 @@ export interface ITextField {
 
   /**
    * Sets the start and end positions of a selection in a text field.
+   * Call with start and end set to the same value to set the cursor position.
    * @param start - Index of the start of the selection.
    * @param end - Index of the end of the selection.
    */
@@ -40,58 +41,58 @@ export interface ITextField {
  */
 export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   /**
-   * Optional callback to access the ITextField interface. Use this instead of ref for accessing
+   * Optional callback to access the ITextField component. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<ITextField>;
 
   /**
-   * Whether or not the textfield is a multiline textfield.
+   * Whether or not the text field is a multiline text field.
    * @defaultvalue false
    */
   multiline?: boolean;
 
   /**
-   * Whether or not the multiline textfield is resizable.
+   * Whether or not the multiline text field is resizable.
    * @defaultvalue true
    */
   resizable?: boolean;
 
   /**
-   * Whether or not to auto adjust textField height. Applies only to multiline textfield.
+   * Whether or not to auto adjust text field height. Applies only to multiline text field.
    * @defaultvalue false
    */
   autoAdjustHeight?: boolean;
 
   /**
-   * Whether or not the textfield is underlined.
+   * Whether or not the text field is underlined.
    * @defaultvalue false
    */
   underlined?: boolean;
 
   /**
-   * Whether or not the textfield is borderless.
+   * Whether or not the text field is borderless.
    * @defaultvalue false
    */
   borderless?: boolean;
 
   /**
-   * Label for the textfield.
+   * Label displayed above the text field (and read by screen readers).
    */
   label?: string;
 
   /**
-   * Optional custom renderer for the label.
+   * Custom renderer for the label.
    */
   onRenderLabel?: IRenderFunction<ITextFieldProps>;
 
   /**
-   * The textfield input description
+   * Description displayed below the text field to provide additional details about what text to enter.
    */
   description?: string;
 
   /**
-   * Optional custom renderer for the description.
+   * Custom renderer for the description.
    */
   onRenderDescription?: IRenderFunction<ITextFieldProps>;
 
@@ -101,12 +102,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   addonString?: string;
 
   /**
-   * String for prefix
+   * Prefix displayed before the text field contents. This is not included in the value.
    */
   prefix?: string;
 
   /**
-   * String for suffix
+   * Suffix displayed after the text field contents. This is not included in the value.
    */
   suffix?: string;
 
@@ -126,36 +127,37 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   onRenderSuffix?: IRenderFunction<ITextFieldProps>;
 
   /**
-   * Optional icon props for an icon.
+   * Props for an optional icon, displayed in the far right end of the text field.
    */
   iconProps?: IIconProps;
 
   /**
-   * Default value of the textfield, if any. Only provide this if the textfield is an uncontrolled component;
-   * otherwise, use the "value" property.
+   * Default value of the text field. Only provide this if the text field is an uncontrolled component;
+   * otherwise, use the `value` property.
    */
   defaultValue?: string;
 
   /**
-   * Current value of the textfield. Only provide this if the textfield is a controlled component where you
-   * are maintaining its current state; otherwise, use the "defaultValue" property.
+   * Current value of the text field. Only provide this if the text field is a controlled component where you
+   * are maintaining its current state; otherwise, use the `defaultValue` property.
    */
   value?: string;
 
   /**
-   * Disabled state of the textfield.
+   * Disabled state of the text field.
    * @defaultvalue false
    */
   disabled?: boolean;
 
   /**
-   * If true, the textfield is readonly.
+   * If true, the text field is readonly.
    * @defaultvalue false
    */
   readOnly?: boolean;
 
   /**
-   * If set, this will display an error message for the text field.
+   * Static error message displayed below the text field. Use `onGetErrorMessage` to dynamically
+   * change the error message displayed (if any) based on the current value.
    */
   errorMessage?: string;
 
@@ -170,17 +172,18 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   onChanged?: (newValue: any) => void;
 
   /**
-   * Callback for the onBeforeChange event.
+   * Called after the input's value updates but before re-rendering.
+   * @param newValue - The new value. Type should be string.
    */
   onBeforeChange?: (newValue: any) => void;
 
   /**
-   * Callback for the onNotifyValidationResult event.
+   * Function called after validation completes.
    */
   onNotifyValidationResult?: (errorMessage: string, value: string | undefined) => void;
 
   /**
-   * The method is used to get the validation error message and determine whether the input value is valid or not.
+   * Function used to determine whether the input value is valid and get an error message if not.
    *
    *   When it returns string:
    *   - If valid, it returns empty string.
@@ -211,30 +214,30 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   inputClassName?: string;
 
   /**
-   * Aria Label for textfield, if any.
+   * Aria label for the text field.
    */
   ariaLabel?: string;
 
   /**
-   * Run validation only on input focus
+   * Run validation only on input focus.
    * @defaultvalue false
    */
   validateOnFocusIn?: boolean;
 
   /**
-   * Run validation only on input focus out
+   * Run validation only on input focus out.
    * @defaultvalue false
    */
   validateOnFocusOut?: boolean;
 
   /**
-   * Optional flag to disable onload validation
+   * Disable on-load validation.
    * @defaultvalue true
    */
   validateOnLoad?: boolean;
 
   /**
-   * Theme (provided through customization.)
+   * Theme (provided through customization).
    */
   theme?: ITheme;
 
@@ -261,6 +264,8 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * '9': [0-9]
    * 'a': [a-zA-Z]
    * '*': [a-zA-Z0-9]
+   *
+   * @example `Phone Number: (999) 999-9999`
    */
   mask?: string;
 
@@ -281,7 +286,6 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   maskFormat?: { [key: string]: RegExp };
 
   /**
-   * Deprecated property. Serves no function.
    * @deprecated Serves no function.
    */
   componentId?: string;

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Multiline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Multiline.Example.tsx
@@ -3,17 +3,40 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import './TextField.Examples.scss';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 
-export class TextFieldMultilineExample extends React.Component<any, any> {
+export interface IState {
+  multiline: boolean;
+}
+
+export class TextFieldMultilineExample extends React.Component<any, IState> {
+  private _lorem: string;
+  constructor(props: any) {
+    super(props);
+    this.state = { multiline: false };
+    this._lorem = lorem(100);
+  }
+
   public render(): JSX.Element {
     return (
       <div className="docs-TextFieldExample">
         <TextField label="Standard" multiline rows={4} />
-        <TextField label="Disabled" multiline rows={4} disabled={true} value={lorem(100)} />
+        <TextField label="Disabled" multiline rows={4} disabled={true} value={this._lorem} />
         <TextField label="Required" multiline rows={4} required={true} />
         <TextField label="With error message" multiline rows={4} errorMessage="This is an error message." />
         <TextField label="Non-resizable" multiline resizable={false} />
         <TextField label="With auto adjusting height" multiline autoAdjustHeight />
+        <TextField
+          label="Switches from single to multiline if more than 50 characters are entered"
+          multiline={this.state.multiline}
+          onChange={this._onChange}
+        />
       </div>
     );
   }
+
+  private _onChange = (ev: any, newText: string): void => {
+    const newMultiline = newText.length > 50;
+    if (newMultiline !== this.state.multiline) {
+      this.setState({ multiline: newMultiline });
+    }
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -865,5 +865,138 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
       </div>
     </div>
   </div>
+  <div
+    className=
+        ms-TextField
+        {
+          box-shadow: none;
+          box-sizing: border-box;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          border-width: 2px;
+        }
+  >
+    <div
+      className=
+          ms-TextField-wrapper
+
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        htmlFor="TextField12"
+      >
+        Switches from single to multiline if more than 50 characters are entered
+      </label>
+      <div
+        className=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border: 1px solid #a6a6a6;
+              box-shadow: none;
+              box-sizing: border-box;
+              display: flex;
+              flex-direction: row;
+              height: 32px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            &:hover {
+              border-color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
+      >
+        <input
+          aria-invalid={false}
+          className=
+              ms-TextField-field
+              {
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                font-size: 14px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 12px;
+                padding-right: 12px;
+                padding-top: 0;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              &::placeholder {
+                color: #666666;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #666666;
+                opacity: 1;
+              }
+          id="TextField12"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6437
- [x] Include a change request file using `$ npm run change`

#### Description of changes

* Fix #6347: when text field changes between single- and multi-line, focus (and selection/cursor) should be maintained
* Minor TextField and MaskedTextField documentation updates
* Convert internal MaskedTextField enum `inputType` to use a string type rather than an enum (inspired by Ken's recent update on #6386 -- `inputType` wasn't a const enum but easily could have been)
* Other minor cleanup
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7058)

