### PR TITLE
Fluent Theme: adds some fluent styles to DatePicker

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-DatePicker_2018-11-10-04-46.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-DatePicker_2018-11-10-04-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "DatePicker: adds fluent styles.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -4,6 +4,7 @@ import { ChoiceGroupOptionStyles } from './styles/ChoiceGroupOption.styles';
 import { ComboBoxStyles } from './styles/ComboBox.styles';
 import { CompoundButtonStyles } from './styles/CompoundButton.styles';
 import { ContextualMenuStyles } from './styles/ContextualMenu.styles';
+import { DatePickerStyles } from './styles/DatePicker.styles';
 import { DefaultButtonStyles } from './styles/DefaultButton.styles';
 import { DialogStyles, DialogContentStyles, DialogFooterStyles } from './styles/Dialog.styles';
 import { DropdownStyles } from './styles/Dropdown.styles';
@@ -45,6 +46,9 @@ export const FluentStyles: any = {
   },
   ContextualMenu: {
     styles: ContextualMenuStyles
+  },
+  DatePicker: {
+    styles: DatePickerStyles
   },
   DefaultButton: {
     styles: DefaultButtonStyles

--- a/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
@@ -1,0 +1,16 @@
+import { IDatePickerStyleProps } from 'office-ui-fabric-react/lib/DatePicker';
+import { fluentBorderRadius } from './styleConstants';
+import { Depths } from '../FluentDepths';
+
+export const DatePickerStyles = (props: IDatePickerStyleProps) => {
+  return {
+    callout: {
+      border: 'none',
+      borderRadius: fluentBorderRadius,
+      boxShadow: Depths.depth8,
+      selectors: {
+        '.ms-Callout-main': { borderRadius: fluentBorderRadius }
+      }
+    }
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #7070 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

A very tiny PR to make the corners of the `Callout` holding the `Calendar` rounded and remove the border around it.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7072)

