### PR TITLE
Fluent theme: SwatchColorPicker fluent styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-SwatchColorPicker_2018-11-13-02-36.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-SwatchColorPicker_2018-11-13-02-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "SwatchColorPicker: add fluent styles.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -2,12 +2,14 @@ import { BreadcrumbStyles } from './styles/Breadcrumb.styles';
 import { CheckboxStyles } from './styles/Checkbox.styles';
 import { ChoiceGroupOptionStyles } from './styles/ChoiceGroupOption.styles';
 import { ComboBoxStyles } from './styles/ComboBox.styles';
+import { CommandBarButtonStyles } from './styles/CommandBarButton.styles';
 import { CompoundButtonStyles } from './styles/CompoundButton.styles';
 import { ContextualMenuStyles } from './styles/ContextualMenu.styles';
 import { DatePickerStyles } from './styles/DatePicker.styles';
 import { DefaultButtonStyles } from './styles/DefaultButton.styles';
 import { DialogStyles, DialogContentStyles, DialogFooterStyles } from './styles/Dialog.styles';
 import { DropdownStyles } from './styles/Dropdown.styles';
+import { IconButtonStyles } from './styles/IconButton.styles';
 import { LabelStyles } from './styles/Label.styles';
 import { LinkStyles } from './styles/Link.styles';
 import { PivotStyles } from './styles/Pivot.styles';
@@ -17,8 +19,7 @@ import { SliderStyles } from './styles/Slider.styles';
 import { SpinButtonStyles } from './styles/SpinButton.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
-import { IconButtonStyles } from './styles/IconButton.styles';
-import { CommandBarButtonStyles } from './styles/CommandBarButton.styles';
+import { ColorPickerGridCellStyles } from './styles/ColorPickerGridCell.styles';
 
 // Roll up all style overrides in a single "Fluent theme" object
 
@@ -40,6 +41,9 @@ export const FluentStyles: any = {
   },
   ChoiceGroupOption: {
     styles: ChoiceGroupOptionStyles
+  },
+  ColorPickerGridCell: {
+    styles: ColorPickerGridCellStyles
   },
   ComboBox: {
     styles: ComboBoxStyles

--- a/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
@@ -1,0 +1,62 @@
+import { IColorPickerGridCellStyleProps } from 'office-ui-fabric-react/lib/SwatchColorPicker';
+import { NeutralColors } from '../FluentColors';
+import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
+
+export const ColorPickerGridCellStyles = (props: IColorPickerGridCellStyleProps) => {
+  const { theme, selected, isWhite, circle, borderWidth } = props;
+  const { palette } = theme;
+
+  return {
+    colorCell: [
+      {
+        selectors: {
+          [`.${IsFocusVisibleClassName} &:focus`]: [
+            !circle && {
+              // According to the toolkit the outline is flush with the rest swatches without adding visually in size.
+              outlineOffset: '-1px'
+            },
+            // Might need to be reworked after some changes in SwatchColorPicker default styles
+            circle && {
+              outlineColor: 'transparent',
+              border: `1px solid ${palette.neutralSecondary}`,
+              padding: borderWidth! + (borderWidth! - 1)
+            }
+          ]
+        }
+      },
+      isWhite &&
+        !selected && {
+          backgroundColor: NeutralColors.gray80
+        },
+      !selected && {
+        selectors: {
+          ':focus': {
+            borderColor: palette.white
+          },
+          ':hover': {
+            borderColor: palette.neutralLighter
+          },
+          ':active:hover': {
+            borderColor: palette.neutralLight
+          }
+        }
+      },
+      selected && {
+        borderColor: palette.neutralLight,
+        selectors: {
+          ':hover': [
+            !circle && {
+              outline: `1px solid ${palette.neutralSecondary}`,
+              outlineOffset: '-1px'
+            },
+            // Might need to be reworked after some changes in SwatchColorPicker default styles
+            circle && {
+              border: `1px solid ${palette.neutralSecondary}`,
+              padding: borderWidth! + (borderWidth! - 1)
+            }
+          ]
+        }
+      }
+    ]
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #7069 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Adds fluent styles to the `fluent-theme` package.

Before:
![screen shot 2018-11-12 at 6 46 31 pm](https://user-images.githubusercontent.com/29514833/48387683-a2355380-e6ab-11e8-9674-73176440c8d3.png)

After:
![screen shot 2018-11-12 at 6 47 39 pm](https://user-images.githubusercontent.com/29514833/48387693-a9f4f800-e6ab-11e8-9473-5c4b8e13be48.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7084)

