### PR TITLE
[ScrollablePane] DetailsList sticky header alignment bug fix

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2018-11-09-20-15.json
+++ b/common/changes/office-ui-fabric-react/master_2018-11-09-20-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "\"Fix scrollable pane sticky alignment issue\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rusarkar@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9229,6 +9229,7 @@ interface IScrollablePaneContext {
     removeSticky: (sticky: Sticky) => void;
     sortSticky: (sticky: Sticky) => void;
     subscribe: (handler: (container: HTMLElement, stickyContainer: HTMLElement) => void) => void;
+    syncScrollSticky: (sticky: Sticky) => void;
     unsubscribe: (handler: (container: HTMLElement, stickyContainer: HTMLElement) => void) => void;
     updateStickyRefHeights: () => void;
   }
@@ -11470,6 +11471,8 @@ class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScrollable
   readonly stickyBelow: HTMLDivElement | null;
   // (undocumented)
   subscribe: (handler: Function) => void;
+  // (undocumented)
+  syncScrollSticky: (sticky: Sticky) => void;
   // (undocumented)
   unsubscribe: (handler: Function) => void;
   // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -13,6 +13,7 @@ export interface IScrollablePaneContext {
     updateStickyRefHeights: () => void;
     sortSticky: (sticky: Sticky) => void;
     notifySubscribers: (sort?: boolean) => void;
+    syncScrollSticky: (sticky: Sticky) => void;
   };
 }
 
@@ -79,7 +80,8 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
         removeSticky: this.removeSticky,
         updateStickyRefHeights: this.updateStickyRefHeights,
         sortSticky: this.sortSticky,
-        notifySubscribers: this.notifySubscribers
+        notifySubscribers: this.notifySubscribers,
+        syncScrollSticky: this.syncScrollSticky
       }
     };
   }
@@ -286,6 +288,12 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     }
 
     return 0;
+  };
+
+  public syncScrollSticky = (sticky: Sticky): void => {
+    if (sticky && this.contentContainer) {
+      sticky.syncScroll(this.contentContainer);
+    }
   };
 
   private _checkStickyStatus(sticky: Sticky): void {

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -104,6 +104,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
     if (prevState.isStickyTop !== this.state.isStickyTop || prevState.isStickyBottom !== this.state.isStickyBottom) {
       scrollablePane.updateStickyRefHeights();
+      // Sync Sticky scroll position with content container on each update
+      scrollablePane.syncScrollSticky(this);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7059
- [x] Include a change request file using `$ npm run change`

#### Description of changes
This issue is happening because scroll position of the content container is not synced with the sticky content till it has not become sticky yet . So in the example, at the moment it is becoming sticky , we can see the DetailsList header is not aligned with rows . 

Here , we are syncing the scroll position in componentDidUpdate of sticky component so that sticky content scroll position should always be in sync with the content container scroll position.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7060)

