### PR TITLE
Made dropHintElement to not take up space when not visible

### DIFF
--- a/common/changes/office-ui-fabric-react/arkgupta-dragDropScrollBarFix_2018-12-10-10-32.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-dragDropScrollBarFix_2018-12-10-10-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "DetailsList: changed drop hint diplay to none to not occupy any space",
+      "comment": "DetailsList: changed drop hint display to none to not occupy any space",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/arkgupta-dragDropScrollBarFix_2018-12-10-10-32.json
+++ b/common/changes/office-ui-fabric-react/arkgupta-dragDropScrollBarFix_2018-12-10-10-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: changed drop hint diplay to none to not occupy any space",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "arkgupta@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -410,14 +410,14 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
 
   private _resetDropHints(): void {
     if (this._currentDropHintIndex >= 0) {
-      this._updateDropHintElement(this._dropHintDetails[this._currentDropHintIndex].dropHintElementRef, 'hidden');
+      this._updateDropHintElement(this._dropHintDetails[this._currentDropHintIndex].dropHintElementRef, 'none');
       this._currentDropHintIndex = Number.MIN_SAFE_INTEGER;
     }
   }
 
-  private _updateDropHintElement(element: HTMLElement, property: string) {
-    (element.childNodes[1] as HTMLElement).style.visibility = property;
-    (element.childNodes[0] as HTMLElement).style.visibility = property;
+  private _updateDropHintElement(element: HTMLElement, displayProperty: string) {
+    (element.childNodes[1] as HTMLElement).style.display = displayProperty;
+    (element.childNodes[0] as HTMLElement).style.display = displayProperty;
   }
 
   private _getDropHintPositions = (): void => {
@@ -554,7 +554,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
         }
       } else if (currentDropHintIndex !== indexToUpdate && indexToUpdate >= 0) {
         this._resetDropHints();
-        this._updateDropHintElement(this._dropHintDetails[indexToUpdate].dropHintElementRef, 'visible');
+        this._updateDropHintElement(this._dropHintDetails[indexToUpdate].dropHintElementRef, 'inline-block');
         this._currentDropHintIndex = indexToUpdate;
       }
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -300,8 +300,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
     dropHintCaretStyle: [
       classNames.dropHintCaretStyle,
       {
-        display: 'inline-block',
-        visibility: 'hidden',
+        display: 'none',
         position: 'absolute',
         top: 22,
         left: -7.5,
@@ -315,8 +314,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
     dropHintLineStyle: [
       classNames.dropHintLineStyle,
       {
-        display: 'inline-block',
-        visibility: 'hidden',
+        display: 'none',
         position: 'absolute',
         bottom: 0,
         top: -3,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -510,7 +510,8 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(1);
     let dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     let dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: visible;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
 
     // dragover b/w b&c and c&d -> dead zone b/w 370 and 810
     _RaiseEvent(detailsColSourceC, _DRAGOVER, 400);
@@ -525,10 +526,12 @@ describe('DetailsHeader', () => {
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
     expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual(null);
 
     dropHintElement = component.find('#columnDropHint_3').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
     expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual(null);
 
     // dragover e
     _RaiseEvent(detailsColTargetE, _DRAGOVER, 811);
@@ -536,7 +539,8 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(4);
     dropHintElement = component.find('#columnDropHint_4').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: visible;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
 
     // raise dragend on column c
     _RaiseEvent(detailsColSourceC, _DRAGEND, 490);
@@ -544,7 +548,8 @@ describe('DetailsHeader', () => {
     // drop hint should be hidden on doing a dragend
     dropHintElement = component.find('#columnDropHint_4').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: hidden;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: none;');
 
     // do a mousedown and dragstart on source column c
     _RaiseEvent(detailsColSourceC, _MOUSEDOWN, 490);
@@ -556,7 +561,11 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(5);
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: visible;');
+    console.log(dropHintElementChildren.item(0).getAttribute('style'));
+    console.log(dropHintElementChildren.item(1).getAttribute('style'));
+
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
 
     // dragover outside f's zone (frozen) -> should get last valid drop hint
     _RaiseEvent(detailsColTargetF, _DRAGOVER, 1169);
@@ -564,7 +573,8 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(5);
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: visible;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
   });
 
   it('should set source and target index correctly on drop', () => {
@@ -616,7 +626,8 @@ describe('DetailsHeader', () => {
 
     let dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     let dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: visible;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
 
     _RaiseEvent(detailsColTarget, _DROP, 160);
     expect(_sourceIndex).toBe(4);
@@ -624,7 +635,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: hidden;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: none;');
 
     // try moving column c after frozen column f (abcdef -> abdecf)
     let detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
@@ -641,7 +653,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: visible;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
 
     _RaiseEvent(detailsColTarget, _DROP, 1169);
     expect(_sourceIndex).toBe(2);
@@ -649,7 +662,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('visibility: hidden;');
+    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: none;');
 
     // source and target column are the same
     detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
@@ -665,6 +679,7 @@ describe('DetailsHeader', () => {
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
     expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual(null);
 
     // drop on source column itself -> drophintindex should not be set and hence target index not updated
     _RaiseEvent(detailsColTarget, _DROP, 500);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -561,8 +561,6 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(5);
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    console.log(dropHintElementChildren.item(0).getAttribute('style'));
-    console.log(dropHintElementChildren.item(1).getAttribute('style'));
 
     expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
     expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6394
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The dropHints were taking up space when they were not visible because of the `visibility` property set to `'hidden'`. It has been changed to have `display` property set to `none`. Now the drop hints are not taking up space when not visible and hence the horizontal scroll bar isn't visible. It's visible only if the right most drop hint is rendered.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7346)

