### PR TITLE
Fixing Panel's Overlay in high contrast mode

### DIFF
--- a/common/changes/office-ui-fabric-react/panel_hc_2018-11-20-00-46.json
+++ b/common/changes/office-ui-fabric-react/panel_hc_2018-11-20-00-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing background color of overlay so that screen behind panel isn't hidden in high contrast mode when panel's open",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -132,7 +132,13 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         pointerEvents: 'none',
         opacity: 1,
         cursor: 'pointer',
-        transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction1}`
+        transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction1}`,
+        selectors: {
+          '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)': {
+            // For IE high contrast mode
+            backgroundColor: 'transparent'
+          }
+        }
       },
       isOpen && {
         cursor: 'pointer',

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -120,6 +120,9 @@ exports[`Panel renders Panel correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 border: 1px solid WindowText;
               }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                background-color: transparent;
+              }
         />
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #7095
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fixing background color of overlay so that screen behind panel isn't hidden in HC mode when panel's open. This is what it looks like now with the overlay's background set to transparent. If I can improve this in any way, please let me know! I just took a shot at it with setting the overlay's background color to transparent. 

![image](https://user-images.githubusercontent.com/4161791/48744224-37d86200-ec1b-11e8-855d-52668836df7d.png)

#### Focus areas to test

The different high contrast modes on Edge (and Firefox too?)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7155)

