### PR TITLE
DetailsList Drag & Drop Example: Enable drag & drop by default

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-invert-dnd-example-initial-state_2018-11-30-19-43.json
+++ b/common/changes/office-ui-fabric-react/keco-invert-dnd-example-initial-state_2018-11-30-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList Example: Drag & Drop example should have the feature enabled by default.",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -45,7 +45,7 @@ export class DetailsListDragDropExample extends React.Component<
     this.state = {
       items: createListItems(10),
       columns: _columns,
-      isColumnReorderEnabled: false,
+      isColumnReorderEnabled: true,
       frozenColumnCountFromStart: '1',
       frozenColumnCountFromEnd: '0'
     };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Enables the drag & drop feature by default in the DetailsList Drag & Drop Example. The assumption is that folks visiting that example will be expect to use the drag & drop feature without having to toggle it ON.

#### Focus areas to test

DetailsList Drag & Drop example should allow for column reordering on initial render without the need to toggle.

cc: @arkogupta 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7271)

