### PR TITLE
DetailsList: fix focus rectangle color.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-FocusBorderDetailsList_2018-11-21-22-38.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-FocusBorderDetailsList_2018-11-21-22-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: fixing focus rectangle color from themePrimary to neutralSecondary.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -56,17 +56,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
     cellStyleProps = DEFAULT_CELL_STYLE_PROPS
   } = props;
 
-  const {
-    neutralPrimary,
-    white,
-    neutralSecondary,
-    neutralLighter,
-    neutralLight,
-    neutralDark,
-    neutralQuaternaryAlt,
-    black,
-    themePrimary
-  } = theme.palette;
+  const { neutralPrimary, white, neutralSecondary, neutralLighter, neutralLight, neutralDark, neutralQuaternaryAlt, black } = theme.palette;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -99,7 +89,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
   const shimmerRightBorderStyle = `${cellStyleProps.cellRightPadding * 4}px solid ${colors.defaultBackgroundColor}`;
   const shimmerLeftBorderStyle = `${cellStyleProps.cellLeftPadding}px solid ${colors.defaultBackgroundColor}`;
   const selectedStyles: IStyle = [
-    getFocusStyle(theme, -1, undefined, undefined, themePrimary, white),
+    getFocusStyle(theme, -1, undefined, undefined, neutralSecondary, white),
     classNames.isSelected,
     {
       color: colors.selectedMetaTextColor,
@@ -292,7 +282,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       droppingClassName,
       theme.fonts.small,
       isCheckVisible && classNames.isCheckVisible,
-      getFocusStyle(theme, 0, undefined, undefined, isSelected ? neutralSecondary : themePrimary, white),
+      getFocusStyle(theme, 0, undefined, undefined, neutralSecondary, white),
       {
         borderBottom: `1px solid ${neutralLighter}`,
         background: colors.defaultBackgroundColor,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -57,6 +57,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
   } = props;
 
   const { neutralPrimary, white, neutralSecondary, neutralLighter, neutralLight, neutralDark, neutralQuaternaryAlt, black } = theme.palette;
+  const { focusBorder } = theme.semanticColors;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -89,7 +90,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
   const shimmerRightBorderStyle = `${cellStyleProps.cellRightPadding * 4}px solid ${colors.defaultBackgroundColor}`;
   const shimmerLeftBorderStyle = `${cellStyleProps.cellLeftPadding}px solid ${colors.defaultBackgroundColor}`;
   const selectedStyles: IStyle = [
-    getFocusStyle(theme, -1, undefined, undefined, neutralSecondary, white),
+    getFocusStyle(theme, -1, undefined, undefined, focusBorder, white),
     classNames.isSelected,
     {
       color: colors.selectedMetaTextColor,
@@ -282,7 +283,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       droppingClassName,
       theme.fonts.small,
       isCheckVisible && classNames.isCheckVisible,
-      getFocusStyle(theme, 0, undefined, undefined, neutralSecondary, white),
+      getFocusStyle(theme, 0, undefined, undefined, focusBorder, white),
       {
         borderBottom: `1px solid ${neutralLighter}`,
         background: colors.defaultBackgroundColor,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -5165,7 +5165,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         border: 0;
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #0078d4;
+                                        border: 1px solid #666666;
                                         bottom: 1px;
                                         content: "";
                                         left: 1px;
@@ -5363,7 +5363,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         border: 0;
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #0078d4;
+                                        border: 1px solid #666666;
                                         bottom: 1px;
                                         content: "";
                                         left: 1px;
@@ -5789,7 +5789,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         border: 0;
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #0078d4;
+                                        border: 1px solid #666666;
                                         bottom: 1px;
                                         content: "";
                                         left: 1px;
@@ -5987,7 +5987,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         border: 0;
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #0078d4;
+                                        border: 1px solid #666666;
                                         bottom: 1px;
                                         content: "";
                                         left: 1px;
@@ -6185,7 +6185,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                         border: 0;
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #0078d4;
+                                        border: 1px solid #666666;
                                         bottom: 1px;
                                         content: "";
                                         left: 1px;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1662,7 +1662,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
         border: 0;
       }
       .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid #0078d4;
+        border: 1px solid #666666;
         bottom: 1px;
         content: "";
         left: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -46,7 +46,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -719,7 +719,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -1392,7 +1392,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -2065,7 +2065,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -2738,7 +2738,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -3411,7 +3411,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -4084,7 +4084,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -4757,7 +4757,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -5430,7 +5430,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;
@@ -6103,7 +6103,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           border: 0;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #0078d4;
+          border: 1px solid #666666;
           bottom: 1px;
           content: "";
           left: 1px;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7193 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Details about the change in the corresponding issue, but to be short focus rectangle color now is `neutralSecondary` instead of `themePrimary` regardless if it's a selected row or not. Confirmed with the designer.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7194)

