### PR TITLE
Upgrade to Rush 5.5.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Don't allow people to merge changes to these generated files, because the result
+# may be invalid.  You need to run "rush update" again.
+shrinkwrap.yaml              merge=binary
+npm-shrinkwrap.json          merge=binary
+yarn.lock                    merge=binary

--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,6 @@ lib-commonjs
 lib-es2015
 coverage
 dist
-npm-debug.log
-npminstall-log.txt
 test-dependencies
 screenshots
 
@@ -96,8 +94,12 @@ ftpconfig.json
 # Package output folder
 package
 
-# Log files from building
+# Logs
 *.log
+npminstall-log.txt
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
 # Dependency change files generated from npmx aka rush
 package-deps.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,9 @@
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": false,
   "editor.formatOnSave": true,
   "typescript.tsdk": "./common/temp/node_modules/typescript/lib",
-  "tslint.autoFixOnSave": false
+  "tslint.autoFixOnSave": false,
+  "files.associations": {
+    "rush.json": "jsonc",
+    "**/common/config/rush/*.json": "jsonc"
+  }
 }

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -1,41 +1,195 @@
+/**
+ * This configuration file defines custom commands for the "rush" command-line.
+ * For full documentation, please see https://rushjs.io
+ */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/command-line.schema.json",
+
+  /**
+   * Custom "commands" introduce new verbs for the command-line.  To see the help for these
+   * example commands, try "rush --help", "rush my-bulk-command --help", or
+   * "rush my-global-command --help".
+   */
   "commands": [
     {
+      /**
+       * (Required) The name that will be typed as part of the command line.  This is also the name
+       * of the "scripts" hook in the project's package.json file.
+       * The name should be comprised of lower case words separated by hyphens.
+       */
       "name": "code-style",
+
+      /**
+       * (Required) A short summary of the custom command to be shown when printing command line
+       * help, e.g. "rush --help".
+       */
       "summary": "Runs prettier and tslint.",
+
+      /**
+       * (Required) Determines the type of custom command.
+       * Rush's "bulk" commands are invoked separately for each project.  Rush will look in
+       * each project's package.json file for a "scripts" entry whose name matches the
+       * command name.  By default, the command will run for every project in the repo,
+       * according to the dependency graph (similar to how "rush build" works).
+       * The set of projects can be restricted e.g. using the "--to" or "--from" parameters.
+       */
       "commandKind": "bulk",
+
+      /**
+       * A detailed description of the command to be shown when printing command line
+       * help (e.g. "rush --help my-command").
+       * If omitted, the "summary" text will be shown instead.
+       *
+       * Whenever you introduce commands/parameters, taking a little time to write meaningful
+       * documentation can make a big difference for the developer experience in your repo.
+       */
       "description": "Runs prettier and tslint for each of the packages that have a code-style task.",
+
+      /**
+       * (Required) If true, then this command is safe to be run in parallel, i.e. executed
+       * simultaneously for multiple projects.  Similar to "rush build", regardless of parallelism
+       * projects will not start processing until their dependencies have completed processing.
+       */
       "enableParallelism": true
+
+      //   /**
+      //    * By default, Rush operations acquire a lock file which prevents multiple commands from executing simultaneously
+      //    * in the same repo folder.  (For example, it would be a mistake to run "rush install" and "rush build" at the
+      //    * same time.)  If your command makes sense to run concurrently with other operations,
+      //    * set "safeForSimultaneousRushProcesses" to true to disable this protection.
+      //    *
+      //    * In particular, this is needed for custom scripts that invoke other Rush commands.
+      //    */
+      //   "safeForSimultaneousRushProcesses": false,
+      //
+      //
+      //   /**
+      //    * Normally Rush requires that each project's package.json has a "scripts" entry matching
+      //    * the custom command name.  To disable this check, set "ignoreMissingScript" to true;
+      //    * projects with a missing definition will be skipped.
+      //    */
+      //   "ignoreMissingScript": false
     }
+
+    // {
+    //   /**
+    //    * (Required) Determines the type of custom command.
+    //    * Rush's "global" commands are invoked once for the entire repo.
+    //    */
+    //   "commandKind": "global",
+    //
+    //   "name": "my-global-command",
+    //   "summary": "Example global custom command",
+    //   "description": "This is an example custom command that runs once for the entire repo",
+    //
+    //   "safeForSimultaneousRushProcesses": false,
+    //
+    //   /**
+    //    * A script that will be invoked using the OS shell. The working directory will be the folder
+    //    * that contains rush.json.  If custom parameters are associated with this command, their
+    //    * values will be appended to the end of this string.
+    //    */
+    //   "shellCommand": "node common/scripts/my-global-command.js"
+    // }
   ],
+
+  /**
+   * Custom "parameters" introduce new parameters for specified Rush command-line commands.
+   * For example, you might define a "--production" parameter for the "rush build" command.
+   */
   "parameters": [
     {
+      /**
+       * (Required) The long name of the parameter.  It must be lower-case and use dash delimiters.
+       */
       "longName": "--production",
+
+      /**
+       * (Required) Determines the type of custom parameter.
+       * A "flag" is a custom command-line parameter whose presence acts as an on/off switch.
+       */
       "parameterKind": "flag",
+
+      /**
+       * (Required) A long description to be shown in the command-line help.
+       *
+       * Whenever you introduce commands/parameters, taking a little time to write meaningful
+       * documentation can make a big difference for the developer experience in your repo.
+       */
       "description": "Builds production bits.",
-      "associatedCommands": [
-        "build",
-        "rebuild"
-      ]
+
+      /**
+       * (Required) A list of custom commands and/or built-in Rush commands that this parameter may
+       * be used with.  The parameter will be appended to the shell command that Rush invokes.
+       */
+      "associatedCommands": ["build", "rebuild"]
+      // /**
+      //  * An optional alternative short name for the parameter.  It must be a dash followed by a single
+      //  * lower-case or upper-case letter, which is case-sensitive.
+      //  *
+      //  * NOTE: The Rush developers recommend that automation scripts should always use the long name
+      //  * to improve readability.  The short name is only intended as a convenience for humans.
+      //  * The alphabet letters run out quickly, and are difficult to memorize, so *only* use
+      //  * a short name if you expect the parameter to be needed very often in everyday operations.
+      //  */
+      // "shortName": "-m",
     },
     {
       "longName": "--lint",
       "parameterKind": "flag",
       "description": "Builds with linting.",
-      "associatedCommands": [
-        "build",
-        "rebuild"
-      ]
+      "associatedCommands": ["build", "rebuild"]
     },
     {
       "longName": "--npm-install-mode",
       "parameterKind": "flag",
       "description": "Skips tasks that are irrelevant during npm install",
-      "associatedCommands": [
-        "build",
-        "rebuild"
-      ]
+      "associatedCommands": ["build", "rebuild"]
     }
+    // {
+    //   "parameterKind": "choice",
+    //   "longName": "--my-choice",
+    //   "description": "A custom choice parameter for the \"my-global-command\" custom command",
+    //   "associatedCommands": [ "my-global-command" ],
+    //
+    //   /**
+    //    * Normally if a parameter is omitted from the command line, it will not be passed
+    //    * to the shell command. this value will be inserted by default.  Whereas if a "defaultValue"
+    //    * is defined, the parameter will always be passed to the shell command, and will use the
+    //    * default value if unspecified.  The value must be one of the defined alternatives.
+    //    */
+    //   "defaultValue": "vanilla",
+    //
+    //   /**
+    //    * (Required) A list of alternative argument values that can be chosen for this parameter.
+    //    */
+    //   "alternatives": [
+    //     {
+    //       /**
+    //        * A token that is one of the alternatives that can be used with the choice parameter,
+    //        * e.g. "vanilla" in "--flavor vanilla".
+    //        */
+    //       "name": "vanilla",
+    //
+    //       /**
+    //        * A detailed description for the alternative that can be shown in the command-line help.
+    //        *
+    //        * Whenever you introduce commands/parameters, taking a little time to write meaningful
+    //        * documentation can make a big difference for the developer experience in your repo.
+    //        */
+    //       "description": "Use the vanilla flavor (the default)"
+    //     },
+    //
+    //     {
+    //       "name": "chocolate",
+    //       "description": "Use the chocolate flavor"
+    //     },
+    //
+    //     {
+    //       "name": "strawberry",
+    //       "description": "Use the strawberry flavor"
+    //     }
+    //   ]
+    // }
   ]
 }

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -1,8 +1,43 @@
+/**
+ * This configuration file specifies NPM dependency version selections that affect all projects
+ * in a Rush repo.  For full documentation, please see https://rushjs.io
+ */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/common-versions.schema.json",
+
+  /**
+   * A table that specifies a "preferred version" for a dependency package. The "preferred version"
+   * is typically used to hold an indirect dependency back to a specific version, however generally
+   * it can be any SemVer range specifier (e.g. "~1.2.3"), and it will narrow any (compatible)
+   * SemVer range specifier.  See the Rush documentation for details about this feature.
+   */
   "preferredVersions": {
+    /**
+     * When someone asks for "^3.0.0" make sure they get "3.11.0" when working in this repo,
+     * instead of the latest version.
+     */
     "webpack": "3.11.0",
     "webpack-dev-server": "2.11.2",
     "webpack-cli": "2.0.15"
+  },
+
+  /**
+   * The "rush check" command can be used to enforce that every project in the repo must specify
+   * the same SemVer range for a given dependency.  However, sometimes exceptions are needed.
+   * The allowedAlternativeVersions table allows you to list other SemVer ranges that will be
+   * accepted by "rush check" for a given dependency.
+   *
+   * IMPORTANT: THIS TABLE IS FOR *ADDITIONAL* VERSION RANGES THAT ARE ALTERNATIVES TO THE
+   * USUAL VERSION (WHICH IS INFERRED BY LOOKING AT ALL PROJECTS IN THE REPO).
+   * This design avoids unnecessary churn in this file.
+   */
+  "allowedAlternativeVersions": {
+    /**
+     * For example, allow some projects to use an older TypeScript compiler
+     * (in addition to whatever "usual" version is being used by other projects in the repo):
+     */
+    // "typescript": [
+    //   "~2.4.0"
+    // ]
   }
 }

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -30,9 +30,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.5.tgz",
-      "integrity": "sha512-WXKf5K5HT6X0kKiCOezJZFljsfxKV1FpU8Tf1A7ZpGvyd/Q4hlrJm2EwoH2onaUq3O4tLDp+4gk0hHPsMyxmOg=="
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+      "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ=="
     },
     "@babel/runtime": {
       "version": "7.1.5",
@@ -50,11 +50,11 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-6.1.4.tgz",
-      "integrity": "sha512-fgKr3BvgD7rXingrsvreLDhEQyH6RCGThNrQLIwCGiR1VXAGolC41fgzyQ8xNlKDvAwlAaaDFhw7DKQSz1192g==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-6.1.6.tgz",
+      "integrity": "sha512-Iik7A/PA3bhGBtlsxFWlEVIwBNuEshpzPZKAAfdQL2LrsUdPI3Ehjad0SJA1Sri9Hg241npVOx5L5g9aPIzBoQ==",
       "requires": {
-        "@microsoft/node-core-library": "3.5.2",
+        "@microsoft/node-core-library": "3.6.0",
         "@microsoft/ts-command-line": "4.2.2",
         "@microsoft/tsdoc": "0.12.2",
         "@types/node": "8.5.8",
@@ -62,35 +62,35 @@
         "colors": "1.2.5",
         "jju": "1.3.0",
         "lodash": "4.17.11",
-        "typescript": "3.0.3",
+        "typescript": "3.1.6",
         "z-schema": "3.18.4"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-          "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg=="
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
         }
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.8.37",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.37.tgz",
-      "integrity": "sha512-UmXKrpcp5N1d/MmVVypjpT2WARJPK7wZV4XFhYFNqzfNO22PxM33a3zObJXm3TYp4IK/L7fp7i1lGv6t9dhSpA=="
+      "version": "1.8.39",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.39.tgz",
+      "integrity": "sha512-p1NEyjP+QEStszRKMkxJf/aedjyQ2FK0deCvvLRHOmG1B+pTtby78l8y4ka98a3jNkSm6mEhAmWrOrmMbXqDMQ=="
     },
     "@microsoft/loader-load-themed-styles": {
-      "version": "1.7.105",
-      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.105.tgz",
-      "integrity": "sha512-jCfsGHF1Nj9PSDQ/n4zQaMqDw9OmJQ2AHEg7umpAI0qmpl15P3TrjhfXaWebk4aMXwG0Y/7scmYqGjeQRhr8cA==",
+      "version": "1.7.107",
+      "resolved": "https://registry.npmjs.org/@microsoft/loader-load-themed-styles/-/loader-load-themed-styles-1.7.107.tgz",
+      "integrity": "sha512-hUCX7hPQLBIf7b3U6JB9SFRiSBTIwt2Mjh4VNiC+0t6nXekbkbaI0qHKrrC44XCCWbuQb4QRiD32X7e2GeFNSA==",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "loader-utils": "1.1.0"
       }
     },
     "@microsoft/node-core-library": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.5.2.tgz",
