### PR TITLE
DetailsColumn: Prefer BaseComponent async over raw setTimeout usage to avoid leaking memory

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-clear-timeouts_2018-11-19-18-18.json
+++ b/common/changes/office-ui-fabric-react/keco-clear-timeouts_2018-11-19-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Prefer BaseComponent async when using setTimeout to avoid memory leak when toggling drag & drop class.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -106,8 +106,9 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
                   {column.isGrouped && <Icon className={classNames.nearIcon} iconName={'GroupedDescending'} />}
 
-                  {column.columnActionsMode === ColumnActionsMode.hasDropdown &&
-                    !column.isIconOnly && <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />}
+                  {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
+                    <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />
+                  )}
                 </span>
               )
             },
@@ -142,7 +143,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       if (this._root!.current!) {
         this._root!.current!.classList!.add(classNames.borderAfterDropping);
       }
-      setTimeout(() => {
+      this._async.setTimeout(() => {
         if (this._root!.current!) {
           this._root!.current!.classList!.remove(classNames.borderAfterDropping);
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

We should _prefer_ `BaseComponent`'s `async` over raw `setTimeout` usage as it automatically clears timeouts on `componentWillUnmount` ([Source](https://github.com/OfficeDev/office-ui-fabric-react/blob/4eeee48e8e036ad585122a591405f22be2e36605/packages/utilities/src/BaseComponent.ts#L98)). Otherwise, it is possible to _leak memory_ due to DOM being captured in the timeout closure.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7146)

