### PR TITLE
Check: Use styles prop when generating classNames to support customization

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-check-use-styles_2018-11-20-19-06.json
+++ b/common/changes/office-ui-fabric-react/keco-check-use-styles_2018-11-20-19-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Check: Fix component not using styles prop when generating classNames.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { BaseComponent } from '../../Utilities';
 import { ICheckProps } from './Check.types';
 import { Icon } from '../../Icon';
-import { getStyles } from './Check.styles';
 import { classNamesFunction } from '../../Utilities';
 import { ICheckStyleProps, ICheckStyles } from './Check.types';
 
@@ -18,9 +17,9 @@ export class CheckBase extends BaseComponent<ICheckProps, {}> {
   }
 
   public render(): JSX.Element {
-    const { checked, className, theme } = this.props;
+    const { checked, className, theme, styles } = this.props;
 
-    const classNames = getClassNames(getStyles!, { theme: theme!, className, checked });
+    const classNames = getClassNames(styles!, { theme: theme!, className, checked });
 
     return (
       <div className={classNames.root}>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7168
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Properly uses `styles` when generating `classNames` for `Check` which allows for theming via `styles` and `Customizer`. Prior, it was using default styles as `styles` rather than only supplying that in the base implementation.

#### Focus areas to test

**Note:** I was using the `Checkbox` page for testing hence why the header says "Default Checkbox".

**Customized**

Here is this branch's `Check` rendering the customized `Check` supplied in https://codepen.io/vitalius1/pen/oQoooY?editors=1010

![ouifr_customizer_check](https://user-images.githubusercontent.com/706967/48796766-52f7b000-ecb5-11e8-9cf6-9740fe4ca39b.gif)

**Default**

![ouifr_default_check](https://user-images.githubusercontent.com/706967/48796916-b41f8380-ecb5-11e8-947a-9b71b3cb31f5.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7170)

