### PR TITLE
ColorPicker: Export subcomponents

### DIFF
--- a/common/changes/office-ui-fabric-react/export-color-picker-subcomponents_2018-11-12-17-52.json
+++ b/common/changes/office-ui-fabric-react/export-color-picker-subcomponents_2018-11-12-17-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ColorPicker: Export sub-components",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2824,6 +2824,69 @@ interface IColorPickerStyles {
 }
 
 // @public (undocumented)
+interface IColorRectangle {
+}
+
+// @public (undocumented)
+interface IColorRectangleProps extends IBaseProps<IColorRectangle> {
+  className?: string;
+  color: IColor;
+  componentRef?: IRefObject<IColorRectangle>;
+  minSize?: number;
+  onSVChanged?: (s: number, v: number) => void;
+  styles?: IStyleFunctionOrObject<IColorRectangleStyleProps, IColorRectangleStyles>;
+  theme?: ITheme;
+}
+
+// @public (undocumented)
+interface IColorRectangleStyleProps {
+  className?: string;
+  theme: ITheme;
+}
+
+// @public (undocumented)
+interface IColorRectangleStyles {
+  dark?: IStyle;
+  light?: IStyle;
+  root?: IStyle;
+  thumb?: IStyle;
+}
+
+// @public (undocumented)
+interface IColorSlider {
+}
+
+// @public (undocumented)
+interface IColorSliderProps extends IBaseProps<IColorSlider> {
+  className?: string;
+  componentRef?: IRefObject<IColorSlider>;
+  isAlpha?: boolean;
+  maxValue?: number;
+  minValue?: number;
+  onChange?: (event: React.MouseEvent<HTMLElement>, newValue?: number) => void;
+  // @deprecated
+  onChanged?: (newValue: number) => void;
+  overlayStyle?: any;
+  styles?: IStyleFunctionOrObject<IColorSliderStyleProps, IColorSliderStyles>;
+  theme?: ITheme;
+  thumbColor?: string;
+  value?: number;
+}
+
+// @public (undocumented)
+interface IColorSliderStyleProps {
+  className?: string;
+  theme: ITheme;
+}
+
+// @public (undocumented)
+interface IColorSliderStyles {
+  root?: IStyle;
+  sliderOverlay?: IStyle;
+  sliderThumb?: IStyle;
+}
+
+// @public (undocumented)
 interface IColumn {
   ariaLabel?: string;
   calculatedWidth?: number;
@@ -12354,6 +12417,8 @@ module ZIndexes {
 // WARNING: Unsupported export: MAX_COLOR_VALUE
 // WARNING: Unsupported export: MAX_COLOR_RGBA
 // WARNING: Unsupported export: ColorPicker
+// WARNING: Unsupported export: ColorRectangle
+// WARNING: Unsupported export: ColorSlider
 // WARNING: Unsupported export: CommandBar
 // WARNING: Unsupported export: ContextualMenu
 // WARNING: Unsupported export: ContextualMenuItem

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/index.ts
@@ -1,0 +1,2 @@
+export * from './ColorRectangle';
+export * from './ColorRectangle.types';

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/index.ts
@@ -1,0 +1,2 @@
+export * from './ColorSlider';
+export * from './ColorSlider.types';

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/index.ts
@@ -1,3 +1,5 @@
 export * from './ColorPicker';
 export * from './ColorPicker.base';
 export * from './ColorPicker.types';
+export * from './ColorRectangle/index';
+export * from './ColorSlider/index';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

While [styling the ColorPicker](https://github.com/OfficeDev/office-ui-fabric-react/issues/7044) I ran into an issue where the styles and style prop types were not available for its subcomponents, ColorRectangle and ColorSlider. This PR exports the subcomponents and their type definitions.