### PR TITLE
Allow passing arguments to start-test

### DIFF
--- a/scripts/start-test.js
+++ b/scripts/start-test.js
@@ -1,3 +1,8 @@
 require('./tasks/jest')({
-  'args': '--watch -i'
-});;
+  args: '--watch -i',
+  coverage: isCoverageOptionPassed()
+});
+
+function isCoverageOptionPassed() {
+  return process.argv.indexOf('--coverage') >= 0;
+}

--- a/scripts/start-test.js
+++ b/scripts/start-test.js
@@ -1,8 +1,5 @@
-require('./tasks/jest')({
-  args: '--watch -i',
-  coverage: isCoverageOptionPassed()
-});
+const customArgs = process && process.argv ? process.argv.slice(2).join(' ') : '';
 
-function isCoverageOptionPassed() {
-  return process.argv.indexOf('--coverage') >= 0;
-}
+require('./tasks/jest')({
+  args: `--watch -i ${customArgs}`
+});

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -8,7 +8,6 @@ module.exports = function(options) {
 
   if (fs.existsSync(jestConfigPath)) {
     const jestPath = resolve.sync('jest/bin/jest');
-    const customArgs = options && options.argv ? options.argv.slice(3).join(' ') : '';
 
     const args = [
       // Specify the config file.

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -25,7 +25,7 @@ module.exports = function(options) {
       process.env.TRAVIS ? `--runInBand` : undefined,
 
       // In production builds, produce coverage information.
-      (options.isProduction || process.env.TRAVIS) && '--coverage',
+      (options.isProduction || process.env.TRAVIS || options.coverage) && '--coverage',
 
       // If the -u flag is passed, pass it through.
       options.argv && options.argv.indexOf('-u') >= 0 ? '-u' : '',

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -24,7 +24,7 @@ module.exports = function(options) {
       process.env.TRAVIS ? `--runInBand` : undefined,
 
       // In production builds, produce coverage information.
-      (options.isProduction || process.env.TRAVIS || options.coverage) && '--coverage',
+      (options.isProduction || process.env.TRAVIS) && '--coverage',
 
       // If the -u flag is passed, pass it through.
       options.argv && options.argv.indexOf('-u') >= 0 ? '-u' : '',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR enables you to pass options through to jest when running start test.

For example to generate coverage when running tests in watch mode:
`npm run start-test -- --coverage`

#### Focus areas to test

(optional)
