### PR TITLE
Check: center the check icon within the circle when in RTL

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-CheckAlignment_2018-12-06-23-41.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-CheckAlignment_2018-12-06-23-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Check: fixing alignment of the check inside the circle when in RTL.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.styles.ts
@@ -1,5 +1,6 @@
 import { ICheckStyleProps, ICheckStyles } from './Check.types';
 import { HighContrastSelector, IStyle, getGlobalClassNames } from '../../Styling';
+import { getRTL } from '../../Utilities';
 
 const GlobalClassNames = {
   root: 'ms-Check',
@@ -11,6 +12,7 @@ export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
   const { checkBoxHeight = '18px', checked, className, theme } = props;
 
   const { palette, semanticColors } = theme;
+  const isRTL = getRTL();
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -107,7 +109,7 @@ export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
         opacity: 0,
         color: palette.neutralTertiaryAlt,
         fontSize: '16px',
-        left: '.5px',
+        left: isRTL ? '-0.5px' : '.5px', // for centering the check icon inside the circle.
 
         selectors: {
           ':hover': {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes a bug brought up to attention in #7281
- [X] Include a change request file using `$ npm run change`

#### Description of changes
This is a temporary fix for the bug noticed in #7281 by @natalieethell (Thanks for noticing). A future fix will be by replacing the used glyphs to construct the `Check` by something other ones which will not require hacks as `0.5px` which might not work correctly in some browsers which are not supporting sub-pixel rendering and decide to round up vs down this value. (Plus it looks ugly 😄 )

#### Focus areas to test
Go to Deploy demo link and navigate to DetailsList. Switch to RTL and check a row.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7321)

