### PR TITLE
DetailsList Example Accessibility Fixes, Bugs 5 & 12

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListA11y_2018-11-29-18-41.json
+++ b/common/changes/office-ui-fabric-react/detailsListA11y_2018-11-29-18-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList Example: fix modal selection and make aria label more descriptive",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -96,7 +96,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         headerClassName: 'DetailsListExample-header--FileIcon',
         className: 'DetailsListExample-cell--FileIcon',
         iconClassName: 'DetailsListExample-Header-FileTypeIcon',
-        ariaLabel: 'Column operations for File type',
+        ariaLabel: 'Column operations for File type, Press to sort on File type',
         iconName: 'Page',
         isIconOnly: true,
         fieldName: 'name',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -229,7 +229,9 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
 
   public componentDidUpdate(previousProps: any, previousState: IDetailsListDocumentsExampleState) {
     if (previousState.isModalSelection !== this.state.isModalSelection) {
-      this._selection.setModal(this.state.isModalSelection);
+      if (this.state.isModalSelection === false) {
+        this._selection.setAllSelected(false);
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -171,8 +171,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
     this._selection = new Selection({
       onSelectionChanged: () => {
         this.setState({
-          selectionDetails: this._getSelectionDetails(),
-          isModalSelection: this._selection.isModal()
+          selectionDetails: this._getSelectionDetails()
         });
       }
     });
@@ -181,13 +180,13 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
       items: _items,
       columns: _columns,
       selectionDetails: this._getSelectionDetails(),
-      isModalSelection: this._selection.isModal(),
+      isModalSelection: false,
       isCompactMode: false
     };
   }
 
   public render() {
-    const { columns, isCompactMode, items, selectionDetails } = this.state;
+    const { columns, isCompactMode, items, selectionDetails, isModalSelection } = this.state;
 
     return (
       <div>
@@ -200,7 +199,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
         />
         <Toggle
           label="Enable Modal Selection"
-          checked={this.state.isModalSelection}
+          checked={isModalSelection}
           onChange={this._onChangeModalSelection}
           onText="Modal"
           offText="Normal"
@@ -212,7 +211,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
             items={items}
             compact={isCompactMode}
             columns={columns}
-            selectionMode={this.state.isModalSelection ? SelectionMode.multiple : SelectionMode.none}
+            selectionMode={isModalSelection ? SelectionMode.multiple : SelectionMode.none}
             setKey="set"
             layoutMode={DetailsListLayoutMode.justified}
             isHeaderVisible={true}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -229,7 +229,7 @@ export class DetailsListDocumentsExample extends React.Component<any, IDetailsLi
 
   public componentDidUpdate(previousProps: any, previousState: IDetailsListDocumentsExampleState) {
     if (previousState.isModalSelection !== this.state.isModalSelection) {
-      if (this.state.isModalSelection === false) {
+      if (!this.state.isModalSelection) {
         this._selection.setAllSelected(false);
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #6646, bugs 5 and 12
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes fix some bugs in the DetailsList Documents Example. A user should now be able to use their keyboard to select multiple rows in the list without the modal selection toggle switching off.

Before:
![detailslistmodalselectionnotworking](https://user-images.githubusercontent.com/14134000/49244472-bd4ed580-f3c4-11e8-969c-8ac3a266a6f7.gif)

After:
![detailslistmodalselectionworking](https://user-images.githubusercontent.com/14134000/49244638-1d457c00-f3c5-11e8-9ee4-3aa88775317d.gif)

The aria label for the File Type column header is now more informative, letting the user know that it can be activated to sort the column on file type. The screen reader will now read out "Column operations for File type, Press to sort on File type".

#### Focus areas to test

Go to the main DetailsList example. Observe the changes.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7256)

