### PR TITLE
ContextualMenu: style adjustments.

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-SplitButtonFix_2018-11-27-02-03.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-SplitButtonFix_2018-11-27-02-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Fixes alignment of the chevron button of a regular submenu and the split button chevron. Changes positioning of the divider of the split button to fix a hover state background visual bug.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -112,7 +112,6 @@ export const getItemClassNames = memoizeFunction(
         styles.root,
         checked && [classNames.isChecked, styles.rootChecked],
         isAnchorLink && styles.anchorLink,
-        // { paddingRight: 8 },
         expanded && [classNames.isExpanded, styles.rootExpanded],
         disabled && [classNames.isDisabled, styles.rootDisabled],
         !disabled &&

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -1,6 +1,6 @@
 import { getDividerClassNames } from '../Divider/VerticalDivider.classNames';
 import { getMenuItemStyles } from './ContextualMenu.cnstyles';
-import { ITheme, mergeStyleSets, getGlobalClassNames } from '../../Styling';
+import { ITheme, mergeStyleSets, getGlobalClassNames, getScreenSelector, ScreenWidthMaxMedium } from '../../Styling';
 import { IVerticalDividerClassNames } from '../Divider/VerticalDivider.types';
 import { memoizeFunction, IsFocusVisibleClassName } from '../../Utilities';
 import { IContextualMenuItemStyles, IContextualMenuItemStyleProps } from './ContextualMenuItem.types';
@@ -37,9 +37,20 @@ export interface IMenuItemClassNames {
   linkContentMenu: string;
 }
 
+const MediumScreenSelector = getScreenSelector(0, ScreenWidthMaxMedium);
+
 export const getSplitButtonVerticalDividerClassNames = memoizeFunction(
   (theme: ITheme): IVerticalDividerClassNames => {
     return mergeStyleSets(getDividerClassNames(theme), {
+      wrapper: {
+        position: 'absolute',
+        right: 28, // width of the splitMenu based on the padding plus icon fontSize
+        selectors: {
+          [MediumScreenSelector]: {
+            right: 32 // fontSize of the icon increased from 12px to 16px
+          }
+        }
+      },
       divider: {
         height: 16,
         width: 1
@@ -101,6 +112,7 @@ export const getItemClassNames = memoizeFunction(
         styles.root,
         checked && [classNames.isChecked, styles.rootChecked],
         isAnchorLink && styles.anchorLink,
+        // { paddingRight: 8 },
         expanded && [classNames.isExpanded, styles.rootExpanded],
         disabled && [classNames.isDisabled, styles.rootDisabled],
         !disabled &&
@@ -125,6 +137,7 @@ export const getItemClassNames = memoizeFunction(
             {
               selectors: {
                 ':hover': styles.rootHovered,
+                ':hover ~ $splitMenu': styles.rootHovered, // when hovering over the splitPrimary also affect the splitMenu
                 ':active': styles.rootPressed,
                 [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus:hover`]: styles.rootFocused,
                 [`.${IsFocusVisibleClassName} &:hover`]: { background: 'inherit;' }
@@ -135,7 +148,8 @@ export const getItemClassNames = memoizeFunction(
       splitMenu: [
         styles.root,
         {
-          width: 32
+          flexBasis: '0',
+          padding: '0 8px'
         },
         expanded && ['is-expanded', styles.rootExpanded],
         disabled && ['is-disabled', styles.rootDisabled],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -1,8 +1,19 @@
-import { concatStyleSets, FontSizes, getFocusStyle, HighContrastSelector, IRawStyle, ITheme } from '../../Styling';
+import {
+  concatStyleSets,
+  FontSizes,
+  getFocusStyle,
+  HighContrastSelector,
+  IRawStyle,
+  ITheme,
+  getScreenSelector,
+  ScreenWidthMaxMedium
+} from '../../Styling';
 import { IMenuItemStyles } from './ContextualMenu.types';
 import { memoizeFunction } from '../../Utilities';
 
 export const CONTEXTUAL_MENU_ITEM_HEIGHT = '32px';
+
+const MediumScreenSelector = getScreenSelector(0, ScreenWidthMaxMedium);
 
 const getItemHighContrastStyles = memoizeFunction(
   (): IRawStyle => {
@@ -53,7 +64,7 @@ export const getMenuItemStyles = memoizeFunction(
           lineHeight: CONTEXTUAL_MENU_ITEM_HEIGHT,
           display: 'block',
           cursor: 'pointer',
-          padding: '0px 6px',
+          padding: '0px 8px 0 4px', // inner elements have a margin of 4px (4 + 4 = 8px as on right side)
           textAlign: 'left'
         }
       ],
@@ -96,7 +107,7 @@ export const getMenuItemStyles = memoizeFunction(
         maxWidth: '100%'
       },
       anchorLink: {
-        padding: '0px 6px',
+        padding: '0px 8px 0 4px', // inner elements have a margin of 4px (4 + 4 = 8px as on right side)
         textRendering: 'auto',
         color: 'inherit',
         letterSpacing: 'normal',
@@ -170,7 +181,12 @@ export const getMenuItemStyles = memoizeFunction(
         display: 'inline-block',
         verticalAlign: 'middle',
         flexShrink: '0',
-        fontSize: FontSizes.mini
+        fontSize: FontSizes.small, // 12px
+        selectors: {
+          [MediumScreenSelector]: {
+            fontSize: FontSizes.icon // 16px
+          }
+        }
       },
       splitButtonFlexContainer: [
         getFocusStyle(theme),

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
@@ -1,32 +1,34 @@
 import * as React from 'react';
-import { ContextualMenuBasicExample } from './examples/ContextualMenu.Basic.Example';
 
 import { IDocPageProps } from '../../common/DocPage.types';
+import { ContextualMenuStatus } from './ContextualMenu.checklist';
+
+import { ContextualMenuBasicExample } from './examples/ContextualMenu.Basic.Example';
 import { ContextualMenuIconExample } from './examples/ContextualMenu.Icon.Example';
 import { ContextualMenuIconSecondaryTextExample } from './examples/ContextualMenu.Icon.SecondaryText.Example';
-import { ContextualMenuSectionExample } from './examples/ContextualMenu.Section.Example';
 import { ContextualMenuSubmenuExample } from './examples/ContextualMenu.Submenu.Example';
-import { ContextualMenuCustomizationWithNoWrapExample } from './examples/ContextualMenu.CustomizationWithNoWrap.Example';
+import { ContextualMenuSectionExample } from './examples/ContextualMenu.Section.Example';
 import { ContextualMenuCheckmarksExample } from './examples/ContextualMenu.Checkmarks.Example';
 import { ContextualMenuDirectionalExample } from './examples/ContextualMenu.Directional.Example';
 import { ContextualMenuCustomizationExample } from './examples/ContextualMenu.Customization.Example';
+import { ContextualMenuCustomizationWithNoWrapExample } from './examples/ContextualMenu.CustomizationWithNoWrap.Example';
 import { ContextualMenuWithScrollBarExample } from './examples/ContextualMenu.ScrollBar.Example';
 import { ContextualMenuWithCustomMenuItemExample } from './examples/ContextualMenu.CustomMenuItem.Example';
 import { ContextualMenuWithCustomMenuListExample } from './examples/ContextualMenu.CustomMenuList.Example';
-import { ContextualMenuStatus } from './ContextualMenu.checklist';
 
 const ContextualMenuBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx') as string;
 const ContextualMenuBasicExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/ContextualMenu/ContextualMenu.Basic.Example.Codepen.txt') as string;
 const ContextualMenuIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx') as string;
 const ContextualMenuIconSecondaryTextExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx') as string;
-const ContextualMenuSectionExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx') as string;
 const ContextualMenuSubmenuExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx') as string;
-const ContextualMenuCustomMenuListExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx') as string;
+const ContextualMenuSectionExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx') as string;
 const ContextualMenuCheckmarksExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx') as string;
 const ContextualMenuDirectionalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx') as string;
 const ContextualMenuCustomizationExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx') as string;
+const ContextualMenuCustomizationWithNoWrapExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx') as string;
 const ContextualMenuWithScrollBarExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx') as string;
 const ContextualMenuWithCustomMenuItemExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx') as string;
+const ContextualMenuCustomMenuListExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx') as string;
 
 export const ContextualMenuPageProps: IDocPageProps = {
   title: 'ContextualMenu',
@@ -78,7 +80,7 @@ export const ContextualMenuPageProps: IDocPageProps = {
     },
     {
       title: 'ContextualMenu with customized submenus and noWrap attributes',
-      code: ContextualMenuSubmenuExampleCode,
+      code: ContextualMenuCustomizationWithNoWrapExampleCode,
       view: <ContextualMenuCustomizationWithNoWrapExample />
     },
     {
@@ -92,7 +94,7 @@ export const ContextualMenuPageProps: IDocPageProps = {
       view: <ContextualMenuWithCustomMenuItemExample />
     },
     {
-      title: 'ContextualMenu with custom rendered menu list that renders a searchbox to filter menu items',
+      title: 'ContextualMenu with custom rendered menu list that renders a search box to filter menu items',
       code: ContextualMenuCustomMenuListExampleCode,
       view: <ContextualMenuWithCustomMenuListExample />
     }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
@@ -32,6 +32,11 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
           align-items: center;
           display: inline-flex;
           height: 100%;
+          position: absolute;
+          right: 28px;
+        }
+        @media only screen and (min-width: 0px) and (max-width: 639px){& {
+          right: 32px;
         }
   >
     <span

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
@@ -32,6 +32,11 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
           align-items: center;
           display: inline-flex;
           height: 100%;
+          position: absolute;
+          right: 28px;
+        }
+        @media only screen and (min-width: 0px) and (max-width: 639px){& {
+          right: 32px;
         }
   >
     <span


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7223
- [X] Include a change request file using `$ npm run change`

#### Description of changes
A more detailed description of the bug can be seen here: #7223 

Talked to designers and got some redlines because this variation of a `ContextualMenuItem` was missing from the toolkit.

- Changed some padding to allign the chevron buttons
- Introduced a screen breakpoint to change the font size of the chevron icon (following the redlines)
- Changed the positioning of the divider to fix the gap seen in the screenshot
- Rearranged the imports in the `.doc.tsx` to follow the order of the examples on the page and fixed a wrong code sample

Overall this changes should not count as breaking layout change so I clasified the change as `patch`. If I am treating it the wrong way, let me know and I'll correct the change log.

## Before:
![screen shot 2018-11-26 at 6 10 54 pm](https://user-images.githubusercontent.com/29514833/49055130-599d9000-f1ab-11e8-99a0-dd01c9e5d002.png)

## After: 
![screen shot 2018-11-26 at 6 26 21 pm](https://user-images.githubusercontent.com/29514833/49055137-60c49e00-f1ab-11e8-862b-254b3bc85a62.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7224)

