### PR TITLE
Fix spelling of FocusZoneDirection.bidirectional in FocusZone doc block

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-defaultvalue-focuszone-sp_2018-11-29-01-33.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-defaultvalue-focuszone-sp_2018-11-29-01-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: Fix the spelling of direction prop's default value.",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.types.ts
@@ -41,7 +41,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
 
   /**
    * Defines which arrows to react to.
-   * @defaultvalue FocusZoneDirection.bidriectional
+   * @defaultvalue FocusZoneDirection.bidirectional
    */
   direction?: FocusZoneDirection;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes a minor spelling error with the `@defaultvalue` for `direction` prop in `FocusZone`. Discovered while discussing an open issue with @aftab-hassan. Did not find other occurrences when grepped.

I ran `npm run build && npm run update-api` but it didn't detect any changes to commit.

#### Focus areas to test

None.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7248)

