### PR TITLE
Fix for Issue7225 : Clicking outside a Panel when Panel and Dialog are both open

### DIFF
--- a/common/changes/office-ui-fabric-react/Panel-Dialog-7225_2018-12-07-08-52.json
+++ b/common/changes/office-ui-fabric-react/Panel-Dialog-7225_2018-12-07-08-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "'Fix for Issue7225 : Clicking outside a Panel when Panel and Dialog are both open",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -327,8 +327,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
         if (this.props.onOuterClick) {
           this.props.onOuterClick();
           ev.preventDefault();
-        } else {
-          this.dismiss();
         }
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7225 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Modified the condition to disallow closing the panel if the click is outside and onOuterClick is not defined.

#### Focus areas to test

- Click Open Panel button
- Panel opens.
- Click Open Confirm button.
- Click some where outside the Panel & Dialog area.
- Panel should not close automatically.
- Dialog remains open.

[Here](https://drive.google.com/file/d/1BhJBp6bg9vzrOJ2bqjEqSpKi4h2u5PAi/view) is the original behavior prior to the fix

[Here](https://drive.google.com/file/d/1UxWWCVHCxIKJlzhyzVCSIPF_oiRQX-yD/view) is a screen recording of the fix.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7332)
