### PR TITLE
Fluent theme: Add ColorPicker styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-color-picker-updates_2018-11-12-22-30.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-color-picker-updates_2018-11-12-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Add styles for ColorPicker",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -1,6 +1,7 @@
 import { BreadcrumbStyles } from './styles/Breadcrumb.styles';
 import { CheckboxStyles } from './styles/Checkbox.styles';
 import { ChoiceGroupOptionStyles } from './styles/ChoiceGroupOption.styles';
+import { ColorPickerStyles, ColorRectangleStyles, ColorSliderStyles } from './styles/ColorPicker.styles';
 import { ComboBoxStyles } from './styles/ComboBox.styles';
 import { CompoundButtonStyles } from './styles/CompoundButton.styles';
 import { ContextualMenuStyles } from './styles/ContextualMenu.styles';
@@ -28,6 +29,15 @@ import { CommandBarButtonStyles } from './styles/CommandBarButton.styles';
 export const FluentStyles: any = {
   Breadcrumb: {
     styles: BreadcrumbStyles
+  },
+  ColorPicker: {
+    styles: ColorPickerStyles
+  },
+  ColorRectangle: {
+    styles: ColorRectangleStyles
+  },
+  ColorSlider: {
+    styles: ColorSliderStyles
   },
   CommandBarButton: {
     styles: CommandBarButtonStyles

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -42,8 +42,6 @@ export const ColorPickerStyles = (props: IColorPickerStyleProps): IColorPickerSt
   };
 };
 
-// @todo: There are interfaces for props and styles, but they
-//        are currently not exported from ColorPicker's index.ts.
 export const ColorRectangleStyles = (props: IColorRectangleStyleProps): IColorRectangleStyles => {
   const { theme } = props;
   const { palette } = theme;
@@ -60,8 +58,6 @@ export const ColorRectangleStyles = (props: IColorRectangleStyleProps): IColorRe
   };
 };
 
-// @todo: There are interfaces for props and styles, but they
-//        are currently not exported from ColorPicker's index.ts.
 export const ColorSliderStyles = (props: IColorSliderStyleProps): IColorSliderStyles => {
   return {
     root: {

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -1,0 +1,76 @@
+import {
+  IColorPickerStyleProps,
+  IColorPickerStyles,
+  IColorRectangleStyleProps,
+  IColorRectangleStyles,
+  IColorSliderStyleProps,
+  IColorSliderStyles
+} from 'office-ui-fabric-react/lib/ColorPicker';
+
+import { NeutralColors } from '../FluentColors';
+import { Depths } from '../FluentDepths';
+import { fluentBorderRadius } from './styleConstants';
+
+export const ColorPickerStyles = (props: IColorPickerStyleProps): IColorPickerStyles => {
+  return {
+    input: {
+      selectors: {
+        '&.ms-TextField': {
+          paddingRight: 4
+        },
+        '.ms-TextField-field': {
+          minWidth: 'auto',
+          padding: 5,
+          textOverflow: 'clip'
+        }
+      }
+    },
+    table: {
+      selectors: {
+        'tbody td:last-of-type .ms-ColorPicker-input': {
+          paddingRight: 0
+        }
+      }
+    },
+    tableHeader: {
+      selectors: {
+        td: {
+          paddingBottom: 4
+        }
+      }
+    }
+  };
+};
+
+// @todo: There are interfaces for props and styles, but they
+//        are currently not exported from ColorPicker's index.ts.
+export const ColorRectangleStyles = (props: IColorRectangleStyleProps): IColorRectangleStyles => {
+  const { theme } = props;
+  const { palette } = theme;
+
+  return {
+    root: {
+      border: `1px solid ${palette.neutralLighter}`,
+      borderRadius: fluentBorderRadius
+    },
+    thumb: {
+      borderColor: NeutralColors.gray80,
+      boxShadow: Depths.depth8
+    }
+  };
+};
+
+// @todo: There are interfaces for props and styles, but they
+//        are currently not exported from ColorPicker's index.ts.
+export const ColorSliderStyles = (props: IColorSliderStyleProps): IColorSliderStyles => {
+  return {
+    root: {
+      borderRadius: fluentBorderRadius,
+      marginBottom: 8
+    },
+    sliderThumb: {
+      borderColor: NeutralColors.gray80,
+      boxShadow: Depths.depth8
+    }
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7044
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds ColorPicker styles to the Fluent theme to match the latest designs.

Before:
![image](https://user-images.githubusercontent.com/1382445/48379135-ef073300-e687-11e8-8998-c75572b6d992.png)

After:
![image](https://user-images.githubusercontent.com/1382445/48379122-e7478e80-e687-11e8-8923-9dea4f7e57ae.png)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7081)

