### PR TITLE
Add customizer scope to TeachingBubbleContent

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-TeachingBubleContent_2018-12-04-02-57.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-TeachingBubleContent_2018-12-04-02-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TeachingBubble: add customizer scope to TeachingBubbleContent to allow using it individually.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.ts
@@ -5,5 +5,7 @@ import { getStyles } from './TeachingBubble.styles';
 
 export const TeachingBubbleContent = styled<ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles>(
   TeachingBubbleContentBase,
-  getStyles
+  getStyles,
+  undefined,
+  { scope: 'TeachingBubbleContent' }
 );


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`
Adding a customizer scope to `TeachingBubbleContent` to allow pass some fluent styles through `Customizer`. This issue surfaced when testing `Coachmark` component example which is using it in its own Callout resulting in a broken fluent style for `Coachmark`
![screen shot 2018-12-03 at 6 54 34 pm](https://user-images.githubusercontent.com/29514833/49415934-16a06700-f72d-11e8-8b04-96cd8a7cb8cc.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7294)

