### PR TITLE
DatePicker: Invoke optional onBlur prop on TextField blur if provided

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-datepicker-onblur_2018-11-27-22-22.json
+++ b/common/changes/office-ui-fabric-react/keco-datepicker-onblur_2018-11-27-22-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: Invoke optional onBlur prop if provided on TextField blur. Add unit tests for onFocus and onBlur.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -303,6 +303,12 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   };
 
   private _onTextFieldBlur = (ev: React.FocusEvent<HTMLElement>): void => {
+    const { onBlur } = this.props;
+
+    if (onBlur) {
+      onBlur(ev);
+    }
+
     this._validateTextInput();
   };
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -8,6 +8,7 @@ import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { shallow, mount, ReactWrapper } from 'enzyme';
 import { resetIds } from '../../Utilities';
 import { Callout } from '../Callout/Callout';
+import { TextField } from '../TextField/TextField';
 
 describe('DatePicker', () => {
   beforeEach(() => {
@@ -61,6 +62,27 @@ describe('DatePicker', () => {
     const calloutProps = datePicker.find(Callout).props();
 
     expect(calloutProps.ariaLabel).toBe('Calendar');
+  });
+
+  it('should invoke onBlur when TextField is blurred if provided', () => {
+    const onFocus = jest.fn();
+    const wrapper = mount(<DatePickerBase onFocus={onFocus} />);
+    const textFieldEl = wrapper.find(TextField);
+
+    textFieldEl.simulate('focus');
+
+    expect(onFocus).toHaveBeenCalled();
+  });
+
+  it('should invoke onBlur when TextField is blurred if provided', () => {
+    const onBlur = jest.fn();
+    const wrapper = mount(<DatePickerBase onBlur={onBlur} />);
+    const textFieldEl = wrapper.find(TextField);
+
+    textFieldEl.simulate('focus');
+    textFieldEl.simulate('blur');
+
+    expect(onBlur).toHaveBeenCalled();
   });
 
   describe('when Calendar properties are not specified', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes  #7181
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Invokes _optional_ `onBlur` `DatePicker` prop if provided when inner `TextField` is blurred. This is to provide consistency with other components and `DatePicker`'s `onFocus` prop.

#### Focus areas to test

I've added unit test coverage for the following:

- `DatePicker`'s `onFocus` prop testing that it is called when `TextField` gains focus.
- `DatePicker`'s `onBlur` propr testing that it is called when `TextField` loses focus.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7236)

