### PR TITLE
DetailsList Example: add alt text to img

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListAltText_2018-11-22-00-05.json
+++ b/common/changes/office-ui-fabric-react/detailsListAltText_2018-11-22-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: add alt text to img in example",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -47,6 +47,7 @@ export interface IDocument {
   name: string;
   value: string;
   iconName: string;
+  fileType: string;
   modifiedBy: string;
   dateModified: string;
   dateModifiedValue: number;
@@ -77,6 +78,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
           name: fileName,
           value: fileName,
           iconName: randomFileType.url,
+          fileType: randomFileType.docType,
           modifiedBy: userName,
           dateModified: randomDate.dateFormatted,
           dateModifiedValue: randomDate.value,
@@ -102,7 +104,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         maxWidth: 16,
         onColumnClick: this._onColumnClick,
         onRender: (item: IDocument) => {
-          return <img src={item.iconName} className={'DetailsListExample-documentIconImage'} />;
+          return <img src={item.iconName} className={'DetailsListExample-documentIconImage'} alt={item.fileType + ' file icon'} />;
         }
       },
       {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Shimmer.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Shimmer.Example.tsx
@@ -42,6 +42,7 @@ export interface IDocument {
   name: string;
   value: string;
   iconName: string;
+  fileType: string;
   modifiedBy: string;
   dateModified: string;
   dateModifiedValue: number;
@@ -70,6 +71,7 @@ export class DetailsListShimmerExample extends React.Component<any, IDetailsList
           name: fileName,
           value: fileName,
           iconName: randomFileType.url,
+          fileType: randomFileType.docType,
           modifiedBy: userName,
           dateModified: randomDate.dateFormatted,
           dateModifiedValue: randomDate.value,
@@ -92,7 +94,7 @@ export class DetailsListShimmerExample extends React.Component<any, IDetailsList
         minWidth: 16,
         maxWidth: 16,
         onRender: (item: IDocument) => {
-          return <img src={item.iconName} className={'DetailsListExample-documentIconImage'} />;
+          return <img src={item.iconName} className={'DetailsListExample-documentIconImage'} alt={item.fileType + ' file icon'} />;
         }
       },
       {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #6646, number 2
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds alt text to <img> elements in the DetailsList Document and DetailsList Shimmer examples on the demo page.

#### Focus areas to test

Go to the DetailsList Document demo page and open inspector. Inspect a file icon in any of the rows, and ensure that the <img> element now has an `alt` attribute.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7199)

