### PR TITLE
Add prop and return types to component style functions

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-theme-return-types_2018-11-29-09-48.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-theme-return-types_2018-11-29-09-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Add types to all component style functions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Breadcrumb.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Breadcrumb.styles.ts
@@ -1,9 +1,9 @@
-import { IBreadcrumbStyleProps } from 'office-ui-fabric-react/lib/Breadcrumb';
+import { IBreadcrumbStyleProps, IBreadcrumbStyles } from 'office-ui-fabric-react/lib/Breadcrumb';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { FontSizes } from '../FluentType';
 import { MediumScreenSelector, MinimumScreenSelector } from './styleConstants';
 
-export const BreadcrumbStyles = (props: IBreadcrumbStyleProps) => {
+export const BreadcrumbStyles = (props: IBreadcrumbStyleProps): Partial<IBreadcrumbStyles> => {
   const { theme } = props;
   const { palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -1,8 +1,8 @@
-import { ICalloutContentStyleProps } from 'office-ui-fabric-react/lib/Callout';
+import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react/lib/Callout';
 import { Depths } from '../FluentDepths';
 import { fluentBorderRadius } from './styleConstants';
 
-export const CalloutContentStyles = (props: ICalloutContentStyleProps) => {
+export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   return {
     root: {
       borderRadius: fluentBorderRadius,

--- a/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
@@ -2,7 +2,7 @@ import { ICheckboxStyleProps, ICheckboxStyles } from 'office-ui-fabric-react/lib
 import { fluentBorderRadius } from './styleConstants';
 import { NeutralColors } from '../FluentColors';
 
-export const CheckboxStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
+export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxStyles> => {
   const { disabled, checked, theme } = props;
   const { semanticColors, palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/ChoiceGroupOption.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ChoiceGroupOption.styles.ts
@@ -1,7 +1,7 @@
 import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { NeutralColors } from '../FluentColors';
 
-export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOptionStyles => {
+export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Partial<IChoiceGroupOptionStyles> => {
   const { checked, disabled, theme, hasIcon, hasImage } = props;
   const { semanticColors, palette } = theme;
   return {

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -11,7 +11,7 @@ import { NeutralColors } from '../FluentColors';
 import { Depths } from '../FluentDepths';
 import { fluentBorderRadius } from './styleConstants';
 
-export const ColorPickerStyles = (props: IColorPickerStyleProps): IColorPickerStyles => {
+export const ColorPickerStyles = (props: IColorPickerStyleProps): Partial<IColorPickerStyles> => {
   return {
     input: {
       selectors: {
@@ -42,7 +42,7 @@ export const ColorPickerStyles = (props: IColorPickerStyleProps): IColorPickerSt
   };
 };
 
-export const ColorRectangleStyles = (props: IColorRectangleStyleProps): IColorRectangleStyles => {
+export const ColorRectangleStyles = (props: IColorRectangleStyleProps): Partial<IColorRectangleStyles> => {
   const { theme } = props;
   const { palette } = theme;
 
@@ -58,7 +58,7 @@ export const ColorRectangleStyles = (props: IColorRectangleStyleProps): IColorRe
   };
 };
 
-export const ColorSliderStyles = (props: IColorSliderStyleProps): IColorSliderStyles => {
+export const ColorSliderStyles = (props: IColorSliderStyleProps): Partial<IColorSliderStyles> => {
   return {
     root: {
       borderRadius: fluentBorderRadius,

--- a/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
@@ -1,8 +1,8 @@
-import { IColorPickerGridCellStyleProps } from 'office-ui-fabric-react/lib/SwatchColorPicker';
+import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from 'office-ui-fabric-react/lib/SwatchColorPicker';
 import { NeutralColors } from '../FluentColors';
 import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
-export const ColorPickerGridCellStyles = (props: IColorPickerGridCellStyleProps) => {
+export const ColorPickerGridCellStyles = (props: IColorPickerGridCellStyleProps): Partial<IColorPickerGridCellStyles> => {
   const { theme, selected, isWhite, circle, borderWidth } = props;
   const { palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -1,8 +1,9 @@
 import { fluentBorderRadius } from './styleConstants';
 import { Depths } from '../FluentDepths';
 import { NeutralColors, SharedColors } from '../FluentColors';
+import { IComboBoxStyles } from 'office-ui-fabric-react/lib/ComboBox';
 
-export const ComboBoxStyles = {
+export const ComboBoxStyles: Partial<IComboBoxStyles> = {
   root: {
     borderRadius: fluentBorderRadius, // the bound input box
     borderColor: NeutralColors.gray80,

--- a/packages/fluent-theme/src/fluent/styles/CommandBar.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBar.styles.ts
@@ -1,6 +1,6 @@
-import { ICommandBarStyleProps } from 'office-ui-fabric-react/lib/CommandBar';
+import { ICommandBarStyleProps, ICommandBarStyles } from 'office-ui-fabric-react/lib/CommandBar';
 
-export const CommandBarStyles = (props: ICommandBarStyleProps) => {
+export const CommandBarStyles = (props: ICommandBarStyleProps): Partial<ICommandBarStyles> => {
   return {
     root: [
       {

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -1,10 +1,11 @@
 import FluentTheme from '../FluentTheme';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 
 // TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
 //        this 'any' once we upgrade to TS3.1+
 // tslint:disable-next-line:no-any
-export const CommandBarButtonStyles: any = {
+export const CommandBarButtonStyles: Partial<IButtonStyles> = {
   root: {
     ...getFocusStyle(FluentTheme, 2)
   }

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -2,8 +2,9 @@ import { fluentBorderRadius } from './styleConstants';
 import { NeutralColors, CommunicationColors } from '../FluentColors';
 import FluentTheme from '../FluentTheme';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 
-export const CompoundButtonStyles = {
+export const CompoundButtonStyles: Partial<IButtonStyles> = {
   root: {
     ...getFocusStyle(FluentTheme, 2),
     backgroundColor: NeutralColors.white,

--- a/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
@@ -1,10 +1,15 @@
-import { IContextualMenuStyleProps, IContextualMenuItemStyleProps } from 'office-ui-fabric-react/lib/ContextualMenu';
+import {
+  IContextualMenuStyleProps,
+  IContextualMenuStyles,
+  IContextualMenuItemStyleProps,
+  IContextualMenuItemStyles
+} from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 import { fluentBorderRadius, MinimumScreenSelector } from './styleConstants';
 import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';
 
-export const ContextualMenuStyles = (props: IContextualMenuStyleProps) => {
+export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<IContextualMenuStyles> => {
   const { theme } = props;
   const { palette } = theme;
   const CONTEXTUAL_MENU_ITEM_HEIGHT = 36;
@@ -34,7 +39,7 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps) => {
         },
         beakCurtain: { borderRadius: fluentBorderRadius }
       },
-      menuItem: (itemStyleProps: IContextualMenuItemStyleProps) => {
+      menuItem: (itemStyleProps: IContextualMenuItemStyleProps): Partial<IContextualMenuItemStyles> => {
         const { disabled, expanded, primaryDisabled, checked } = itemStyleProps;
 
         return {

--- a/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
@@ -1,8 +1,8 @@
-import { IDatePickerStyleProps } from 'office-ui-fabric-react/lib/DatePicker';
+import { IDatePickerStyleProps, IDatePickerStyles } from 'office-ui-fabric-react/lib/DatePicker';
 import { fluentBorderRadius } from './styleConstants';
 import { Depths } from '../FluentDepths';
 
-export const DatePickerStyles = (props: IDatePickerStyleProps) => {
+export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
   return {
     callout: {
       border: 'none',

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -2,11 +2,12 @@ import { fluentBorderRadius } from './styleConstants';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import FluentTheme from '../FluentTheme';
 import { NeutralColors, CommunicationColors } from '../FluentColors';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 
 // TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
 //        this 'any' once we upgrade to TS3.1+
 // tslint:disable-next-line:no-any
-export const DefaultButtonStyles: any = {
+export const DefaultButtonStyles: Partial<IButtonStyles> = {
   root: {
     borderRadius: fluentBorderRadius,
     backgroundColor: NeutralColors.white,
@@ -30,7 +31,6 @@ export const DefaultButtonStyles: any = {
     backgroundColor: NeutralColors.gray20,
     borderColor: NeutralColors.gray20
   },
-
   splitButtonMenuButton: {
     background: 'transparent',
     borderTopRightRadius: fluentBorderRadius,
@@ -38,13 +38,12 @@ export const DefaultButtonStyles: any = {
     border: `1px solid ${NeutralColors.gray110}`,
     borderLeft: 'none'
   },
-
   splitButtonContainer: {
     selectors: {
       '.ms-Button--default': {
         borderRight: 'none',
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0
+        borderTopRightRadius: '0',
+        borderBottomRightRadius: '0'
       },
       '.ms-Button--primary': {
         border: 'none',

--- a/packages/fluent-theme/src/fluent/styles/DetailsList.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DetailsList.styles.ts
@@ -1,7 +1,7 @@
-import { ICheckStyleProps } from 'office-ui-fabric-react/lib/Check';
-import { IDetailsRowStyleProps } from 'office-ui-fabric-react/lib/DetailsList';
+import { ICheckStyleProps, ICheckStyles } from 'office-ui-fabric-react/lib/Check';
+import { IDetailsRowStyleProps, IDetailsRowStyles } from 'office-ui-fabric-react/lib/DetailsList';
 
-export const CheckStyles = (props: ICheckStyleProps) => {
+export const CheckStyles = (props: ICheckStyleProps): Partial<ICheckStyles> => {
   const { theme, checked } = props;
   const { palette } = theme;
 
@@ -11,7 +11,7 @@ export const CheckStyles = (props: ICheckStyleProps) => {
   };
 };
 
-export const DetailsRowStyles = (props: IDetailsRowStyleProps) => {
+export const DetailsRowStyles = (props: IDetailsRowStyleProps): Partial<IDetailsRowStyles> => {
   const { theme, isSelected } = props;
   const { palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -1,10 +1,15 @@
-import { IDialogContentStyleProps } from 'office-ui-fabric-react/lib/Dialog';
+import {
+  IDialogContentStyleProps,
+  IDialogContentStyles,
+  IDialogFooterStyleProps,
+  IDialogFooterStyles
+} from 'office-ui-fabric-react/lib/Dialog';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 import { FontSizes } from '../FluentType';
 import { fluentBorderRadius } from './styleConstants';
 
-export const DialogContentStyles = (props: IDialogContentStyleProps) => {
+export const DialogContentStyles = (props: IDialogContentStyleProps): Partial<IDialogContentStyles> => {
   const { theme } = props;
   const { palette } = theme;
 
@@ -36,8 +41,10 @@ export const DialogContentStyles = (props: IDialogContentStyleProps) => {
   };
 };
 
-export const DialogFooterStyles = {
-  actions: {
-    margin: '16px 0 0'
-  }
+export const DialogFooterStyles = (props: IDialogFooterStyleProps): Partial<IDialogFooterStyles> => {
+  return {
+    actions: {
+      margin: '16px 0 0'
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -1,10 +1,10 @@
-import { IDropdownStyleProps } from 'office-ui-fabric-react/lib/Dropdown';
+import { IDropdownStyleProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
 import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
 import { fluentBorderRadius } from './styleConstants';
 import { SharedColors, NeutralColors } from '../FluentColors';
 import { Depths } from '../FluentDepths';
 
-export const DropdownStyles = (props: IDropdownStyleProps) => {
+export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownStyles> => {
   const { disabled, hasError, isOpen, calloutRenderEdge, theme, isRenderingPlaceholder } = props;
 
   if (!theme) {

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -1,4 +1,9 @@
-import { IExpandingCardStyleProps, IPlainCardStyleProps } from 'office-ui-fabric-react/lib/HoverCard';
+import {
+  IExpandingCardStyleProps,
+  IExpandingCardStyles,
+  IPlainCardStyleProps,
+  IPlainCardStyles
+} from 'office-ui-fabric-react/lib/HoverCard';
 import { Depths } from '../FluentDepths';
 import { fluentBorderRadius } from './styleConstants';
 
@@ -11,7 +16,7 @@ const commonCardStyles = {
   }
 };
 
-export const ExpandingCardStyles = (props: IExpandingCardStyleProps) => {
+export const ExpandingCardStyles = (props: IExpandingCardStyleProps): Partial<IExpandingCardStyles> => {
   return {
     root: {
       ...commonCardStyles,
@@ -27,7 +32,7 @@ export const ExpandingCardStyles = (props: IExpandingCardStyleProps) => {
   };
 };
 
-export const PlainCardStyles = (props: IPlainCardStyleProps) => {
+export const PlainCardStyles = (props: IPlainCardStyleProps): Partial<IPlainCardStyles> => {
   return {
     root: { ...commonCardStyles }
   };

--- a/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
@@ -1,6 +1,7 @@
 import { CommunicationColors, NeutralColors } from '../FluentColors';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 
-export const IconButtonStyles = {
+export const IconButtonStyles: Partial<IButtonStyles> = {
   root: {
     backgroundColor: NeutralColors.white,
     color: CommunicationColors.primary

--- a/packages/fluent-theme/src/fluent/styles/Label.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Label.styles.ts
@@ -1,7 +1,7 @@
-import { ILabelStyleProps } from 'office-ui-fabric-react/lib/Label';
+import { ILabelStyleProps, ILabelStyles } from 'office-ui-fabric-react/lib/Label';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
-export const LabelStyles = (props: ILabelStyleProps) => {
+export const LabelStyles = (props: ILabelStyleProps): Partial<ILabelStyles> => {
   const { theme, disabled } = props;
   const { palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/Link.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Link.styles.ts
@@ -1,6 +1,6 @@
-import { ILinkStyleProps } from 'office-ui-fabric-react/lib/Link';
+import { ILinkStyleProps, ILinkStyles } from 'office-ui-fabric-react/lib/Link';
 
-export const LinkStyles = (props: ILinkStyleProps) => {
+export const LinkStyles = (props: ILinkStyleProps): Partial<ILinkStyles> => {
   const { isDisabled } = props;
 
   return {

--- a/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
@@ -1,12 +1,10 @@
 import { Depths } from '../FluentDepths';
 import { fluentBorderRadius } from './styleConstants';
-import { IModalStyleProps, IModalStyles } from 'office-ui-fabric-react/lib/Modal';
+import { IModalStyles } from 'office-ui-fabric-react/lib/Modal';
 
-export const ModalStyles = (props: IModalStyleProps): Partial<IModalStyles> => {
-  return {
-    main: {
-      boxShadow: Depths.depth64,
-      borderRadius: fluentBorderRadius
-    }
-  };
+export const ModalStyles: Partial<IModalStyles> = {
+  main: {
+    boxShadow: Depths.depth64,
+    borderRadius: fluentBorderRadius
+  }
 };

--- a/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
@@ -1,9 +1,12 @@
 import { Depths } from '../FluentDepths';
 import { fluentBorderRadius } from './styleConstants';
+import { IModalStyleProps, IModalStyles } from 'office-ui-fabric-react/lib/Modal';
 
-export const ModalStyles = {
-  main: {
-    boxShadow: Depths.depth64,
-    borderRadius: fluentBorderRadius
-  }
+export const ModalStyles = (props: IModalStyleProps): Partial<IModalStyles> => {
+  return {
+    main: {
+      boxShadow: Depths.depth64,
+      borderRadius: fluentBorderRadius
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/Pivot.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Pivot.styles.ts
@@ -1,7 +1,7 @@
-import { IPivotStyleProps } from 'office-ui-fabric-react/lib/Pivot';
+import { IPivotStyleProps, IPivotStyles } from 'office-ui-fabric-react/lib/Pivot';
 import { AnimationVariables } from 'office-ui-fabric-react/lib/Styling';
 
-export const PivotStyles = (props: IPivotStyleProps) => {
+export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
   const { theme, rootIsTabs } = props;
   const { palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
@@ -1,7 +1,8 @@
 import { fluentBorderRadius } from './styleConstants';
 import { CommunicationColors, NeutralColors } from '../FluentColors';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 
-export const PrimaryButtonStyles = {
+export const PrimaryButtonStyles: Partial<IButtonStyles> = {
   root: {
     borderRadius: fluentBorderRadius,
     border: 'none',

--- a/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
@@ -1,7 +1,7 @@
-import { IRatingStyleProps } from 'office-ui-fabric-react/lib/Rating';
+import { IRatingStyleProps, IRatingStyles } from 'office-ui-fabric-react/lib/Rating';
 import { NeutralColors } from '../FluentColors';
 
-export const RatingStyles = (props: IRatingStyleProps) => {
+export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> => {
   const { disabled, readOnly, theme } = props;
   const { semanticColors } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/Slider.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Slider.styles.ts
@@ -1,6 +1,6 @@
-import { ISliderStyleProps } from 'office-ui-fabric-react/lib/Slider';
+import { ISliderStyleProps, ISliderStyles } from 'office-ui-fabric-react/lib/Slider';
 
-export const SliderStyles = (props: ISliderStyleProps) => {
+export const SliderStyles = (props: ISliderStyleProps): Partial<ISliderStyles> => {
   const { disabled, theme } = props;
   const { palette } = theme;
 

--- a/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
@@ -1,5 +1,6 @@
 import { fluentBorderRadius } from './styleConstants';
 import { NeutralColors } from '../FluentColors';
+import { ISpinButtonStyles } from 'office-ui-fabric-react/lib/SpinButton';
 
 const buttonStyles = {
   color: NeutralColors.gray130,
@@ -19,7 +20,7 @@ const buttonStyles = {
   }
 };
 
-export const SpinButtonStyles = {
+export const SpinButtonStyles: Partial<ISpinButtonStyles> = {
   spinButtonWrapper: {
     borderRadius: fluentBorderRadius,
     borderColor: NeutralColors.gray80

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -1,8 +1,8 @@
-import { ITextFieldStyleProps } from 'office-ui-fabric-react/lib/TextField';
+import { ITextFieldStyleProps, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
 import { fluentBorderRadius } from './styleConstants';
 import { NeutralColors, SharedColors } from '../FluentColors';
 
-export const TextFieldStyles = (props: ITextFieldStyleProps) => {
+export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
   const { focused, disabled, hasErrorMessage, multiline, theme } = props;
   const { palette } = theme;
 
@@ -24,7 +24,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps) => {
       hasErrorMessage && [
         {
           borderColor: SharedColors.red10,
-          selector: {
+          selectors: {
             '&:hover': {
               borderColor: SharedColors.red20
             }

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -25,7 +25,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         {
           borderColor: SharedColors.red10,
           selectors: {
-            '&:hover': {
+            '&:focus, &:hover': {
               borderColor: SharedColors.red20
             }
           }

--- a/packages/fluent-theme/src/fluent/styles/Toggle.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Toggle.styles.ts
@@ -1,7 +1,7 @@
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { IToggleProps } from 'office-ui-fabric-react/lib/Toggle';
+import { IToggleStyleProps, IToggleStyles } from 'office-ui-fabric-react/lib/Toggle';
 
-export const ToggleStyles = (props: IToggleProps) => {
+export const ToggleStyles = (props: IToggleStyleProps): Partial<IToggleStyles> => {
   const { disabled, checked, theme } = props;
 
   if (!theme) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds types to the Fluent theme's component styles. Where the styles are produced by a function, the props will use a type like `IComponentStyleProps`. And they all now return an object of type like `IComponentStyles`. Adding these types revealed some minor issues with the styles that I've corrected here, but there should be no visible differences.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7250)

