### PR TITLE
Add Screener tests for Signals

### DIFF
--- a/apps/vr-tests/src/stories/FolderCover.stories.tsx
+++ b/apps/vr-tests/src/stories/FolderCover.stories.tsx
@@ -2,13 +2,12 @@
 import * as React from 'react';
 import {
   FolderCover,
-  initializeFolderCovers,
   IFolderCoverProps,
   getFolderCoverLayout,
   renderFolderCoverWithLayout,
   SharedSignal
 } from '@uifabric/experiments';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { ISize, fitContentToBounds } from 'office-ui-fabric-react';
 import { FabricDecorator } from '../utilities';

--- a/apps/vr-tests/src/stories/Signals.stories.tsx
+++ b/apps/vr-tests/src/stories/Signals.stories.tsx
@@ -1,0 +1,102 @@
+
+import * as React from 'react';
+import {
+  SharedSignal,
+  SignalField,
+  YouCheckedOutSignal,
+  MalwareDetectedSignal,
+  BlockedSignal,
+  MissingMetadataSignal,
+  WarningSignal,
+  AwaitingApprovalSignal,
+  TrendingSignal,
+  SomeoneCheckedOutSignal,
+  NewSignal,
+  LiveEditSignal,
+  MentionSignal,
+  CommentsSignal,
+  UnseenReplySignal,
+  UnseenEditSignal,
+  EmailedSignal,
+  RecordSignal,
+  ReadOnlySignal
+} from '@uifabric/experiments';
+import Screener from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { FabricDecorator } from '../utilities';
+
+interface ISignalExampleProps {
+  name: string;
+  signal: React.ReactNode;
+}
+
+const SignalExample: React.StatelessComponent<ISignalExampleProps> = (props: ISignalExampleProps): JSX.Element => {
+  return (
+    <div>
+      <SignalField before={props.signal}>{props.name}</SignalField>
+    </div>
+  );
+};
+
+storiesOf('Signals', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+  ))
+  .addStory('You checked out', () => (
+    <SignalExample name="You checked out" signal={<YouCheckedOutSignal />} />
+  ))
+  .addStory('Malware detected', () => (
+    <SignalExample name="Malware detected" signal={<MalwareDetectedSignal />} />
+  ))
+  .addStory('Blocked', () => (
+    <SignalExample name="Blocked" signal={<BlockedSignal />} />
+  ))
+  .addStory('Missing metadata', () => (
+    <SignalExample name="Missing metadata" signal={<MissingMetadataSignal />} />
+  ))
+  .addStory('Warning', () => (
+    <SignalExample name="Warning" signal={<WarningSignal />} />
+  ))
+  .addStory('Awaiting approval', () => (
+    <SignalExample name="Awaiting approval" signal={<AwaitingApprovalSignal />} />
+  ))
+  .addStory('Trending', () => (
+    <SignalExample name="Trending" signal={<TrendingSignal />} />
+  ))
+  .addStory('Someone checked out', () => (
+    <SignalExample name="Someone checked out" signal={<SomeoneCheckedOutSignal />} />
+  ))
+  .addStory('New', () => (
+    <SignalExample name="New" signal={<NewSignal />} />
+  ))
+  .addStory('New (positioning)', () => (
+    <SignalExample name="O" signal={<NewSignal />} />
+  ))
+  .addStory('Mention', () => (
+    <SignalExample name="Mention" signal={<MentionSignal />} />
+  ))
+  .addStory('Comments', () => (
+    <SignalExample name="Comments" signal={<CommentsSignal />} />
+  ))
+  .addStory('Comments (count)', () => (
+    <SignalExample name="Comments" signal={<CommentsSignal>2</CommentsSignal>} />
+  ))
+  .addStory('Unseen reply', () => (
+    <SignalExample name="Unseen reply" signal={<UnseenReplySignal />} />
+  ))
+  .addStory('Unseen edit', () => (
+    <SignalExample name="Unseen edit" signal={<UnseenEditSignal />} />
+  ))
+  .addStory('Emailed', () => (
+    <SignalExample name="Emailed" signal={<EmailedSignal />} />
+  ))
+  .addStory('Record', () => (
+    <SignalExample name="Record" signal={<RecordSignal />} />
+  ))
+  .addStory('Read-only', () => (
+    <SignalExample name="Read-only" signal={<ReadOnlySignal />} />
+  ))
+  .addStory('Shared', () => (
+    <SignalExample name="Shared" signal={<SharedSignal />} />
+  ));


### PR DESCRIPTION
This change adds Screener tests for the various `<___Signal>` components, to prevent regressions in color and alignment as styling behaviors change.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7235)

