### PR TITLE
@uifabric/variants: Add image file types to .npmignore to avoid shipping unnecessary images

### DIFF
--- a/common/changes/@uifabric/variants/keco-npmignore-images_2018-12-06-23-46.json
+++ b/common/changes/@uifabric/variants/keco-npmignore-images_2018-12-06-23-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/variants",
+      "comment": "Add image file types to .npmignore.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "keco@microsoft.com"
+}

--- a/packages/variants/.npmignore
+++ b/packages/variants/.npmignore
@@ -20,3 +20,6 @@ tsd.json
 tslint.json
 typings
 webpack.config.js
+*.png
+*.jpg
+*.bmp


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Part of #7255, which aims to reduce the size of our NPM packages by removing unnecessary bits.

I discovered while working with @aftab-hassan that we have a few unnecessary image files which we currently ship downstream. See https://unpkg.com/@uifabric/variants@6.14.0/example.png.

Here are the images across this repo, listed using the following PowerShell command,

`dir -Recurse -include *png,*jpg,*bmp`.

```shell
Directory: ~\office-ui-fabric-react\ghdocs\img


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        12/6/2018   3:41 PM          24759 outlook-350-150.png
-a----        12/6/2018   3:41 PM           7933 VS_rgb_Purple.png
-a----        12/6/2018   3:41 PM          16404 yammer.png


Directory: ~\office-ui-fabric-react\packages\dashboard\public\images


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        12/6/2018   3:41 PM        1846117 download.jpg
-a----        12/6/2018   3:41 PM           5397 facepile.png
-a----        12/6/2018   3:41 PM          11279 facepile2.png


Directory: ~\office-ui-fabric-react\packages\dashboard\src\images


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        12/6/2018   3:41 PM        1846117 download.jpg


Directory: ~\office-ui-fabric-react\packages\variants


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        12/6/2018   3:41 PM          35309 example.png
```

The images within `@uifabric/dashboard` are currently used in example code and therefore _I don't think_ can be safely ignored without code changes. cc: @Raghurk

The image I'm removing from `@uifabric/variants` is only used for the Github hosted README and therefore can safely be removed IMO. At a glance, it looks to be _the largest file_ shipped in `@uifabric/variants` 😄.

#### Focus areas to test

Here are the following steps I used to test:

1. Run `npm pack` within the "variants" package path to simulate NPM's tarball packaging.
1. Extract the tarball.
1. Using PowerShell, run `dir -Recurse -include *png,*jpg,*bmp` to recursively list image files within the unpacked tarball (what an end-user or machine would have on their machine after `npm install`).

**Output**

```shell
\package> dir -Recurse -include *png,*jpg,*bmp | measure


Count    : 0
Average  :
Sum      :
Maximum  :
Minimum  :
Property :
```

@kenotron, if you think this rule should be applied across other packages within this repo just say the word.

🌎 🐟 🤖 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7322)

