### PR TITLE
Stack empty divs

### DIFF
--- a/common/changes/@uifabric/experiments/stack-empty-divs_2018-11-21-21-34.json
+++ b/common/changes/@uifabric/experiments/stack-empty-divs_2018-11-21-21-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Stack: remove display: none styling on empty children",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/HorizontalStack/__snapshots__/HorizontalStack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/HorizontalStack/__snapshots__/HorizontalStack.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`HorizontalStack renders default HorizontalStack correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -58,7 +58,7 @@ exports[`HorizontalStack renders gap correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-left: 5px;
       }
       & > *:not(.ms-StackItem) {
@@ -95,7 +95,7 @@ exports[`HorizontalStack renders growing items correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -158,7 +158,7 @@ exports[`HorizontalStack renders item alignments correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -291,7 +291,7 @@ exports[`HorizontalStack renders shrinking items correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {

--- a/packages/experiments/src/components/Stack/HorizontalStack/__snapshots__/HorizontalStack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/HorizontalStack/__snapshots__/HorizontalStack.test.tsx.snap
@@ -24,9 +24,6 @@ exports[`HorizontalStack renders default HorizontalStack correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-left: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -64,9 +61,6 @@ exports[`HorizontalStack renders gap correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-left: 5px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -103,9 +97,6 @@ exports[`HorizontalStack renders growing items correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-left: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
@@ -169,9 +160,6 @@ exports[`HorizontalStack renders item alignments correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-left: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
@@ -306,9 +294,6 @@ exports[`HorizontalStack renders shrinking items correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-left: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
       }
@@ -394,9 +379,6 @@ exports[`HorizontalStack renders wrapped HorizontalStack correctly 1`] = `
           max-width: 100%;
           text-overflow: ellipsis;
           white-space: nowrap;
-        }
-        & > *:empty {
-          display: none;
         }
         & > *:not(.ms-StackItem) {
           flex-shrink: 0;

--- a/packages/experiments/src/components/Stack/HorizontalStack/examples/HorizontalStack.Configure.Example.tsx
+++ b/packages/experiments/src/components/Stack/HorizontalStack/examples/HorizontalStack.Configure.Example.tsx
@@ -22,6 +22,7 @@ export interface IExampleState {
   paddingBottom: number;
   horizontalAlignment: HorizontalAlignment;
   verticalAlignment: VerticalAlignment;
+  hideEmptyChildren: boolean;
   emptyChildren: string[];
 }
 
@@ -43,6 +44,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
       paddingBottom: 0,
       horizontalAlignment: 'left',
       verticalAlignment: 'top',
+      hideEmptyChildren: false,
       emptyChildren: []
     };
   }
@@ -63,6 +65,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
       paddingBottom,
       horizontalAlignment,
       verticalAlignment,
+      hideEmptyChildren,
       emptyChildren
     } = this.state;
 
@@ -208,7 +211,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
           </HorizontalStack.Item>
         </HorizontalStack>
 
-        <HorizontalStack gap={20}>
+        <HorizontalStack gap={20} verticalAlign="bottom">
           <HorizontalStack.Item grow>
             <Dropdown
               selectedKey={horizontalAlignment}
@@ -234,6 +237,9 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
               onChange={this._onVerticalAlignChange}
             />
           </HorizontalStack.Item>
+          <HorizontalStack.Item>
+            <Checkbox label="Hide empty children" onChange={this._onHideEmptyChildrenChange} />
+          </HorizontalStack.Item>
           <HorizontalStack.Item grow>
             <TextField label="Enter a space-separated list of empty children (e.g. 1 2 3):" onChange={this._onEmptyChildrenChange} />
           </HorizontalStack.Item>
@@ -252,7 +258,11 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
         >
           {this._range(1, numItems).map((value: number, index: number) => {
             if (emptyChildren.indexOf(value.toString()) !== -1) {
-              return <Text key={index} className={styles.item} />;
+              return hideEmptyChildren ? (
+                <HorizontalStack.Item key={index} className={styles.item} />
+              ) : (
+                <Text key={index} className={styles.item} />
+              );
             }
 
             return (
@@ -327,6 +337,10 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
 
   private _onVerticalAlignChange = (ev: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
     this.setState({ verticalAlignment: option.key as VerticalAlignment });
+  };
+
+  private _onHideEmptyChildrenChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean): void => {
+    this.setState({ hideEmptyChildren: isChecked });
   };
 
   private _onEmptyChildrenChange = (ev: React.FormEvent<HTMLInputElement>, value?: string): void => {

--- a/packages/experiments/src/components/Stack/HorizontalStack/examples/HorizontalStack.Configure.Example.tsx
+++ b/packages/experiments/src/components/Stack/HorizontalStack/examples/HorizontalStack.Configure.Example.tsx
@@ -281,10 +281,11 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
   };
 
   private _range = (start: number, end: number): number[] => {
-    const length = end - start + 1;
-    return Array(length)
-      .fill(start)
-      .map((value: number, index: number) => start + index);
+    const result = [];
+    for (let i = start; i <= end; i++) {
+      result.push(i);
+    }
+    return result;
   };
 
   private _onBoxShadowChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean): void => {

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -83,8 +83,8 @@ export const styles: IStackComponent['styles'] = props => {
         selectors: {
           '> *': childStyles,
 
-          // apply gap margin to every direct child except the first non-empty direct child
-          '> *:not(:empty) ~ *': [
+          // apply gap margin to every direct child except the first direct child
+          '> *:not(:first-child)': [
             horizontal && {
               marginLeft: `${hGap.value}${hGap.unit}`
             },

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -36,10 +36,6 @@ export const styles: IStackComponent['styles'] = props => {
 
   // selectors to be applied regardless of wrap or direction
   const commonSelectors = {
-    '> *:empty': {
-      display: 'none'
-    },
-
     // flexShrink styles are applied by the StackItem
     '> *:not(.ms-StackItem)': {
       flexShrink: shrinkItems ? 1 : 0

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
@@ -7,7 +7,7 @@ const view: IStackItemComponent['view'] = props => {
   const childNodes: React.ReactElement<{}>[] = React.Children.toArray(props.children) as React.ReactElement<{}>[];
   const first = childNodes[0];
   if (!first) {
-    return <span />;
+    return null;
   }
 
   return <span className={props.classNames.root}>{first}</span>;

--- a/packages/experiments/src/components/Stack/VerticalStack/__snapshots__/VerticalStack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/VerticalStack/__snapshots__/VerticalStack.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`VerticalStack renders default VerticalStack correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -58,7 +58,7 @@ exports[`VerticalStack renders gap correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 5px;
       }
       & > *:not(.ms-StackItem) {
@@ -95,7 +95,7 @@ exports[`VerticalStack renders growing items correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -158,7 +158,7 @@ exports[`VerticalStack renders item alignments correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -291,7 +291,7 @@ exports[`VerticalStack renders shrinking items correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {

--- a/packages/experiments/src/components/Stack/VerticalStack/__snapshots__/VerticalStack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/VerticalStack/__snapshots__/VerticalStack.test.tsx.snap
@@ -24,9 +24,6 @@ exports[`VerticalStack renders default VerticalStack correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-top: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -64,9 +61,6 @@ exports[`VerticalStack renders gap correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-top: 5px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -103,9 +97,6 @@ exports[`VerticalStack renders growing items correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
@@ -169,9 +160,6 @@ exports[`VerticalStack renders item alignments correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
@@ -305,9 +293,6 @@ exports[`VerticalStack renders shrinking items correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;

--- a/packages/experiments/src/components/Stack/VerticalStack/examples/VerticalStack.Configure.Example.tsx
+++ b/packages/experiments/src/components/Stack/VerticalStack/examples/VerticalStack.Configure.Example.tsx
@@ -21,6 +21,7 @@ export interface IExampleState {
   paddingBottom: number;
   verticalAlignment: VerticalAlignment;
   horizontalAlignment: HorizontalAlignment;
+  hideEmptyChildren: boolean;
   emptyChildren: string[];
 }
 
@@ -41,6 +42,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
       paddingBottom: 0,
       verticalAlignment: 'top',
       horizontalAlignment: 'left',
+      hideEmptyChildren: false,
       emptyChildren: []
     };
   }
@@ -60,6 +62,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
       paddingBottom,
       verticalAlignment,
       horizontalAlignment,
+      hideEmptyChildren,
       emptyChildren
     } = this.state;
 
@@ -138,7 +141,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
                 showValue={true}
                 onChange={this._onGapChange}
               />
-              <HorizontalStack gap={20}>
+              <HorizontalStack gap={20} verticalAlign="bottom">
                 <HorizontalStack.Item grow>
                   <Dropdown
                     selectedKey={verticalAlignment}
@@ -163,6 +166,9 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
                     options={[{ key: 'left', text: 'Left' }, { key: 'center', text: 'Center' }, { key: 'right', text: 'Right' }]}
                     onChange={this._onHorizontalAlignChange}
                   />
+                </HorizontalStack.Item>
+                <HorizontalStack.Item>
+                  <Checkbox label="Hide empty children" onChange={this._onHideEmptyChildrenChange} />
                 </HorizontalStack.Item>
                 <HorizontalStack.Item grow>
                   <TextField label="List of empty children (e.g. 1 2 3):" onChange={this._onEmptyChildrenChange} />
@@ -226,7 +232,11 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
         >
           {this._range(1, numItems).map((value: number, index: number) => {
             if (emptyChildren.indexOf(value.toString()) !== -1) {
-              return <Text key={index} className={styles.item} />;
+              return hideEmptyChildren ? (
+                <VerticalStack.Item key={index} className={styles.item} />
+              ) : (
+                <Text key={index} className={styles.item} />
+              );
             }
 
             return (
@@ -241,10 +251,11 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
   }
 
   private _range = (start: number, end: number): number[] => {
-    const length = end - start + 1;
-    return Array(length)
-      .fill(start)
-      .map((value: number, index: number) => start + index);
+    const result = [];
+    for (let i = start; i <= end; i++) {
+      result.push(i);
+    }
+    return result;
   };
 
   private _onNumItemsChange = (value: number): void => {
@@ -297,6 +308,10 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
 
   private _onHorizontalAlignChange = (ev: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
     this.setState({ horizontalAlignment: option.key as HorizontalAlignment });
+  };
+
+  private _onHideEmptyChildrenChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean): void => {
+    this.setState({ hideEmptyChildren: isChecked });
   };
 
   private _onEmptyChildrenChange = (ev: React.FormEvent<HTMLInputElement>, value?: string): void => {

--- a/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Stack accepts custom className on child items 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -78,7 +78,7 @@ exports[`Stack renders Stack with StackItems correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -141,7 +141,7 @@ exports[`Stack renders Stack with a gap correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -204,7 +204,7 @@ exports[`Stack renders Stack with grow correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -233,7 +233,7 @@ exports[`Stack renders Stack with grow correctly 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-        & > *:not(:empty) ~ * {
+        & > *:not(:first-child) {
           margin-top: 0px;
         }
         & > *:not(.ms-StackItem) {
@@ -264,7 +264,7 @@ exports[`Stack renders Stack with grow correctly 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-        & > *:not(:empty) ~ * {
+        & > *:not(:first-child) {
           margin-top: 0px;
         }
         & > *:not(.ms-StackItem) {
@@ -295,7 +295,7 @@ exports[`Stack renders Stack with grow correctly 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-        & > *:not(:empty) ~ * {
+        & > *:not(:first-child) {
           margin-top: 0px;
         }
         & > *:not(.ms-StackItem) {
@@ -328,7 +328,7 @@ exports[`Stack renders Stack with shrinking StackItems correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -393,7 +393,7 @@ exports[`Stack renders Stack with vertical and horizontal alignment correctly 1`
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -430,7 +430,7 @@ exports[`Stack renders Stack with vertical and horizontal fill correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -467,7 +467,7 @@ exports[`Stack renders horizontal Stack correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
@@ -504,7 +504,7 @@ exports[`Stack renders vertical Stack correctly 1`] = `
         text-overflow: ellipsis;
         white-space: nowrap;
       }
-      & > *:not(:empty) ~ * {
+      & > *:not(:first-child) {
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {

--- a/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -24,9 +24,6 @@ exports[`Stack accepts custom className on child items 1`] = `
       & > *:not(:empty) ~ * {
         margin-top: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -83,9 +80,6 @@ exports[`Stack renders Stack with StackItems correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
@@ -150,9 +144,6 @@ exports[`Stack renders Stack with a gap correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-top: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -216,9 +207,6 @@ exports[`Stack renders Stack with grow correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-top: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -247,9 +235,6 @@ exports[`Stack renders Stack with grow correctly 1`] = `
         }
         & > *:not(:empty) ~ * {
           margin-top: 0px;
-        }
-        & > *:empty {
-          display: none;
         }
         & > *:not(.ms-StackItem) {
           flex-shrink: 0;
@@ -282,9 +267,6 @@ exports[`Stack renders Stack with grow correctly 1`] = `
         & > *:not(:empty) ~ * {
           margin-top: 0px;
         }
-        & > *:empty {
-          display: none;
-        }
         & > *:not(.ms-StackItem) {
           flex-shrink: 0;
         }
@@ -315,9 +297,6 @@ exports[`Stack renders Stack with grow correctly 1`] = `
         }
         & > *:not(:empty) ~ * {
           margin-top: 0px;
-        }
-        & > *:empty {
-          display: none;
         }
         & > *:not(.ms-StackItem) {
           flex-shrink: 0;
@@ -351,9 +330,6 @@ exports[`Stack renders Stack with shrinking StackItems correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
@@ -420,9 +396,6 @@ exports[`Stack renders Stack with vertical and horizontal alignment correctly 1`
       & > *:not(:empty) ~ * {
         margin-top: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -459,9 +432,6 @@ exports[`Stack renders Stack with vertical and horizontal fill correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
@@ -500,9 +470,6 @@ exports[`Stack renders horizontal Stack correctly 1`] = `
       & > *:not(:empty) ~ * {
         margin-left: 0px;
       }
-      & > *:empty {
-        display: none;
-      }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;
       }
@@ -539,9 +506,6 @@ exports[`Stack renders vertical Stack correctly 1`] = `
       }
       & > *:not(:empty) ~ * {
         margin-top: 0px;
-      }
-      & > *:empty {
-        display: none;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 0;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7189 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Remove `display: "none"` styling on empty Stack children. StackItem now returns `null` rather than an empty `<span />` if it does not have any children.

Examples:

HorizontalStack:

When child elements 1, 3, and 5 are empty (`<Text />`):
```
<div class="ms-HorizontalStack root-331">
    <span class="item-244"></span>
    <span class="item-244">2</span>
    <span class="item-244"></span>
    <span class="item-244">4</span>
    <span class="item-244"></span>
</div>
```
<img width="1042" alt="horizontal_empty" src="https://user-images.githubusercontent.com/6687333/48871451-a0e5e400-ed99-11e8-88a2-7ce64646b289.png">


When child elements 1, 3, and 5 are empty StackItems, which return null: (`<HorizontalStack.Item />`):
```
<div class="ms-HorizontalStack root-331">
    <span class="item-244">2</span>
    <span class="item-244">4</span>
</div>
```
<img width="1051" alt="horizontal_null" src="https://user-images.githubusercontent.com/6687333/48871469-ae02d300-ed99-11e8-9d56-771abb7ba82a.png">

VerticalStack:

When child elements 1, 3, and 5 are empty (`<Text />`):
```
<div class="ms-VerticalStack root-226">
    <span class="item-227"></span>
    <span class="item-227">2</span>
    <span class="item-227"></span>
    <span class="item-227">4</span>
    <span class="item-227"></span>
</div>
```
<img width="728" alt="vertical_empty" src="https://user-images.githubusercontent.com/6687333/48871508-e2768f00-ed99-11e8-95d2-c2560fefeaa2.png">



When child elements 1, 3, and 5 are empty StackItems, which return null: (`<VerticalStack.Item />`):
```
<div class="ms-VerticalStack root-226">
    <span class="item-227">2</span>
    <span class="item-227">4</span>
</div>
```
<img width="724" alt="vertical_null" src="https://user-images.githubusercontent.com/6687333/48871514-e7d3d980-ed99-11e8-8bdc-f8d7d4f20720.png">


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7190)

