### PR TITLE
Fluent theme: Add Callout/Tooltip styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/callout-fluent-styles_2018-11-20-02-24.json
+++ b/common/changes/@uifabric/fluent-theme/callout-fluent-styles_2018-11-20-02-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Add Callout styles (also used by Tooltip)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/common/changes/@uifabric/fluent-theme/callout-fluent-styles_2018-11-20-02-24.json
+++ b/common/changes/@uifabric/fluent-theme/callout-fluent-styles_2018-11-20-02-24.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@uifabric/fluent-theme",
       "comment": "Add Callout styles (also used by Tooltip)",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@uifabric/fluent-theme",

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -1,4 +1,5 @@
 import { BreadcrumbStyles } from './styles/Breadcrumb.styles';
+import { CalloutContentStyles } from './styles/Callout.styles';
 import { CheckboxStyles } from './styles/Checkbox.styles';
 import { ChoiceGroupOptionStyles } from './styles/ChoiceGroupOption.styles';
 import { ColorPickerStyles, ColorRectangleStyles, ColorSliderStyles } from './styles/ColorPicker.styles';
@@ -31,6 +32,9 @@ import { ColorPickerGridCellStyles } from './styles/ColorPickerGridCell.styles';
 export const FluentStyles: any = {
   Breadcrumb: {
     styles: BreadcrumbStyles
+  },
+  CalloutContent: {
+    styles: CalloutContentStyles
   },
   ColorPicker: {
     styles: ColorPickerStyles

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -8,6 +8,12 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps) => {
       borderRadius: fluentBorderRadius,
       borderWidth: 0,
       boxShadow: Depths.depth16
+    },
+    beakCurtain: {
+      backgroundColor: 'transparent'
+    },
+    calloutMain: {
+      borderRadius: fluentBorderRadius
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -6,6 +6,7 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps) => {
   return {
     root: {
       borderRadius: fluentBorderRadius,
+      borderWidth: 0,
       boxShadow: Depths.depth16
     }
   };

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -10,7 +10,7 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps) => {
       boxShadow: Depths.depth16
     },
     beakCurtain: {
-      backgroundColor: 'transparent'
+      borderRadius: fluentBorderRadius
     },
     calloutMain: {
       borderRadius: fluentBorderRadius

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -1,0 +1,12 @@
+import { ICalloutContentStyleProps } from 'office-ui-fabric-react/lib/Callout';
+import { Depths } from '../FluentDepths';
+import { fluentBorderRadius } from './styleConstants';
+
+export const CalloutContentStyles = (props: ICalloutContentStyleProps) => {
+  return {
+    root: {
+      borderRadius: fluentBorderRadius,
+      boxShadow: Depths.depth16
+    }
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7156 and #7157
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds styles for `CalloutContainer`, which is used by both Callout and Tooltip. The only difference here is adding a 2px rounded border to the Callout and changing the drop shadow.

#### Before
![image](https://user-images.githubusercontent.com/1382445/48750624-f7c8bc00-ecba-11e8-9d5a-c92696ef862b.png)

#### After
![image](https://user-images.githubusercontent.com/1382445/48750675-54c47200-ecbb-11e8-9480-b965a2e0436a.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7158)

