### PR TITLE
GroupedList/DetailsList with groups: use aria role "grid"

### DIFF
--- a/common/changes/office-ui-fabric-react/groupedListAriaRoleGrid_2018-11-09-21-54.json
+++ b/common/changes/office-ui-fabric-react/groupedListAriaRoleGrid_2018-11-09-21-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupedList: rendered with aria-role grid instead of list",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -4891,7 +4891,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             >
               <div
                 className="ms-List"
-                role="list"
+                role="presentation"
               >
                 <div
                   className="ms-List-surface"
@@ -4906,7 +4906,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       className="ms-List-cell"
                       data-automationid="ListCell"
                       data-list-index={0}
-                      role="listitem"
+                      role="presentation"
                     >
                       <div
                         className=
@@ -5108,7 +5108,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         <div
                           className="ms-List"
                           id="GroupedListSection18"
-                          role="list"
+                          role="grid"
                         >
                           <div
                             className="ms-List-surface"
@@ -5123,7 +5123,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 className="ms-List-cell"
                                 data-automationid="ListCell"
                                 data-list-index={0}
-                                role="listitem"
+                                role="presentation"
                               >
                                 <div
                                   aria-rowindex={1}
@@ -5321,7 +5321,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 className="ms-List-cell"
                                 data-automationid="ListCell"
                                 data-list-index={1}
-                                role="listitem"
+                                role="presentation"
                               >
                                 <div
                                   aria-rowindex={2}
@@ -5530,7 +5530,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       className="ms-List-cell"
                       data-automationid="ListCell"
                       data-list-index={1}
-                      role="listitem"
+                      role="presentation"
                     >
                       <div
                         className=
@@ -5732,7 +5732,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         <div
                           className="ms-List"
                           id="GroupedListSection20"
-                          role="list"
+                          role="grid"
                         >
                           <div
                             className="ms-List-surface"
@@ -5747,7 +5747,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 className="ms-List-cell"
                                 data-automationid="ListCell"
                                 data-list-index={2}
-                                role="listitem"
+                                role="presentation"
                               >
                                 <div
                                   aria-rowindex={3}
@@ -5945,7 +5945,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 className="ms-List-cell"
                                 data-automationid="ListCell"
                                 data-list-index={3}
-                                role="listitem"
+                                role="presentation"
                               >
                                 <div
                                   aria-rowindex={4}
@@ -6143,7 +6143,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                 className="ms-List-cell"
                                 data-automationid="ListCell"
                                 data-list-index={4}
-                                role="listitem"
+                                role="presentation"
                               >
                                 <div
                                   aria-rowindex={5}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -84,6 +84,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
         ) : (
           <List
             ref={this._list}
+            role="presentation"
             items={groups}
             onRenderCell={this._renderGroup}
             getItemCountForPage={this._returnOne}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -211,6 +211,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
         {onRenderGroupHeader(groupHeaderProps, this._onRenderGroupHeader)}
         {group && group.isCollapsed ? null : hasNestedGroups ? (
           <List
+            role="presentation"
             ref={this._list}
             items={group!.children}
             onRenderCell={this._renderSubGroup}
@@ -295,6 +296,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
 
     return (
       <List
+        role="grid"
         items={items}
         onRenderCell={this._onRenderGroupCell(onRenderCell, groupNestingDepth)}
         ref={this._list}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6478 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes aim to come up with a better aria role hierarchy for **DetailsLists with groups** and **GroupedLists**. Before, DetailsRows, which are made up of elements with role `row` and `gridcell`, were contained by elements with role `list` and `listitem`. This is (roughly) how the hierarchy looked:

* `list`
  * `listitem`
    * `row`
      * `gridcell`

As per the [W3C standards](https://www.w3.org/TR/wai-aria-1.0/roles#row), however:

> Authors MUST ensure elements with role row are contained in, or owned by, an element with the role table, grid, rowgroup, or treegrid.

Given that DetailsLits without groups make use of role `grid`, I thought it would make sense to align with that structuring. So, with these changes, the (rough) hierarchy for a DetailsList with groups looks like the following:

* `grid`
  * `row`
    * `gridcell`

Notice that there is no `list` or `listitem` role in the hierarchy.

#### Before and After (NVDA + Chrome)

**Before:**
Item 4, 4, row, row 5, 1 of 1

**After:**
Item 4, 4, row, row 5, 5 of 70

DetailsList - LargeGrouped
**Before:**
d blue, row, row 4, 1 of 1

**After:**
d blue, row, row 4, 2 of 3

Note: Revisiting "row 4, 2 of 3". Row 4 is the number of the row with respect to the total number of rows in the entire list. "2 of 3" is the number of the row with respect to the number of rows in the group we're in. The `aria-rowindex` is based off of the entirety of the list and the role `grid` is applied to each group.

Note: Narrator does not read out the "row 4" nor does it read out the "2 of 3". It doesn't read out this information for any of our lists at the moment.

#### Focus areas to test

1. Go to the **DetailsList - LargeGrouped**, **DetailsList - SimpleGrouped**, or **GroupedList** demo page in the deploy demo link.
2. Turn on NVDA.
3. Focus on a row.
4. Ensure that the screen reader now reads out "1 of [# of rows]" instead of "1 of 1".