-      "integrity": "sha512-2zDWLqJ/ABjxtk0thb//bohWEFGOLKQ7gjfAS6cfCcpyVXX08qvO79pb0eGOvNXi2ggfuuKsoEIRXl6idbV7UQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.6.0.tgz",
+      "integrity": "sha512-dwxBTdr3i3JcntPiklv6//Z/UVZO9pO1TcvKYy+hNZ/bpK32hyT0LaCCS27jyWHPnxHIRA130Y9CptfqrDzrCg==",
       "requires": {
         "@types/fs-extra": "5.0.4",
         "@types/node": "8.5.8",
@@ -133,11 +133,11 @@
     },
     "@rush-temp/build": {
       "version": "file:projects/build.tgz",
-      "integrity": "sha1-mk8byI6aJADanERrd+DurmK3vcQ=",
+      "integrity": "sha1-a/Cj1Wx+ccgqdnP6n2Bl7/On2Qc=",
       "requires": {
-        "@microsoft/api-extractor": "6.1.4",
-        "@microsoft/load-themed-styles": "1.8.37",
-        "@microsoft/loader-load-themed-styles": "1.7.105",
+        "@microsoft/api-extractor": "6.1.6",
+        "@microsoft/load-themed-styles": "1.8.39",
+        "@microsoft/loader-load-themed-styles": "1.7.107",
         "autoprefixer": "7.2.6",
         "babylon": "7.0.0-beta.47",
         "bundlesize": "0.15.3",
@@ -168,6 +168,7 @@
         "resolve": "1.8.1",
         "sass-loader": "6.0.7",
         "source-map-loader": "0.2.4",
+        "strip-json-comments": "2.0.1",
         "style-loader": "0.19.1",
         "ts-jest": "22.4.6",
         "ts-loader": "4.5.0",
@@ -621,6 +622,159 @@
             }
           }
         },
