### PR TITLE
Remove Hard coded fontFamily and Add default fontFamily from fabric 

### DIFF
--- a/common/changes/@uifabric/dashboard/dashboardSetDefaultFonts_2018-11-20-12-47.json
+++ b/common/changes/@uifabric/dashboard/dashboardSetDefaultFonts_2018-11-20-12-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "add default fonts from fabric  for dashboard package ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "gorigarajesh@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/BodyText/BodyText.styles.ts
+++ b/packages/dashboard/src/components/Card/BodyText/BodyText.styles.ts
@@ -1,4 +1,5 @@
 import { IBodyTextStyles } from './BodyText.types';
+import { DefaultFontStyles } from 'office-ui-fabric-react/lib/Styling';
 
 export const getStyles = (): IBodyTextStyles => {
   return {
@@ -7,14 +8,14 @@ export const getStyles = (): IBodyTextStyles => {
       flexDirection: 'column'
     },
     subHeaderText: {
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       fontWeight: 'bold',
       lineHeight: '16px',
       fontSize: '12px',
       color: '#000000'
     },
     bodyText: {
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       lineHeight: '16px',
       fontSize: '12px',
       paddingTop: '8px',

--- a/packages/dashboard/src/components/Card/CardFrame/CardFrame.styles.ts
+++ b/packages/dashboard/src/components/Card/CardFrame/CardFrame.styles.ts
@@ -1,4 +1,5 @@
 import { ICardFrameStyles, ICardFrameProps } from './CardFrame.types';
+import { DefaultFontStyles } from 'office-ui-fabric-react/lib/Styling';
 
 const cardTitleBox = 40;
 
@@ -40,7 +41,7 @@ export const getStyles = (props: ICardFrameProps): ICardFrameStyles => {
       lineHeight: '19px',
       paddingLeft: '16px',
       fontSize: fontSize ? fontSize : '14px',
-      fontFamily: fontFamily ? fontFamily : 'Segoe UI',
+      fontFamily: fontFamily ? fontFamily : DefaultFontStyles.medium.fontFamily,
       fontWeight: 600,
       display: 'inline-block',
       selectors: {

--- a/packages/dashboard/src/components/Card/CardHeader/CardHeader.styles.ts
+++ b/packages/dashboard/src/components/Card/CardHeader/CardHeader.styles.ts
@@ -1,5 +1,6 @@
 import { ICardHeaderProps, ICardHeaderStyles } from './CardHeader.types';
 import { FontSize } from './CardHeader.types';
+import { DefaultFontStyles } from 'office-ui-fabric-react/lib/Styling';
 
 export const getStyles = (props: ICardHeaderProps): ICardHeaderStyles => {
   const { fontSize } = props;
@@ -15,14 +16,14 @@ export const getStyles = (props: ICardHeaderProps): ICardHeaderStyles => {
     headerText: {
       fontSize: fontSize === FontSize.medium ? '16px' : '28px',
       lineHeight: '38px',
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       marginRight: '16px',
       color: '#000000',
       fontWeight: 'bold'
     },
     annotationText: {
       whiteSpace: 'noWrap',
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       textOverflow: 'ellipsis',
       overflow: 'hidden',
       fontSize: '12px',

--- a/packages/dashboard/src/components/MultiCount/MultiCountStyles.ts
+++ b/packages/dashboard/src/components/MultiCount/MultiCountStyles.ts
@@ -1,4 +1,5 @@
 import { IMultiCountStyles, IMultiCountStyleProps } from './MultiCount.types';
+import { DefaultFontStyles } from 'office-ui-fabric-react/lib/Styling';
 
 export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
   const {
@@ -31,7 +32,7 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
       fontSize: bodyTextSize,
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       fontWeight: 600,
       lineHeight: '1.286em',
       marginLeft: '8px',
@@ -41,13 +42,13 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       flex: '0 0 auto',
       fontSize: bodyTextSize,
       lineHeight: '1.286em',
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       fontWeight: 'bold',
       color: bodyTextColor ? bodyTextColor : color
     },
     annotation: {
       flex: '0 0 auto',
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       marginLeft: '16px',
       width: '12px',
       height: '12px'
@@ -68,7 +69,7 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       paddingBottom: '3px'
     },
     hoverCardData: {
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       fontWeight: 'bold',
       fontSize: '28px',
       lineHeight: '33px',
@@ -82,11 +83,11 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
       marginRight: '16px'
     },
     hoverCardAnnotationText: {
-      fontFamily: 'Segoe UI'
+      fontFamily: DefaultFontStyles.medium.fontFamily
     },
     hoverCardBodyText: {
       marginRight: '16px',
-      fontFamily: 'Segoe UI'
+      fontFamily: DefaultFontStyles.medium.fontFamily
     },
     hoverCardIcon: {
       width: '12px',
@@ -96,7 +97,7 @@ export const getStyles = (props: IMultiCountStyleProps): IMultiCountStyles => {
     customMessage: {
       fontSize: '10px',
       lineHeight: '12px',
-      fontFamily: 'Segoe UI',
+      fontFamily: DefaultFontStyles.medium.fontFamily,
       fontWeight: 600,
       marginTop: '13px',
       marginLeft: '16px',

--- a/packages/dashboard/src/components/Recommendation/Recommendation.styles.ts
+++ b/packages/dashboard/src/components/Recommendation/Recommendation.styles.ts
@@ -1,9 +1,10 @@
 import { ICardComponentCustomizationStyles, IRecommendationStyles } from './Recommendation.types';
 import { IStyle, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { DefaultFontStyles } from 'office-ui-fabric-react/lib/Styling';
 
 const cardFrameColor = 'rgba(0, 120, 215, 1)';
 const recommendationBaseColor = 'rgba(0,0,0,1)';
-const commonFontFamily = 'Segoe UI';
+const commonFontFamily = DefaultFontStyles.medium.fontFamily;
 const commonFontWeight = 'bold';
 const largeFontSize = 28;
 const regularFontSize = 12;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Remove Hard coded fontFamily and Add default fontFamily from fabric 



(give an overview)

#### Focus areas to test

(optional)


####Screenshot 
<img width="928" alt="defaultfont" src="https://user-images.githubusercontent.com/13463251/48775015-d0411600-ecf1-11e8-9ffe-78458244f49b.PNG">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7165)

