### PR TITLE
Only support LTS versions of Node 8 and 10

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -92,7 +92,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=8.0.0 <9.0.0 || >=10.0.0 <11.0.0",
+  "nodeSupportedVersionRange": ">=8.9.0 <9.0.0 || >=10.9.0 <11.0.0",
 
   /**
    * If you would like the version specifiers for your dependencies to be consistent, then


### PR DESCRIPTION
In response to [this conversation](https://github.com/OfficeDev/office-ui-fabric-react/pull/7264#discussion_r237729788), only support actual LTS versions of Node 8 and 10. Node 8 became LTS at 8.9.0, and Node 10 became LTS at 10.9.0. We could potentially also limit to even more recent versions.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7290)