+        "listr-update-renderer": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+          "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-truncate": "0.2.1",
+            "elegant-spinner": "1.0.1",
+            "figures": "1.7.0",
+            "indent-string": "3.2.0",
+            "log-symbols": "1.0.2",
+            "log-update": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
+              }
+            },
+            "indent-string": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+              "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+              "requires": {
+                "chalk": "1.1.3"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "listr-verbose-renderer": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+          "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "date-fns": "1.29.0",
+            "figures": "1.7.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "requires": {
+                "restore-cursor": "1.0.1"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "log-update": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+          "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "cli-cursor": "1.0.2"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "requires": {
+                "restore-cursor": "1.0.1"
+              }
+            }
+          }
+        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -641,12 +795,26 @@
             "to-regex": "3.0.2"
           }
         },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
         "opn": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
           "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
           "requires": {
             "is-wsl": "1.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "rxjs": {
@@ -836,14 +1004,14 @@
     },
     "@rush-temp/charting": {
       "version": "file:projects/charting.tgz",
-      "integrity": "sha1-M+DY0SIKMDvWISrLpLSJuxCfngI=",
+      "integrity": "sha1-XFj+zHyD90Z+lk8tn/LQS45+UGA=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/d3-array": "1.2.1",
         "@types/d3-axis": "1.0.10",
         "@types/d3-scale": "2.0.0",
         "@types/d3-selection": "1.3.0",
-        "@types/d3-shape": "1.2.5",
+        "@types/d3-shape": "1.2.6",
         "@types/d3-time-format": "2.1.0",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
@@ -877,9 +1045,9 @@
     },
     "@rush-temp/dashboard": {
       "version": "file:projects/dashboard.tgz",
-      "integrity": "sha1-9hQ8iHDuC3TLzQg8hpNKJH91W2o=",
+      "integrity": "sha1-YgWZe/BSnR6JoS67GHsxOxHI2cc=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
         "@types/jest": "23.0.0",
@@ -1230,7 +1398,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": "1.0.1"
@@ -1261,9 +1429,9 @@
     },
     "@rush-temp/date-time": {
       "version": "file:projects/date-time.tgz",
-      "integrity": "sha1-v9CM5+koJzMTYyy8oqNm7XbRqmM=",
+      "integrity": "sha1-R/sDuC+DGnlmOmeOZiITV5fjpBM=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
         "@types/es6-promise": "0.0.32",
@@ -1284,9 +1452,9 @@
     },
     "@rush-temp/example-app-base": {
       "version": "file:projects/example-app-base.tgz",
-      "integrity": "sha1-hx/TUxZRDmhnzSPh176VetREpgs=",
+      "integrity": "sha1-JWj04HPBOhvYExaFTUN6giEJp7g=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/es6-promise": "0.0.32",
         "@types/highlight.js": "9.12.2",
         "@types/jest": "23.0.0",
@@ -1307,9 +1475,9 @@
     },
     "@rush-temp/experiments": {
       "version": "file:projects/experiments.tgz",
-      "integrity": "sha1-bqFVe8nRqxIpO2KZvgg/ZjMDJw4=",
+      "integrity": "sha1-GPlQ6/ZlpKiuUQgawHaL8aYqOOc=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/deep-assign": "0.1.1",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
@@ -1336,9 +1504,9 @@
     },
     "@rush-temp/fabric-website": {
       "version": "file:projects/fabric-website.tgz",
-      "integrity": "sha1-xYJMCL2miN5WC2pIqCE9lznK6DQ=",
+      "integrity": "sha1-v+79APXmo3fO3AjoAZOA+phjspI=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/es6-promise": "0.0.32",
         "@types/node": "8.0.26",
         "@types/react": "16.3.16",
@@ -1355,7 +1523,7 @@
         "react-dom": "16.6.3",
         "react-highlight": "0.10.0",
         "tslib": "1.9.3",
-        "write-file-webpack-plugin": "4.4.1"
+        "write-file-webpack-plugin": "4.5.0"
       },
       "dependencies": {
         "@types/node": {
@@ -1367,9 +1535,9 @@
     },
     "@rush-temp/fabric-website-resources": {
       "version": "file:projects/fabric-website-resources.tgz",
-      "integrity": "sha1-2WeXGZZ7vBMkakLFaKrz6riSuYc=",
+      "integrity": "sha1-5Myqtq58zrZ2q904j2QbUuwhtD4=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
         "@types/es6-promise": "0.0.32",
@@ -1401,7 +1569,7 @@
     },
     "@rush-temp/file-type-icons": {
       "version": "file:projects/file-type-icons.tgz",
-      "integrity": "sha1-LKdepjP2tO4tf2dekVSYJ1jgXHs=",
+      "integrity": "sha1-yCdqEV4wxlh4E/gpcCOGz70pK1E=",
       "requires": {
         "@types/react": "16.3.16",
         "@types/react-dom": "16.0.5",
@@ -1412,7 +1580,7 @@
     },
     "@rush-temp/fluent-theme": {
       "version": "file:projects/fluent-theme.tgz",
-      "integrity": "sha1-HIsi8KFthSIIAbREcddEQd+SRjE=",
+      "integrity": "sha1-rOcA5VwEXzVI7eN7ViQL+SjLhgE=",
       "requires": {
         "@types/jest": "23.0.0",
         "tslib": "1.9.3"
@@ -1420,7 +1588,7 @@
     },
     "@rush-temp/foundation": {
       "version": "file:projects/foundation.tgz",
-      "integrity": "sha1-QhrrIphRyIAoZlOI5Kse5DYiiyc=",
+      "integrity": "sha1-lB/pNijFFempPCVu3Q/zwR2LENs=",
       "requires": {
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
@@ -1440,9 +1608,9 @@
     },
     "@rush-temp/foundation-scenarios": {
       "version": "file:projects/foundation-scenarios.tgz",
-      "integrity": "sha1-KPTofuKffyRl696E8w2SZQuifxc=",
+      "integrity": "sha1-zAHFK4zBwzIXXpUjVZbM5qpYxJQ=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
         "@types/es6-promise": "0.0.32",
@@ -1462,21 +1630,21 @@
     },
     "@rush-temp/icons": {
       "version": "file:projects/icons.tgz",
-      "integrity": "sha1-sN6L1QPTubsC/Fo+v5FGHgBlbgk=",
+      "integrity": "sha1-CXH7tIfxq3YoGbBXJQ+ZfjaVou4=",
       "requires": {
         "tslib": "1.9.3"
       }
     },
     "@rush-temp/jest-serializer-merge-styles": {
       "version": "file:projects/jest-serializer-merge-styles.tgz",
-      "integrity": "sha1-UTJ3UDbZwSJIwBK7kcyl4lEuu80=",
+      "integrity": "sha1-6s/lYho2UFiWgjJQdzitF53VjXw=",
       "requires": {
         "@types/jest": "23.0.0"
       }
     },
     "@rush-temp/merge-styles": {
       "version": "file:projects/merge-styles.tgz",
-      "integrity": "sha1-oui7TrI7Znp8i+NcPVfrXvYvwY0=",
+      "integrity": "sha1-J0/Jtv4WEW7HEh33gWGRAjmzks4=",
       "requires": {
         "@types/jest": "23.0.0",
         "tslib": "1.9.3"
@@ -1484,9 +1652,9 @@
     },
     "@rush-temp/office-ui-fabric-react": {
       "version": "file:projects/office-ui-fabric-react.tgz",
-      "integrity": "sha1-PBMYBfoRVUztDi6SvOClAnrVfAg=",
+      "integrity": "sha1-h764kMdTzN3whdVmfSjNyp0qL74=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
         "@types/es6-promise": "0.0.32",
@@ -1527,13 +1695,13 @@
     },
     "@rush-temp/prettier-rules": {
       "version": "file:projects/prettier-rules.tgz",
-      "integrity": "sha1-hgovSPORlAVakkXDIUrUKt6R9iI="
+      "integrity": "sha1-eo7/qOUOd9+6qZxs4r7ZUj2PdHU="
     },
     "@rush-temp/server-rendered-app": {
       "version": "file:projects/server-rendered-app.tgz",
-      "integrity": "sha1-JaeQigLyVP1tFQVXa39RpPdttVY=",
+      "integrity": "sha1-8NYvc0wTywZ9Dehvi8m9JMmRyDQ=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/es6-promise": "0.0.32",
         "@types/react": "16.3.16",
         "@types/react-dom": "16.0.5",
@@ -1549,7 +1717,7 @@
     },
     "@rush-temp/set-version": {
       "version": "file:projects/set-version.tgz",
-      "integrity": "sha1-iOLR0bC2HOpB7osESpiLBXfvs1k=",
+      "integrity": "sha1-+2rmd+nDSsASCS94JQ9VXedQM7Y=",
       "requires": {
         "@types/jest": "23.0.0",
         "tslib": "1.9.3"
@@ -1557,9 +1725,9 @@
     },
     "@rush-temp/ssr-tests": {
       "version": "file:projects/ssr-tests.tgz",
-      "integrity": "sha1-LOqbZEYIRXfxmMRjUH8UYgWTWe0=",
+      "integrity": "sha1-mspocC7CnJylj+cXs4o0vZ6+D2o=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/es6-promise": "0.0.32",
         "@types/mocha": "2.2.39",
         "@types/webpack-env": "1.13.0",
@@ -1569,7 +1737,7 @@
         "react": "16.6.3",
         "react-dom": "16.6.3",
         "tslib": "1.9.3",
-        "webpack": "4.25.1"
+        "webpack": "4.26.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -1846,9 +2014,9 @@
           }
         },
         "webpack": {
-          "version": "4.25.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
-          "integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.26.0.tgz",
+          "integrity": "sha512-J/dP9SJIc5OtX2FZ/+U9ikQtd6H6Mcbqt0xeXtmPwYGDKf8nkbOQQA9KL2Y0rJOsN1Al9Pdn+/j63X58ub8gvQ==",
           "requires": {
             "@webassemblyjs/ast": "1.7.11",
             "@webassemblyjs/helper-module-context": "1.7.11",
@@ -1871,7 +2039,7 @@
             "node-libs-browser": "2.1.0",
             "schema-utils": "0.4.7",
             "tapable": "1.1.0",
-            "uglifyjs-webpack-plugin": "1.3.0",
+            "terser-webpack-plugin": "1.1.0",
             "watchpack": "1.6.0",
             "webpack-sources": "1.3.0"
           }
@@ -1880,9 +2048,9 @@
     },
     "@rush-temp/styling": {
       "version": "file:projects/styling.tgz",
-      "integrity": "sha1-tQar3Enfjn6hNahWuXq+2GlcUKc=",
+      "integrity": "sha1-BiA54vo67UDgUvj3HazGJxj37ro=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/jest": "23.0.0",
         "@types/react": "16.3.16",
         "@types/webpack-env": "1.13.0",
@@ -1895,7 +2063,7 @@
     },
     "@rush-temp/test-bundles": {
       "version": "file:projects/test-bundles.tgz",
-      "integrity": "sha1-S6xOFnCRlrkczIyoZzgMc4Eziag=",
+      "integrity": "sha1-ZQqHQvXme18FDEYQuv8bqvRPmSM=",
       "requires": {
         "@types/react": "16.3.16",
         "@types/react-dom": "16.0.5",
@@ -1907,7 +2075,7 @@
     },
     "@rush-temp/test-utilities": {
       "version": "file:projects/test-utilities.tgz",
-      "integrity": "sha1-RMCUMbanmRrC0nr011tHAcRf5is=",
+      "integrity": "sha1-pw7So5kZ0eIoTy745/Eixq5yne8=",
       "requires": {
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
@@ -1927,7 +2095,7 @@
     },
     "@rush-temp/theme-samples": {
       "version": "file:projects/theme-samples.tgz",
-      "integrity": "sha1-Q+CFY7T2Mm6Eq1bJJIlvMwjIPdA=",
+      "integrity": "sha1-Xi4/EhTWVsNdREgknnOCJRgjSts=",
       "requires": {
         "@types/jest": "23.0.0",
         "tslib": "1.9.3"
@@ -1935,9 +2103,9 @@
     },
     "@rush-temp/todo-app": {
       "version": "file:projects/todo-app.tgz",
-      "integrity": "sha1-aIwFZYqSAxtWXFvokzQnXivPMho=",
+      "integrity": "sha1-jwcYc759gl58TfLbzr5BWHAIeRU=",
       "requires": {
-        "@microsoft/load-themed-styles": "1.8.37",
+        "@microsoft/load-themed-styles": "1.8.39",
         "@types/es6-promise": "0.0.32",
         "@types/react": "16.3.16",
         "@types/react-dom": "16.0.5",
@@ -1952,14 +2120,14 @@
     },
     "@rush-temp/tslint-rules": {
       "version": "file:projects/tslint-rules.tgz",
-      "integrity": "sha1-kFD5Z3CzpEMZLUoJL3BEZ02xPsw=",
+      "integrity": "sha1-63eDdt1d/ZsGC4csYrqSPPJkXzw=",
       "requires": {
         "tslint-react": "3.6.0"
       }
     },
     "@rush-temp/utilities": {
       "version": "file:projects/utilities.tgz",
-      "integrity": "sha1-K4MfZicHJSLi+kbjtXT+zrsD8Vo=",
+      "integrity": "sha1-4CWlhl8jDyejKUGPwWjQEPZBss8=",
       "requires": {
         "@types/enzyme": "3.1.13",
         "@types/enzyme-adapter-react-16": "1.0.3",
@@ -1981,7 +2149,7 @@
     },
     "@rush-temp/variants": {
       "version": "file:projects/variants.tgz",
-      "integrity": "sha1-6EPIOhLPB1C2OVAT22PjRytc+os=",
+      "integrity": "sha1-3Elj1gy7pYefmH5OPjGpOWap39s=",
       "requires": {
         "@types/jest": "23.0.0",
         "tslib": "1.9.3"
@@ -1989,7 +2157,7 @@
     },
     "@rush-temp/vr-tests": {
       "version": "file:projects/vr-tests.tgz",
-      "integrity": "sha1-+94KKOQQuzOAwqouZeAJRHR6kpA=",
+      "integrity": "sha1-vNVSgxco3XDlF0N9EgtsUuhlzAE=",
       "requires": {
         "@storybook/addon-options": "3.2.3",
         "@storybook/react": "3.4.11",
@@ -2003,7 +2171,7 @@
         "raw-loader": "0.5.1",
         "react": "16.6.3",
         "react-dom": "16.6.3",
-        "screener-runner": "0.10.21",
+        "screener-runner": "0.10.22",
         "screener-storybook": "0.14.13",
         "storybook-readme": "3.0.6",
         "style-loader": "0.19.1",
@@ -2013,14 +2181,15 @@
     },
     "@rush-temp/webpack-utils": {
       "version": "file:projects/webpack-utils.tgz",
-      "integrity": "sha1-Q2PdujkBHOW5s7+V2AsWy+0gRIs=",
+      "integrity": "sha1-8vE0KJ4meUmtsJnIHBzczwx0sGw=",
       "requires": {
         "@types/jest": "23.0.0",
         "@types/loader-utils": "1.1.3",
         "@types/webpack": "4.4.0",
         "loader-utils": "1.1.0",
+        "react-loadable": "5.5.0",
         "tslib": "1.9.3",
-        "webpack": "4.25.1"
+        "webpack": "4.26.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -2297,9 +2466,9 @@
           }
         },
         "webpack": {
-          "version": "4.25.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
-          "integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.26.0.tgz",
+          "integrity": "sha512-J/dP9SJIc5OtX2FZ/+U9ikQtd6H6Mcbqt0xeXtmPwYGDKf8nkbOQQA9KL2Y0rJOsN1Al9Pdn+/j63X58ub8gvQ==",
           "requires": {
             "@webassemblyjs/ast": "1.7.11",
             "@webassemblyjs/helper-module-context": "1.7.11",
@@ -2322,7 +2491,7 @@
             "node-libs-browser": "2.1.0",
             "schema-utils": "0.4.7",
             "tapable": "1.1.0",
-            "uglifyjs-webpack-plugin": "1.3.0",
+            "terser-webpack-plugin": "1.1.0",
             "watchpack": "1.6.0",
             "webpack-sources": "1.3.0"
           }
@@ -2681,9 +2850,9 @@
       "integrity": "sha512-1SJhi3kTk/SHHIE6XkHuHU2REYkbSOjkQuo3HT71FOTs8/tjeGcvtXMsX4N3kU1UE1nVG+A5pg7TSjuJ4zUN3A=="
     },
     "@types/d3-shape": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.5.tgz",
-      "integrity": "sha512-Y1eq7rtWhfc6iix1e2dWqrqwSoedzK/Skg2cCgjzeb3a9wQWNWZXTCEceIDEZ9EvDynufxRDADM49QM8bYidvQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.2.6.tgz",
+      "integrity": "sha512-BdewMqqinhNNV8rrnjr6tIdm6WCl/eVaePDs1dl52Le/c0m1ML/LaZc2S/Sht3VjPbAqeDFXhTgRgeDkrvzt/w==",
       "requires": {
         "@types/d3-path": "1.0.7"
       }
@@ -3075,7 +3244,7 @@
       "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
       "requires": {
         "acorn": "6.0.4",
-        "acorn-walk": "6.1.0"
+        "acorn-walk": "6.1.1"
       },
       "dependencies": {
         "acorn": {
@@ -3086,9 +3255,9 @@
       }
     },
     "acorn-walk": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
-      "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "address": {
       "version": "1.0.3",
@@ -3143,6 +3312,11 @@
         "json-schema-traverse": "0.4.1",
         "uri-js": "4.2.2"
       }
+    },
+    "ajv-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
+      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
     },
     "ajv-keywords": {
       "version": "3.2.0",
@@ -3474,7 +3648,7 @@
     },
     "autolinker": {
       "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+      "resolved": "http://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
       "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
     },
     "autoprefixer": {
@@ -3483,7 +3657,7 @@
       "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "requires": {
         "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000907",
+        "caniuse-lite": "1.0.30000910",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.23",
@@ -3496,7 +3670,7 @@
       "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
       "requires": {
         "browserslist": "0.4.0",
-        "caniuse-db": "1.0.30000907",
+        "caniuse-db": "1.0.30000910",
         "num2fraction": "1.2.2",
         "postcss": "4.1.16"
       },
@@ -3506,7 +3680,7 @@
           "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
           "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
           "requires": {
-            "caniuse-db": "1.0.30000907"
+            "caniuse-db": "1.0.30000910"
           }
         },
         "es6-promise": {
@@ -3531,7 +3705,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": "1.0.1"
@@ -3851,7 +4025,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "1.5.9",
+        "follow-redirects": "1.5.10",
         "is-buffer": "1.1.6"
       }
     },
@@ -4883,7 +5057,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "requires": {
-            "caniuse-lite": "1.0.30000907",
+            "caniuse-lite": "1.0.30000910",
             "electron-to-chromium": "1.3.84"
           }
         }
@@ -5443,7 +5617,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "caniuse-lite": "1.0.30000907",
+        "caniuse-lite": "1.0.30000910",
         "electron-to-chromium": "1.3.84"
       }
     },
@@ -5556,7 +5730,7 @@
         "chownr": "1.1.1",
         "glob": "7.1.3",
         "graceful-fs": "4.1.15",
-        "lru-cache": "4.1.3",
+        "lru-cache": "4.1.4",
         "mississippi": "2.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
@@ -5674,7 +5848,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
@@ -5713,7 +5887,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000907",
+        "caniuse-db": "1.0.30000910",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -5723,21 +5897,21 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000907",
+            "caniuse-db": "1.0.30000910",
             "electron-to-chromium": "1.3.84"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000907",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000907.tgz",
-      "integrity": "sha512-OKtlTmEPR9GgCxnKMlvdHTT2QD6n4eIovcVqEnjoR8iB9l6rk4abKnjsDSyTD36an/ebgigl8T2CSdwSf4JoGw=="
+      "version": "1.0.30000910",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000910.tgz",
+      "integrity": "sha512-eysv5eAsXCBnfnhTZsKBtCZKdgeFaRqOlTN74kCfzdHdz0In3E5Aop7PyqPI757DsdjVwJOWrFHIrTPYzmll6g=="
     },
     "caniuse-lite": {
-      "version": "1.0.30000907",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000907.tgz",
-      "integrity": "sha512-No5sQ/OB2Nmka8MNOOM6nJx+Hxt6MQ6h7t7kgJFu9oTuwjykyKRSBP/+i/QAyFHxeHB+ddE0Da1CG5ihx9oehQ=="
+      "version": "1.0.30000910",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000910.tgz",
+      "integrity": "sha512-u/nxtHGAzCGZzIxt3dA/tpSPOcirBZFWKwz1EPz4aaupnBI2XR0Rbr74g0zc6Hzy41OEM4uMoZ38k56TpYAWjQ=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -6008,6 +6182,17 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "optional": true,
+      "requires": {
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
+      }
     },
     "cliui": {
       "version": "4.1.0",
@@ -6504,7 +6689,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.3",
+        "lru-cache": "4.1.4",
         "shebang-command": "1.2.0",
         "which": "1.3.1"
       }
@@ -6785,7 +6970,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000907",
+            "caniuse-db": "1.0.30000910",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -6797,7 +6982,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000907",
+            "caniuse-db": "1.0.30000910",
             "electron-to-chromium": "1.3.84"
           }
         },
@@ -7002,7 +7187,7 @@
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "requires": {
         "abab": "2.0.0",
-        "whatwg-mimetype": "2.2.0",
+        "whatwg-mimetype": "2.3.0",
         "whatwg-url": "7.0.0"
       },
       "dependencies": {
@@ -7217,7 +7402,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "1.0.2",
@@ -7240,6 +7425,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -7492,9 +7683,9 @@
       }
     },
     "editions": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.0.2.tgz",
-      "integrity": "sha512-0B8aSTWUu9+JW99zHoeogavCi+lkE5l35FK0OKe0pCobixJYoeof3ZujtqYzSsU2MskhRadY5V9oWUuyG4aJ3A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.0.tgz",
+      "integrity": "sha512-yKrimWcvOXcYXtqsOeebbMLynm9qbYVd0005wveGU2biPxJaJoxA0jtaZrxiMe3mAanLr5lxoYFVz5zjv9JdnA==",
       "requires": {
         "errlop": "1.0.3",
         "semver": "5.6.0"
@@ -8472,6 +8663,11 @@
         }
       }
     },
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -8618,9 +8814,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
-      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "3.1.0"
       }
