### PR TITLE
Add Screener tests for FolderCover component

### DIFF
--- a/apps/vr-tests/src/stories/FolderCover.stories.tsx
+++ b/apps/vr-tests/src/stories/FolderCover.stories.tsx
@@ -1,0 +1,98 @@
+
+import * as React from 'react';
+import {
+  FolderCover,
+  initializeFolderCovers,
+  IFolderCoverProps,
+  getFolderCoverLayout,
+  renderFolderCoverWithLayout,
+  SharedSignal
+} from '@uifabric/experiments';
+import Screener, { Steps } from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { ISize, fitContentToBounds } from 'office-ui-fabric-react';
+import { FabricDecorator } from '../utilities';
+
+interface IFolderCoverWithImageProps extends IFolderCoverProps {
+  originalImageSize: ISize;
+}
+
+const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps> = (props: IFolderCoverWithImageProps): JSX.Element => {
+  const { originalImageSize, ...folderCoverProps } = props;
+
+  const folderCover = <FolderCover {...folderCoverProps} />;
+
+  const { contentSize } = getFolderCoverLayout(folderCover);
+
+  const imageSize = fitContentToBounds({
+    contentSize: originalImageSize,
+    boundsSize: contentSize,
+    mode: 'cover'
+  });
+
+  return renderFolderCoverWithLayout(folderCover, {
+    children: <img src={`//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`} />
+  });
+};
+
+storiesOf('FolderCover', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory('Large Default Cover', () => (
+    <FolderCoverWithImage
+      originalImageSize={{
+        width: 200,
+        height: 150
+      }}
+      folderCoverSize="large"
+      metadata={20}
+      signal={<SharedSignal />}
+    />
+  ))
+  .addStory('Small Default Cover', () => (
+    <FolderCoverWithImage
+      originalImageSize={{
+        width: 200,
+        height: 150
+      }}
+      folderCoverSize="small"
+      metadata={15}
+    />
+  ))
+  .addStory('Large Media Cover', () => (
+    <FolderCoverWithImage
+      originalImageSize={{
+        width: 200,
+        height: 150
+      }}
+      folderCoverSize="large"
+      folderCoverType="media"
+      metadata={20}
+      signal={<SharedSignal />}
+    />
+  ))
+  .addStory('Small Media Cover', () => (
+    <FolderCoverWithImage
+      originalImageSize={{
+        width: 200,
+        height: 150
+      }}
+      folderCoverSize="small"
+      folderCoverType="media"
+      metadata={15}
+    />
+  ))
+  .addStory('Shared Cover', () => (
+    <FolderCoverWithImage
+      originalImageSize={{
+        width: 200,
+        height: 150
+      }}
+      folderCoverSize="small"
+      folderCoverType="media"
+      metadata={15}
+      signal={<SharedSignal />}
+    />
+  ));

--- a/apps/vr-tests/src/utilities/index.ts
+++ b/apps/vr-tests/src/utilities/index.ts
@@ -1,6 +1,8 @@
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
+import { initializeFolderCovers } from '@uifabric/experiments/lib/FolderCover';
 
 initializeIcons();
+initializeFolderCovers();
 
 export interface IStoryConfig {
   rtl?: boolean;

--- a/common/changes/@uifabric/experiments/folder-covers_2018-11-21-23-12.json
+++ b/common/changes/@uifabric/experiments/folder-covers_2018-11-21-23-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Re-export Signals from package root",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/Signals.ts
+++ b/packages/experiments/src/Signals.ts
@@ -1,0 +1,2 @@
+export * from './components/signals/Signals';
+export * from './components/signals/Signal';

--- a/packages/experiments/src/index.ts
+++ b/packages/experiments/src/index.ts
@@ -6,6 +6,7 @@ export * from './Form';
 export * from './LayoutGroup';
 export * from './Shimmer';
 export * from './Sidebar';
+export * from './Signals';
 export * from './Stack';
 export * from './StaticList';
 export * from './Text';


### PR DESCRIPTION
# Overview

This change adds Screener tests for the `FolderCover` component in order to avoid future visual regressions (there haven't been any in this component's history, but better safe than sorry!)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7197)

