### PR TITLE
Prevent an exception in ScrollablePaneBase during unmount when MutationObserver isn't supported

### DIFF
--- a/common/changes/office-ui-fabric-react/scrollpanebase-fix_2018-11-20-12-20.json
+++ b/common/changes/office-ui-fabric-react/scrollpanebase-fix_2018-11-20-12-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "A bug fix to avoid crash in ScrollablePane when the componenent is unmounted in an environment where MutationObserver is not supported (for example in jsdom)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "speray@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -156,7 +156,10 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   public componentWillUnmount() {
     this._events.off(this.contentContainer);
     this._events.off(window);
-    this._mutationObserver.disconnect();
+
+    if (this._mutationObserver) {
+      this._mutationObserver.disconnect();
+    }
   }
 
   // Only updates if props/state change, just to prevent excessive setState with updateStickyRefHeights


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Checks that _mutationObserver is set before using it in componentWillUnmount inside ScrollablePaneBase.

Context:
The crash was encountered when running a test in the default config of 'create-react-app'. 
The test command is react-scripts test --env=jsdom and the default test provided looks like:
```js
const div = document.createElement("div");
ReactDOM.render(<App />, div);
ReactDOM.unmountComponentAtNode(div);
```
If App contains at some point a ScrollablePaneBase, it will throw during unmount.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7164)