@@ -9446,7 +9642,7 @@
     },
     "globby": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "requires": {
         "array-union": "1.0.2",
@@ -9466,6 +9662,15 @@
         "glob": "7.1.3",
         "lodash": "4.17.11",
         "minimatch": "3.0.4"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "3.2.0"
       }
     },
     "got": {
@@ -9540,7 +9745,8 @@
       "requires": {
         "async": "2.6.1",
         "optimist": "0.6.1",
-        "source-map": "0.6.1"
+        "source-map": "0.6.1",
+        "uglify-js": "3.4.9"
       }
     },
     "har-schema": {
@@ -9684,13 +9890,13 @@
       "integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw=="
     },
     "hastscript": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-4.1.0.tgz",
-      "integrity": "sha512-bOTn9hEfzewvHyXdbYGKqOr/LOz+2zYhKbC17U2YAjd16mnjqB1BQ0nooM/RdMy/htVyli0NAznXiBtwDi1cmQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.0.tgz",
+      "integrity": "sha512-xJtuJ8D42Xtq5yJrnDg/KAIxl2cXBXKoiIJwmWX9XMf8113qHTGl/Bf7jEsxmENJ4w6q4Tfl8s/Y6mEZo8x8qw==",
       "requires": {
         "comma-separated-tokens": "1.0.5",
         "hast-util-parse-selector": "2.2.1",
-        "property-information": "4.2.0",
+        "property-information": "5.0.1",
         "space-separated-tokens": "1.1.2"
       }
     },
