### PR TITLE
Update FolderCover to support initialize pattern to override CDN base URL

### DIFF
--- a/common/changes/@uifabric/experiments/folder-covers_2018-11-21-00-54.json
+++ b/common/changes/@uifabric/experiments/folder-covers_2018-11-21-00-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add initializeFolderCovers pathway to override CDN for FolderCover",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -58,6 +58,7 @@
     "@uifabric/variants": ">=6.12.0 <7.0.0",
     "@uifabric/set-version": ">=1.1.3 <2.0.0",
     "@uifabric/merge-styles": ">=6.15.0 <7.0.0",
+    "@uifabric/styling": ">=6.35.0 <7.0.0",
     "deep-assign": "^2.0.0",
     "office-ui-fabric-react": ">=6.106.1 <7.0.0",
     "tslib": "^1.7.1"

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -3,6 +3,7 @@ import { IFolderCoverProps, FolderCoverSize, FolderCoverType } from './FolderCov
 import { ISize, css } from '../../Utilities';
 import * as FolderCoverStylesModule from './FolderCover.scss';
 import * as SignalStylesModule from '../signals/Signal.scss';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
 // tslint:disable-next-line:no-any
 const FolderCoverStyles = FolderCoverStylesModule as any;
@@ -20,8 +21,6 @@ const enum FolderCoverLayoutValues {
   largeHeight = 80,
   contentPadding = 4
 }
-
-const ASSET_CDN_BASE_URL = 'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets';
 
 const SIZES: { [P in FolderCoverSize]: ISize } = {
   small: {
@@ -44,22 +43,22 @@ const ASSETS: {
 } = {
   small: {
     default: {
-      back: `${ASSET_CDN_BASE_URL}/foldericons/folder-small_backplate.svg`,
-      front: `${ASSET_CDN_BASE_URL}/foldericons/folder-small_frontplate_thumbnail.svg` // Yes, it's mis-named.
+      back: `folderCoverSmallDefaultBack`,
+      front: `folderCoverSmallDefaultFront`
     },
     media: {
-      back: `${ASSET_CDN_BASE_URL}/foldericons/folder-small_backplate.svg`,
-      front: `${ASSET_CDN_BASE_URL}/foldericons//folder-small_frontplate_nopreview.svg` // Yes, it's mis-named
+      back: `folderCoverSmallMediaBack`,
+      front: `folderCoverSmallMediaFront`
     }
   },
   large: {
     default: {
-      back: `${ASSET_CDN_BASE_URL}/foldericons/folder-large_backplate.svg`,
-      front: `${ASSET_CDN_BASE_URL}/foldericons/folder-large_frontplate_nopreview.svg`
+      back: `folderCoverLargeDefaultBack`,
+      front: `folderCoverLargeDefaultFront`
     },
     media: {
-      back: `${ASSET_CDN_BASE_URL}/foldericons/folder-large_backplate.svg`,
-      front: `${ASSET_CDN_BASE_URL}/foldericons//folder-large_frontplate_thumbnail.svg`
+      back: `folderCoverLargeMediaBack`,
+      front: `folderCoverLargeMediaFront`
     }
   }
 };
@@ -90,13 +89,13 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent
         })}
       >
-        <img aria-hidden={true} className={css('ms-FolderCover-back', FolderCoverStyles.back)} src={assets.back} />
+        <Icon aria-hidden={true} className={css('ms-FolderCover-back', FolderCoverStyles.back)} iconName={assets.back} />
         {children ? (
           <span className={css('ms-FolderCover-content', FolderCoverStyles.content)}>
             <span className={css('ms-FolderCover-frame', FolderCoverStyles.frame)}>{children}</span>
           </span>
         ) : null}
-        <img aria-hidden={true} className={css('ms-FolderCover-front', FolderCoverStyles.front)} src={assets.front} />
+        <Icon aria-hidden={true} className={css('ms-FolderCover-front', FolderCoverStyles.front)} iconName={assets.front} />
         {signal ? <span className={css('ms-FolderCover-signal', FolderCoverStyles.signal, SignalStyles.dark)}>{signal}</span> : null}
         {metadata ? <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span> : null}
       </div>

--- a/packages/experiments/src/components/FolderCover/FolderCoverPage.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCoverPage.tsx
@@ -22,7 +22,11 @@ export class FolderCoverPage extends React.Component<IComponentDemoPageProps, {}
             sources={[require<string>('!raw-loader!@uifabric/experiments/src/components/FolderCover/FolderCover.types.ts')]}
           />
         }
-        overview={<div />}
+        overview={
+          <div>
+            Initialize folder covers first using <code>initializeFolderCovers()</code>.
+          </div>
+        }
         bestPractices={<div />}
         dos={
           <div>

--- a/packages/experiments/src/components/FolderCover/index.ts
+++ b/packages/experiments/src/components/FolderCover/index.ts
@@ -1,2 +1,3 @@
 export * from './FolderCover.types';
 export * from './FolderCover';
+export * from './initializeFolderCovers';

--- a/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { registerIcons, IIconOptions } from '@uifabric/styling';
+
+const ASSET_CDN_BASE_URL = 'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/foldericons';
+
+export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, options?: Partial<IIconOptions>): void {
+  registerIcons(
+    {
+      fontFace: {},
+      style: {
+        width: 118,
+        height: 86,
+        overflow: 'hidden'
+      },
+      icons: {
+        folderCoverLargeDefaultFront: <img src={`${baseUrl}/folder-large_frontplate_nopreview.svg`} />,
+        folderCoverLargeDefaultBack: <img src={`${baseUrl}/folder-large_backplate.svg`} />,
+        folderCoverLargeMediaFront: <img src={`${baseUrl}/folder-large_frontplate_thumbnail.svg`} />,
+        folderCoverLargeMediaBack: <img src={`${baseUrl}/folder-large_backplate.svg`} />
+      }
+    },
+    options
+  );
+
+  registerIcons(
+    {
+      fontFace: {},
+      style: {
+        width: 78,
+        height: 58,
+        overflow: 'hidden'
+      },
+      icons: {
+        // Yes, it's mis-named.
+        folderCoverSmallDefaultFront: <img src={`${baseUrl}/folder-small_frontplate_thumbnail.svg`} />,
+        folderCoverSmallDefaultBack: <img src={`${baseUrl}/folder-small_backplate.svg`} />,
+        // Yes, it's mis-named.
+        folderCoverSmallMediaFront: <img src={`${baseUrl}/folder-small_frontplate_nopreview.svg`} />,
+        folderCoverSmallMediaBack: <img src={`${baseUrl}/folder-small_backplate.svg`} />
+      }
+    },
+    options
+  );
+}

--- a/packages/experiments/src/demo/index.tsx
+++ b/packages/experiments/src/demo/index.tsx
@@ -10,6 +10,7 @@ import { setBaseUrl } from 'office-ui-fabric-react/lib/Utilities';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
 import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
+import { initializeFolderCovers } from '../components/FolderCover/initializeFolderCovers';
 
 import './index.scss';
 import './ColorStyles.scss';
@@ -19,6 +20,7 @@ setBaseUrl('./dist/');
 // Initialize all icons.
 initializeIcons();
 initializeFileTypeIcons();
+initializeFolderCovers();
 
 let rootElement: HTMLElement | null;
 


### PR DESCRIPTION
# Overview
This change converts `FolderCover` to support (and require) initialization via `initializeFolderCovers`, which may optionally override the CDN base URL.
The `initializeFolderCovers` pathway registers the covers as 'icons', similar to `initializeFileTypeIcons`. They are then rendered using `<Icon />` within the `<FolderCover />` component for consistency.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7178)

