### PR TITLE
fixing drag drop to reorder columns by changing _root.value to _root.current

### DIFF
--- a/common/changes/office-ui-fabric-react/arkgupta-dragDropExampleBugFix_2018-11-19-08-52.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-dragDropExampleBugFix_2018-11-19-08-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "changed _root.value to _root.current in componentDidMount",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "arkgupta@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -106,8 +106,9 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
                   {column.isGrouped && <Icon className={classNames.nearIcon} iconName={'GroupedDescending'} />}
 
-                  {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
-                    !column.isIconOnly && <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />}
+                  {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
+                    <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />
+                  )}
                 </span>
               )
             },
@@ -160,7 +161,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   public componentDidUpdate(): void {
     if (!this._dragDropSubscription && this.props.dragDropHelper && this.props.isDraggable!) {
       this._dragDropSubscription = this.props.dragDropHelper.subscribe(
-        this._root.value as HTMLElement,
+        this._root.current as HTMLElement,
         this._events,
         this._getColumnDragDropOptions()
       );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
In  componentDidUpdate() for DetailsColumn.Base, earlier _root.value was being used which was working fine when root was getting the ref from Utilities, but root.value becomes undefined on using React.createRef, which was modified in this [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/7042) and the subscription to dragDropHelper is failing. Using _root.current like in the other lifecycle hooks fixes the issue.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7144)

