### PR TITLE
Feature/autocomplete component

### DIFF
--- a/common/changes/office-ui-fabric-react/feature-autocomplete_component_2018-11-22-05-26.json
+++ b/common/changes/office-ui-fabric-react/feature-autocomplete_component_2018-11-22-05-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "A new Component AutoComplete has been introduced based on the common use case of autosuggesting changes based on input. In order to accomplish this, the BasePicker component has been enhanced to support any type of input element which can trigger the suggestions retrieval logic",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "bishwenduk029@gmail.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -316,6 +316,8 @@ class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<P, IBas
   // (undocumented)
   protected _isFocusZoneInnerKeystroke: (ev: React.KeyboardEvent<HTMLElement>) => boolean;
   // (undocumented)
+  protected _onRenderSearchInputTarget: (props: any) => JSX.Element | null;
+  // (undocumented)
   protected addItem: (item: T) => void;
   // (undocumented)
   protected addItemByIndex: (index: number) => void;
@@ -375,8 +377,6 @@ class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<P, IBas
   protected onItemChange: (changedItem: T, index: number) => void;
   // (undocumented)
   protected onKeyDown: (ev: React.KeyboardEvent<HTMLElement>) => void;
-  // (undocumented)
-  protected onRenderSearchInputTarget(): JSX.Element | null;
   // (undocumented)
   protected onSelectionChange(): void;
   // (undocumented)