@@ -9815,15 +10021,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
           "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-          "requires": {
-            "commander": "2.17.1",
-            "source-map": "0.6.1"
-          }
         }
       }
     },
@@ -9920,7 +10117,7 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
         "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.9",
+        "follow-redirects": "1.5.10",
         "requires-port": "1.0.0"
       }
     },
@@ -10996,7 +11193,7 @@
       "integrity": "sha512-xs+IFjzw1/5n45nMYUh2ipLWGarmE0bDVR85WAiYUXzawc8NYn1WW0qaq2rSEFIR3NoNkaAvOr3FVMojFz5uUg==",
       "requires": {
         "binaryextensions": "2.1.2",
-        "editions": "2.0.2",
+        "editions": "2.1.0",
         "textextensions": "2.4.0"
       }
     },
@@ -11252,7 +11449,7 @@
         "chalk": "2.4.1",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
-        "stack-utils": "1.0.1"
+        "stack-utils": "1.0.2"
       }
     },
     "jest-mock": {
@@ -11539,7 +11736,7 @@
         "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.5",
-        "whatwg-mimetype": "2.2.0",
+        "whatwg-mimetype": "2.3.0",
         "whatwg-url": "6.5.0",
         "ws": "5.2.2",
         "xml-name-validator": "3.0.0"
@@ -11705,7 +11902,7 @@
         "is-glob": "4.0.0",
         "is-windows": "1.0.2",
         "jest-validate": "23.6.0",
-        "listr": "0.14.2",
+        "listr": "0.14.3",
         "lodash": "4.17.11",
         "log-symbols": "2.2.0",
         "micromatch": "3.1.10",
@@ -12005,19 +12202,26 @@
       }
     },
     "listr": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.2.tgz",
-      "integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
       "requires": {
         "@samverschueren/stream-to-observable": "0.3.0",
         "is-observable": "1.1.0",
         "is-promise": "2.1.0",
         "is-stream": "1.1.0",
         "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.4.0",
-        "listr-verbose-renderer": "0.4.1",
-        "p-map": "1.2.0",
+        "listr-update-renderer": "0.5.0",
+        "listr-verbose-renderer": "0.5.0",
+        "p-map": "2.0.0",
         "rxjs": "6.3.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
+          "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w=="
+        }
       }
     },
     "listr-silent-renderer": {
@@ -12026,9 +12230,9 @@
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
     },
     "listr-update-renderer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
-      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "requires": {
         "chalk": "1.1.3",
         "cli-truncate": "0.2.1",
@@ -12036,7 +12240,7 @@
         "figures": "1.7.0",
         "indent-string": "3.2.0",
         "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
+        "log-update": "2.3.0",
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
@@ -12082,69 +12286,14 @@
       }
     },
     "listr-verbose-renderer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
         "date-fns": "1.29.0",
-        "figures": "1.7.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
+        "figures": "2.0.0"
       }
     },
     "load-json-file": {
@@ -12357,34 +12506,40 @@
       }
     },
     "log-update": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "3.1.0",
+        "cli-cursor": "2.1.0",
+        "wrap-ansi": "3.0.1"
       },
       "dependencies": {
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "restore-cursor": "1.0.1"
+            "ansi-regex": "3.0.0"
           }
         },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0"
           }
         }
       }
@@ -12457,12 +12612,12 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
+      "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
       "requires": {
         "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "yallist": "3.0.3"
       }
     },
     "make-dir": {
@@ -13157,7 +13312,7 @@
       "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-3.1.0.tgz",
       "integrity": "sha512-8eui7ZJkBaczrl8FS4m7G2qh8JJYUOeznE7UsJAbeGuktGtb6aWXiCGqbgngqK/l0S4jue1JIgIZbFtbMJMv6A==",
       "requires": {
-        "@types/node": "8.10.37",
+        "@types/node": "8.10.38",
         "decompress-zip": "0.3.1",
         "request": "2.88.0",
         "request-promise-native": "1.0.5",
@@ -13165,9 +13320,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.37",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-          "integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig=="
+          "version": "8.10.38",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+          "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A=="
         }
       }
     },
@@ -13370,7 +13525,7 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
           "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
           "requires": {
-            "lru-cache": "4.1.3",
+            "lru-cache": "4.1.4",
             "which": "1.3.1"
           }
         },
@@ -14820,7 +14975,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": "1.0.1"
@@ -15020,7 +15175,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000907",
+            "caniuse-db": "1.0.30000910",
             "electron-to-chromium": "1.3.84"
           }
         },
@@ -15174,7 +15329,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": "1.0.1"
@@ -15868,7 +16023,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": "1.0.1"
@@ -16163,7 +16318,10 @@
     "prismjs": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
-      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA=="
+      "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
+      "requires": {
+        "clipboard": "2.0.4"
+      }
     },
     "private": {
       "version": "0.1.8",
@@ -16222,9 +16380,9 @@
       }
     },
     "property-information": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-      "integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
+      "integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
       "requires": {
         "xtend": "4.0.1"
       }
@@ -16612,13 +16770,13 @@
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-3.0.0-rc.2.tgz",
       "integrity": "sha512-tXbIvq7Hxdc92jW570rztqsz0adtWEM5FX8bShJYozT2Y6L/LeHvBMQcED6mSqJ72niiNMPV8fi3S37OHrGMEw==",
       "requires": {
-        "@babel/parser": "7.1.5",
+        "@babel/parser": "7.1.6",
         "@babel/runtime": "7.1.5",
         "async": "2.6.1",
         "commander": "2.19.0",
         "doctrine": "2.1.0",
         "node-dir": "0.1.17",
-        "recast": "0.16.0"
+        "recast": "0.16.1"
       },
       "dependencies": {
         "ast-types": {
@@ -16635,9 +16793,9 @@
           }
         },
         "recast": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.16.0.tgz",
-          "integrity": "sha512-cm2jw4gCBatvs404ZJrxmGirSgWswW+S1U3SQTPHKNqdlUMg+V3J2XAOUvdAAgD7Hg2th2nxZ4wmYUekHI2Qmg==",
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.16.1.tgz",
+          "integrity": "sha512-ZUQm94F3AHozRaTo4Vz6yIgkSEZIL7p+BsWeGZ23rx+ZVRoqX+bvBA8br0xmCOU0DSR4qYGtV7Y5HxTsC4V78A==",
           "requires": {
             "ast-types": "0.11.6",
             "esprima": "4.0.1",
@@ -16768,6 +16926,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-loadable": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.5.0.tgz",
+      "integrity": "sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==",
+      "requires": {
+        "prop-types": "15.6.2"
+      }
+    },
     "react-modal": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.6.1.tgz",
