### PR TITLE
Fix for Issue7225 : Clicking outside a Panel when Panel and Dialog are both open

### DIFF
--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "node ../../scripts/build.js",
+    "build": "node ../../scripts/build.js && node ../../scripts/bundle-size-collect.js",
     "clean": "node ../../scripts/clean.js",
     "code-style": "node ../../scripts/code-style.js",
     "start": "node ../../scripts/start.js"

--- a/common/changes/office-ui-fabric-react/PanelOuterClick7225_2018-12-07-07-51.json
+++ b/common/changes/office-ui-fabric-react/PanelOuterClick7225_2018-12-07-07-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix for Clicking outside Panel when Panel and Dialog are both opened: Issue7225",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -327,8 +327,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
         if (this.props.onOuterClick) {
           this.props.onOuterClick();
           ev.preventDefault();
-        } else {
-          this.dismiss();
         }
       }
     }

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -1,6 +1,6 @@
 // This script collates bundle size information from
 // minified files in apps/test-bundles/dist and writes to
-// dist/bundlesizes.json.
+// apps/test-bundles/dist/bundlesizes.json.
 // It is uploaded as an artifact by the build definition in
 // Azure Dev Ops and used to compare baseline and PR file size
 // information which gets reported by Size Auditor

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -1,0 +1,37 @@
+// This script collates bundle size information from
+// minified files in apps/test-bundles/dist and writes to
+// dist/bundlesizes.json.
+// It is uploaded as an artifact by the build definition in
+// Azure Dev Ops and used to compare baseline and PR file size
+// information which gets reported by Size Auditor
+
+var fs = require('fs');
+
+var path = 'dist';
+var sizes = {};
+var outputFilePath = 'dist/bundlesizes.json';
+
+fs.readdir(path, function(err, items) {
+  for (var i = 0; i < items.length; i++) {
+    var file = path + '/' + items[i];
+
+    const isMinifiedJavascriptFile = items[i].match(/.min.js$/);
+    if (isMinifiedJavascriptFile) {
+      var fileName = getComponentName(items[i]);
+      var fileSize = getFilesizeInBytes(file);
+      sizes[fileName] = fileSize;
+    }
+  }
+
+  fs.writeFileSync(outputFilePath, JSON.stringify({ sizes }));
+});
+
+function getFilesizeInBytes(fileName) {
+  const stats = fs.statSync(fileName);
+  const fileSizeInBytes = stats.size;
+  return fileSizeInBytes;
+}
+
+function getComponentName(fileName) {
+  return fileName.match('office-ui-fabric-react-(.*).min.js')[1];
+}

--- a/scripts/bundle-size-collect.js
+++ b/scripts/bundle-size-collect.js
@@ -5,31 +5,27 @@
 // Azure Dev Ops and used to compare baseline and PR file size
 // information which gets reported by Size Auditor
 
-var fs = require('fs');
+const fs = require('fs');
+const path = require('path');
 
-var path = 'dist';
-var sizes = {};
-var outputFilePath = 'dist/bundlesizes.json';
+const distRoot = 'dist';
+const sizes = {};
+const outputFilename = 'bundlesizes.json';
 
-fs.readdir(path, function(err, items) {
-  for (var i = 0; i < items.length; i++) {
-    var file = path + '/' + items[i];
+var items = fs.readdirSync(distRoot);
+items.forEach(item => {
+  const file = path.join(distRoot, item);
 
-    const isMinifiedJavascriptFile = items[i].match(/.min.js$/);
-    if (isMinifiedJavascriptFile) {
-      var fileName = getComponentName(items[i]);
-      var fileSize = getFilesizeInBytes(file);
-      sizes[fileName] = fileSize;
-    }
+  const isMinifiedJavascriptFile = item.match(/.min.js$/);
+  if (isMinifiedJavascriptFile) {
+    sizes[getComponentName(item)] = getFilesizeInBytes(file);
   }
-
-  fs.writeFileSync(outputFilePath, JSON.stringify({ sizes }));
 });
 
+fs.writeFileSync(path.join(distRoot, outputFilename), JSON.stringify({ sizes }));
+
 function getFilesizeInBytes(fileName) {
-  const stats = fs.statSync(fileName);
-  const fileSizeInBytes = stats.size;
-  return fileSizeInBytes;
+  return fs.statSync(fileName).size;
 }
 
 function getComponentName(fileName) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7225 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Modified the condition to disallow closing the panel if the click is outside and onOuterClick is not defined.

#### Focus areas to test

- Click Open Panel button
- Panel opens.
- Click Open Confirm button.
- Click some where outside the Panel & Dialog area.
- Panel should not close automatically.
- Dialog remains open.

[Here](https://drive.google.com/file/d/1UxWWCVHCxIKJlzhyzVCSIPF_oiRQX-yD/view) is a screen recording of the fix.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7331)

