### PR TITLE
Fix for FocusZone: bidirectional has an unexpected behavior for up down arrows - Issue 7247

### DIFF
--- a/common/changes/office-ui-fabric-react/FocusZoneIssue7247_2018-11-30-22-11.json
+++ b/common/changes/office-ui-fabric-react/FocusZoneIssue7247_2018-11-30-22-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: bidirectional has an unexpected behavior for up down arrows",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -517,7 +517,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
     const activeRect = isBidirectional ? element.getBoundingClientRect() : null;
 
-    let elementDistanceDisabled = -1;
+    let elementDistanceToBreak = -1;
     do {
       element = (isForward ? getNextElement(this._root.current, element) : getPreviousElement(this._root.current, element)) as HTMLElement;
 
@@ -526,7 +526,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           const targetRect = element.getBoundingClientRect();
           const elementDistance = getDistanceFromCenter(activeRect as ClientRect, targetRect);
 
-          elementDistanceDisabled = elementDistance;
+          elementDistanceToBreak = elementDistance;
           if (elementDistance === -1 && candidateDistance === -1) {
             candidateElement = element;
             break;
@@ -546,7 +546,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         break;
       }
     } while (element);
-    if (elementDistanceDisabled === LARGE_DISTANCE_FROM_CENTER) {
+    if (elementDistanceToBreak === LARGE_DISTANCE_FROM_CENTER) {
       return false;
     }
 

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -517,6 +517,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
     const activeRect = isBidirectional ? element.getBoundingClientRect() : null;
 
+    let elementDistanceDisabled = -1;
     do {
       element = (isForward ? getNextElement(this._root.current, element) : getPreviousElement(this._root.current, element)) as HTMLElement;
 
@@ -525,6 +526,7 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
           const targetRect = element.getBoundingClientRect();
           const elementDistance = getDistanceFromCenter(activeRect as ClientRect, targetRect);
 
+          elementDistanceDisabled = elementDistance;
           if (elementDistance === -1 && candidateDistance === -1) {
             candidateElement = element;
             break;
@@ -544,6 +546,9 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
         break;
       }
     } while (element);
+    if (elementDistanceDisabled === LARGE_DISTANCE_FROM_CENTER) {
+      return false;
+    }
 
     // Focus the closest candidate
     if (candidateElement && candidateElement !== this._activeElement) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7247 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The fix is to check if the distance of the element from the center is a large value, LARGE_DISTANCE_FROM_CENTER, signifying no element to move to 

#### Focus areas to test
Set focus on the top most tile and hit up arrow, nothing should happen as there are no rows above it.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7277)

