### PR TITLE
Fluent theme: Add TeachingBubble styles

### DIFF
--- a/apps/fabric-website-resources/src/customizations/customizations.ts
+++ b/apps/fabric-website-resources/src/customizations/customizations.ts
@@ -3,8 +3,8 @@ import { FluentCustomizations } from '@uifabric/fluent-theme';
 import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
-  { title: 'Default', customizations: DefaultCustomizations },
   { title: 'Fluent', customizations: FluentCustomizations },
+  { title: 'Default', customizations: DefaultCustomizations },
   { title: 'Word', customizations: WordCustomizations },
   { title: 'Teams', customizations: TeamsCustomizations }
 ];

--- a/apps/fabric-website-resources/src/customizations/customizations.ts
+++ b/apps/fabric-website-resources/src/customizations/customizations.ts
@@ -3,8 +3,8 @@ import { FluentCustomizations } from '@uifabric/fluent-theme';
 import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
-  { title: 'Fluent', customizations: FluentCustomizations },
   { title: 'Default', customizations: DefaultCustomizations },
+  { title: 'Fluent', customizations: FluentCustomizations },
   { title: 'Word', customizations: WordCustomizations },
   { title: 'Teams', customizations: TeamsCustomizations }
 ];

--- a/common/changes/@uifabric/fluent-theme/fluent-teaching-bubble_2018-11-29-09-58.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-teaching-bubble_2018-11-29-09-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Add styles for TeachingBubble",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -23,6 +23,7 @@ import { PrimaryButtonStyles } from './styles/PrimaryButton.styles';
 import { RatingStyles } from './styles/Rating.styles';
 import { SliderStyles } from './styles/Slider.styles';
 import { SpinButtonStyles } from './styles/SpinButton.styles';
+import { TeachingBubbleStyles } from './styles/TeachingBubble.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
 import { ColorPickerGridCellStyles } from './styles/ColorPickerGridCell.styles';
@@ -125,6 +126,9 @@ export const FluentStyles: any = {
   },
   SpinButton: {
     styles: SpinButtonStyles
+  },
+  TeachingBubble: {
+    styles: TeachingBubbleStyles
   },
   TextField: {
     styles: TextFieldStyles

--- a/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
@@ -1,0 +1,43 @@
+import { Depths } from '../FluentDepths';
+import { FontSizes } from '../FluentType';
+import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react/lib/TeachingBubble';
+
+export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
+  const { hasCondensedHeadline, hasSmallHeadline, theme } = props;
+  const { palette } = theme;
+
+  let headlineSize = FontSizes.size14;
+  if (!hasCondensedHeadline && !hasSmallHeadline) {
+    headlineSize = FontSizes.size20;
+  }
+
+  return {
+    headline: {
+      fontSize: headlineSize,
+      fontWeight: FontWeights.semibold
+    },
+    footer: {
+      selectors: {
+        '.ms-Button:not(:first-child)': {
+          marginLeft: '16px'
+        }
+      }
+    },
+    closeButton: {
+      backgroundColor: 'transparent',
+      selectors: {
+        '&:hover': {
+          color: palette.black
+        }
+      }
+    },
+    subComponentStyles: {
+      callout: {
+        root: {
+          boxShadow: Depths.depth16
+        }
+      }
+    }
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7138
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Adds styles for TeachingBubble to the Fluent theme.

#### Before
![image](https://user-images.githubusercontent.com/1382445/49260586-2abc3e00-f479-11e8-8f9e-acbaa1ac8002.png)
![image](https://user-images.githubusercontent.com/1382445/49260596-3c9de100-f479-11e8-9934-b8c1419a8a4a.png)

#### After
![image](https://user-images.githubusercontent.com/1382445/49260601-445d8580-f479-11e8-8ea5-ea60824d8edf.png)
![image](https://user-images.githubusercontent.com/1382445/49260606-4b849380-f479-11e8-9daf-15ea7bbb84ac.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7251)

