### PR TITLE
Reverts #7064, fixing the searchbox focus for all browsers, but reverts the fix for IE

### DIFF
--- a/common/changes/office-ui-fabric-react/revert_2018-12-06-22-57.json
+++ b/common/changes/office-ui-fabric-react/revert_2018-12-06-22-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Searchbox: Reverts the focus fix for IE since it broke focus for other browsers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -142,7 +142,7 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
   }
 
   private _onClickFocus = () => {
-    const inputElement = this._inputElement.current;
+    const inputElement = this._inputElement.value;
     if (inputElement) {
       this.focus();
       inputElement.selectionStart = inputElement.selectionEnd = 0;
@@ -150,18 +150,9 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
   };
 
   private _onFocusCapture = (ev: React.FocusEvent<HTMLElement>) => {
-    this.setState(
-      {
-        hasFocus: true
-      },
-      () => {
-        // IE doesn't capture the onClickFocus, so we will focus here
-        const inputElement = this._inputElement.current;
-        if (inputElement && document.activeElement !== inputElement) {
-          this.focus();
-        }
-      }
-    );
+    this.setState({
+      hasFocus: true
+    });
 
     this._events.on(ev.currentTarget, 'blur', this._onBlur, true);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7291
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In my pervious fix, I added a focus call in the "onfocuscapture" handler, but it ended up causing issues because the "focus" call was called asynchronously. This causes some instability in how focus is called for all browsers in searchbox. I'm simply reverting it - a more comprehensive control refactor is probably needed to truly fix this.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7319)

