### PR TITLE
SearchBox: IE now will consistently focus when click between icon and placeholder text

### DIFF
--- a/common/changes/office-ui-fabric-react/7035-searchbox_2018-11-09-23-20.json
+++ b/common/changes/office-ui-fabric-react/7035-searchbox_2018-11-09-23-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox: IE now will consistently focus when click between icon and placeholder text",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -142,7 +142,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
   }
 
   private _onClickFocus = () => {
-    const inputElement = this._inputElement.value;
+    const inputElement = this._inputElement.current;
     if (inputElement) {
       this.focus();
       inputElement.selectionStart = inputElement.selectionEnd = 0;
@@ -150,9 +150,18 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
   };
 
   private _onFocusCapture = (ev: React.FocusEvent<HTMLElement>) => {
-    this.setState({
-      hasFocus: true
-    });
+    this.setState(
+      {
+        hasFocus: true
+      },
+      () => {
+        // IE doesn't capture the onClickFocus, so we will focus here
+        const inputElement = this._inputElement.current;
+        if (inputElement && document.activeElement !== inputElement) {
+          this.focus();
+        }
+      }
+    );
 
     this._events.on(ev.currentTarget, 'blur', this._onBlur, true);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7035 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This change will add a focus at the end of the setState of focusCapture. This way that it makes sure that the focused element is selected. The issue is that IE doesn't fire the clickFocus handler. 

#### Focus areas to test

(optional)
