### PR TITLE
ColorPicker: Fix opacity slider and improve demo

### DIFF
--- a/common/changes/office-ui-fabric-react/color-picker-fixes_2018-11-11-21-44.json
+++ b/common/changes/office-ui-fabric-react/color-picker-fixes_2018-11-11-21-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix bug in ColorPicker opacity slider and improve demo page",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-
-import { ITextField, TextField } from '../../TextField';
 import { BaseComponent, classNamesFunction } from '../../Utilities';
-import { getColorFromRGBA, getColorFromString, IColor, MAX_COLOR_HUE, updateA, updateH, updateSV } from '../../utilities/color/colors';
 import { IColorPickerProps, IColorPickerStyleProps, IColorPickerStyles } from './ColorPicker.types';
+import { ITextField, TextField } from '../../TextField';
 import { ColorRectangle } from './ColorRectangle/ColorRectangle';
 import { ColorSlider } from './ColorSlider/ColorSlider';
+import { MAX_COLOR_HUE, IColor, getColorFromString, getColorFromRGBA, updateA, updateH, updateSV } from '../../utilities/color/colors';
 
 export interface IColorPickerState {
   isOpen: boolean;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../Utilities';
-import { IColorPickerProps, IColorPickerStyleProps, IColorPickerStyles } from './ColorPicker.types';
+
 import { ITextField, TextField } from '../../TextField';
+import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { getColorFromRGBA, getColorFromString, IColor, MAX_COLOR_HUE, updateA, updateH, updateSV } from '../../utilities/color/colors';
+import { IColorPickerProps, IColorPickerStyleProps, IColorPickerStyles } from './ColorPicker.types';
 import { ColorRectangle } from './ColorRectangle/ColorRectangle';
 import { ColorSlider } from './ColorSlider/ColorSlider';
-import { MAX_COLOR_HUE, IColor, getColorFromString, getColorFromRGBA, updateA, updateH, updateSV } from '../../utilities/color/colors';
 
 export interface IColorPickerState {
   isOpen: boolean;
@@ -60,7 +61,7 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
             <ColorSlider
               className="is-alpha"
               isAlpha
-              overlayStyle={{ background: `linear-gradient(to right, transparent 0, ${color.str} 100%)` }}
+              overlayStyle={{ background: `linear-gradient(to right, transparent 0, #${color.hex} 100%)` }}
               minValue={0}
               maxValue={100}
               value={color.a}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
             }
         style={
           Object {
-            "background": "linear-gradient(to right, transparent 0, #FFFFFF 100%)",
+            "background": "linear-gradient(to right, transparent 0, #ffffff 100%)",
           }
         }
       />

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
@@ -1,12 +1,33 @@
-import * as React from 'react';
 import { ColorPicker } from 'office-ui-fabric-react/lib/ColorPicker';
+import * as React from 'react';
 
 export interface IBasicColorPickerExampleState {
   color: string;
 }
 
 export class ColorPickerBasicExample extends React.Component<any, IBasicColorPickerExampleState> {
-  public render(): JSX.Element {
-    return <ColorPicker color="#FFFFFF" />;
+  constructor(props: any) {
+    super(props);
+
+    this.state = {
+      color: '#ffffff'
+    };
+
+    this._updateColor = this._updateColor.bind(this);
   }
+
+  public render(): JSX.Element {
+    return (
+      <div style={{ display: 'flex' }}>
+        <ColorPicker color={this.state.color} onColorChanged={this._updateColor} />
+        <div style={{ backgroundColor: this.state.color, width: 100, height: 100, margin: 16, border: '1px solid #c8c6c4' }} />
+      </div>
+    );
+  }
+
+  private _updateColor = (color: string): void => {
+    this.setState({
+      color: color
+    });
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
@@ -1,5 +1,5 @@
-import { ColorPicker } from 'office-ui-fabric-react/lib/ColorPicker';
 import * as React from 'react';
+import { ColorPicker } from 'office-ui-fabric-react/lib/ColorPicker';
 
 export interface IBasicColorPickerExampleState {
   color: string;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -2,896 +2,915 @@
 
 exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] = `
 <div
-  className=
-      ms-ColorPicker
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        max-width: 300px;
-        position: relative;
-      }
+  style={
+    Object {
+      "display": "flex",
+    }
+  }
 >
   <div
     className=
-        ms-ColorPicker-panel
+        ms-ColorPicker
         {
-          padding-bottom: 16px;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 16px;
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          max-width: 300px;
+          position: relative;
         }
   >
     <div
       className=
-          ms-ColorPicker-colorRect
+          ms-ColorPicker-panel
           {
-            margin-bottom: 10px;
-            position: relative;
+            padding-bottom: 16px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 16px;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            -ms-high-contrast-adjust: none;
-          }
-      onMouseDown={[Function]}
-      style={
-        Object {
-          "backgroundColor": "#ff0000",
-          "minHeight": 220,
-          "minWidth": 220,
-        }
-      }
     >
       <div
         className=
-            ms-ColorPicker-light
+            ms-ColorPicker-colorRect
             {
-              background: linear-gradient(to right, white 0%, transparent 100%);
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+              margin-bottom: 10px;
+              position: relative;
             }
-      />
-      <div
-        className=
-            ms-ColorPicker-dark
-            {
-              background: linear-gradient(to bottom, transparent 0, #000 100%);
-              bottom: 0px;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
             }
-      />
-      <div
-        className=
-            ms-ColorPicker-thumb
-            {
-              background: white;
-              border-radius: 50%;
-              border: 1px solid rgba(255,255,255,.8);
-              box-shadow: 0 0 15px -5px black;
-              height: 20px;
-              position: absolute;
-              transform: translate(-50%, -50%);
-              width: 20px;
-            }
+        onMouseDown={[Function]}
         style={
           Object {
-            "backgroundColor": "#FFFFFF",
-            "left": "0%",
-            "top": "0%",
+            "backgroundColor": "#ff0000",
+            "minHeight": 220,
+            "minWidth": 220,
           }
         }
-      />
-    </div>
-    <div
-      className=
-          ms-ColorPicker-slider
-          is-hue
-          {
-            border: 1px solid #eaeaea;
-            box-sizing: border-box;
-            height: 20px;
-            margin-bottom: 5px;
-            position: relative;
-          }
-      onMouseDown={[Function]}
-      style={
-        Object {
-          "background": "linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)",
-        }
-      }
-    >
-      <div
-        className=
-            ms-ColorPicker-sliderOverlay
-            {
-              bottom: 0px;
-              content: ;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-      />
-      <div
-        className=
-            ms-ColorPicker-thumb
-            is-slider
-            {
-              background: white;
-              border-radius: 50%;
-              border: 1px solid rgba(255,255,255,.8);
-              box-shadow: 0 0 15px -5px black;
-              height: 20px;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%, -50%);
-              width: 20px;
-            }
-        style={
-          Object {
-            "left": "0%",
-          }
-        }
-      />
-    </div>
-    <div
-      className=
-          ms-ColorPicker-slider
-          is-alpha
-          {
-            border: 1px solid #eaeaea;
-            box-sizing: border-box;
-            height: 20px;
-            margin-bottom: 5px;
-            position: relative;
-          }
-      onMouseDown={[Function]}
-      style={
-        Object {
-          "backgroundImage": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)",
-        }
-      }
-    >
-      <div
-        className=
-            ms-ColorPicker-sliderOverlay
-            {
-              bottom: 0px;
-              content: ;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-        style={
-          Object {
-            "background": "linear-gradient(to right, transparent 0, #FFFFFF 100%)",
-          }
-        }
-      />
-      <div
-        className=
-            ms-ColorPicker-thumb
-            is-slider
-            {
-              background: white;
-              border-radius: 50%;
-              border: 1px solid rgba(255,255,255,.8);
-              box-shadow: 0 0 15px -5px black;
-              height: 20px;
-              position: absolute;
-              top: 50%;
-              transform: translate(-50%, -50%);
-              width: 20px;
-            }
-        style={
-          Object {
-            "left": "100%",
-          }
-        }
-      />
-    </div>
-    <table
-      cellPadding="0"
-      cellSpacing="0"
-      className=
-          ms-ColorPicker-table
-          {
-            table-layout: fixed;
-            width: 100%;
-          }
-    >
-      <thead>
-        <tr
+      >
+        <div
           className=
-
+              ms-ColorPicker-light
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
+                background: linear-gradient(to right, white 0%, transparent 100%);
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
               }
-        >
-          <td
+        />
+        <div
+          className=
+              ms-ColorPicker-dark
+              {
+                background: linear-gradient(to bottom, transparent 0, #000 100%);
+                bottom: 0px;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          className=
+              ms-ColorPicker-thumb
+              {
+                background: white;
+                border-radius: 50%;
+                border: 1px solid rgba(255,255,255,.8);
+                box-shadow: 0 0 15px -5px black;
+                height: 20px;
+                position: absolute;
+                transform: translate(-50%, -50%);
+                width: 20px;
+              }
+          style={
+            Object {
+              "backgroundColor": "#ffffff",
+              "left": "0%",
+              "top": "0%",
+            }
+          }
+        />
+      </div>
+      <div
+        className=
+            ms-ColorPicker-slider
+            is-hue
+            {
+              border: 1px solid #eaeaea;
+              box-sizing: border-box;
+              height: 20px;
+              margin-bottom: 5px;
+              position: relative;
+            }
+        onMouseDown={[Function]}
+        style={
+          Object {
+            "background": "linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%)",
+          }
+        }
+      >
+        <div
+          className=
+              ms-ColorPicker-sliderOverlay
+              {
+                bottom: 0px;
+                content: ;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+        />
+        <div
+          className=
+              ms-ColorPicker-thumb
+              is-slider
+              {
+                background: white;
+                border-radius: 50%;
+                border: 1px solid rgba(255,255,255,.8);
+                box-shadow: 0 0 15px -5px black;
+                height: 20px;
+                position: absolute;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                width: 20px;
+              }
+          style={
+            Object {
+              "left": "0%",
+            }
+          }
+        />
+      </div>
+      <div
+        className=
+            ms-ColorPicker-slider
+            is-alpha
+            {
+              border: 1px solid #eaeaea;
+              box-sizing: border-box;
+              height: 20px;
+              margin-bottom: 5px;
+              position: relative;
+            }
+        onMouseDown={[Function]}
+        style={
+          Object {
+            "backgroundImage": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==)",
+          }
+        }
+      >
+        <div
+          className=
+              ms-ColorPicker-sliderOverlay
+              {
+                bottom: 0px;
+                content: ;
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+          style={
+            Object {
+              "background": "linear-gradient(to right, transparent 0, #ffffff 100%)",
+            }
+          }
+        />
+        <div
+          className=
+              ms-ColorPicker-thumb
+              is-slider
+              {
+                background: white;
+                border-radius: 50%;
+                border: 1px solid rgba(255,255,255,.8);
+                box-shadow: 0 0 15px -5px black;
+                height: 20px;
+                position: absolute;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                width: 20px;
+              }
+          style={
+            Object {
+              "left": "100%",
+            }
+          }
+        />
+      </div>
+      <table
+        cellPadding="0"
+        cellSpacing="0"
+        className=
+            ms-ColorPicker-table
+            {
+              table-layout: fixed;
+              width: 100%;
+            }
+      >
+        <thead>
+          <tr
             className=
 
                 {
-                  width: 25%;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
                 }
           >
-            Hex
-          </td>
-          <td>
-            Red
-          </td>
-          <td>
-            Green
-          </td>
-          <td>
-            Blue
-          </td>
-          <td>
-            Alpha
-          </td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <div
+            <td
               className=
-                  ms-TextField
-                  ms-ColorPicker-input
+
                   {
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border-width: 2px;
-                  }
-                  &.ms-TextField {
-                    padding-right: 2px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
+                    width: 25%;
                   }
             >
+              Hex
+            </td>
+            <td>
+              Red
+            </td>
+            <td>
+              Green
+            </td>
+            <td>
+              Blue
+            </td>
+            <td>
+              Alpha
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
               <div
                 className=
-                    ms-TextField-wrapper
-
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-width: 2px;
+                    }
+                    &.ms-TextField {
+                      padding-right: 2px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
                   className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border: 1px solid #a6a6a6;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #212121;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
-                      }
+                      ms-TextField-wrapper
+
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Hex"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border: 1px solid #a6a6a6;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #333333;
-                          font-size: 14px;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 12px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
+                        &:hover {
+                          border-color: #212121;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active){&:hover {
+                          border-color: Highlight;
                         }
-                        &::placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                    id="TextField0"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="ffffff"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Hex"
+                      className=
+                          ms-TextField-field
+                          {
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #333333;
+                            font-size: 14px;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 12px;
+                            padding-right: 12px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          &::placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                      id="TextField0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="ffffff"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "18%",
+                }
               }
-            }
-          >
-            <div
-              className=
-                  ms-TextField
-                  ms-ColorPicker-input
-                  {
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border-width: 2px;
-                  }
-                  &.ms-TextField {
-                    padding-right: 2px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
             >
               <div
                 className=
-                    ms-TextField-wrapper
-
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-width: 2px;
+                    }
+                    &.ms-TextField {
+                      padding-right: 2px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
                   className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border: 1px solid #a6a6a6;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #212121;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
-                      }
+                      ms-TextField-wrapper
+
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Red"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border: 1px solid #a6a6a6;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #333333;
-                          font-size: 14px;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 12px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
+                        &:hover {
+                          border-color: #212121;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active){&:hover {
+                          border-color: Highlight;
                         }
-                        &::placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                    id="TextField2"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="255"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Red"
+                      className=
+                          ms-TextField-field
+                          {
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #333333;
+                            font-size: 14px;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 12px;
+                            padding-right: 12px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          &::placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                      id="TextField2"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="255"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "18%",
+                }
               }
-            }
-          >
-            <div
-              className=
-                  ms-TextField
-                  ms-ColorPicker-input
-                  {
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border-width: 2px;
-                  }
-                  &.ms-TextField {
-                    padding-right: 2px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
             >
               <div
                 className=
-                    ms-TextField-wrapper
-
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-width: 2px;
+                    }
+                    &.ms-TextField {
+                      padding-right: 2px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
                   className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border: 1px solid #a6a6a6;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #212121;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
-                      }
+                      ms-TextField-wrapper
+
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Green"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border: 1px solid #a6a6a6;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #333333;
-                          font-size: 14px;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 12px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
+                        &:hover {
+                          border-color: #212121;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active){&:hover {
+                          border-color: Highlight;
                         }
-                        &::placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                    id="TextField4"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="255"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Green"
+                      className=
+                          ms-TextField-field
+                          {
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #333333;
+                            font-size: 14px;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 12px;
+                            padding-right: 12px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          &::placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                      id="TextField4"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="255"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "18%",
+                }
               }
-            }
-          >
-            <div
-              className=
-                  ms-TextField
-                  ms-ColorPicker-input
-                  {
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border-width: 2px;
-                  }
-                  &.ms-TextField {
-                    padding-right: 2px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
             >
               <div
                 className=
-                    ms-TextField-wrapper
-
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-width: 2px;
+                    }
+                    &.ms-TextField {
+                      padding-right: 2px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
                   className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border: 1px solid #a6a6a6;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #212121;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
-                      }
+                      ms-TextField-wrapper
+
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Blue"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border: 1px solid #a6a6a6;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #333333;
-                          font-size: 14px;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 12px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
+                        &:hover {
+                          border-color: #212121;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active){&:hover {
+                          border-color: Highlight;
                         }
-                        &::placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                    id="TextField6"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="255"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Blue"
+                      className=
+                          ms-TextField-field
+                          {
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #333333;
+                            font-size: 14px;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 12px;
+                            padding-right: 12px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          &::placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                      id="TextField6"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="255"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
+            </td>
+            <td
+              style={
+                Object {
+                  "width": "18%",
+                }
               }
-            }
-          >
-            <div
-              className=
-                  ms-TextField
-                  ms-ColorPicker-input
-                  {
-                    border: none;
-                    box-shadow: none;
-                    box-sizing: border-box;
-                    height: 30px;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    position: relative;
-                    width: 100%;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    border-width: 2px;
-                  }
-                  &.ms-TextField {
-                    padding-right: 2px;
-                  }
-                  & .ms-TextField-field {
-                    min-width: auto;
-                    padding-bottom: 5px;
-                    padding-left: 5px;
-                    padding-right: 5px;
-                    padding-top: 5px;
-                    text-overflow: clip;
-                  }
             >
               <div
                 className=
-                    ms-TextField-wrapper
-
+                    ms-TextField
+                    ms-ColorPicker-input
+                    {
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      height: 30px;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
+                      position: relative;
+                      width: 100%;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-width: 2px;
+                    }
+                    &.ms-TextField {
+                      padding-right: 2px;
+                    }
+                    & .ms-TextField-field {
+                      min-width: auto;
+                      padding-bottom: 5px;
+                      padding-left: 5px;
+                      padding-right: 5px;
+                      padding-top: 5px;
+                      text-overflow: clip;
+                    }
               >
                 <div
                   className=
-                      ms-TextField-fieldGroup
-                      {
-                        align-items: stretch;
-                        background: #ffffff;
-                        border: 1px solid #a6a6a6;
-                        box-shadow: none;
-                        box-sizing: border-box;
-                        display: flex;
-                        flex-direction: row;
-                        height: 32px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
-                        position: relative;
-                      }
-                      &:hover {
-                        border-color: #212121;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
-                      }
+                      ms-TextField-wrapper
+
                 >
-                  <input
-                    aria-invalid={false}
-                    aria-label="Alpha"
+                  <div
                     className=
-                        ms-TextField-field
+                        ms-TextField-fieldGroup
                         {
-                          background-color: transparent;
-                          background: none;
-                          border-radius: 0px;
-                          border: none;
+                          align-items: stretch;
+                          background: #ffffff;
+                          border: 1px solid #a6a6a6;
                           box-shadow: none;
                           box-sizing: border-box;
-                          color: #333333;
-                          font-size: 14px;
+                          display: flex;
+                          flex-direction: row;
+                          height: 32px;
                           margin-bottom: 0px;
                           margin-left: 0px;
                           margin-right: 0px;
                           margin-top: 0px;
-                          min-width: 0px;
-                          outline: 0px;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 12px;
-                          padding-top: 0;
-                          text-overflow: ellipsis;
-                          width: 100%;
+                          padding-bottom: 0px;
+                          padding-left: 0px;
+                          padding-right: 0px;
+                          padding-top: 0px;
+                          position: relative;
                         }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
+                        &:hover {
+                          border-color: #212121;
                         }
-                        &::-ms-clear {
-                          display: none;
+                        @media screen and (-ms-high-contrast: active){&:hover {
+                          border-color: Highlight;
                         }
-                        &::placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          color: #666666;
-                          opacity: 1;
-                        }
-                    id="TextField8"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onInput={[Function]}
-                    spellCheck={false}
-                    type="text"
-                    value="100"
-                  />
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-label="Alpha"
+                      className=
+                          ms-TextField-field
+                          {
+                            background-color: transparent;
+                            background: none;
+                            border-radius: 0px;
+                            border: none;
+                            box-shadow: none;
+                            box-sizing: border-box;
+                            color: #333333;
+                            font-size: 14px;
+                            margin-bottom: 0px;
+                            margin-left: 0px;
+                            margin-right: 0px;
+                            margin-top: 0px;
+                            min-width: 0px;
+                            outline: 0px;
+                            padding-bottom: 0;
+                            padding-left: 12px;
+                            padding-right: 12px;
+                            padding-top: 0;
+                            text-overflow: ellipsis;
+                            width: 100%;
+                          }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
+                          &::placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #666666;
+                            opacity: 1;
+                          }
+                      id="TextField8"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      spellCheck={false}
+                      type="text"
+                      value="100"
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
+  <div
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+        "border": "1px solid #c8c6c4",
+        "height": 100,
+        "margin": 16,
+        "width": 100,
+      }
+    }
+  />
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7073
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes a bug where the opacity slider was not showing the correct value on the right side (see #7073). I've also added a selected color swatch to the example page to preview the final color and demonstrate how to use the component.

**Before**:
![image](https://user-images.githubusercontent.com/1382445/48318652-b8161c00-e5b8-11e8-9021-8325e5905921.png)
![image](https://user-images.githubusercontent.com/1382445/48318641-82713300-e5b8-11e8-96b1-8eeca59bb66c.png)

**After**:
![image](https://user-images.githubusercontent.com/1382445/48318619-4b028680-e5b8-11e8-9c26-1be73f42c549.png)
![image](https://user-images.githubusercontent.com/1382445/48318622-55248500-e5b8-11e8-9b81-7c9dae71d815.png)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7074)

