### PR TITLE
Ensures that nav links are announced once

### DIFF
--- a/common/changes/office-ui-fabric-react/bugfix-7052-nav-links-read-twice_2018-11-20-20-17.json
+++ b/common/changes/office-ui-fabric-react/bugfix-7052-nav-links-read-twice_2018-11-20-20-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Ensures nav links are announced once",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "shiran.pasternak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -123,7 +123,6 @@ export class NavBase extends BaseComponent<INavProps, INavState> implements INav
         styles={buttonStyles}
         href={link.url || (link.forceAnchor ? 'javascript:' : undefined)}
         iconProps={link.iconProps || { iconName: link.icon || '' }}
-        ariaDescription={link.title || link.name}
         onClick={link.onClick ? this._onNavButtonLinkClicked.bind(this, link) : this._onNavAnchorLinkClicked.bind(this, link)}
         title={link.title || link.name}
         target={link.target}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -169,7 +169,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   </i>
                 </button>
                 <a
-                  aria-describedby="id__3"
                   className=
                       ms-Button
                       ms-Button--action
@@ -296,28 +295,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       data-icon-name=""
                       role="presentation"
                     />
-                    <span
-                      className=
-                          ms-Button-screenReaderText
-                          {
-                            border: 0px;
-                            height: 1px;
-                            margin-bottom: -1px;
-                            margin-left: -1px;
-                            margin-right: -1px;
-                            margin-top: -1px;
-                            overflow: hidden;
-                            padding-bottom: 0px;
-                            padding-left: 0px;
-                            padding-right: 0px;
-                            padding-top: 0px;
-                            position: absolute;
-                            width: 1px;
-                          }
-                      id="id__3"
-                    >
-                      Home
-                    </span>
                     <div
                       className=
                           ms-Nav-linkText
@@ -371,7 +348,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                     name="Activity"
                   >
                     <a
-                      aria-describedby="id__6"
                       className=
                           ms-Button
                           ms-Button--action
@@ -498,28 +474,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           data-icon-name=""
                           role="presentation"
                         />
-                        <span
-                          className=
-                              ms-Button-screenReaderText
-                              {
-                                border: 0px;
-                                height: 1px;
-                                margin-bottom: -1px;
-                                margin-left: -1px;
-                                margin-right: -1px;
-                                margin-top: -1px;
-                                overflow: hidden;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: absolute;
-                                width: 1px;
-                              }
-                          id="id__6"
-                        >
-                          Activity
-                        </span>
                         <div
                           className=
                               ms-Nav-linkText
@@ -562,7 +516,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                     name="MSN"
                   >
                     <a
-                      aria-describedby="id__9"
                       className=
                           ms-Button
                           ms-Button--action
@@ -689,28 +642,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           data-icon-name=""
                           role="presentation"
                         />
-                        <span
-                          className=
-                              ms-Button-screenReaderText
-                              {
-                                border: 0px;
-                                height: 1px;
-                                margin-bottom: -1px;
-                                margin-left: -1px;
-                                margin-right: -1px;
-                                margin-top: -1px;
-                                overflow: hidden;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: absolute;
-                                width: 1px;
-                              }
-                          id="id__9"
-                        >
-                          MSN
-                        </span>
                         <div
                           className=
                               ms-Nav-linkText
@@ -757,7 +688,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 name="Documents"
               >
                 <a
-                  aria-describedby="id__12"
                   className=
                       ms-Button
                       ms-Button--action
@@ -893,28 +823,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       data-icon-name=""
                       role="presentation"
                     />
-                    <span
-                      className=
-                          ms-Button-screenReaderText
-                          {
-                            border: 0px;
-                            height: 1px;
-                            margin-bottom: -1px;
-                            margin-left: -1px;
-                            margin-right: -1px;
-                            margin-top: -1px;
-                            overflow: hidden;
-                            padding-bottom: 0px;
-                            padding-left: 0px;
-                            padding-right: 0px;
-                            padding-top: 0px;
-                            position: absolute;
-                            width: 1px;
-                          }
-                      id="id__12"
-                    >
-                      Documents
-                    </span>
                     <div
                       className=
                           ms-Nav-linkText
@@ -957,7 +865,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 name="Pages"
               >
                 <a
-                  aria-describedby="id__15"
                   className=
                       ms-Button
                       ms-Button--action
@@ -1084,28 +991,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       data-icon-name=""
                       role="presentation"
                     />
-                    <span
-                      className=
-                          ms-Button-screenReaderText
-                          {
-                            border: 0px;
-                            height: 1px;
-                            margin-bottom: -1px;
-                            margin-left: -1px;
-                            margin-right: -1px;
-                            margin-top: -1px;
-                            overflow: hidden;
-                            padding-bottom: 0px;
-                            padding-left: 0px;
-                            padding-right: 0px;
-                            padding-top: 0px;
-                            position: absolute;
-                            width: 1px;
-                          }
-                      id="id__15"
-                    >
-                      Pages
-                    </span>
                     <div
                       className=
                           ms-Nav-linkText
@@ -1148,7 +1033,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 name="Notebook"
               >
                 <a
-                  aria-describedby="id__18"
                   className=
                       ms-Button
                       ms-Button--action
@@ -1275,28 +1159,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       data-icon-name=""
                       role="presentation"
                     />
