### PR TITLE
Fluent-theme: Add fluent styles to HoverCard

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-HoverCard_2018-11-16-01-04.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-HoverCard_2018-11-16-01-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "HoverCard: Add fluent styles to ExpandingCard and PlainCard.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -10,6 +10,7 @@ import { DatePickerStyles } from './styles/DatePicker.styles';
 import { DefaultButtonStyles } from './styles/DefaultButton.styles';
 import { DialogStyles, DialogContentStyles, DialogFooterStyles } from './styles/Dialog.styles';
 import { DropdownStyles } from './styles/Dropdown.styles';
+import { ExpandingCardStyles, PlainCardStyles } from './styles/HoverCard.styles';
 import { IconButtonStyles } from './styles/IconButton.styles';
 import { LabelStyles } from './styles/Label.styles';
 import { LinkStyles } from './styles/Link.styles';
@@ -79,6 +80,9 @@ export const FluentStyles: any = {
   Dropdown: {
     styles: DropdownStyles
   },
+  ExpandingCard: {
+    styles: ExpandingCardStyles
+  },
   IconButton: {
     styles: IconButtonStyles
   },
@@ -90,6 +94,9 @@ export const FluentStyles: any = {
   },
   Pivot: {
     styles: PivotStyles
+  },
+  PlainCard: {
+    styles: PlainCardStyles
   },
   PrimaryButton: {
     styles: PrimaryButtonStyles

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -1,0 +1,34 @@
+import { IExpandingCardStyleProps, IPlainCardStyleProps } from 'office-ui-fabric-react/lib/HoverCard';
+import { Depths } from '../FluentDepths';
+import { fluentBorderRadius } from './styleConstants';
+
+const commonCardStyles = {
+  border: 'none',
+  boxShadow: Depths.depth16,
+  borderRadius: fluentBorderRadius,
+  selectors: {
+    '.ms-Callout-main': { borderRadius: fluentBorderRadius }
+  }
+};
+
+export const ExpandingCardStyles = (props: IExpandingCardStyleProps) => {
+  return {
+    root: {
+      ...commonCardStyles,
+      width: 320
+    },
+    expandedCard: {
+      selectors: {
+        ':before': {
+          width: 272
+        }
+      }
+    }
+  };
+};
+
+export const PlainCardStyles = (props: IPlainCardStyleProps) => {
+  return {
+    root: { ...commonCardStyles }
+  };
+};

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -20,7 +20,7 @@ export const ExpandingCardStyles = (props: IExpandingCardStyleProps) => {
     expandedCard: {
       selectors: {
         ':before': {
-          width: 272
+          width: 272 // needs to change due to above change
         }
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #7120 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adding some styles to HoverCard.
Changes include rounded corners and a new shadow. Also, the width decreases from 340px to 320px.

# **Before:**
## CARD:
![screen shot 2018-11-15 at 5 15 03 pm](https://user-images.githubusercontent.com/29514833/48591790-51676a00-e8fa-11e8-9d7d-b408d29d1fcc.png)
## CORNER + SHADOW:
![screen shot 2018-11-15 at 5 16 42 pm](https://user-images.githubusercontent.com/29514833/48591806-617f4980-e8fa-11e8-84d2-89a82cce1191.png)

# **After:**
## CARD:
![screen shot 2018-11-15 at 5 15 34 pm](https://user-images.githubusercontent.com/29514833/48591818-6e9c3880-e8fa-11e8-8b9f-c71c60b85018.png)
## CORNER + SHADOW
![screen shot 2018-11-15 at 5 16 10 pm](https://user-images.githubusercontent.com/29514833/48591824-778d0a00-e8fa-11e8-9f31-164ef29357ec.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7124)

