### PR TITLE
[Hotfix/Cherry-pick] Fix ComboBox multiSelect on mouse click regression (#6998)

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-multiselect-combobox_2018-11-06-19-06.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-multiselect-combobox_2018-11-06-19-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove defaultPrevented check in ComboBox item click due to multiSelect regression.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1003,7 +1003,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             (this._autofill.current &&
               this._autofill.current.isValueSelected &&
               currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-              pendingOptionText.length)) ||
+                pendingOptionText.length)) ||
             (this._autofill.current &&
               this._autofill.current.inputElement &&
               this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
@@ -1346,14 +1346,12 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     return (ev: any): void => {
       onItemClick && onItemClick(ev, item, index);
-      if (!ev.defaultPrevented) {
-        this._setSelectedIndex(index as number, ev);
-        if (!this.props.multiSelect) {
-          // only close the callout when it's in single-select mode
-          this.setState({
-            isOpen: false
-          });
-        }
+      this._setSelectedIndex(index as number, ev);
+      if (!this.props.multiSelect) {
+        // only close the callout when it's in single-select mode
+        this.setState({
+          isOpen: false
+        });
       }
     };
   }


### PR DESCRIPTION
* Remove defaultPrevented check in ComboBox due to multi-select regression

* Add changefile.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Cherry picking PR https://github.com/OfficeDev/office-ui-fabric-react/pull/6998 into hotfix package

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7082)

