### PR TITLE
Dropdown aria labelledby - items wrapper

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-aria-labelledby_2018-12-06-18-47.json
+++ b/common/changes/office-ui-fabric-react/dropdown-aria-labelledby_2018-12-06-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: remove aria-labelledby from items wrapper div if no label property is provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -444,7 +444,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
 
   /** Render List of items */
   private _onRenderList = (props: IDropdownProps): JSX.Element => {
-    const { onRenderItem = this._onRenderItem } = this.props;
+    const { onRenderItem = this._onRenderItem, label } = this.props;
 
     const id = this._id;
 
@@ -461,7 +461,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
           direction={FocusZoneDirection.vertical}
           id={id + '-list'}
           className={this._classNames.dropdownItems}
-          aria-labelledby={id + '-label'}
+          aria-labelledby={label ? id + '-label' : undefined}
           role="listbox"
         >
           {this.props.options.map((item: any, index: number) => onRenderItem({ ...item, index }, this._onRenderItem))}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7305 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

#6555 removed the `aria-labelledy` attribute from the root Dropdown div if no `label` property is provided. This adds the same fix to the dropdownItemsWrapper div.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7317)