@@ -1971,6 +1971,7 @@ interface IBasePickerProps<T> extends React.Props<any> {
   onItemSelected?: (selectedItem?: T) => T | PromiseLike<T> | null;
   onRemoveSuggestion?: (item: IPersonaProps) => void;
   onRenderItem?: (props: IPickerItemProps<T>) => JSX.Element;
+  onRenderSearchInputTarget?: (props?: any) => JSX.Element;
   onRenderSuggestionsItem?: (props: T, itemProps: any) => JSX.Element;
   onResolveSuggestions: (filter: string, selectedItems?: T[]) => T[] | PromiseLike<T[]>;
   onValidateInput?: (input: string) => ValidationState;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -376,6 +376,8 @@ class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<P, IBas
   // (undocumented)
   protected onKeyDown: (ev: React.KeyboardEvent<HTMLElement>) => void;
   // (undocumented)
+  protected onRenderSearchInputTarget(): JSX.Element | null;
+  // (undocumented)
   protected onSelectionChange(): void;
   // (undocumented)
   protected onSuggestionClick: (ev: React.MouseEvent<HTMLElement>, item: any, index: number) => void;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -67,6 +67,15 @@ export function autobind<T extends Function>(target: any, key: string, descripto
 } | void;
 
 // @public (undocumented)
+class AutoComplete extends BasePicker<ISuggestedItem, IAutoCompleteProps> {
+  // (undocumented)
+  protected static defaultProps: {
+    onRenderSearchInputTarget: (props: any) => void;
+    onRenderSuggestionsItem: (props: ISuggestedItem) => JSX.Element;
+  }
+}
+
+// @public (undocumented)
 class Autofill extends BaseComponent<IAutofillProps, IAutofillState>, implements IAutofill {
   constructor(props: IAutofillProps);
   // (undocumented)
@@ -1788,6 +1797,10 @@ interface IAsAsyncOptions<TProps> {
   load: () => Promise<React.ReactType<TProps>>;
   onError?: (error: Error) => void;
   onLoad?: () => void;
+}
+
+// @public (undocumented)
+interface IAutoCompleteProps extends IBasePickerProps<ISuggestedItem> {
 }
 
 // @public (undocumented)
@@ -10045,6 +10058,14 @@ interface IStyleSheetConfig {
   injectionMode?: InjectionMode;
   namespace?: string;
   onInsertRule?: (rule: string) => void;
+}
+
+// @public (undocumented)
+interface ISuggestedItem {
+  // (undocumented)
+  key: string;
+  // (undocumented)
+  name: string;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/pickers/AutoComplete/AutoComplete.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/AutoComplete/AutoComplete.tsx
@@ -1,0 +1,23 @@
+/* tslint:disable */
+import * as React from 'react';
+import { css } from '../../../Utilities';
+/* tslint:enable */
+import { BasePicker } from '../BasePicker';
+import { IBasePickerProps } from '../BasePicker.types';
+import { SearchBox } from '../../../SearchBox';
+
+export interface ISuggestedItem {
+  key: string;
+  name: string;
+}
+
+export interface IAutoCompleteProps extends IBasePickerProps<ISuggestedItem> {}
+
+export class AutoComplete extends BasePicker<ISuggestedItem, IAutoCompleteProps> {
+  protected static defaultProps = {
+    onRenderSearchInputTarget: (props: any) => {
+      <SearchBox />;
+    },
+    onRenderSuggestionsItem: (props: ISuggestedItem) => <div className={css('ms-TagItem-TextOverflow')}> {props.name} </div>
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -184,21 +184,25 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   };
 
   public render(): JSX.Element {
-    const { className } = this.props;
+    const { className, onRenderSearchInputTarget = this._onRenderSearchInputTarget } = this.props;
 
     return (
       <div ref={this.root} className={css('ms-BasePicker', className ? className : '')} onKeyDown={this.onKeyDown}>
-        {this.onRenderSearchInputTarget()}
+        {onRenderSearchInputTarget({
+          suggestedDisplayValue: this.state.suggestedDisplayValue,
+          inputProps: this.props.inputProps,
+          disabled: this.props.disabled,
+          selectedSuggestionAlertId: this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '',
+          suggestionsAvailable: this.state.suggestionsVisible ? this._ariaMap.suggestionList : '',
+          onInputChange: this.onInputChange.bind(this)
+        })}
         {this.renderSuggestions()}
       </div>
     );
   }
 
-  protected onRenderSearchInputTarget(): JSX.Element | null {
-    const { suggestedDisplayValue } = this.state;
-    const { inputProps, disabled } = this.props;
-    const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
-    const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
+  protected _onRenderSearchInputTarget = (props: any): JSX.Element | null => {
+    const { suggestedDisplayValue, inputProps, disabled, selectedSuggestionAlertId, suggestionsAvailable, onInputChange } = props;
     return (
       <FocusZone
         componentRef={this.focusZone}
@@ -218,7 +222,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
                 ref={this.input}
                 onFocus={this.onInputFocus}
                 onBlur={this.onInputBlur}
-                onInputValueChange={this.onInputChange}
+                onInputValueChange={onInputChange}
                 suggestedDisplayValue={suggestedDisplayValue}
                 aria-activedescendant={this.getActiveDescendant()}
                 aria-expanded={!!this.state.suggestionsVisible}
@@ -238,7 +242,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
         </SelectionZone>
       </FocusZone>
     );
-  }
+  };
 
   protected canAddItems(): boolean {
     const { items } = this.state;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -184,53 +184,59 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   };
 
   public render(): JSX.Element {
-    const { suggestedDisplayValue } = this.state;
-    const { className, inputProps, disabled } = this.props;
-
-    const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
-    const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
+    const { className } = this.props;
 
     return (
       <div ref={this.root} className={css('ms-BasePicker', className ? className : '')} onKeyDown={this.onKeyDown}>
-        <FocusZone
-          componentRef={this.focusZone}
-          direction={FocusZoneDirection.bidirectional}
-          isInnerZoneKeystroke={this._isFocusZoneInnerKeystroke}
-        >
-          {this.getSuggestionsAlert()}
-          <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused)}>
-              <span id={this._ariaMap.selectedItems} className={styles.pickerItems} role={'list'}>
-                {this.renderItems()}
-              </span>
-              {this.canAddItems() && (
-                <Autofill
-                  {...inputProps as any}
-                  className={css('ms-BasePicker-input', styles.pickerInput)}
-                  ref={this.input}
-                  onFocus={this.onInputFocus}
-                  onBlur={this.onInputBlur}
-                  onInputValueChange={this.onInputChange}
-                  suggestedDisplayValue={suggestedDisplayValue}
-                  aria-activedescendant={this.getActiveDescendant()}
-                  aria-expanded={!!this.state.suggestionsVisible}
-                  aria-haspopup="true"
-                  aria-describedby={this._ariaMap.selectedItems}
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  role={'combobox'}
-                  disabled={disabled}
-                  aria-controls={`${suggestionsAvailable} ${selectedSuggestionAlertId}` || undefined}
-                  aria-owns={suggestionsAvailable || undefined}
-                  aria-autocomplete={'both'}
-                  onInputChange={this.props.onInputChange}
-                />
-              )}
-            </div>
-          </SelectionZone>
-        </FocusZone>
+        {this.onRenderSearchInputTarget()}
         {this.renderSuggestions()}
       </div>
+    );
+  }
+
+  protected onRenderSearchInputTarget(): JSX.Element | null {
+    const { suggestedDisplayValue } = this.state;
+    const { inputProps, disabled } = this.props;
+    const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
+    const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
+    return (
+      <FocusZone
+        componentRef={this.focusZone}
+        direction={FocusZoneDirection.bidirectional}
+        isInnerZoneKeystroke={this._isFocusZoneInnerKeystroke}
+      >
+        {this.getSuggestionsAlert()}
+        <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
+          <div className={css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused)}>
+            <span id={this._ariaMap.selectedItems} className={styles.pickerItems} role={'list'}>
+              {this.renderItems()}
+            </span>
+            {this.canAddItems() && (
+              <Autofill
+                {...inputProps as any}
+                className={css('ms-BasePicker-input', styles.pickerInput)}
+                ref={this.input}
+                onFocus={this.onInputFocus}
+                onBlur={this.onInputBlur}
+                onInputValueChange={this.onInputChange}
+                suggestedDisplayValue={suggestedDisplayValue}
+                aria-activedescendant={this.getActiveDescendant()}
+                aria-expanded={!!this.state.suggestionsVisible}
+                aria-haspopup="true"
+                aria-describedby={this._ariaMap.selectedItems}
+                autoCapitalize="off"
+                autoComplete="off"
+                role={'combobox'}
+                disabled={disabled}
+                aria-controls={`${suggestionsAvailable} ${selectedSuggestionAlertId}` || undefined}
+                aria-owns={suggestionsAvailable || undefined}
+                aria-autocomplete={'both'}
+                onInputChange={this.props.onInputChange}
+              />
+            )}
+          </div>
+        </SelectionZone>
+      </FocusZone>
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -148,6 +148,10 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * @defaultvalue false
    */
   enableSelectedSuggestionAlert?: boolean;
+  /**
+   * Function that specifies how the input element will appear.
+   */
+  onRenderSearchInputTarget?: (props?: any) => JSX.Element;
 }
 
 export interface IBasePickerSuggestionsProps {

--- a/packages/office-ui-fabric-react/src/components/pickers/index.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/index.ts
@@ -9,3 +9,4 @@ export * from './PickerItem.types';
 export * from './PeoplePicker/PeoplePicker';
 export * from './TagPicker/TagPicker';
 export * from './TagPicker/TagItem';
+export * from './AutoComplete/AutoComplete';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5660 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

AutoComplete search box seems to be a common use case. The existing basePicker component has the logic for retrieving suggestions and displaying them. But the UI element triggering this logic is fixed and tightly coupled to BasePicker. Using renderProps, this component can now be provided as input by the client code. The AutoComplete box is actually based on BasePicker with the UI element being the SearchBox. 

#### Focus areas to test

To test if the new input element's onChange event is triggering the suggestion retrieval logic of the BasePicker.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7205)

