### PR TITLE
default spellCheck=false in BasePicker

### DIFF
--- a/common/changes/office-ui-fabric-react/huaxi-no-spellcheck-in-picker_2018-12-04-22-21.json
+++ b/common/changes/office-ui-fabric-react/huaxi-no-spellcheck-in-picker_2018-12-04-22-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "spellCheck defaults to false in BasePicker",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "huaxi@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -53,6 +53,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
             onInput={[Function]}
             onKeyDown={[Function]}
             role="combobox"
+            spellCheck={false}
             value=""
           />
         </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -208,6 +208,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             onInput={[Function]}
             onKeyDown={[Function]}
             role="combobox"
+            spellCheck={false}
             value=""
           />
         </div>
@@ -268,6 +269,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             onInput={[Function]}
             onKeyDown={[Function]}
             role="combobox"
+            spellCheck={false}
             value=""
           />
         </div>

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -224,6 +224,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
                   aria-owns={suggestionsAvailable || undefined}
                   aria-autocomplete={'both'}
                   onInputChange={this.props.onInputChange}
+                  spellCheck={false}
                 />
               )}
             </div>

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -205,6 +205,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
               </span>
               {this.canAddItems() && (
                 <Autofill
+                  spellCheck={false}
                   {...inputProps as any}
                   className={css('ms-BasePicker-input', styles.pickerInput, inputProps && inputProps.className)}
                   ref={this.input}
@@ -224,7 +225,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
                   aria-owns={suggestionsAvailable || undefined}
                   aria-autocomplete={'both'}
                   onInputChange={this.props.onInputChange}
-                  spellCheck={false}
                 />
               )}
             </div>

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
           onInput={[Function]}
           onKeyDown={[Function]}
           role="combobox"
+          spellCheck={false}
           value=""
         />
       </div>
@@ -112,6 +113,7 @@ exports[`Pickers BasePicker renders BasePicker with inputProps supply classnames
           onKeyDown={[Function]}
           placeholder="Bitte einen Benutzer angeben..."
           role="combobox"
+          spellCheck={false}
           value=""
         />
       </div>
@@ -171,6 +173,7 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
           onInput={[Function]}
           onKeyDown={[Function]}
           role="combobox"
+          spellCheck={false}
           value=""
         />
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6470
- [X] Include a change request file using `$ npm run change`

#### Description of changes

No autocorrect pops up when typing in Safari browser.

#### Focus areas to test

(optional)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7301)

