### PR TITLE
Facepile: Fix overflow button title not rendered in Firefox

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-facepile-overflow-title-ff_2018-11-30-04-39.json
+++ b/common/changes/office-ui-fabric-react/keco-facepile-overflow-title-ff_2018-11-30-04-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Facepile: Fix overflow title not rendered in Firefox.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -5,6 +5,7 @@ import { FacepileButton } from './FacepileButton';
 import { Icon } from '../../Icon';
 import { Persona, IPersonaStyles } from '../../Persona';
 import { PersonaCoin, PersonaSize, PersonaInitialsColor } from '../../PersonaCoin';
+import { IButtonProps } from '../Button/Button.types';
 
 const getClassNames = classNamesFunction<IFacepileStyleProps, IFacepileStyles>();
 
@@ -183,14 +184,13 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
   }
 
   private _getDescriptiveOverflowElement(personasOverflow: IFacepilePersona[]): JSX.Element | null {
-    const { overflowButtonProps, personaSize } = this.props;
-
+    const { personaSize } = this.props;
     if (!personasOverflow || personasOverflow.length < 1) {
       return null;
     }
 
     const personaNames: string = personasOverflow.map((p: IFacepilePersona) => p.personaName).join(', ');
-    const overflowButtonTitle: string | undefined = overflowButtonProps && overflowButtonProps.title;
+    const overflowButtonProps: IButtonProps = { ...{ title: personaNames }, ...this.props.overflowButtonProps };
     const numPersonasNotPictured: number = Math.max(personasOverflow.length, 0);
 
     const { _classNames } = this;
@@ -198,12 +198,10 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     return (
       <FacepileButton
         {...overflowButtonProps}
-        ariaDescription={overflowButtonTitle ? undefined : personaNames}
+        ariaDescription={overflowButtonProps.title}
         className={_classNames.descriptiveOverflowButton}
       >
         <PersonaCoin
-          // Check if a title is being added to the parenting FacepileButton. If so, do not set title on child PersonaCoin
-          title={overflowButtonTitle ? undefined : personaNames}
           size={personaSize}
           onRenderInitials={this._renderInitialsNotPictured(numPersonasNotPictured)}
           initialsColor={PersonaInitialsColor.transparent}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
@@ -82,6 +82,31 @@ describe('Facepile', () => {
     expect(findNodes(wrapper, '.ms-Facepile-itemButton').length).toEqual(6);
   });
 
+  it('renders descriptive overflow button with comma-delimited persona names as title value by default', () => {
+    const personas: IFacepilePersona[] = facepilePersonas.concat(...facepilePersonas, ...facepilePersonas);
+    const maxDisplayablePersonas: number = 5;
+
+    const wrapper = mount(
+      <Facepile
+        personas={personas}
+        maxDisplayablePersonas={maxDisplayablePersonas}
+        overflowButtonProps={{}}
+        overflowButtonType={OverflowButtonType.descriptive}
+      />
+    );
+
+    const overflowPersonasTitle = personas
+      .slice(maxDisplayablePersonas, personas.length)
+      .map((p: IFacepilePersona) => p.personaName)
+      .join(', ');
+
+    expect(
+      findNodes(wrapper, '.ms-Facepile-descriptiveOverflowButton')
+        .getDOMNode()
+        .attributes.getNamedItem('title')
+    ).toHaveProperty('value', overflowPersonasTitle);
+  });
+
   it('renders a descriptive overflow button with a custom title', () => {
     const personas: IFacepilePersona[] = facepilePersonas.concat(...facepilePersonas, ...facepilePersonas);
     const title: string = 'custom title';
@@ -89,13 +114,15 @@ describe('Facepile', () => {
       <Facepile
         personas={personas}
         maxDisplayablePersonas={5}
-        overflowButtonProps={{title}}
+        overflowButtonProps={{ title }}
         overflowButtonType={OverflowButtonType.descriptive}
       />
     );
     expect(
-      findNodes(wrapper, '.ms-Facepile-descriptiveOverflowButton').getDOMNode().attributes.getNamedItem('title')
-      ).toHaveProperty('value', title);
+      findNodes(wrapper, '.ms-Facepile-descriptiveOverflowButton')
+        .getDOMNode()
+        .attributes.getNamedItem('title')
+    ).toHaveProperty('value', title);
   });
 
   it('renders no more than maximum allowed personas', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7246
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As mentioned in the above linked issue, certain browsers namely Firefox, do not respect attributes of interactive DOM nodes nested within a `<button>` [[w3 spec](https://dev.w3.org/html5/spec-LC/the-button-element.html#the-button-element)]. A symptom of this is that the `Facepile` component's overflow button `title` is not _currently_ rendered on `:hover` in Firefox unlike Edge and Chrome. This was discovered while reviewing #7220.

To fix this, I've simply hoisted the `title` to the component which renders a `button`. As a result of this move, I've consolidated the `overflowButtonProps` logic.

The `ariaDescription` value change is irrelevant as `aria-description` **is not** a valid ARIA attribute. I have a follow up task to address that across OUFR at a later date.

#### Focus areas to test

1. Open Firefox.
1. Navigate to the "Facepile with overflow buttons" example using the deploy link or local dev server.
1. Choose "Descriptive" overflow button from the drop-down.
1. Hover your moues over the Facepile overflow button.
1. The stringified comma-delimited persona names should render in the native browser title.
1. Compare with `master` / https://developer.microsoft.com/en-us/fabric#/components/facepile in Firefox and other browser.

cc: @tabrumle

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7265)

