### PR TITLE
Add support for Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - '10'
 script:
   - node common/scripts/install-run-rush.js install --bypass-policy
   - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST != "false" ];

--- a/rush.json
+++ b/rush.json
@@ -92,7 +92,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=8.0.0 <10.0.0",
+  "nodeSupportedVersionRange": ">=8.0.0 <9.0.0 || >=10.0.0 <11.0.0",
 
   /**
    * If you would like the version specifiers for your dependencies to be consistent, then


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7184
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Node 10 is now LTS, so we should support it in Fabric. We will also continue to support Node 8 for now.

#### Scripts to test
Checked items work; unchecked items are broken or untested.
- [x] build (also includes basic tests)
- [x] start
- [x] start-exp
- [x] code-style
- [x] bundlesize
- [x] create-component
- [x] create-package
- [x] update-api
- [x] update-snapshots
- [x] check-for-changed-files
- [x] prettier
- [x] generate-version-files
- [x] codepen
- [x] precommit
- [x] (apps/vr-tests) screener
- [x] (apps/vr-tests) screener:local
- [x] (apps/vr-tests) start

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7264)