### PR TITLE
Using composition to add more specificity to avoid style override

### DIFF
--- a/common/changes/office-ui-fabric-react/arkgupta-dragDropBorderStyling_2018-11-20-19-54.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-dragDropBorderStyling_2018-11-20-19-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "adding more specificity by adding selectors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "arkgupta@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -191,9 +191,13 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
 
     borderWhileDragging: [
       {
-        borderStyle: 'solid',
-        borderWidth: 1,
-        borderColor: palette.themePrimary
+        selectors: {
+          '.ms-DetailsHeader &.ms-DetailsHeader-cell': {
+            borderStyle: 'solid',
+            borderWidth: 1,
+            borderColor: palette.themePrimary
+          }
+        }
       }
     ]
   };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7161 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The style applied to the `borderWhileDragging` class was getting overridden inconsistently by the style applied to the `root` class. So I used composition by making use of `selectors` to add more specificity to prevent it from getting overridden. 

This demo link can be used to check that the border is indeed getting added and the selectors are getting applied: 
[https://msft.spoppe.com/teams/SPGroups/playground/cookieredirect/redirect.aspx?mobile=0&setcookie=https%3A%2F%2Fresourceseng.blob.core.windows.net%2Ffiles%2Fdev-arkgupta-arko-p510e
--git-odsp-next-app-min-master%2F&redirect=https%3A%2F%2Fmsft.spoppe.com%2Fteams%2FSPGroups%2FVNextDocLib%2FForms%2FAllItems.aspx](url). 

Here's what was happening before : 

![image](https://user-images.githubusercontent.com/15196876/48799889-41062380-ed2e-11e8-9c95-5573db8d7b2e.png)


After the changes : 

![image](https://user-images.githubusercontent.com/15196876/48799566-824a0380-ed2d-11e8-9cd6-5676e2615caf.png)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7171)

