### PR TITLE
add bundle-size-collect script for size-auditor

### DIFF
--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "node ../../scripts/build.js && node ../../scripts/bundle-size-collect.js",
+    "build": "node ../../scripts/build.js",
     "clean": "node ../../scripts/clean.js",
     "code-style": "node ../../scripts/code-style.js",
     "start": "node ../../scripts/start.js"

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js && node ../../scripts/bundle-size-collect.js",
     "clean": "node ../../scripts/clean.js",
     "code-style": "node ../../scripts/code-style.js",
     "start": "node ../../scripts/start.js"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rush-update": "node common/scripts/install-run-rush.js update",
     "generate": "npm run rush-update",
     "bundlesize": "cd scripts && npm run bundlesize",
+    "bundlesizecollect": "node scripts/bundle-size-collect.js",
     "create-component": "node scripts/create-component.js",
     "create-package": "node scripts/create-package.js",
     "checkchange": "node common/scripts/install-run-rush.js change -v",

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -1,6 +1,6 @@
 // This script collates bundle size information from
 // minified files in apps/test-bundles/dist and writes to
-// dist/bundlesizes.json.
+// apps/test-bundles/dist/bundlesizes.json.
 // It is uploaded as an artifact by the build definition in
 // Azure Dev Ops and used to compare baseline and PR file size
 // information which gets reported by Size Auditor

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -1,0 +1,37 @@
+// This script collates bundle size information from
+// minified files in apps/test-bundles/dist and writes to
+// dist/bundlesizes.json.
+// It is uploaded as an artifact by the build definition in
+// Azure Dev Ops and used to compare baseline and PR file size
+// information which gets reported by Size Auditor
+
+var fs = require('fs');
+
+var path = 'dist';
+var sizes = {};
+var outputFilePath = 'dist/bundlesizes.json';
+
+fs.readdir(path, function(err, items) {
+  for (var i = 0; i < items.length; i++) {
+    var file = path + '/' + items[i];
+
+    const isMinifiedJavascriptFile = items[i].match(/.min.js$/);
+    if (isMinifiedJavascriptFile) {
+      var fileName = getComponentName(items[i]);
+      var fileSize = getFilesizeInBytes(file);
+      sizes[fileName] = fileSize;
+    }
+  }
+
+  fs.writeFileSync(outputFilePath, JSON.stringify({ sizes }));
+});
+
+function getFilesizeInBytes(fileName) {
+  const stats = fs.statSync(fileName);
+  const fileSizeInBytes = stats.size;
+  return fileSizeInBytes;
+}
+
+function getComponentName(fileName) {
+  return fileName.match('office-ui-fabric-react-(.*).min.js')[1];
+}

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -5,31 +5,27 @@
 // Azure Dev Ops and used to compare baseline and PR file size
 // information which gets reported by Size Auditor
 
-var fs = require('fs');
+const fs = require('fs');
+const path = require('path');
 
-var path = 'dist';
-var sizes = {};
-var outputFilePath = 'dist/bundlesizes.json';
+const distRoot = 'dist';
+const sizes = {};
+const outputFilename = 'bundlesizes.json';
 
-fs.readdir(path, function(err, items) {
-  for (var i = 0; i < items.length; i++) {
-    var file = path + '/' + items[i];
+var items = fs.readdirSync(distRoot);
+items.forEach(item => {
+  const file = path.join(distRoot, item);
 
-    const isMinifiedJavascriptFile = items[i].match(/.min.js$/);
-    if (isMinifiedJavascriptFile) {
-      var fileName = getComponentName(items[i]);
-      var fileSize = getFilesizeInBytes(file);
-      sizes[fileName] = fileSize;
-    }
+  const isMinifiedJavascriptFile = item.match(/.min.js$/);
+  if (isMinifiedJavascriptFile) {
+    sizes[getComponentName(item)] = getFilesizeInBytes(file);
   }
-
-  fs.writeFileSync(outputFilePath, JSON.stringify({ sizes }));
 });
 
+fs.writeFileSync(path.join(distRoot, outputFilename), JSON.stringify({ sizes }));
+
 function getFilesizeInBytes(fileName) {
-  const stats = fs.statSync(fileName);
-  const fileSizeInBytes = stats.size;
-  return fileSizeInBytes;
+  return fs.statSync(fileName).size;
 }
 
 function getComponentName(fileName) {

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -8,7 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const distRoot = 'dist';
+const distRoot = 'apps/test-bundles/dist';
 const sizes = {};
 const outputFilename = 'bundlesizes.json';
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
This script collates bundle size information from minified files in apps/test-bundles/dist and writes to apps/test-bundles/dist/bundlesizes.json. It is uploaded as an artifact by the build definition in Azure Dev Ops and used to compare baseline and PR file size information which gets reported by Size Auditor

#### Focus areas to test
Verify that upon doing rush build, the apps/test-bundles/dist folder contains a file named bundlesizes.json

Sample format:
`{"sizes":{"ActivityItem":159361,"Autofill":67988,"Breadcrumb":236355}}`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7311)

