### PR TITLE
Fix #7258 - Documentation is missing for button

### DIFF
--- a/common/changes/@uifabric/example-app-base/IButtonProps-docx_2018-12-05-00-06.json
+++ b/common/changes/@uifabric/example-app-base/IButtonProps-docx_2018-12-05-00-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Fix for issue#7258:Documentation is missing for button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/parser/Parse.ts
+++ b/packages/example-app-base/src/utilities/parser/Parse.ts
@@ -32,7 +32,7 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
   const escapedSource = source.replace(/\\(?!\\)/g, '');
 
   if (propsInterfaceOrEnumName) {
-    regex = new RegExp(`^export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'm');
+    regex = new RegExp(`^export (interface|(?:const )?enum) ${propsInterfaceOrEnumName}(?:\\s*extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'm');
     let regexResult = regex.exec(escapedSource);
     if (regexResult && regexResult.length > 0) {
       parseInfo = _parseEnumOrInterface(regexResult);
@@ -46,7 +46,7 @@ export function parse(source: string, propsInterfaceOrEnumName?: string): IPrope
       ];
     }
   } else {
-    regex = new RegExp(`^export (interface|(?:const )?enum) (\\S*?)(?: extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'gm');
+    regex = new RegExp(`^export (interface|(?:const )?enum) (\\S*?)(?:\\s*extends .*?)? \\{( |.*[\\r\\n]*)*?\\}`, 'gm');
     let regexResult: RegExpExecArray | null;
     let results: Array<IProperty> = [];
     while ((regexResult = regex.exec(escapedSource)) !== null) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7258 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The Regex in Parse.ts, which parses types.ts files to generate documentation does not parse an interface correctly, if it is spread across multiple lines (if code formatting lines split them into multiple lines). The fix was to edit the regular expression to allow such scenarios. 

#### Focus areas to test
Look at the documentation in /examples/button. Documentation for interface IButtonProps now gets generated.
Screenshot here : https://snag.gy/KEruVd.jpg

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7302)

