### PR TITLE
Re-adding animation for drag-n-drop to reorder columns

### DIFF
--- a/common/changes/office-ui-fabric-react/arkgupta-dragDropBorderAnimation_2018-11-23-13-59.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-dragDropBorderAnimation_2018-11-23-13-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "re-adding animation for drag-n-drop to reorder columns",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "arkgupta@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/arkgupta-dragDropBorderAnimation_2018-11-23-13-59.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-dragDropBorderAnimation_2018-11-23-13-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "re-adding animation for drag-n-drop to reorder columns",
+      "comment": "DetailsList: Re-adding border fade animation as transition on column reorder",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -12,6 +12,8 @@ import { IDetailsColumnStyleProps, IDetailsColumnProps } from './DetailsColumn.t
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 
 const getClassNames = classNamesFunction<IDetailsColumnStyleProps, IDetailsColumnStyles>();
+const TRANSITION_DURATION_DRAG = 0.2; // sec
+const TRANSITION_DURATION_DROP = 1.5; // sec
 
 export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   private _root: any;
@@ -41,7 +43,9 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       isIconVisible: column.isSorted || column.isGrouped || column.isFiltered,
       isPadded: column.isPadded,
       isIconOnly: column.isIconOnly,
-      cellStyleProps
+      cellStyleProps,
+      transitionDurationDrag: TRANSITION_DURATION_DRAG,
+      transitionDurationDrop: TRANSITION_DURATION_DROP
     });
 
     const classNames = this._classNames;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -157,8 +157,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
       this._async.setTimeout(() => {
         if (this._root!.current!) {
-          this._root!.current!.classList!.remove(classNames.borderAfterDropping);
-          this._root!.current!.classList!.remove(classNames.noBorderAfterDropping);
+          this._root!.current!.classList!.remove(classNames.borderAfterDropping, classNames.noBorderAfterDropping);
         }
       }, TRANSITION_DURATION_DROP + CLASSNAME_ADD_INTERVAL);
     }
@@ -271,8 +270,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     if (event) {
       this._updateHeaderDragInfo(-1, event);
     }
-    this._root.current.classList.remove(classNames.borderWhileDragging);
-    this._root.current.classList.remove(classNames.noBorderWhileDragging);
+    this._root.current.classList.remove(classNames.borderWhileDragging, classNames.noBorderWhileDragging);
   }
 
   private _updateHeaderDragInfo(itemIndex: number, event?: MouseEvent) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -12,8 +12,9 @@ import { IDetailsColumnStyleProps, IDetailsColumnProps } from './DetailsColumn.t
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 
 const getClassNames = classNamesFunction<IDetailsColumnStyleProps, IDetailsColumnStyles>();
-const TRANSITION_DURATION_DRAG = 0.2; // sec
-const TRANSITION_DURATION_DROP = 1.5; // sec
+const TRANSITION_DURATION_DRAG = 200; // ms
+const TRANSITION_DURATION_DROP = 1500; // ms
+const CLASSNAME_ADD_INTERVAL = 20; // ms
 
 export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   private _root: any;
@@ -151,7 +152,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
           if (this._root!.current!) {
             this._root!.current!.classList!.add(classNames.noBorderAfterDropping);
           }
-        }, 20);
+        }, CLASSNAME_ADD_INTERVAL);
       }
 
       this._async.setTimeout(() => {
@@ -159,7 +160,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
           this._root!.current!.classList!.remove(classNames.borderAfterDropping);
           this._root!.current!.classList!.remove(classNames.noBorderAfterDropping);
         }
-      }, 1520);
+      }, TRANSITION_DURATION_DROP + CLASSNAME_ADD_INTERVAL);
     }
   }
 
@@ -261,7 +262,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
         if (this._root!.current!) {
           this._root!.current!.classList!.add(classNames.noBorderWhileDragging);
         }
-      }, 20);
+      }, CLASSNAME_ADD_INTERVAL);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -157,7 +157,8 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
       this._async.setTimeout(() => {
         if (this._root!.current!) {
-          this._root!.current!.classList!.remove(classNames.borderAfterDropping, classNames.noBorderAfterDropping);
+          this._root!.current!.classList!.remove(classNames.borderAfterDropping);
+          this._root!.current!.classList!.remove(classNames.noBorderAfterDropping);
         }
       }, TRANSITION_DURATION_DROP + CLASSNAME_ADD_INTERVAL);
     }
@@ -270,7 +271,8 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     if (event) {
       this._updateHeaderDragInfo(-1, event);
     }
-    this._root.current.classList.remove(classNames.borderWhileDragging, classNames.noBorderWhileDragging);
+    this._root.current.classList.remove(classNames.borderWhileDragging);
+    this._root.current.classList.remove(classNames.noBorderWhileDragging);
   }
 
   private _updateHeaderDragInfo(itemIndex: number, event?: MouseEvent) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -142,12 +142,20 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     if (this.props.isDropped) {
       if (this._root!.current!) {
         this._root!.current!.classList!.add(classNames.borderAfterDropping);
+
+        this._async.setTimeout(() => {
+          if (this._root!.current!) {
+            this._root!.current!.classList!.add(classNames.noBorderAfterDropping);
+          }
+        }, 20);
       }
+
       this._async.setTimeout(() => {
         if (this._root!.current!) {
           this._root!.current!.classList!.remove(classNames.borderAfterDropping);
+          this._root!.current!.classList!.remove(classNames.noBorderAfterDropping);
         }
-      }, 1500);
+      }, 1520);
     }
   }
 