-                    <span
-                      className=
-                          ms-Button-screenReaderText
-                          {
-                            border: 0px;
-                            height: 1px;
-                            margin-bottom: -1px;
-                            margin-left: -1px;
-                            margin-right: -1px;
-                            margin-top: -1px;
-                            overflow: hidden;
-                            padding-bottom: 0px;
-                            padding-left: 0px;
-                            padding-right: 0px;
-                            padding-top: 0px;
-                            position: absolute;
-                            width: 1px;
-                          }
-                      id="id__18"
-                    >
-                      Notebook
-                    </span>
                     <div
                       className=
                           ms-Nav-linkText
@@ -1339,7 +1201,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 name="Long Name Test for ellipse"
               >
                 <a
-                  aria-describedby="id__21"
                   className=
                       ms-Button
                       ms-Button--action
@@ -1466,28 +1327,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       data-icon-name=""
                       role="presentation"
                     />
-                    <span
-                      className=
-                          ms-Button-screenReaderText
-                          {
-                            border: 0px;
-                            height: 1px;
-                            margin-bottom: -1px;
-                            margin-left: -1px;
-                            margin-right: -1px;
-                            margin-top: -1px;
-                            overflow: hidden;
-                            padding-bottom: 0px;
-                            padding-left: 0px;
-                            padding-right: 0px;
-                            padding-top: 0px;
-                            position: absolute;
-                            width: 1px;
-                          }
-                      id="id__21"
-                    >
-                      Long Name Test for ellipse
-                    </span>
                     <div
                       className=
                           ms-Nav-linkText
@@ -1531,7 +1370,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 name="News"
               >
                 <a
-                  aria-describedby="id__24"
                   className=
                       ms-Button
                       ms-Button--action
@@ -1664,28 +1502,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                     >
                       
                     </i>
-                    <span
-                      className=
-                          ms-Button-screenReaderText
-                          {
-                            border: 0px;
-                            height: 1px;
-                            margin-bottom: -1px;
-                            margin-left: -1px;
-                            margin-right: -1px;
-                            margin-top: -1px;
-                            overflow: hidden;
-                            padding-bottom: 0px;
-                            padding-left: 0px;
-                            padding-right: 0px;
-                            padding-top: 0px;
-                            position: absolute;
-                            width: 1px;
-                          }
-                      id="id__24"
-                    >
-                      News
-                    </span>
                     <div
                       className=
                           ms-Nav-linkText

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
@@ -77,7 +77,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
               name="Home"
             >
               <button
-                aria-describedby="id__3"
                 className=
                     ms-Button
                     ms-Button--action
@@ -204,28 +203,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__3"
-                  >
-                    Home
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText
@@ -268,7 +245,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
               name="Activity"
             >
               <button
-                aria-describedby="id__6"
                 className=
                     ms-Button
                     ms-Button--action
@@ -395,28 +371,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__6"
-                  >
-                    Activity
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText
@@ -459,7 +413,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
               name="News"
             >
               <button
-                aria-describedby="id__9"
                 className=
                     ms-Button
                     ms-Button--action
@@ -586,28 +539,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__9"
-                  >
-                    News
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText
@@ -650,7 +581,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
               name="Documents"
             >
               <button
-                aria-describedby="id__12"
                 className=
                     ms-Button
                     ms-Button--action
@@ -777,28 +707,6 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__12"
-                  >
-                    Documents
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -80,7 +80,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
               name="Activity"
             >
               <a
-                aria-describedby="id__3"
                 className=
                     ms-Button
                     ms-Button--action
@@ -207,28 +206,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__3"
-                  >
-                    Activity
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText
@@ -271,7 +248,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
               name="News"
             >
               <a
-                aria-describedby="id__6"
                 className=
                     ms-Button
                     ms-Button--action
@@ -398,28 +374,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__6"
-                  >
-                    News
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -164,7 +164,6 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 </i>
               </button>
               <a
-                aria-describedby="id__3"
                 className=
                     ms-Button
                     ms-Button--action
@@ -291,28 +290,6 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__3"
-                  >
-                    Parent link
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText
@@ -442,7 +419,6 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 </i>
               </button>
               <a
-                aria-describedby="id__6"
                 className=
                     ms-Button
                     ms-Button--action
@@ -569,28 +545,6 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                     data-icon-name=""
                     role="presentation"
                   />
-                  <span
-                    className=
-                        ms-Button-screenReaderText
-                        {
-                          border: 0px;
-                          height: 1px;
-                          margin-bottom: -1px;
-                          margin-left: -1px;
-                          margin-right: -1px;
-                          margin-top: -1px;
-                          overflow: hidden;
-                          padding-bottom: 0px;
-                          padding-left: 0px;
-                          padding-right: 0px;
-                          padding-top: 0px;
-                          position: absolute;
-                          width: 1px;
-                        }
-                    id="id__6"
-                  >
-                    Parent link
-                  </span>
                   <div
                     className=
                         ms-Nav-linkText


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7052
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds `aria-hidden="true"` to the nested `linkText` elements of Nav items. This prevents assistive technologies (AT) from reading them. AT already read the nested `screenReaderText` elements referenced in the `aria-describedBy` attribute of the list item.

#### Focus areas to test

Ensure that nav items are still properly read by AT, especially with different property combinations (e.g., `name`, `title`, `aria-label`).
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7172)

