### PR TITLE
Tabrumle/custom overflow label

### DIFF
--- a/common/changes/office-ui-fabric-react/tabrumle-CustomOverflowLabel_2018-11-26-23-36.json
+++ b/common/changes/office-ui-fabric-react/tabrumle-CustomOverflowLabel_2018-11-26-23-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fix custom title on overflow button not being used in facepile",
+      "comment": "Facepile: Fix custom title on overflow button not being used in facepile",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/tabrumle-CustomOverflowLabel_2018-11-26-23-36.json
+++ b/common/changes/office-ui-fabric-react/tabrumle-CustomOverflowLabel_2018-11-26-23-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix custom title on overflow button not being used in facepile",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tabrumle@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -202,6 +202,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
         className={_classNames.descriptiveOverflowButton}
       >
         <PersonaCoin
+          // Check if a title is being added to the parenting FacepileButton. If so, do not set title on child PersonaCoin
           title={overflowButtonTitle ? undefined : personaNames}
           size={personaSize}
           onRenderInitials={this._renderInitialsNotPictured(numPersonasNotPictured)}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -190,14 +190,19 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     }
 
     const personaNames: string = personasOverflow.map((p: IFacepilePersona) => p.personaName).join(', ');
+    const overflowButtonTitle: string | undefined = overflowButtonProps && overflowButtonProps.title;
     const numPersonasNotPictured: number = Math.max(personasOverflow.length, 0);
 
     const { _classNames } = this;
 
     return (
-      <FacepileButton {...overflowButtonProps} ariaDescription={personaNames} className={_classNames.descriptiveOverflowButton}>
+      <FacepileButton
+        {...overflowButtonProps}
+        ariaDescription={overflowButtonTitle ? undefined : personaNames}
+        className={_classNames.descriptiveOverflowButton}
+      >
         <PersonaCoin
-          title={personaNames}
+          title={overflowButtonTitle ? undefined : personaNames}
           size={personaSize}
           onRenderInitials={this._renderInitialsNotPictured(numPersonasNotPictured)}
           initialsColor={PersonaInitialsColor.transparent}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
@@ -82,6 +82,22 @@ describe('Facepile', () => {
     expect(findNodes(wrapper, '.ms-Facepile-itemButton').length).toEqual(6);
   });
 
+  it('renders a descriptive overflow button with a custom title', () => {
+    const personas: IFacepilePersona[] = facepilePersonas.concat(...facepilePersonas, ...facepilePersonas);
+    const title: string = 'custom title';
+    const wrapper = mount(
+      <Facepile
+        personas={personas}
+        maxDisplayablePersonas={5}
+        overflowButtonProps={{title}}
+        overflowButtonType={OverflowButtonType.descriptive}
+      />
+    );
+    expect(
+      findNodes(wrapper, '.ms-Facepile-descriptiveOverflowButton').getDOMNode().attributes.getNamedItem('title')
+      ).toHaveProperty('value', title);
+  });
+
   it('renders no more than maximum allowed personas', () => {
     const wrapper = mount(
       <Facepile personas={facepilePersonas.concat(facepilePersonas, facepilePersonas, facepilePersonas)} maxDisplayablePersonas={2} />


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Currently you cannot add a custom title to the overflow button in a facepile. You must use the generated title that consists of the names of all of the personas not shown in the facepile. Change this so that when a title field is passed in with overflowButtonProps, it overwrites the generated title.
![current overflow tooltip](https://user-images.githubusercontent.com/42159057/49049825-7d55db80-f195-11e8-873d-18962aa18b1a.gif)
![custom overflow tooltip](https://user-images.githubusercontent.com/42159057/49049827-8050cc00-f195-11e8-9976-784086b8168d.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7220)

