### PR TITLE
ContextualMenu: Fix event is undefined when checkmark clicked in ContextualMenuItem

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-ctx-menu-checkmark-click_2018-11-19-19-29.json
+++ b/common/changes/office-ui-fabric-react/keco-ctx-menu-checkmark-click_2018-11-19-19-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Remove ContextualMenuItemWrapper onItemClick binds which drop DOM event from args list.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
@@ -23,6 +23,7 @@ const renderItemIcon = (props: IContextualMenuItemProps) => {
 const renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextualMenuItemProps) => {
   const isItemChecked = getIsChecked(item);
   if (onCheckmarkClick) {
+    // Ensures that the item is passed as the first argument to the checkmark click callback.
     const onClick = (e: React.MouseEvent<HTMLElement>) => onCheckmarkClick(item, e);
 
     return <Icon iconName={isItemChecked ? 'CheckMark' : ''} className={classNames.checkmarkIcon} onClick={onClick} />;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 import { IContextualMenuItem } from '../ContextualMenu.types';
 import { IMenuItemClassNames } from '../ContextualMenu.classNames';
 import { ContextualMenuAnchor } from './ContextualMenuAnchor';
@@ -20,6 +21,45 @@ describe('ContextualMenuButton', () => {
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+
+    it('invokes optional onItemClick on anchor node "click"', () => {
+      const onClickMock = jest.fn();
+      const component = mount(
+        <ContextualMenuAnchor
+          item={menuItem}
+          classNames={menuClassNames}
+          index={0}
+          focusableElementIndex={0}
+          totalItemCount={1}
+          hasCheckmarks={true}
+          onItemClick={onClickMock}
+        />
+      );
+      component.find('a').simulate('click');
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toBeCalledWith(menuItem, expect.anything());
+    });
+
+    it('invokes optional onItemClick on checkmark node "click"', () => {
+      const onClickMock = jest.fn();
+      const component = mount(
+        <ContextualMenuAnchor
+          item={menuItem}
+          classNames={menuClassNames}
+          index={0}
+          focusableElementIndex={0}
+          totalItemCount={1}
+          hasCheckmarks={true}
+          onItemClick={onClickMock}
+        />
+      );
+      component
+        .find('.checkmarkIcon')
+        .at(0)
+        .simulate('click');
+      expect(onClickMock).toHaveBeenCalledTimes(2);
+      expect(onClickMock).toBeCalledWith(menuItem, expect.anything());
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -24,6 +24,7 @@ describe('ContextualMenuButton', () => {
     });
 
     it('invokes optional onItemClick on anchor node "click"', () => {
+      const mockEvent = { foo: 'bar' };
       const onClickMock = jest.fn();
       const component = mount(
         <ContextualMenuAnchor
@@ -36,9 +37,9 @@ describe('ContextualMenuButton', () => {
           onItemClick={onClickMock}
         />
       );
-      component.find('a').simulate('click', { foo: 'bar' });
+      component.find('a').simulate('click', mockEvent);
       expect(onClickMock).toHaveBeenCalledTimes(1);
-      expect(onClickMock).toBeCalledWith(menuItem, expect.anything());
+      expect(onClickMock).toBeCalledWith(menuItem, expect.objectContaining(mockEvent));
     });
 
     it('invokes optional onItemClick on checkmark node "click"', () => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.test.tsx
@@ -36,12 +36,13 @@ describe('ContextualMenuButton', () => {
           onItemClick={onClickMock}
         />
       );
-      component.find('a').simulate('click');
+      component.find('a').simulate('click', { foo: 'bar' });
       expect(onClickMock).toHaveBeenCalledTimes(1);
       expect(onClickMock).toBeCalledWith(menuItem, expect.anything());
     });
 
     it('invokes optional onItemClick on checkmark node "click"', () => {
+      const mockEvent = { foo: 'bar' };
       const onClickMock = jest.fn();
       const component = mount(
         <ContextualMenuAnchor
@@ -54,12 +55,19 @@ describe('ContextualMenuButton', () => {
           onItemClick={onClickMock}
         />
       );
+
       component
         .find('.checkmarkIcon')
         .at(0)
-        .simulate('click');
+        .simulate('click', mockEvent);
+
+      // onItemClick is invoked twice, once for Check and again for ContextualMenuItem.
+      // This logic can be cleaned-up using Jest's toHaveNthReturnedWith when available.
       expect(onClickMock).toHaveBeenCalledTimes(2);
-      expect(onClickMock).toBeCalledWith(menuItem, expect.anything());
+      expect(onClickMock.mock.calls[0][0]).toBe(menuItem);
+      expect(onClickMock.mock.calls[0][1]).toHaveProperty('foo', 'bar');
+      expect(onClickMock.mock.calls[1][0]).toBe(menuItem);
+      expect(onClickMock.mock.calls[1][1]).toHaveProperty('foo', 'bar');
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -74,7 +74,7 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
                 item={item}
                 classNames={classNames}
                 index={index}
-                onCheckmarkClick={hasCheckmarks && onItemClick ? onItemClick.bind(this, item) : undefined}
+                onCheckmarkClick={hasCheckmarks && onItemClick ? onItemClick : undefined}
                 hasIcons={hasIcons}
                 openSubMenu={openSubMenu}
                 dismissSubMenu={dismissSubMenu}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 import { IContextualMenuItem } from '../ContextualMenu.types';
 import { IMenuItemClassNames } from '../ContextualMenu.classNames';
 import { ContextualMenuButton } from './ContextualMenuButton';
@@ -20,6 +21,30 @@ describe('ContextualMenuButton', () => {
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+
+    it('invokes optional onItemClick on checkmark node "click"', () => {
+      const mockEvent = { foo: 'bar' };
+      const onClickMock = jest.fn();
+      const component = mount(
+        <ContextualMenuButton
+          item={menuItem}
+          classNames={menuClassNames}
+          index={0}
+          focusableElementIndex={0}
+          totalItemCount={1}
+          hasCheckmarks={true}
+          onItemClick={onClickMock}
+        />
+      );
+
+      component
+        .find('.checkmarkIcon')
+        .at(0)
+        .simulate('click', mockEvent);
+
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(menuItem, expect.objectContaining(mockEvent));
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -86,7 +86,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
               item={item}
               classNames={classNames}
               index={index}
-              onCheckmarkClick={hasCheckmarks && onItemClick ? onItemClick.bind(this, item) : undefined}
+              onCheckmarkClick={hasCheckmarks && onItemClick ? onItemClick : undefined}
               hasIcons={hasIcons}
               openSubMenu={openSubMenu}
               dismissSubMenu={dismissSubMenu}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 import { IContextualMenuItem } from '../ContextualMenu.types';
 import { IMenuItemClassNames } from '../ContextualMenu.classNames';
 import { ContextualMenuSplitButton } from './ContextualMenuSplitButton';
@@ -20,6 +21,30 @@ describe('ContextualMenuSplitButton', () => {
       );
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
+    });
+
+    it('invokes optional onItemClick on checkmark node "click"', () => {
+      const mockEvent = { foo: 'bar' };
+      const onClickMock = jest.fn();
+      const component = mount(
+        <ContextualMenuSplitButton
+          item={menuItem}
+          classNames={menuClassNames}
+          index={0}
+          focusableElementIndex={0}
+          totalItemCount={1}
+          hasCheckmarks={true}
+          onItemClick={onClickMock}
+        />
+      );
+
+      component
+        .find('.checkmarkIcon')
+        .at(0)
+        .simulate('click', mockEvent);
+
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+      expect(onClickMock).toHaveBeenCalledWith(expect.objectContaining(menuItem), expect.objectContaining(mockEvent));
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -128,7 +128,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
           item={itemProps}
           classNames={classNames}
           index={index}
-          onCheckmarkClick={hasCheckmarks && onItemClick ? onItemClick.bind(this, item) : undefined}
+          onCheckmarkClick={hasCheckmarks && onItemClick ? onItemClick : undefined}
           hasIcons={hasIcons}
           {...itemComponentProps}
         />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7145
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Removes what seem to be unnecessary binds in the `ContextualMenuItem` wrapper classes which result in `$event` being dropped in the `onItemClick` callback args. This is due to `bind` modifying the callback _context_ and _arguments list_.

#### Focus areas to test

Test this branch in https://codepen.io/avenezia/pen/pQWqEy by proxying localhost or modify the "Basic" example to match the Codepen.

When the check-mark is clicked it will no longer throw an error because the args list is not missing `event` (and target). **Note:** As you can see in the repro Codepen, the click target is _narrow_ to get this to occur.

I plan to add a unit test for this behavior prior to merging this PR.

**Edit:** Unit tests have been added.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7147)

