### PR TITLE
Date picker callout props

### DIFF
--- a/common/changes/office-ui-fabric-react/datePicker-calloutProps_2018-11-21-22-42.json
+++ b/common/changes/office-ui-fabric-react/datePicker-calloutProps_2018-11-21-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: Support custom callout props, and therefor layer props",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/datePicker-calloutProps_2018-11-21-22-42.json
+++ b/common/changes/office-ui-fabric-react/datePicker-calloutProps_2018-11-21-22-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "DatePicker: Support custom callout props, and therefor layer props",
+      "comment": "DatePicker: Support custom callout props, and therefore layer props",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6690,6 +6690,7 @@ interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAttributes
   ariaLabel?: string;
   borderless?: boolean;
   calendarProps?: ICalendarProps;
+  calloutProps?: ICalloutProps;
   className?: string;
   componentRef?: IRefObject<IDatePicker>;
   dateTimeFormatter?: ICalendarFormatDateCallbacks;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IDatePicker, IDatePickerProps, IDatePickerStrings, IDatePickerStyleProps, IDatePickerStyles } from './DatePicker.types';
-import { BaseComponent, KeyCodes, classNamesFunction, getId, getNativeProps, divProperties } from '../../Utilities';
+import { BaseComponent, KeyCodes, classNamesFunction, getId, getNativeProps, divProperties, css } from '../../Utilities';
 import { Calendar, ICalendar, DayOfWeek } from '../../Calendar';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { Callout } from '../../Callout';
@@ -161,6 +161,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       maxDate,
       showCloseButton,
       calendarProps,
+      calloutProps,
       underlined,
       allFocusable
     } = this.props;
@@ -212,11 +213,12 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             role="dialog"
             ariaLabel={pickerAriaLabel}
             isBeakVisible={false}
-            className={classNames.callout}
             gapSpace={0}
             doNotLayer={false}
             target={this._datePickerDiv.current}
             directionalHint={DirectionalHint.bottomLeftEdge}
+            {...calloutProps}
+            className={css(classNames.callout, calloutProps && calloutProps.className)}
             onDismiss={this._calendarDismissed}
             onPositioned={this._onCalloutPositioned}
           >

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -31,7 +31,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
   theme?: ITheme;
 
   /**
-   * Pass calendar props to calendar component
+   * Pass callout props to callout component
    */
   calloutProps?: ICalloutProps;
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -2,6 +2,7 @@ import { DayOfWeek, ICalendarProps } from '../../Calendar';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { ICalendarFormatDateCallbacks } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '../../Styling';
+import { ICalloutProps } from '../../Callout';
 import { IRefObject, IBaseProps, IStyleFunction } from '../../Utilities';
 
 export interface IDatePicker {
@@ -28,6 +29,11 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
    * Theme provided by High-Order Component.
    */
   theme?: ITheme;
+
+  /**
+   * Pass calendar props to calendar component
+   */
+  calloutProps?: ICalloutProps;
 
   /**
    * Pass calendar props to calendar component


### PR DESCRIPTION
Adding callout Props to date picker so that you can access, among other things, layer props. This will let you set hostID and position the calendar within whatever host you want

![image](https://user-images.githubusercontent.com/1434956/48871965-d8ee2680-ed9b-11e8-9bdb-dabc99de038d.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7195)

