### PR TITLE
DevExp: packages will no longer include the api.json from api extractor to reduce package size

### DIFF
--- a/common/changes/office-ui-fabric-react/ignore_2018-11-29-19-01.json
+++ b/common/changes/office-ui-fabric-react/ignore_2018-11-29-19-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DevExp: packages will no longer include the api.json from api extractor to reduce package size",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/.npmignore
+++ b/packages/office-ui-fabric-react/.npmignore
@@ -28,3 +28,4 @@ tslint.json
 typings
 webpack.config.js
 fabric-test*
+*.api.json


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Relates to #7255
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Addresses one aspect of the large (7mb) npm package of OUFR. Other files should also be included in `.npmignore`, but this is just one file we for sure don't need to publish.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7257)