@@ -16824,7 +16990,7 @@
         "highlight.js": "9.12.0",
         "lowlight": "1.9.2",
         "prismjs": "1.15.0",
-        "refractor": "2.6.1"
+        "refractor": "2.6.2"
       },
       "dependencies": {
         "highlight.js": {
@@ -17313,11 +17479,11 @@
       }
     },
     "refractor": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.6.1.tgz",
-      "integrity": "sha512-tdRAsgmoNw8BKsCD9lQkLnCXVBnhtYU254VNXJQ1n6cDd9Dw+vaofGjt507Hymwpy7BhhySyc/sEtiL6Q2G7KA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.6.2.tgz",
+      "integrity": "sha512-AMNEGkhaXfhoa0/0mW0bHdfizDJnuHDK29/D5oQaKICf6DALQ+kDEHW/36oDHCdfva4XrZ+cdMhRvPsTI4OIjA==",
       "requires": {
-        "hastscript": "4.1.0",
+        "hastscript": "5.0.0",
         "parse-entities": "1.2.0",
         "prismjs": "1.15.0"
       }
@@ -18245,9 +18411,9 @@
       }
     },
     "screener-runner": {
-      "version": "0.10.21",
-      "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.10.21.tgz",
-      "integrity": "sha512-GAQgullSnM0Me9wTUKMrby7tQzHORnDZSNnRIJeLTk2HSdgVbhisQ4gjS2h8/TijqqeyHn2OB8AcH3CmQd4s5g==",
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/screener-runner/-/screener-runner-0.10.22.tgz",
+      "integrity": "sha512-CwEClEfZPJTXqx6SLWZql8EV0QV2UnXBe8Yw3QaWFQA8E48ah39avPfmxiutdEg5FihpgHmginU4k7O3cysPSw==",
       "requires": {
         "bluebird": "3.4.7",
         "colors": "1.1.2",
@@ -18389,7 +18555,7 @@
         "react-dom": "16.6.3",
         "request": "2.88.0",
         "requestretry": "1.12.3",
-        "screener-runner": "0.10.21"
+        "screener-runner": "0.10.22"
       },
       "dependencies": {
         "abab": {
@@ -18461,7 +18627,7 @@
             "w3c-hr-time": "1.0.1",
             "webidl-conversions": "4.0.2",
             "whatwg-encoding": "1.0.5",
-            "whatwg-mimetype": "2.2.0",
+            "whatwg-mimetype": "2.3.0",
             "whatwg-url": "6.5.0",
             "ws": "4.1.0",
             "xml-name-validator": "3.0.0"
@@ -18500,13 +18666,19 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": "1.0.1"
           }
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -19105,9 +19277,9 @@
       }
     },
     "stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
     },
     "staged-git-files": {
       "version": "1.1.1",
@@ -19163,7 +19335,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "2.0.3",
@@ -19391,6 +19563,11 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
     "style-loader": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
@@ -19533,6 +19710,175 @@
           "version": "2.2.8",
           "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        }
+      }
+    },
+    "terser": {
+      "version": "3.10.12",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.12.tgz",
+      "integrity": "sha512-3ODPC1eVt25EVNb04s/PkHxOmzKBQUF6bwwuR6h2DbEF8/j265Y1UkwNtOk9am/pRxfJ5HPapOlUlO6c16mKQQ==",
+      "requires": {
+        "commander": "2.17.1",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "requires": {
+            "buffer-from": "1.1.1",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
+      "integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
+      "requires": {
+        "cacache": "11.3.1",
+        "find-cache-dir": "2.0.0",
+        "schema-utils": "1.0.0",
+        "serialize-javascript": "1.5.0",
+        "source-map": "0.6.1",
+        "terser": "3.10.12",
+        "webpack-sources": "1.3.0",
+        "worker-farm": "1.6.0"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "11.3.1",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
+          "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+          "requires": {
+            "bluebird": "3.5.3",
+            "chownr": "1.1.1",
+            "figgy-pudding": "3.5.1",
+            "glob": "7.1.3",
+            "graceful-fs": "4.1.15",
+            "lru-cache": "4.1.4",
+            "mississippi": "3.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "6.0.1",
+            "unique-filename": "1.1.1",
+            "y18n": "4.0.0"
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+          "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.3.0",
+            "pkg-dir": "3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+          "requires": {
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.1",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.3",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "3.0.0",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.3",
+            "through2": "2.0.5"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "requires": {
+            "find-up": "3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "requires": {
+            "ajv": "6.5.5",
+            "ajv-errors": "1.0.0",
+            "ajv-keywords": "3.2.0"
+          }
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "requires": {
+            "figgy-pudding": "3.5.1"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         }
       }
     },
@@ -19696,6 +20042,12 @@
       "requires": {
         "setimmediate": "1.0.5"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "optional": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -19991,7 +20343,7 @@
             "chalk": "2.4.1",
             "micromatch": "2.3.11",
             "slash": "1.0.0",
-            "stack-utils": "1.0.1"
+            "stack-utils": "1.0.2"
           }
         },
         "jest-mock": {
@@ -20479,21 +20831,27 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
       "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
     },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "requires": {
-        "commander": "2.13.0",
+        "commander": "2.17.1",
         "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
         }
       }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
     },
     "uglifyjs-webpack-plugin": {
       "version": "1.3.0",
@@ -20508,6 +20866,22 @@
         "uglify-es": "3.3.9",
         "webpack-sources": "1.3.0",
         "worker-farm": "1.6.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+        },
+        "uglify-es": {
+          "version": "3.3.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+          "requires": {
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
+          }
+        }
       }
     },
     "underscore": {
@@ -21387,6 +21761,7 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
             "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
             "yargs": "3.10.0"
           },
           "dependencies": {
@@ -21766,6 +22141,173 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
+          }
+        },
+        "listr-update-renderer": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+          "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-truncate": "0.2.1",
+            "elegant-spinner": "1.0.1",
+            "figures": "1.7.0",
+            "indent-string": "3.2.0",
+            "log-symbols": "1.0.2",
+            "log-update": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
+              }
+            },
+            "indent-string": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+              "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+              "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+              "requires": {
+                "chalk": "1.1.3"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "listr-verbose-renderer": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+          "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "date-fns": "1.29.0",
+            "figures": "1.7.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "requires": {
+                "restore-cursor": "1.0.1"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "log-update": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+          "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "cli-cursor": "1.0.2"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "requires": {
+                "restore-cursor": "1.0.1"
+              }
+            }
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "rxjs": {
@@ -22382,9 +22924,9 @@
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
-      "integrity": "sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
       "version": "6.5.0",
@@ -22495,9 +23037,9 @@
       "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE="
     },
     "write-file-webpack-plugin": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.4.1.tgz",
