### PR TITLE
Fix imports in FluentTheme to point to specific path in @uifabric/styling

### DIFF
--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@uifabric/merge-styles": ">=6.15.0 <7.0.0",
     "@uifabric/set-version": ">=1.1.3 <2.0.0",
+    "@uifabric/styling": ">=6.38.0 <7.0.0",
     "@uifabric/variants": ">=6.14.0 <7.0.0",
     "office-ui-fabric-react": ">=6.111.0 <7.0.0",
     "tslib": "^1.7.1"

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,4 +1,5 @@
-import { createTheme, ITheme } from 'office-ui-fabric-react';
+import { createTheme } from '@uifabric/styling/lib/styles/theme';
+import { ITheme } from '@uifabric/styling/lib/interfaces/ITheme';
 import { NeutralColors, CommunicationColors } from './FluentColors';
 
 export const FluentTheme: ITheme = createTheme({


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Using FluentTheme causes a bloat in bundle size because it's currently importing createTheme and ITheme from OUFR's index rather than a specific location.

Adds dependency to `@uifabric/styling` to fluent-theme package.  Fixes paths for createTheme and ITheme to point to specific paths.

#### Focus areas to test

(optional)
