### PR TITLE
Update ExtendedPeoplePicker component to set the spellCheck and autoC…

### DIFF
--- a/common/changes/office-ui-fabric-react/extended-people-picker-patch_2018-11-27-09-15.json
+++ b/common/changes/office-ui-fabric-react/extended-people-picker-patch_2018-11-27-09-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Modify the ExtendedPeoplePicker so that the input props, spellcheck and autocorrect, are always set to false and off, respectively.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "adameury@outlook.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -180,6 +180,8 @@ class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extends BaseC
   // (undocumented)
   readonly inputElement: HTMLInputElement | null;
   // (undocumented)
+  protected inputProps: () => IInputProps;
+  // (undocumented)
   readonly items: any;
   // (undocumented)
   protected onBackspace: (ev: React.KeyboardEvent<HTMLElement>) => void;
@@ -1149,6 +1151,8 @@ enum ExpandingCardMode {
 
 // @public (undocumented)
 class ExtendedPeoplePicker extends BaseExtendedPeoplePicker {
+  // (undocumented)
+  protected inputProps: () => IInputProps;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -95,7 +95,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
   }
 
   public render(): JSX.Element {
-    const { className, inputProps, disabled, focusZoneProps } = this.props;
+    const { className, disabled, focusZoneProps } = this.props;
     const activeDescendant =
       this.floatingPicker.current && this.floatingPicker.current.currentSelectedSuggestionIndex !== -1
         ? 'sug-' + this.floatingPicker.current.currentSelectedSuggestionIndex
@@ -115,7 +115,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
               {this.renderSelectedItemsList()}
               {this.canAddItems() && (
                 <Autofill
-                  {...inputProps as IInputProps}
+                  {...this.inputProps()}
                   className={css('ms-BasePicker-input', styles.pickerInput)}
                   ref={this.input}
                   onFocus={this.onInputFocus}
@@ -171,6 +171,10 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
       ...this.selectedItemsListProps
     });
   }
+
+  protected inputProps = (): IInputProps => {
+    return this.props.inputProps as IInputProps;
+  };
 
   protected onInputChange = (value: string): void => {
     this.setState({ queryString: value });

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.test.tsx
@@ -1,0 +1,111 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+/* tslint:enable:no-unused-variable */
+import * as renderer from 'react-test-renderer';
+
+import { Autofill } from '../../Autofill/index';
+import { IPersonaProps } from '../../Persona/index';
+import { people } from '../examples/PeopleExampleData';
+import { ExtendedPeoplePicker } from './ExtendedPeoplePicker';
+import { SuggestionsStore, FloatingPeoplePicker, IBaseFloatingPickerProps } from '../../FloatingPicker/index';
+import { ISelectedItemProps, IBaseSelectedItemsListProps, IExtendedPersonaProps, SelectedPeopleList } from '../../SelectedItemsList/index';
+
+function onResolveSuggestions(text: string): IPersonaProps[] {
+  const peopleList: IPersonaProps[] = people;
+  return peopleList.filter(p => p.text && p.text.includes(text));
+}
+
+const floatingPickerProps = {
+  onResolveSuggestions: onResolveSuggestions,
+  suggestionsStore: new SuggestionsStore<IPersonaProps>()
+};
+
+const basicItemRenderer = (props: ISelectedItemProps<IPersonaProps>) => {
+  return <div>{props.item.text}</div>;
+};
+
+const selectedItemsListProps: IBaseSelectedItemsListProps<IPersonaProps> = {
+  onRenderItem: basicItemRenderer
+};
+
+const onRenderFloatingPicker = (props: IBaseFloatingPickerProps<IPersonaProps>): JSX.Element => {
+  return <FloatingPeoplePicker {...props} />;
+};
+
+const onRenderSelectedItems = (props: IBaseSelectedItemsListProps<IExtendedPersonaProps>): JSX.Element => {
+  return <SelectedPeopleList {...props} />;
+};
+
+describe('Pickers', () => {
+  describe('ExtendedPeoplePicker', () => {
+    it('sets the Autofill spellCheck is set to false', () => {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+
+      const pickerRenderer = renderer.create(
+        <ExtendedPeoplePicker
+          floatingPickerProps={floatingPickerProps}
+          selectedItemsListProps={selectedItemsListProps}
+          onRenderFloatingPicker={onRenderFloatingPicker}
+          onRenderSelectedItems={onRenderSelectedItems}
+        />
+      );
+      const pickerInstance = pickerRenderer.root;
+
+      expect(pickerInstance.findByType(Autofill).props.spellCheck).toBe(false);
+    });
+
+    it('sets the Autofill autoCorrect prop to off', () => {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+
+      const pickerRenderer = renderer.create(
+        <ExtendedPeoplePicker
+          floatingPickerProps={floatingPickerProps}
+          selectedItemsListProps={selectedItemsListProps}
+          onRenderFloatingPicker={onRenderFloatingPicker}
+          onRenderSelectedItems={onRenderSelectedItems}
+        />
+      );
+      const pickerInstance = pickerRenderer.root;
+
+      expect(pickerInstance.findByType(Autofill).props.autoCorrect).toBe('off');
+    });
+
+    it('overwrites spellCheck', () => {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+
+      const pickerRenderer = renderer.create(
+        <ExtendedPeoplePicker
+          floatingPickerProps={floatingPickerProps}
+          selectedItemsListProps={selectedItemsListProps}
+          onRenderFloatingPicker={onRenderFloatingPicker}
+          onRenderSelectedItems={onRenderSelectedItems}
+          inputProps={{ spellCheck: true }}
+        />
+      );
+      const pickerInstance = pickerRenderer.root;
+
+      expect(pickerInstance.findByType(Autofill).props.spellCheck).toBe(false);
+    });
+
+    it('overwrites autoCorrect', () => {
+      const root = document.createElement('div');
+      document.body.appendChild(root);
+
+      const pickerRenderer = renderer.create(
+        <ExtendedPeoplePicker
+          floatingPickerProps={floatingPickerProps}
+          selectedItemsListProps={selectedItemsListProps}
+          onRenderFloatingPicker={onRenderFloatingPicker}
+          onRenderSelectedItems={onRenderSelectedItems}
+          inputProps={{ autoCorrect: 'on' }}
+        />
+      );
+      const pickerInstance = pickerRenderer.root;
+
+      expect(pickerInstance.findByType(Autofill).props.autoCorrect).toBe('off');
+    });
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.tsx
@@ -1,5 +1,4 @@
 /* tslint:disable */
-import { assign } from 'office-ui-fabric-react/lib/Utilities';
 import { IPickerItemProps, IInputProps } from '../../../Pickers';
 /* tslint:enable */
 
@@ -8,6 +7,7 @@ import { IPersonaProps } from '../../../Persona';
 import './ExtendedPeoplePicker.scss';
 import { BaseExtendedPicker } from '../BaseExtendedPicker';
 import { IBaseExtendedPickerProps } from '../BaseExtendedPicker.types';
+import { assign } from '@uifabric/utilities';
 
 export interface IPeoplePickerItemProps extends IPickerItemProps<IExtendedPersonaProps> {}
 

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.tsx
@@ -1,5 +1,6 @@
 /* tslint:disable */
-import { IPickerItemProps } from '../../../Pickers';
+import { assign } from 'office-ui-fabric-react/lib/Utilities';
+import { IPickerItemProps, IInputProps } from '../../../Pickers';
 /* tslint:enable */
 
 import { IExtendedPersonaProps } from '../../../SelectedItemsList';
@@ -14,4 +15,12 @@ export interface IExtendedPeoplePickerProps extends IBaseExtendedPickerProps<IPe
 
 export class BaseExtendedPeoplePicker extends BaseExtendedPicker<IPersonaProps, IExtendedPeoplePickerProps> {}
 
-export class ExtendedPeoplePicker extends BaseExtendedPeoplePicker {}
+export class ExtendedPeoplePicker extends BaseExtendedPeoplePicker {
+  protected inputProps = (): IInputProps => {
+    const overwrittenInputProps: IInputProps = {
+      autoCorrect: 'off',
+      spellCheck: false
+    };
+    return assign({}, this.props.inputProps, overwrittenInputProps);
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -55,6 +55,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             onKeyDown={[Function]}
             onPaste={[Function]}
             role="combobox"
+            spellCheck={false}
             value=""
           />
         </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6470 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In order to set `spellCheck` to `false` and `autoCorrect` to `'off'` in the `ExtendedPeoplePicker` component, I'm overriding a new method, named `inputProps`, that I added to `BaseExtendedPicker`. 

Test cases are also included to check that these properties are set and are overwritten when the opposite values are passed in by the user (i.e. `spellCheck: true` and `autoCorrect: 'on'`).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7226)