-      "integrity": "sha512-PuYlu2TZqF/Rkdk3Ri6hiofz+6HQAVkH55VpJ75axQXU2m6cS5jvbgwcJe+vwbgJTLhiX0O7GAPMbgO5DMZEiA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.5.0.tgz",
+      "integrity": "sha512-k46VeERtaezbmjpDcMWATjKUWBrVe/ZEEm0cyvUm8FFP8A/r+dw5x3psRvkUOhqh9bqBLUlGYYbtr6luI+HeAg==",
       "requires": {
         "chalk": "2.4.1",
         "debug": "3.1.0",
@@ -22532,9 +23074,9 @@
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
       "version": "6.6.0",

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -1,7 +1,66 @@
+/**
+ * This is configuration file is used for advanced publishing configurations with Rush.
+ * For full documentation, please see https://rushjs.io
+ */
+
+/**
+ * A list of version policy definitions.  A "version policy" is a custom package versioning
+ * strategy that affets "rush change", "rush version", and "rush publish".  The strategy applies
+ * to a set of projects that are specified using the "versionPolicyName" field in rush.json.
+ */
 [
   {
+    /**
+     * (Required) The name that will be used for the "versionPolicyName" field in rush.json.
+     * This name is also used command-line parameters such as "--version-policy"
+     * and "--to-version-policy".
+     */
     "policyName": "lockedMajor",
+
+    /**
+     * (Required) Indicates the kind of version policy being defined ("lockStepVersion" or "individualVersion").
+     *
+     * The "lockStepVersion" mode specifies that the projects will use "lock-step versioning".  This
+     * strategy is appropriate for a set of packages that act as selectable components of a
+     * unified product.  The entire set of packages are always published together, and always share
+     * the same NPM version number.  When the packages depend on other packages in the set, the
+     * SemVer range is usually restricted to a single version.
+     */
     "definitionName": "individualVersion",
+
+    /**
+     * (Optional) This can be used to enforce that all packages in the set must share a common
+     * major version number, e.g. because they are from the same major release branch.
+     * It can also be used to discourage people from accidentally making "MAJOR" SemVer changes
+     * inappropriately.  The minor/patch version parts will be bumped independently according
+     * to the types of changes made to each project, according to the "rush change" command.
+     */
     "lockedMajor": 6
+
+    //   /**
+    //    * (Required) The current version.  All packages belonging to the set should have this version
+    //    * in the current branch.  When bumping versions, Rush uses this to determine the next version.
+    //    * (The "version" field in package.json is NOT considered.)
+    //    */
+    //   "version": "1.0.0",
+    //
+    //   /**
+    //    * (Required) The type of bump that will be performed when publishing the next release.
+    //    * When creating a release branch in Git, this field should be updated according to the
+    //    * type of release.
+    //    *
+    //    * Valid values are: "prerelease", "release", "minor", "patch", "major"
+    //    */
+    //   "nextBump": "prerelease",
+    //
+    //   /**
+    //    * (Optional) If specified, all packages in the set share a common CHANGELOG.md file.
+    //    * This file is stored with the specified "main" project, which must be a member of the set.
+    //    *
+    //    * If this field is omitted, then a separate CHANGELOG.md file will be maintained for each
+    //    * package in the set.
+    //    */
+    //   "mainProject": "my-app"
+    // }
   }
 ]

--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -33,9 +33,10 @@ function getRushVersion() {
     }
 }
 function run() {
-    const [nodePath, /* Ex: /bin/node */ // tslint:disable-line:no-unused-variable
-    scriptPath, /* /repo/common/scripts/install-run-rush.js */ // tslint:disable-line:no-unused-variable
-    ...packageBinArgs /* [build, --to, myproject] */] = process.argv;
+    const [nodePath, /* Ex: /bin/node */ scriptPath, /* /repo/common/scripts/install-run-rush.js */ ...packageBinArgs /* [build, --to, myproject] */] = process.argv;
+    if (!nodePath || !scriptPath) {
+        throw new Error('Unexpected exception: could not detect node path or script path');
+    }
     if (process.argv.length < 3) {
         console.log('Usage: install-run-rush.js <command> [args...]');
         console.log('Example: install-run-rush.js build --to myproject');

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -9,7 +9,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 // version of the specified tool (if not already installed), and then pass a command-line to it.
 // An example usage would be:
 //
-//    node common/scripts/install-run.js rimraf@2.6.2 rimraf -f project1/lib
+//    node common/scripts/install-run.js qrcode@1.2.2 qrcode https://rushjs.io
 //
 // For more information, see: https://rushjs.io/pages/maintainer/setup_new_repo/
 const childProcess = require("child_process");
@@ -369,8 +369,10 @@ function runWithErrorAndStatusCode(fn) {
 }
 exports.runWithErrorAndStatusCode = runWithErrorAndStatusCode;
 function run() {
-    const [nodePath, /* Ex: /bin/node */ // tslint:disable-line:no-unused-variable
-    scriptPath, /* /repo/common/scripts/install-run-rush.js */ rawPackageSpecifier, /* rimraf@^2.0.0 */ packageBinName, /* rimraf */ ...packageBinArgs /* [-f, myproject/lib] */] = process.argv;
+    const [nodePath, /* Ex: /bin/node */ scriptPath, /* /repo/common/scripts/install-run-rush.js */ rawPackageSpecifier, /* qrcode@^1.2.0 */ packageBinName, /* qrcode */ ...packageBinArgs /* [-f, myproject/lib] */] = process.argv;
+    if (!nodePath) {
+        throw new Error('Unexpected exception: could not detect node path');
+    }
     if (path.basename(scriptPath).toLowerCase() !== 'install-run.js') {
         // If install-run.js wasn't directly invoked, don't execute the rest of this function. Return control
         // to the script that (presumably) imported this file
@@ -378,7 +380,7 @@ function run() {
     }
     if (process.argv.length < 4) {
         console.log('Usage: install-run.js <package>@<version> <command> [args...]');
-        console.log('Example: install-run.js rimraf@2.6.2 rimraf -f project1/lib');
+        console.log('Example: install-run.js qrcode@1.2.2 qrcode https://rushjs.io');
         process.exit(1);
     }
     runWithErrorAndStatusCode(() => {

--- a/rush.json
+++ b/rush.json
@@ -1,20 +1,300 @@
+/**
+ * This is the main configuration file for Rush.
+ * For full documentation, please see https://rushjs.io
+ */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
+
+  /**
+   * (Required) This specifies the version of the Rush engine to be used in this repo.
+   * Rush's "version selector" feature ensures that the globally installed tool will
+   * behave like this release, regardless of which version is installed globally.
+   *
+   * The common/scripts/install-run-rush.js automation script also uses this version.
+   *
+   * NOTE: If you upgrade to a new major version of Rush, you should replace the "v5"
+   * path segment in the "$schema" field for all your Rush config files.  This will ensure
+   * correct error-underlining and tab-completion for editors such as VS Code.
+   */
+  "rushVersion": "5.5.2",
+
+  /**
+   * The next field selects which package manager should be installed and determines its version.
+   * Rush installs its own local copy of the package manager to ensure that your build process
+   * is fully isolated from whatever tools are present in the local environment.
+   *
+   * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
+   * for details about these alternatives.
+   */
+  // "pnpmVersion": "2.15.1",
+
   "npmVersion": "5.4.0",
-  "rushVersion": "5.0.6",
+  // "yarnVersion": "1.9.4",
+
+  /**
+   * Options that are only used when the PNPM package manager is selected
+   */
+  "pnpmOptions": {
+    /**
+     * If true, then Rush will add the "--strict-peer-dependencies" option when invoking PNPM.
+     * This causes "rush install" to fail if there are unsatisfied peer dependencies, which is
+     * an invalid state that can cause build failures or incompatible dependency versions.
+     * (For historical reasons, JavaScript package managers generally do not treat this invalid
+     * state as an error.)
+     *
+     * The default value is false to avoid legacy compatibility issues.
+     * It is strongly recommended to set strictPeerDependencies=true.
+     */
+    // "strictPeerDependencies": true
+  },
+
   "repository": {
+    /**
+     * This setting is sometimes needed when using "rush change" with multiple Git remotes.
+     * It specifies the remote url for the official Git repository.  If this URL is provided,
+     * "rush change" will use it to find the right remote to compare against.
+     */
     "url": "https://github.com/OfficeDev/office-ui-fabric-react.git"
   },
+
+  /**
+   * Event hooks are customized script actions that Rush executes when specific events occur
+   */
   "eventHooks": {
-    "postRushInstall": ["node scripts/install-husky.js"]
+    /**
+     * The list of shell commands to run before the Rush installation starts
+     */
+    "preRushInstall": [
+      // "common/scripts/pre-rush-install.js"
+    ],
+
+    /**
+     * The list of shell commands to run after the Rush installation finishes
+     */
+    "postRushInstall": ["node scripts/install-husky.js"],
+
+    /**
+     * The list of shell commands to run before the Rush build command starts
+     */
+    "preRushBuild": [],
+
+    /**
+     * The list of shell commands to run after the Rush build command finishes
+     */
+    "postRushBuild": []
   },
-  "nodeSupportedVersionRange": ">=6.9.0 <10.0.0",
+
+  /**
+   * Older releases of the NodeJS engine may be missing features required by your system.
+   * Other releases may have bugs.  In particular, the "latest" version will not be a
+   * Long Term Support (LTS) version and is likely to have regressions.
+   *
+   * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
+   * for your repo.
+   */
+  "nodeSupportedVersionRange": ">=8.0.0 <10.0.0",
+
+  /**
+   * If you would like the version specifiers for your dependencies to be consistent, then
+   * uncomment this line. This is effectively similar to running "rush check" before any
+   * of the following commands:
+   *
+   *   rush install, rush update, rush link, rush version, rush publish
+   *
+   * In some cases you may want this turned on, but need to allow certain packages to use a different
+   * version. In those cases, you will need to add an entry to the "allowedAlternateVersions"
+   * section of the common-versions.json.
+   */
+  // "ensureConsistentVersions": true,
+
+  /**
+   * Large monorepos can become intimidating for newcomers if project folder paths don't follow
+   * a consistent and recognizable pattern.  When the system allows nested folder trees,
+   * we've found that teams will often use subfolders to create islands that isolate
+   * their work from others ("shipping the org").  This hinders collaboration and code sharing.
+   *
+   * The Rush developers recommend a "category folder" model, where buildable project folders
+   * must always be exactly two levels below the repo root.  The parent folder acts as the category.
+   * This provides a basic facility for grouping related projects (e.g. "apps", "libaries",
+   * "tools", "prototypes") while still encouraging teams to organize their projects into
+   * a unified taxonomy.  Limiting to 2 levels seems very restrictive at first, but if you have
+   * 20 categories and 20 projects in each category, this scheme can easily accommodate hundreds
+   * of projects.  In practice, you will find that the folder hierarchy needs to be rebalanced
+   * occasionally, but if that's painful, it's a warning sign that your development style may
+   * discourage refactoring.  Reorganizing the categories should be an enlightening discussion
+   * that brings people together, and maybe also identifies poor coding practices (e.g. file
+   * references that reach into other project's folders without using NodeJS module resolution).
+   *
+   * The defaults are projectFolderMinDepth=1 and projectFolderMaxDepth=2.
+   *
+   * To remove these restrictions, you could set projectFolderMinDepth=1
+   * and set projectFolderMaxDepth to a large number.
+   */
+  // "projectFolderMinDepth": 2,
+  // "projectFolderMaxDepth": 2,
+
+  /**
+   * This feature helps you to review and approve new packages before they are introduced
+   * to your monorepo.  For example, you may be concerned about licensing, code quality,
+   * performance, or simply accumulating too many libraries with overlapping functionality.
+   * The approvals are tracked in two config files "browser-approved-packages.json"
+   * and "nonbrowser-approved-packages.json".  See the Rush documentation for details.
+   */
+  // "approvedPackagesPolicy": {
+  //   /**
+  //    * The review categories allow you to say for example "This library is approved for usage
+  //    * in prototypes, but not in production code."
+  //    *
+  //    * Each project can be associated with one review category, by assigning the "reviewCategory" field
+  //    * in the "projects" section of rush.json.  The approval is then recorded in the files
+  //    * "common/config/rush/browser-approved-packages.json" and "nonbrowser-approved-packages.json"
+  //    * which are automatically generated during "rush update".
+  //    *
+  //    * Designate categories with whatever granularity is appropriate for your review process,
+  //    * or you could just have a single category called "default".
+  //    */
+  //   "reviewCategories": [
+  //     // Some example categories:
+  //     "production", // projects that ship to production
+  //     "tools",      // non-shipping projects that are part of the developer toolchain
+  //     "prototypes"  // experiments that should mostly be ignored by the review process
+  //   ],
+  //
+  //   /**
+  //    * A list of NPM package scopes that will be excluded from review.
+  //    * We recommend to exclude TypeScript typings (the "@types" scope), because
+  //    * if the underlying package was already approved, this would imply that the typings
+  //    * are also approved.
+  //    */
+  //   // "ignoredNpmScopes": [ "@types" ]
+  // },
+
+  /**
+   * If you use Git as your version control system, this section has some additional
+   * optional features you can use.
+   */
+  "gitPolicy": {
+    /**
+     * Work at a big company?  Tired of finding Git commits at work with unprofessional Git
+     * emails such as "beer-lover@my-college.edu"?  Rush can validate people's Git email address
+     * before they get started.
+     *
+     * Define a list of regular expressions describing allowable e-mail patterns for Git commits.
+     * They are case-insensitive anchored JavaScript RegExps.  Example: ".*@example\.com"
+     *
+     * IMPORTANT: Because these are regular expressions encoded as JSON string literals,
+     * RegExp escapes need two backspashes, and ordinary periods should be "\\.".
+     */
+    // "allowedEmailRegExps": [
+    //   "[^@]+@users\\.noreply\\.github\\.com",
+    //   "travis@example\\.org"
+    // ],
+    /**
+     * When Rush reports that the address is malformed, the notice can include an example
+     * of a recommended email.  Make sure it conforms to one of the allowedEmailRegExps
+     * expressions.
+     */
+    // "sampleEmail": "mrexample@users.noreply.github.com"
+  },
+
+  /**
+   * Installation variants allow you to maintain a parallel set of configuration files that can be
+   * used to build the entire monorepo with an alternate set of dependencies.  For example, suppose
+   * you upgrade all your projects to use a new release of an important framework, but during a transition period
+   * you intend to maintain compability with the old release.  In this situation, you probably want your
+   * CI validation to build the entire repo twice: once with the old release, and once with the new release.
+   *
+   * Rush "installation variants" correspond to sets of config files located under this folder:
+   *
+   *   common/config/rush/variants/<variant_name>
+   *
+   * The variant folder can contain an alternate common-versions.json file.  Its "preferredVersions" field can be used
+   * to select older versions of dependencies (within a loose SemVer range specified in your package.json files).
+   * To install a variant, run "rush install --variant <variant_name>".
+   *
+   * For more details and instructions, see this article:  https://rushjs.io/pages/advanced/installation_variants/
+   */
+  "variants": [
+    // {
+    //   /**
+    //    * The folder name for this variant.
+    //    */
+    //   "variantName": "old-sdk",
+    //
+    //   /**
+    //    * An informative description
+    //    */
+    //   "description": "Build this repo using the previous release of the SDK"
+    // }
+  ],
+
+  /**
+   * Rush can collect anonymous telemetry about everyday developer activity such as
+   * success/failure of installs, builds, and other operations.  You can use this to identify
+   * problems with your toolchain or Rush itself.  THIS TELEMETRY IS NOT SHARED WITH MICROSOFT.
+   * It is written into JSON files in the common/temp folder.  It's up to you to write scripts
+   * that read these JSON files and do something with them.  These scripts are typically registered
+   * in the "eventHooks" section.
+   */
+  // "telemetryEnabled": false,
+
+  /**
+   * Allows creation of hotfix changes. This feature is experimental so it is disabled by default.
+   */
+  // "hotfixChangeEnabled": false,
+
+  /**
+   * (Required) This is the inventory of projects to be managed by Rush.
+   *
+   * Rush does not automatically scan for projects using wildcards, for a few reasons:
+   * 1. Depth-first scans are expensive, particularly when tools need to repeatedly collect the list.
+   * 2. On a caching CI machine, scans can accidentally pick up files left behind from a previous build.
+   * 3. It's useful to have a centralized inventory of all projects and their important metadata.
+   */
   "projects": [
     {
+      /**
+       * The NPM package name of the project (must match package.json)
+       */
       "packageName": "office-ui-fabric-react",
+      /**
+       * The path to the project folder, relative to the rush.json config file.
+       */
       "projectFolder": "packages/office-ui-fabric-react",
+      /**
+       * An optional version policy associated with the project.  Version policies are defined
+       * in "version-policies.json" file.  See the "rush publish" documentation for more info.
+       * NOTE: "versionPolicyName" and "shouldPublish" are alternatives; you cannot specify them both.
+       */
       "versionPolicyName": "lockedMajor",
+      /**
+       * A flag indicating that changes to this project will be published to npm, which affects
+       * the Rush change and publish workflows. The default value is false.
+       * NOTE: "versionPolicyName" and "shouldPublish" are alternatives; you cannot specify them both.
+       */
       "shouldPublish": true
+
+      // /**
+      //   * An optional category for usage in the "browser-approved-packages.json"
+      //   * and "nonbrowser-approved-packages.json" files.  The value must be one of the
+      //   * strings from the "reviewCategories" defined above.
+      //   */
+      // "reviewCategory": "production",
+
+      // /**
+      //   * A list of local projects that appear as devDependencies for this project, but cannot be
+      //   * locally linked because it would create a cyclic dependency; instead, the last published
+      //   * version will be installed in the Common folder.
+      //   */
+      // "cyclicDependencyProjects": [
+      //   // "my-toolchain"
+      // ],
+
+      // /**
+      //   * If true, then this project will be ignored by the "rush check" command.
+      //   * The default value is false.
+      //   */
+      // "skipRushCheck": false,
     },
     {
       "packageName": "@uifabric/webpack-utils",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -44,6 +44,7 @@
     "resolve": "^1.7.1",
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.1",
+    "strip-json-comments": "^2.0.1",
     "style-loader": "^0.19.0",
     "ts-jest": "^22.4.6",
     "ts-loader": "^4.1.0",

--- a/scripts/tasks/lint-imports.js
+++ b/scripts/tasks/lint-imports.js
@@ -1,11 +1,11 @@
-const importKeywordRegex = /^import/gm;
 const importStatementGlobalRegex = /^import [{} a-zA-Z0-9_,*\r?\n ]*(?:from )?['"]{1}([.\/a-zA-Z0-9_@\-]+)['"]{1};.*$/gm;
 const importStatementRegex = /^import [{} a-zA-Z0-9_,*\r?\n ]*(?:from )?['"]{1}([.\/a-zA-Z0-9_@\-]+)['"]{1};.*$/;
 const pkgNameRegex = /^(@[a-z\-]+\/[a-z\-]+)\/|([a-z\-]+)\//;
-module.exports = function(options) {
+module.exports = function() {
   const path = require('path');
   const fs = require('fs');
   const chalk = require('chalk');
+  const stripJsonComments = require('strip-json-comments');
   const sourcePath = path.resolve(process.cwd(), 'src');
   const nodeModulesPath = path.resolve(process.cwd(), 'node_modules');
   const rushJsonPath = findRushJson(process.cwd());
@@ -14,7 +14,7 @@ module.exports = function(options) {
     throw new Error('lint-import: unable to find rush.json');
   }
 
-  const rush = JSON.parse(fs.readFileSync(rushJsonPath, 'utf8'));
+  const rush = JSON.parse(stripJsonComments(fs.readFileSync(rushJsonPath, 'utf8')));
   const rushPackages = rush.projects.map(project => project.packageName);
 
   const currentRushPackage = rush.projects.find(project => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Update to Rush 5.5.2 before switching to pnpm (#7185), per Pete's suggestion. This will allow us to use the `strictPeerDependencies` pnpm flag, which could help catch and fix issues with some build tasks due to missing peer dependencies.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7203)

