### PR TITLE
Dropdown: `defaultSelectedKey`/`defaultSelectedKeys` is no longer ignored if the Dropdown options changes.

### DIFF
--- a/common/changes/office-ui-fabric-react/issue7315_2018-12-07-04-55.json
+++ b/common/changes/office-ui-fabric-react/issue7315_2018-12-07-04-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: `defaultSelectedKey`/`defaultSelectedKeys` is no longer ignored if the Dropdown options changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -115,7 +115,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
     // defaultSelectedKey/defaultSelectedKeys are respected.
     const didOptionsChange = newProps.options !== this.props.options;
 
-    if (this.props.multiSelect) {
+    if (newProps.multiSelect) {
       if (didOptionsChange && newProps.defaultSelectedKeys !== undefined) {
         selectedKeyProp = 'defaultSelectedKeys';
       } else {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -111,14 +111,18 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
     // state if the key or options change.
     let selectedKeyProp: 'defaultSelectedKeys' | 'selectedKeys' | 'defaultSelectedKey' | 'selectedKey';
 
+    // this does a shallow compare (assumes options are pure), for the purposes of determining whether
+    // defaultSelectedKey/defaultSelectedKeys are respected.
+    const didOptionsChange = newProps.options !== this.props.options;
+
     if (this.props.multiSelect) {
-      if (newProps.defaultSelectedKeys !== undefined && newProps.options !== this.props.options) {
+      if (didOptionsChange && newProps.defaultSelectedKeys !== undefined) {
         selectedKeyProp = 'defaultSelectedKeys';
       } else {
         selectedKeyProp = 'selectedKeys';
       }
     } else {
-      if (newProps.defaultSelectedKey !== undefined && newProps.options !== this.props.options) {
+      if (didOptionsChange && newProps.defaultSelectedKey !== undefined) {
         selectedKeyProp = 'defaultSelectedKey';
       } else {
         selectedKeyProp = 'selectedKey';

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -109,7 +109,22 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
   public componentWillReceiveProps(newProps: IDropdownProps): void {
     // In controlled component usage where selectedKey is provided, update the selectedIndex
     // state if the key or options change.
-    const selectedKeyProp: keyof IDropdownProps = this.props.multiSelect ? 'selectedKeys' : 'selectedKey';
+    let selectedKeyProp: 'defaultSelectedKeys' | 'selectedKeys' | 'defaultSelectedKey' | 'selectedKey';
+
+    if (this.props.multiSelect) {
+      if (newProps.defaultSelectedKeys !== undefined && newProps.options !== this.props.options) {
+        selectedKeyProp = 'defaultSelectedKeys';
+      } else {
+        selectedKeyProp = 'selectedKeys';
+      }
+    } else {
+      if (newProps.defaultSelectedKey !== undefined && newProps.options !== this.props.options) {
+        selectedKeyProp = 'defaultSelectedKey';
+      } else {
+        selectedKeyProp = 'selectedKey';
+      }
+    }
+
     if (
       newProps[selectedKeyProp] !== undefined &&
       (newProps[selectedKeyProp] !== this.props[selectedKeyProp] || newProps.options !== this.props.options)

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -129,10 +129,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
       }
     }
 
-    if (
-      newProps[selectedKeyProp] !== undefined &&
-      (newProps[selectedKeyProp] !== this.props[selectedKeyProp] || newProps.options !== this.props.options)
-    ) {
+    if (newProps[selectedKeyProp] !== undefined && (newProps[selectedKeyProp] !== this.props[selectedKeyProp] || didOptionsChange)) {
       this.setState({
         selectedIndices: this._getSelectedIndexes(newProps.options, newProps[selectedKeyProp])
       });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -631,4 +631,57 @@ describe('Dropdown', () => {
       expect(dropdownRoot.attributes.getNamedItem('aria-labelledby')).not.toBeNull();
     });
   });
+
+  describe('with changing props', () => {
+    /** See https://github.com/OfficeDev/office-ui-fabric-react/issues/7315 */
+    class DropdownWithChangingProps extends React.Component<{ multi: boolean }, { options?: IDropdownOption[] }> {
+      public state = {
+        options: undefined
+      };
+
+      public componentDidMount() {
+        this.loadOptions();
+      }
+
+      public render() {
+        return (
+          <div className="docs-DropdownExample">
+            {this.props.multi ? (
+              <Dropdown label="Basic uncontrolled example:" defaultSelectedKeys={['B', 'D']} options={this.state.options!} multiSelect />
+            ) : (
+              <Dropdown label="Basic uncontrolled example:" defaultSelectedKey={'B'} options={this.state.options!} />
+            )}
+          </div>
+        );
+      }
+
+      public loadOptions() {
+        this.setState({
+          options: [
+            { key: 'A', text: 'Option a', title: 'I am option a.' },
+            { key: 'B', text: 'Option b' },
+            { key: 'C', text: 'Option c', disabled: true },
+            { key: 'D', text: 'Option d' },
+            { key: 'E', text: 'Option e' }
+          ]
+        });
+      }
+    }
+
+    it('defaultSelectedKey value is respected if Dropdown options change for single-select Dropdown.', () => {
+      const container = document.createElement('div');
+      ReactDOM.render(<DropdownWithChangingProps multi={false} />, container);
+      const dropdownOptionText = container.querySelector('.ms-Dropdown-title>span') as HTMLSpanElement;
+
+      expect(dropdownOptionText.innerHTML).toBe('Option b');
+    });
+
+    it('defaultSelectedKeys value is respected if Dropdown options change for multi-select Dropdown.', () => {
+      const container = document.createElement('div');
+      ReactDOM.render(<DropdownWithChangingProps multi={true} />, container);
+      const dropdownOptionText = container.querySelector('.ms-Dropdown-title>span') as HTMLSpanElement;
+
+      expect(dropdownOptionText.innerHTML).toBe('Option b, Option d');
+    });
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -632,7 +632,7 @@ describe('Dropdown', () => {
     });
   });
 
-  describe('with changing props', () => {
+  describe('with simulated async loaded options', () => {
     /** See https://github.com/OfficeDev/office-ui-fabric-react/issues/7315 */
     class DropdownWithChangingProps extends React.Component<{ multi: boolean }, { options?: IDropdownOption[] }> {
       public state = {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -26,7 +26,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   placeHolder?: string;
 
   /**
-   * Options for the dropdown.
+   * Options for the dropdown. It is recommended to treat this as pure for performance reasons.
    */
   options: IDropdownOption[];
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7315 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Dropdown: `defaultSelectedKey`/`defaultSelectedKeys` is no longer ignored if the Dropdown options changes.

This fixes #7315 while preserving the existing behavior asserted by unit tests added by @MLoughry where changing `defaultSelectedKey` prop should not have an impact. 

An alternative might have been to always use the `defaultSelectedKey(s)` value during the initial mount, and reevaluate it against the current set of options on each render, but I think this would have been terrible from a usability POV.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7326)

