### PR TITLE
Fluent theme: add styles for Modal and clean-up Dialog styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-Modal_2018-11-19-21-24.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-Modal_2018-11-19-21-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Modal: Add shadow and rounded corners. Remove the global className selector from Dialog.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -8,12 +8,13 @@ import { CompoundButtonStyles } from './styles/CompoundButton.styles';
 import { ContextualMenuStyles } from './styles/ContextualMenu.styles';
 import { DatePickerStyles } from './styles/DatePicker.styles';
 import { DefaultButtonStyles } from './styles/DefaultButton.styles';
-import { DialogStyles, DialogContentStyles, DialogFooterStyles } from './styles/Dialog.styles';
+import { DialogContentStyles, DialogFooterStyles } from './styles/Dialog.styles';
 import { DropdownStyles } from './styles/Dropdown.styles';
 import { ExpandingCardStyles, PlainCardStyles } from './styles/HoverCard.styles';
 import { IconButtonStyles } from './styles/IconButton.styles';
 import { LabelStyles } from './styles/Label.styles';
 import { LinkStyles } from './styles/Link.styles';
+import { ModalStyles } from './styles/Modal.styles';
 import { PivotStyles } from './styles/Pivot.styles';
 import { PrimaryButtonStyles } from './styles/PrimaryButton.styles';
 import { RatingStyles } from './styles/Rating.styles';
@@ -68,9 +69,6 @@ export const FluentStyles: any = {
   DefaultButton: {
     styles: DefaultButtonStyles
   },
-  Dialog: {
-    styles: DialogStyles
-  },
   DialogContent: {
     styles: DialogContentStyles
   },
@@ -91,6 +89,9 @@ export const FluentStyles: any = {
   },
   Link: {
     styles: LinkStyles
+  },
+  Modal: {
+    styles: ModalStyles
   },
   Pivot: {
     styles: PivotStyles

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -1,20 +1,8 @@
 import { IDialogContentStyleProps } from 'office-ui-fabric-react/lib/Dialog';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
-import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';
 import { fluentBorderRadius } from './styleConstants';
-
-export const DialogStyles = {
-  main: {
-    selectors: {
-      '.ms-Modal.ms-Dialog &': {
-        boxShadow: Depths.depth64,
-        borderRadius: fluentBorderRadius
-      }
-    }
-  }
-};
 
 export const DialogContentStyles = (props: IDialogContentStyleProps) => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
@@ -1,0 +1,9 @@
+import { Depths } from '../FluentDepths';
+import { fluentBorderRadius } from './styleConstants';
+
+export const ModalStyles = {
+  main: {
+    boxShadow: Depths.depth64,
+    borderRadius: fluentBorderRadius
+  }
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7148 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adding shadow and rounded corners to `Modal`.
Cleaning up the `Dialog` fluent styles which were targeting the same area in `Modal` through some global classNames.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7149)