@@ -245,6 +253,11 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     if (itemIndex) {
       this._updateHeaderDragInfo(itemIndex);
       this._root.current.classList.add(classNames.borderWhileDragging);
+      this._async.setTimeout(() => {
+        if (this._root!.current!) {
+          this._root!.current!.classList!.add(classNames.noBorderWhileDragging);
+        }
+      }, 20);
     }
   }
 
@@ -254,6 +267,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       this._updateHeaderDragInfo(-1, event);
     }
     this._root.current.classList.remove(classNames.borderWhileDragging);
+    this._root.current.classList.remove(classNames.noBorderWhileDragging);
   }
 
   private _updateHeaderDragInfo(itemIndex: number, event?: MouseEvent) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -33,7 +33,9 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
     isIconVisible,
     isPadded,
     isIconOnly,
-    cellStyleProps = DEFAULT_CELL_STYLE_PROPS
+    cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
+    transitionDurationDrag,
+    transitionDurationDrop
   } = props;
 
   const { semanticColors, palette } = theme;
@@ -195,10 +197,10 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
 
     borderWhileDragging: borderWhileDragging,
 
-    noBorderWhileDragging: [borderAfterDragOrDrop, { transition: 'border-color 0.2s ease' }],
+    noBorderWhileDragging: [borderAfterDragOrDrop, { transition: `border-color  ${transitionDurationDrag}s ease` }],
 
     borderAfterDropping: [borderWhileDragging, { left: -1, lineHeight: 31 }],
 
-    noBorderAfterDropping: [borderAfterDragOrDrop, { transition: 'border-color 1.5s ease' }]
+    noBorderAfterDropping: [borderAfterDragOrDrop, { transition: `border-color  ${transitionDurationDrop}s ease` }]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -197,10 +197,10 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
 
     borderWhileDragging: borderWhileDragging,
 
-    noBorderWhileDragging: [borderAfterDragOrDrop, { transition: `border-color  ${transitionDurationDrag}s ease` }],
+    noBorderWhileDragging: [borderAfterDragOrDrop, { transition: `border-color  ${transitionDurationDrag}ms ease` }],
 
     borderAfterDropping: [borderWhileDragging, { left: -1, lineHeight: 31 }],
 
-    noBorderAfterDropping: [borderAfterDragOrDrop, { transition: `border-color  ${transitionDurationDrop}s ease` }]
+    noBorderAfterDropping: [borderAfterDragOrDrop, { transition: `border-color  ${transitionDurationDrop}ms ease` }]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -53,6 +53,20 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
     paddingLeft: 8
   };
 
+  const borderWhileDragging: IStyle = [
+    {
+      borderStyle: 'solid',
+      borderWidth: 1,
+      borderColor: palette.themePrimary
+    }
+  ];
+
+  const borderAfterDragOrDrop: IStyle = [
+    {
+      borderColor: 'transparent'
+    }
+  ];
+
   return {
     root: [
       getCellStyles(props),
@@ -179,26 +193,12 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
 
     accessibleLabel: [hiddenContentStyle],
 
-    borderAfterDropping: [
-      {
-        borderStyle: 'solid',
-        borderWidth: 1,
-        borderColor: palette.themePrimary,
-        left: -1,
-        lineHeight: 31
-      }
-    ],
+    borderWhileDragging: borderWhileDragging,
 
-    borderWhileDragging: [
-      {
-        selectors: {
-          '.ms-DetailsHeader &.ms-DetailsHeader-cell': {
-            borderStyle: 'solid',
-            borderWidth: 1,
-            borderColor: palette.themePrimary
-          }
-        }
-      }
-    ]
+    noBorderWhileDragging: [borderAfterDragOrDrop, { transition: 'border-color 0.2s ease' }],
+
+    borderAfterDropping: [borderWhileDragging, { left: -1, lineHeight: 31 }],
+
+    noBorderAfterDropping: [borderAfterDragOrDrop, { transition: 'border-color 1.5s ease' }]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -33,6 +33,8 @@ export type IDetailsColumnStyleProps = Required<Pick<IDetailsColumnProps, 'theme
   isPadded?: boolean;
   isIconOnly?: boolean;
   iconClassName?: string;
+  transitionDurationDrag?: number;
+  transitionDurationDrop?: number;
 };
 
 export interface IDetailsColumnStyles {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -47,5 +47,7 @@ export interface IDetailsColumnStyles {
   sortIcon: IStyle;
   filterChevron: IStyle;
   borderAfterDropping: IStyle;
+  noBorderAfterDropping: IStyle;
   borderWhileDragging: IStyle;
+  noBorderWhileDragging: IStyle;
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7173 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
This adds back the animation effect on the border while dragging a column and also while dropping it. CSS3 `transition` property is being used here. The class names are being added programmatically and are removed after a certain interval. 

Also, there is no regeneration of stylesheets on each re-render, the root cause because of which animation was removed in the first place. This has been verified as well.

Video link for the same:
[https://microsoft-my.sharepoint.com/:V:/p/arkgupta/Ea749SV3KclCuqf0KPQayOQBp_xhXxFRTqZpqJW2RNGsbg?e=7VoOQp](url)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7213)

