### PR TITLE
Pickers: convert to CSS-in-JS Part 1

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-PickersPart_1_2018-12-11-03-21.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-PickersPart_1_2018-12-11-03-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pickers: Convert TagPicker and PeoplePicker to use CSS-in-JS. Support SASS styling for custom pickers extended from BasePicker. Fix tests not using componentRef to access component methods. Cleanup TagPicker example page.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -328,7 +328,7 @@ class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<P, IBas
   // (undocumented)
   protected getActiveDescendant(): string | undefined;
   // (undocumented)
-  protected getSuggestionsAlert(): JSX.Element | undefined;
+  protected getSuggestionsAlert(suggestionAlertClassName?: string): JSX.Element | undefined;
   // (undocumented)
   protected input: {
     (component: IAutofill | null): void;
@@ -699,7 +699,7 @@ class CommandBarButton extends BaseComponent<IButtonProps, {}> {
 }
 
 // @public
-class CompactPeoplePicker extends BasePeoplePicker {
+class CompactPeoplePickerBase extends BasePeoplePicker {
   // WARNING: The type "IPeoplePickerItemProps" needs to be exported by the package (e.g. added to index.ts)
   // (undocumented)
   static defaultProps: {
@@ -775,7 +775,7 @@ export function createArray<T>(size: number, getItem: (index: number) => T): T[]
 export function createFontStyles(localeCode: string | null): IFontStyles;
 
 // @public (undocumented)
-export function createGenericItem(name: string, currentValidationState: ValidationState, allowPhoneInitials: boolean): IGenericItem & {
+export function createGenericItem(name: string, currentValidationState: ValidationState, allowPhoneInitials?: boolean): IGenericItem & {
     key: React.Key;
 };
 
@@ -1930,7 +1930,6 @@ interface IBasePicker<T> {
 // @public (undocumented)
 interface IBasePickerProps<T> extends React.Props<any> {
   className?: string;
-  // (undocumented)
   componentRef?: IRefObject<IBasePicker<T>>;
   createGenericItem?: (input: string, ValidationState: ValidationState) => ISuggestionModel<T> | T;
   defaultSelectedItems?: T[];
@@ -1960,6 +1959,8 @@ interface IBasePickerProps<T> extends React.Props<any> {
           input: string;
       }) => string) | string;
   selectedItems?: T[];
+  styles?: IStyleFunctionOrObject<IBasePickerStyleProps, IBasePickerStyles>;
+  theme?: ITheme;
 }
 
 // @public (undocumented)
@@ -1984,6 +1985,20 @@ interface IBasePickerState {
   suggestionsLoading?: boolean;
   // (undocumented)
   suggestionsVisible?: boolean;
+}
+
+// @public
+interface IBasePickerStyles {
+  // (undocumented)
+  input: IStyle;
+  // (undocumented)
+  itemsWrapper: IStyle;
+  // (undocumented)
+  root: IStyle;
+  // (undocumented)
+  screenReaderText: IStyle;
+  // (undocumented)
+  text: IStyle;
 }
 
 // @public (undocumented)
@@ -11091,7 +11106,7 @@ class List extends BaseComponent<IListProps, IListState>, implements IList {
 }
 
 // @public
-class ListPeoplePicker extends MemberListPeoplePicker {
+class ListPeoplePickerBase extends MemberListPeoplePicker {
   // WARNING: The type "IPeoplePickerItemProps" needs to be exported by the package (e.g. added to index.ts)
   // (undocumented)
   static defaultProps: {
@@ -11228,7 +11243,7 @@ class NavBase extends BaseComponent<INavProps, INavState>, implements INav {
 }
 
 // @public
-class NormalPeoplePicker extends BasePeoplePicker {
+class NormalPeoplePickerBase extends BasePeoplePicker {
   // WARNING: The type "IPeoplePickerItemProps" needs to be exported by the package (e.g. added to index.ts)
   // (undocumented)
   static defaultProps: {
@@ -12278,9 +12293,9 @@ class SwatchColorPickerBase extends BaseComponent<ISwatchColorPickerProps, ISwat
 }
 
 // @public (undocumented)
-class TagPicker extends BasePicker<ITag, ITagPickerProps> {
+class TagPickerBase extends BasePicker<ITag, ITagPickerProps> {
   // (undocumented)
-  protected static defaultProps: {
+  static defaultProps: {
     onRenderItem: (props: ITagItemProps) => JSX.Element;
     onRenderSuggestionsItem: (props: ITag) => JSX.Element;
   }
@@ -12594,6 +12609,11 @@ module ZIndexes {
 // WARNING: Unsupported export: sizeToPixels
 // WARNING: Unsupported export: presenceBoolean
 // WARNING: Unsupported export: IPickerAriaIds
+// WARNING: Unsupported export: IBasePickerStyleProps
+// WARNING: Unsupported export: NormalPeoplePicker
+// WARNING: Unsupported export: CompactPeoplePicker
+// WARNING: Unsupported export: ListPeoplePicker
+// WARNING: Unsupported export: TagPicker
 // WARNING: Unsupported export: TagItem
 // WARNING: Unsupported export: Pivot
 // WARNING: Unsupported export: IPivotStyleProps

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -775,7 +775,7 @@ export function createArray<T>(size: number, getItem: (index: number) => T): T[]
 export function createFontStyles(localeCode: string | null): IFontStyles;
 
 // @public (undocumented)
-export function createGenericItem(name: string, currentValidationState: ValidationState, allowPhoneInitials?: boolean): IGenericItem & {
+export function createGenericItem(name: string, currentValidationState: ValidationState): IGenericItem & {
     key: React.Key;
 };
 
@@ -1989,15 +1989,10 @@ interface IBasePickerState {
 
 // @public
 interface IBasePickerStyles {
-  // (undocumented)
   input: IStyle;
-  // (undocumented)
   itemsWrapper: IStyle;
-  // (undocumented)
   root: IStyle;
-  // (undocumented)
   screenReaderText: IStyle;
-  // (undocumented)
   text: IStyle;
 }
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -3,7 +3,10 @@
 exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-BasePicker ms-PeoplePicker"
+    className=
+        ms-BasePicker
+        ms-PeoplePicker
+
     onKeyDown={[Function]}
   >
     <div
@@ -27,9 +30,28 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         role="presentation"
       >
         <div
-          className="ms-BasePicker-text"
+          className=
+              ms-BasePicker-text
+              {
+                align-items: center;
+                border: 1px solid #a6a6a6;
+                box-sizing: border-box;
+                display: flex;
+                flex-wrap: wrap;
+                min-height: 30px;
+                min-width: 180px;
+              }
+              &:hover {
+                border-color: #333333;
+              }
         >
           <span
+            className=
+                ms-BasePicker-itemsWrapper
+                {
+                  display: flex;
+                  flex-wrap: wrap;
+                }
             id="selected-items-id__0"
             role="list"
           />
@@ -42,7 +64,19 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
             aria-label="People Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  align-self: flex-end;
+                  border: none;
+                  flex-grow: 1;
+                  height: 34px;
+                  outline: none;
+                  padding-bottom: 0;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 0;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -157,7 +157,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   </button>
   Filter items in suggestions: This picker will filter added items from the search suggestions.
   <div
-    className="ms-BasePicker"
+    className=
+        ms-BasePicker
+
     onKeyDown={[Function]}
   >
     <div
@@ -181,9 +183,28 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         role="presentation"
       >
         <div
-          className="ms-BasePicker-text"
+          className=
+              ms-BasePicker-text
+              {
+                align-items: center;
+                border: 1px solid #a6a6a6;
+                box-sizing: border-box;
+                display: flex;
+                flex-wrap: wrap;
+                min-height: 30px;
+                min-width: 180px;
+              }
+              &:hover {
+                border-color: #333333;
+              }
         >
           <span
+            className=
+                ms-BasePicker-itemsWrapper
+                {
+                  display: flex;
+                  flex-wrap: wrap;
+                }
             id="selected-items-id__1"
             role="list"
           />
@@ -196,7 +217,19 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             aria-label="Tag Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  align-self: flex-end;
+                  border: none;
+                  flex-grow: 1;
+                  height: 34px;
+                  outline: none;
+                  padding-bottom: 0;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 0;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}
@@ -218,7 +251,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   <br />
   Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
   <div
-    className="ms-BasePicker"
+    className=
+        ms-BasePicker
+
     onKeyDown={[Function]}
   >
     <div
@@ -242,9 +277,28 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         role="presentation"
       >
         <div
-          className="ms-BasePicker-text"
+          className=
+              ms-BasePicker-text
+              {
+                align-items: center;
+                border: 1px solid #a6a6a6;
+                box-sizing: border-box;
+                display: flex;
+                flex-wrap: wrap;
+                min-height: 30px;
+                min-width: 180px;
+              }
+              &:hover {
+                border-color: #333333;
+              }
         >
           <span
+            className=
+                ms-BasePicker-itemsWrapper
+                {
+                  display: flex;
+                  flex-wrap: wrap;
+                }
             id="selected-items-id__3"
             role="list"
           />
@@ -257,7 +311,19 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             aria-label="Tag Picker"
             autoCapitalize="off"
             autoComplete="off"
-            className="ms-BasePicker-input"
+            className=
+                ms-BasePicker-input
+                {
+                  align-self: flex-end;
+                  border: none;
+                  flex-grow: 1;
+                  height: 34px;
+                  outline: none;
+                  padding-bottom: 0;
+                  padding-left: 6px;
+                  padding-right: 6px;
+                  padding-top: 0;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -5,7 +5,7 @@ const GlobalClassNames = {
   root: 'ms-BasePicker',
   text: 'ms-BasePicker-text',
   itemsWrapper: 'ms-BasePicker-itemsWrapper',
-  input: 'ms-BasePicker-itemsWrapper'
+  input: 'ms-BasePicker-input'
 };
 
 export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
@@ -14,14 +14,54 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
   if (!theme) {
     throw new Error('theme is undefined or null in base BasePicker getStyles function.');
   }
+  const { semanticColors } = theme;
+  const { inputBorder, inputBorderHovered, inputFocusBorderAlt } = semanticColors;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
     root: [classNames.root, className],
-    text: [classNames.text, {}],
-    itemsWrapper: [classNames.itemsWrapper, {}],
-    input: [classNames.input, {}, inputClassName],
+    text: [
+      classNames.text,
+      {
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        boxSizing: 'border-box',
+        minWidth: 180,
+        minHeight: 30,
+        border: `1px solid ${inputBorder}`
+      },
+      !isFocused && {
+        selectors: {
+          ':hover': {
+            borderColor: inputBorderHovered
+          }
+        }
+      },
+      isFocused && {
+        borderColor: inputFocusBorderAlt
+      }
+    ],
+    itemsWrapper: [
+      classNames.itemsWrapper,
+      {
+        display: 'flex',
+        flexWrap: 'wrap'
+      }
+    ],
+    input: [
+      classNames.input,
+      {
+        height: 34,
+        border: 'none',
+        flexGrow: 1,
+        outline: 'none',
+        padding: '0 6px 0',
+        alignSelf: 'flex-end'
+      },
+      inputClassName
+    ],
     screenReaderText: hiddenContentStyle
   };
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -1,0 +1,27 @@
+import { getGlobalClassNames, hiddenContentStyle } from '../../Styling';
+import { IBasePickerStyleProps, IBasePickerStyles } from './BasePicker.types';
+
+const GlobalClassNames = {
+  root: 'ms-BasePicker',
+  text: 'ms-BasePicker-text',
+  itemsWrapper: 'ms-BasePicker-itemsWrapper',
+  input: 'ms-BasePicker-itemsWrapper'
+};
+
+export function getStyles<TItem>(props: IBasePickerStyleProps<TItem>): IBasePickerStyles {
+  const { className, theme, isFocused, inputClassName } = props;
+
+  if (!theme) {
+    throw new Error('theme is undefined or null in base BasePicker getStyles function.');
+  }
+
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  return {
+    root: [classNames.root, className],
+    text: [classNames.text, {}],
+    itemsWrapper: [classNames.itemsWrapper, {}],
+    input: [classNames.input, {}, inputClassName],
+    screenReaderText: hiddenContentStyle
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -8,7 +8,7 @@ const GlobalClassNames = {
   input: 'ms-BasePicker-itemsWrapper'
 };
 
-export function getStyles<TItem>(props: IBasePickerStyleProps<TItem>): IBasePickerStyles {
+export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
   const { className, theme, isFocused, inputClassName } = props;
 
   if (!theme) {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -33,7 +33,12 @@ function onResolveSuggestions(text: string): ITag[] {
     .map(item => ({ key: item, name: item }));
 }
 
-const basicRenderer = (props: IPickerItemProps<{ key: string; name: string }>) => {
+export interface ISimple {
+  key: string;
+  name: string;
+}
+
+const basicRenderer = (props: IPickerItemProps<ISimple>) => {
   return <div> {props.item.name} </div>;
 };
 
@@ -41,22 +46,13 @@ const basicSuggestionRenderer = (props: ISimple) => {
   return <div> {props.name} </div>;
 };
 
-export interface ISimple {
-  key: string;
-  name: string;
-}
-
-export type TypedBasePicker = BasePicker<ISimple, IBasePickerProps<ISimple>>;
-
 describe('Pickers', () => {
   describe('BasePicker', () => {
     beforeEach(() => {
       resetIds();
     });
     const BasePickerWithType = BasePicker as new (props: IBasePickerProps<ISimple>) => BasePicker<ISimple, IBasePickerProps<ISimple>>;
-    const onRenderItem = (props: IPickerItemProps<{ key: string; name: string }>): JSX.Element => (
-      <div key={props.item.name}>{basicRenderer(props)}</div>
-    );
+    const onRenderItem = (props: IPickerItemProps<ISimple>): JSX.Element => <div key={props.item.name}>{basicRenderer(props)}</div>;
 
     it('renders BasePicker correctly', () => {
       const component = renderer.create(

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -5,8 +5,8 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 /* tslint:enable:no-unused-variable */
 import * as renderer from 'react-test-renderer';
 
-import { TagPickerBase, ITag } from './TagPicker/TagPicker';
-import { IBasePickerProps } from './BasePicker.types';
+import { TagPicker, ITag } from './TagPicker/TagPicker';
+import { IBasePickerProps, IBasePicker } from './BasePicker.types';
 import { BasePicker } from './BasePicker';
 import { IPickerItemProps } from './PickerItem.types';
 import { resetIds } from '@uifabric/utilities';
@@ -90,30 +90,34 @@ describe('Pickers', () => {
     it('can provide custom renderers', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      const picker: TypedBasePicker = ReactDOM.render(
+
+      const picker = React.createRef<IBasePicker<ISimple>>();
+
+      ReactDOM.render(
         <BasePickerWithType
           onResolveSuggestions={onResolveSuggestions}
           onRenderItem={onRenderItem}
           onRenderSuggestionsItem={basicSuggestionRenderer}
+          componentRef={picker}
         />,
         root
-      ) as TypedBasePicker;
+      );
+
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       input.focus();
       input.value = 'bl';
-
       ReactTestUtils.Simulate.input(input);
 
       const suggestions = document.querySelector('.ms-Suggestions') as HTMLInputElement;
-
       expect(suggestions).toBeDefined();
-      const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
 
+      const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
       expect(suggestionOptions.length).toEqual(2);
       ReactTestUtils.Simulate.click(suggestionOptions[0]);
 
-      expect(picker.items.length).toEqual(1);
-      expect(picker.items[0].name).toEqual('black');
+      const currentPicker = picker.current!.items;
+      expect(currentPicker).toHaveLength(1);
+      expect(currentPicker![0].name).toEqual('black');
 
       ReactDOM.unmountComponentAtNode(root);
     });
@@ -121,15 +125,20 @@ describe('Pickers', () => {
     it('can will not render input when items reach itemLimit', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      const picker: TypedBasePicker = ReactDOM.render(
+
+      const picker = React.createRef<IBasePicker<ISimple>>();
+
+      ReactDOM.render(
         <BasePickerWithType
           onResolveSuggestions={onResolveSuggestions}
           onRenderItem={onRenderItem}
           onRenderSuggestionsItem={basicSuggestionRenderer}
           itemLimit={1}
+          componentRef={picker}
         />,
         root
-      ) as TypedBasePicker;
+      );
+
       let input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       input.focus();
       input.value = 'bl';
@@ -137,7 +146,10 @@ describe('Pickers', () => {
 
       const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
       ReactTestUtils.Simulate.click(suggestionOptions[0]);
-      expect(picker.items.length).toEqual(1);
+
+      const currentPicker = picker.current!.items;
+      expect(currentPicker).toHaveLength(1);
+
       input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       expect(input).toBeNull();
 
@@ -147,6 +159,7 @@ describe('Pickers', () => {
     it('will still render with itemLimit set to 0', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
+
       ReactDOM.render(
         <BasePickerWithType
           onResolveSuggestions={onResolveSuggestions}
@@ -155,7 +168,7 @@ describe('Pickers', () => {
           itemLimit={0}
         />,
         root
-      ) as TypedBasePicker;
+      );
 
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       expect(input).toBeNull();
@@ -166,20 +179,26 @@ describe('Pickers', () => {
     it('can be set with selectedItems and a lower itemLimit', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      const picker: TypedBasePicker = ReactDOM.render(
+
+      const picker = React.createRef<IBasePicker<ISimple>>();
+
+      ReactDOM.render(
         <BasePickerWithType
           selectedItems={[{ key: '1', name: 'blue' }, { key: '2', name: 'black' }]}
           onResolveSuggestions={onResolveSuggestions}
           onRenderItem={onRenderItem}
           onRenderSuggestionsItem={basicSuggestionRenderer}
           itemLimit={0}
+          componentRef={picker}
         />,
         root
-      ) as TypedBasePicker;
+      );
 
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       expect(input).toBeNull();
-      expect(picker.items.length).toEqual(2);
+
+      const currentPicker = picker.current!.items;
+      expect(currentPicker).toHaveLength(2);
 
       ReactDOM.unmountComponentAtNode(root);
     });
@@ -188,24 +207,31 @@ describe('Pickers', () => {
       const root = document.createElement('div');
       const resolveSuggestions = () => onResolveSuggestions('');
       document.body.appendChild(root);
-      const picker: TypedBasePicker = ReactDOM.render(
+
+      const picker = React.createRef<IBasePicker<ISimple>>();
+
+      ReactDOM.render(
         <BasePickerWithType
           onResolveSuggestions={onResolveSuggestions}
           onEmptyInputFocus={resolveSuggestions}
           onRenderItem={onRenderItem}
           onRenderSuggestionsItem={basicSuggestionRenderer}
+          componentRef={picker}
         />,
         root
-      ) as TypedBasePicker;
+      );
+
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       input.focus();
 
       const suggestions = document.querySelector('.ms-Suggestions') as HTMLInputElement;
-
       expect(suggestions).toBeDefined();
+
       const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
       expect(suggestionOptions.length).toEqual(15);
-      expect(picker.items.length).toEqual(0);
+
+      const currentPicker = picker.current!.items;
+      expect(currentPicker).toHaveLength(0);
 
       ReactDOM.unmountComponentAtNode(root);
     });
@@ -217,7 +243,7 @@ describe('Pickers', () => {
     });
 
     it('renders TagPicker correctly', () => {
-      const component = renderer.create(<TagPickerBase onResolveSuggestions={onResolveSuggestions} />);
+      const component = renderer.create(<TagPicker onResolveSuggestions={onResolveSuggestions} />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
@@ -225,7 +251,11 @@ describe('Pickers', () => {
     it('can search for and select tags', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      const picker: TagPickerBase = ReactDOM.render(<TagPickerBase onResolveSuggestions={onResolveSuggestions} />, root) as TagPickerBase;
+
+      const picker = React.createRef<IBasePicker<ISimple>>();
+
+      ReactDOM.render(<TagPicker onResolveSuggestions={onResolveSuggestions} componentRef={picker} />, root);
+
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       input.focus();
       input.value = 'bl';
@@ -240,18 +270,21 @@ describe('Pickers', () => {
       expect(suggestionOptions.length).toEqual(2);
       ReactTestUtils.Simulate.click(suggestionOptions[0]);
 
-      expect(picker.items.length).toEqual(1);
-      expect(picker.items[0].name).toEqual('black');
+      const currentPicker = picker.current!.items;
+      expect(currentPicker).toHaveLength(1);
+      expect(currentPicker![0].name).toEqual('black');
+
       ReactDOM.unmountComponentAtNode(root);
     });
 
     it('can be a controlled component', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      let picker: TagPickerBase = ReactDOM.render(
-        <TagPickerBase onResolveSuggestions={onResolveSuggestions} selectedItems={[]} />,
-        root
-      ) as TagPickerBase;
+
+      const pickerBeforeUpdate = React.createRef<IBasePicker<ISimple>>();
+      const pickerAfterUpdate = React.createRef<IBasePicker<ISimple>>();
+
+      ReactDOM.render(<TagPicker onResolveSuggestions={onResolveSuggestions} selectedItems={[]} componentRef={pickerBeforeUpdate} />, root);
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
 
       input.focus();
@@ -262,15 +295,22 @@ describe('Pickers', () => {
 
       ReactTestUtils.Simulate.click(suggestionOptions[0]);
 
-      expect(picker.items.length).toEqual(0);
+      const currentPicker = pickerBeforeUpdate.current!.items;
+      expect(currentPicker).toHaveLength(0);
 
-      picker = ReactDOM.render(
-        <TagPickerBase onResolveSuggestions={onResolveSuggestions} selectedItems={[{ key: 'testColor', name: 'testColor' }]} />,
+      ReactDOM.render(
+        <TagPicker
+          onResolveSuggestions={onResolveSuggestions}
+          selectedItems={[{ key: 'testColor', name: 'testColor' }]}
+          componentRef={pickerAfterUpdate}
+        />,
         root
-      ) as TagPickerBase;
+      );
 
-      expect(picker.items.length).toEqual(1);
-      expect(picker.items[0].name).toEqual('testColor');
+      const updatedPicker = pickerAfterUpdate.current!.items;
+      expect(updatedPicker).toHaveLength(1);
+      expect(updatedPicker![0].name).toEqual('testColor');
+
       ReactDOM.unmountComponentAtNode(root);
     });
     it('fires change events correctly for controlled components', done => {
@@ -282,10 +322,7 @@ describe('Pickers', () => {
         done();
       };
 
-      ReactDOM.render(
-        <TagPickerBase onResolveSuggestions={onResolveSuggestions} selectedItems={[]} onChange={onChange} />,
-        root
-      ) as TagPickerBase;
+      ReactDOM.render(<TagPicker onResolveSuggestions={onResolveSuggestions} selectedItems={[]} onChange={onChange} />, root);
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
 
       input.focus();

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -5,7 +5,7 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 /* tslint:enable:no-unused-variable */
 import * as renderer from 'react-test-renderer';
 
-import { TagPicker, ITag } from './TagPicker/TagPicker';
+import { TagPickerBase, ITag } from './TagPicker/TagPicker';
 import { IBasePickerProps } from './BasePicker.types';
 import { BasePicker } from './BasePicker';
 import { IPickerItemProps } from './PickerItem.types';
@@ -217,7 +217,7 @@ describe('Pickers', () => {
     });
 
     it('renders TagPicker correctly', () => {
-      const component = renderer.create(<TagPicker onResolveSuggestions={onResolveSuggestions} />);
+      const component = renderer.create(<TagPickerBase onResolveSuggestions={onResolveSuggestions} />);
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
@@ -225,7 +225,7 @@ describe('Pickers', () => {
     it('can search for and select tags', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      const picker: TagPicker = ReactDOM.render(<TagPicker onResolveSuggestions={onResolveSuggestions} />, root) as TagPicker;
+      const picker: TagPickerBase = ReactDOM.render(<TagPickerBase onResolveSuggestions={onResolveSuggestions} />, root) as TagPickerBase;
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
       input.focus();
       input.value = 'bl';
@@ -248,10 +248,10 @@ describe('Pickers', () => {
     it('can be a controlled component', () => {
       const root = document.createElement('div');
       document.body.appendChild(root);
-      let picker: TagPicker = ReactDOM.render(
-        <TagPicker onResolveSuggestions={onResolveSuggestions} selectedItems={[]} />,
+      let picker: TagPickerBase = ReactDOM.render(
+        <TagPickerBase onResolveSuggestions={onResolveSuggestions} selectedItems={[]} />,
         root
-      ) as TagPicker;
+      ) as TagPickerBase;
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
 
       input.focus();
@@ -265,9 +265,9 @@ describe('Pickers', () => {
       expect(picker.items.length).toEqual(0);
 
       picker = ReactDOM.render(
-        <TagPicker onResolveSuggestions={onResolveSuggestions} selectedItems={[{ key: 'testColor', name: 'testColor' }]} />,
+        <TagPickerBase onResolveSuggestions={onResolveSuggestions} selectedItems={[{ key: 'testColor', name: 'testColor' }]} />,
         root
-      ) as TagPicker;
+      ) as TagPickerBase;
 
       expect(picker.items.length).toEqual(1);
       expect(picker.items[0].name).toEqual('testColor');
@@ -282,7 +282,10 @@ describe('Pickers', () => {
         done();
       };
 
-      ReactDOM.render(<TagPicker onResolveSuggestions={onResolveSuggestions} selectedItems={[]} onChange={onChange} />, root) as TagPicker;
+      ReactDOM.render(
+        <TagPickerBase onResolveSuggestions={onResolveSuggestions} selectedItems={[]} onChange={onChange} />,
+        root
+      ) as TagPickerBase;
       const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
 
       input.focus();

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -45,6 +45,8 @@ export type IPickerAriaIds = {
   suggestionList: string;
 };
 
+const getClassNames = classNamesFunction<IBasePickerStyleProps, IBasePickerStyles>();
+
 export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<P, IBasePickerState> implements IBasePicker<T> {
   protected selection: Selection;
 
@@ -58,7 +60,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected currentPromise: PromiseLike<any> | undefined;
   protected _ariaMap: IPickerAriaIds;
   private _id: string;
-  private _getClassNames = classNamesFunction<IBasePickerStyleProps<T>, IBasePickerStyles>();
   private _classNames: IProcessedStyleSet<IBasePickerStyles>;
 
   constructor(basePickerProps: P) {
@@ -193,7 +194,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
 
-    this._classNames = this._getClassNames(styles, {
+    this._classNames = getClassNames(styles, {
       theme,
       className,
       isFocused,

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, createRef, elementContains, getId } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, createRef, elementContains, getId, classNamesFunction } from '../../Utilities';
+import { IProcessedStyleSet } from '../../Styling';
 import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Callout, DirectionalHint } from '../../Callout';
 import { Selection, SelectionZone, SelectionMode } from '../../utilities/selection/index';
 import { Suggestions } from './Suggestions/Suggestions';
 import { ISuggestionsProps } from './Suggestions/Suggestions.types';
 import { SuggestionsController } from './Suggestions/SuggestionsController';
-import { IBasePicker, IBasePickerProps, ValidationState } from './BasePicker.types';
+import { IBasePicker, IBasePickerProps, ValidationState, IBasePickerStyleProps, IBasePickerStyles } from './BasePicker.types';
 import { IAutofill, Autofill } from '../Autofill/index';
 import { IPickerItemProps } from './PickerItem.types';
 import { IPersonaProps } from '../Persona/Persona.types';
 import * as stylesImport from './BasePicker.scss';
-const styles: any = stylesImport;
+const stylesSASS: any = stylesImport;
 
 export interface IBasePickerState {
   items?: any;
@@ -57,6 +58,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected currentPromise: PromiseLike<any> | undefined;
   protected _ariaMap: IPickerAriaIds;
   private _id: string;
+  private _getClassNames = classNamesFunction<IBasePickerStyleProps<T>, IBasePickerStyles>();
+  private _classNames: IProcessedStyleSet<IBasePickerStyles>;
 
   constructor(basePickerProps: P) {
     super(basePickerProps);
@@ -184,11 +187,18 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   };
 
   public render(): JSX.Element {
-    const { suggestedDisplayValue } = this.state;
-    const { className, inputProps, disabled } = this.props;
+    const { suggestedDisplayValue, isFocused } = this.state;
+    const { className, inputProps, disabled, theme, styles } = this.props;
 
     const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
+
+    this._classNames = this._getClassNames(styles, {
+      theme,
+      className,
+      isFocused,
+      inputClassName: inputProps && inputProps.className
+    });
 
     return (
       <div ref={this.root} className={css('ms-BasePicker', className ? className : '')} onKeyDown={this.onKeyDown}>
@@ -199,15 +209,15 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
         >
           {this.getSuggestionsAlert()}
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused)}>
-              <span id={this._ariaMap.selectedItems} className={styles.pickerItems} role={'list'}>
+            <div className={css('ms-BasePicker-text', stylesSASS.pickerText, isFocused && stylesSASS.inputFocused)}>
+              <span id={this._ariaMap.selectedItems} className={stylesSASS.pickerItems} role={'list'}>
                 {this.renderItems()}
               </span>
               {this.canAddItems() && (
                 <Autofill
                   spellCheck={false}
                   {...inputProps as any}
-                  className={css('ms-BasePicker-input', styles.pickerInput, inputProps && inputProps.className)}
+                  className={css('ms-BasePicker-input', stylesSASS.pickerInput, inputProps && inputProps.className)}
                   ref={this.input}
                   onFocus={this.onInputFocus}
                   onBlur={this.onInputBlur}
@@ -734,7 +744,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
         currentIndex > -1 ? this.suggestionStore.getSuggestionAtIndex(this.suggestionStore.currentIndex) : undefined;
       const selectedSuggestionAlertText = selectedSuggestion ? selectedSuggestion.ariaLabel : undefined;
       return (
-        <div className={styles.screenReaderOnly} role="alert" id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
+        <div className={stylesSASS.screenReaderOnly} role="alert" id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
           {selectedSuggestionAlertText}{' '}
         </div>
       );
@@ -821,10 +831,10 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
       <div ref={this.root}>
         <div className={css('ms-BasePicker', className ? className : '')} onKeyDown={this.onKeyDown}>
           {this.getSuggestionsAlert()}
-          <div className={css('ms-BasePicker-text', styles.pickerText, this.state.isFocused && styles.inputFocused)}>
+          <div className={css('ms-BasePicker-text', stylesSASS.pickerText, this.state.isFocused && stylesSASS.inputFocused)}>
             <Autofill
               {...inputProps as any}
-              className={css('ms-BasePicker-input', styles.pickerInput)}
+              className={css('ms-BasePicker-input', stylesSASS.pickerInput)}
               ref={this.input}
               onFocus={this.onInputFocus}
               onBlur={this.onInputBlur}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -201,7 +201,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     });
 
     return (
-      <div ref={this.root} className={css('ms-BasePicker', className ? className : '')} onKeyDown={this.onKeyDown}>
+      <div ref={this.root} className={this._classNames.root} onKeyDown={this.onKeyDown}>
         <FocusZone
           componentRef={this.focusZone}
           direction={FocusZoneDirection.bidirectional}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, createRef, elementContains, getId, classNamesFunction } from '../../Utilities';
+import { BaseComponent, KeyCodes, createRef, elementContains, getId, classNamesFunction } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Callout, DirectionalHint } from '../../Callout';
@@ -59,8 +59,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected SuggestionOfProperType = Suggestions as new (props: ISuggestionsProps<T>) => Suggestions<T>;
   protected currentPromise: PromiseLike<any> | undefined;
   protected _ariaMap: IPickerAriaIds;
+  protected _classNames: IProcessedStyleSet<IBasePickerStyles>;
   private _id: string;
-  private _classNames: IProcessedStyleSet<IBasePickerStyles>;
 
   constructor(basePickerProps: P) {
     super(basePickerProps);
@@ -820,22 +820,29 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
 export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BasePicker<T, P> {
   public render(): JSX.Element {
-    const { suggestedDisplayValue } = this.state;
-    const { className, inputProps, disabled } = this.props;
+    const { suggestedDisplayValue, isFocused } = this.state;
+    const { className, inputProps, disabled, theme, styles } = this.props;
 
     const selectedSuggestionAlertId: string | undefined = this.props.enableSelectedSuggestionAlert
       ? this._ariaMap.selectedSuggestionAlert
       : '';
     const suggestionsAvailable: string | undefined = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
 
+    this._classNames = getClassNames(styles, {
+      theme,
+      className,
+      isFocused,
+      inputClassName: inputProps && inputProps.className
+    });
+
     return (
       <div ref={this.root}>
-        <div className={css('ms-BasePicker', className ? className : '')} onKeyDown={this.onKeyDown}>
+        <div className={this._classNames.root} onKeyDown={this.onKeyDown}>
           {this.getSuggestionsAlert()}
-          <div className={css('ms-BasePicker-text', stylesSASS.pickerText, this.state.isFocused && stylesSASS.inputFocused)}>
+          <div className={this._classNames.text}>
             <Autofill
               {...inputProps as any}
-              className={css('ms-BasePicker-input', stylesSASS.pickerInput)}
+              className={this._classNames.input}
               ref={this.input}
               onFocus={this.onInputFocus}
               onBlur={this.onInputBlur}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, createRef, elementContains, getId, classNamesFunction } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, createRef, elementContains, getId, classNamesFunction } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Callout, DirectionalHint } from '../../Callout';
@@ -12,7 +12,7 @@ import { IAutofill, Autofill } from '../Autofill/index';
 import { IPickerItemProps } from './PickerItem.types';
 import { IPersonaProps } from '../Persona/Persona.types';
 import * as stylesImport from './BasePicker.scss';
-const stylesSASS: any = stylesImport;
+const legacyStyles: any = stylesImport;
 
 export interface IBasePickerState {
   items?: any;
@@ -59,7 +59,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected SuggestionOfProperType = Suggestions as new (props: ISuggestionsProps<T>) => Suggestions<T>;
   protected currentPromise: PromiseLike<any> | undefined;
   protected _ariaMap: IPickerAriaIds;
-  protected _classNames: IProcessedStyleSet<IBasePickerStyles>;
   private _id: string;
 
   constructor(basePickerProps: P) {
@@ -194,31 +193,46 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
 
-    this._classNames = getClassNames(styles, {
-      theme,
-      className,
-      isFocused,
-      inputClassName: inputProps && inputProps.className
-    });
+    // TODO
+    // Clean this up by leaving only the first part after removing support for SASS.
+    // Currently we can not remove the SASS styles from BasePicker class because it
+    // might be used by consumers who created custom pickers from extending from this base class.
+    // We check for 'styles' prop which is going to be injected by the 'styled' HOC
+    // for every other already existing picker variant (PeoplePicker, TagPicker).
+    // If not provided, then we just use the old SASS styles instead.
+    const classNames: Partial<IProcessedStyleSet<IBasePickerStyles>> = styles
+      ? getClassNames(styles, {
+          theme,
+          className,
+          isFocused,
+          inputClassName: inputProps && inputProps.className
+        })
+      : {
+          root: css('ms-BasePicker', className ? className : ''),
+          text: css('ms-BasePicker-text', legacyStyles.pickerText, this.state.isFocused && legacyStyles.inputFocused),
+          itemsWrapper: legacyStyles.pickerItems,
+          input: css('ms-BasePicker-input', legacyStyles.pickerInput, inputProps && inputProps.className),
+          screenReaderText: legacyStyles.screenReaderOnly
+        };
 
     return (
-      <div ref={this.root} className={this._classNames.root} onKeyDown={this.onKeyDown}>
+      <div ref={this.root} className={classNames.root} onKeyDown={this.onKeyDown}>
         <FocusZone
           componentRef={this.focusZone}
           direction={FocusZoneDirection.bidirectional}
           isInnerZoneKeystroke={this._isFocusZoneInnerKeystroke}
         >
-          {this.getSuggestionsAlert()}
+          {this.getSuggestionsAlert(classNames.screenReaderText)}
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={this._classNames.text}>
-              <span id={this._ariaMap.selectedItems} className={this._classNames.itemsWrapper} role={'list'}>
+            <div className={classNames.text}>
+              <span id={this._ariaMap.selectedItems} className={classNames.itemsWrapper} role={'list'}>
                 {this.renderItems()}
               </span>
               {this.canAddItems() && (
                 <Autofill
                   spellCheck={false}
                   {...inputProps as any}
-                  className={this._classNames.input}
+                  className={classNames.input}
                   ref={this.input}
                   onFocus={this.onInputFocus}
                   onBlur={this.onInputBlur}
@@ -738,14 +752,14 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     return currentIndex > -1 && !this.state.suggestionsLoading ? 'sug-' + currentIndex : undefined;
   }
 
-  protected getSuggestionsAlert() {
+  protected getSuggestionsAlert(suggestionAlertClassName: string = legacyStyles.screenReaderOnly) {
     const currentIndex = this.suggestionStore.currentIndex;
     if (this.props.enableSelectedSuggestionAlert) {
       const selectedSuggestion =
         currentIndex > -1 ? this.suggestionStore.getSuggestionAtIndex(this.suggestionStore.currentIndex) : undefined;
       const selectedSuggestionAlertText = selectedSuggestion ? selectedSuggestion.ariaLabel : undefined;
       return (
-        <div className={stylesSASS.screenReaderOnly} role="alert" id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
+        <div className={suggestionAlertClassName} role="alert" id={this._ariaMap.selectedSuggestionAlert} aria-live="assertive">
           {selectedSuggestionAlertText}{' '}
         </div>
       );
@@ -828,21 +842,35 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
       : '';
     const suggestionsAvailable: string | undefined = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
 
-    this._classNames = getClassNames(styles, {
-      theme,
-      className,
-      isFocused,
-      inputClassName: inputProps && inputProps.className
-    });
+    // TODO
+    // Clean this up by leaving only the first part after removing support for SASS.
+    // Currently we can not remove the SASS styles from BasePicker class because it
+    // might be used by consumers who created custom pickers from extending from this base class.
+    // We check for 'styles' prop which is going to be injected by the 'styled' HOC
+    // for every other already existing picker variant (PeoplePicker, TagPicker).
+    // If not provided, then we just use the old SASS styles instead.
+    const classNames: Partial<IProcessedStyleSet<IBasePickerStyles>> = styles
+      ? getClassNames(styles, {
+          theme,
+          className,
+          isFocused,
+          inputClassName: inputProps && inputProps.className
+        })
+      : {
+          root: css('ms-BasePicker', className ? className : ''),
+          text: css('ms-BasePicker-text', legacyStyles.pickerText, this.state.isFocused && legacyStyles.inputFocused),
+          input: css('ms-BasePicker-input', legacyStyles.pickerInput, inputProps && inputProps.className),
+          screenReaderText: legacyStyles.screenReaderOnly
+        };
 
     return (
       <div ref={this.root}>
-        <div className={this._classNames.root} onKeyDown={this.onKeyDown}>
-          {this.getSuggestionsAlert()}
-          <div className={this._classNames.text}>
+        <div className={classNames.root} onKeyDown={this.onKeyDown}>
+          {this.getSuggestionsAlert(classNames.screenReaderText)}
+          <div className={classNames.text}>
             <Autofill
               {...inputProps as any}
-              className={this._classNames.input}
+              className={classNames.input}
               ref={this.input}
               onFocus={this.onInputFocus}
               onBlur={this.onInputBlur}
@@ -865,7 +893,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
         <SelectionZone selection={this.selection} selectionMode={SelectionMode.single}>
           <FocusZone
             componentRef={this.focusZone}
-            className="ms-BasePicker-selectedItems"
+            className="ms-BasePicker-selectedItems" // just a className hook without any styles applied to it.
             isCircularNavigation={true}
             direction={FocusZoneDirection.bidirectional}
             isInnerZoneKeystroke={this._isFocusZoneInnerKeystroke}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -196,10 +196,12 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
-    // might be used by consumers who created custom pickers from extending from this base class.
+    // might be used by consumers who created custom pickers from extending from
+    // this base class and have not used the new 'styles' prop.
     // We check for 'styles' prop which is going to be injected by the 'styled' HOC
-    // for every other already existing picker variant (PeoplePicker, TagPicker).
-    // If not provided, then we just use the old SASS styles instead.
+    // for every other already existing picker variant (PeoplePicker, TagPicker)
+    // so that we can use the CSS-in-JS styles. If the check fails (ex: custom picker),
+    // then we just use the old SASS styles instead.
     const classNames: Partial<IProcessedStyleSet<IBasePickerStyles>> = styles
       ? getClassNames(styles, {
           theme,
@@ -845,10 +847,12 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
     // TODO
     // Clean this up by leaving only the first part after removing support for SASS.
     // Currently we can not remove the SASS styles from BasePicker class because it
-    // might be used by consumers who created custom pickers from extending from this base class.
+    // might be used by consumers who created custom pickers from extending from
+    // this base class and have not used the new 'styles' prop.
     // We check for 'styles' prop which is going to be injected by the 'styled' HOC
-    // for every other already existing picker variant (PeoplePicker, TagPicker).
-    // If not provided, then we just use the old SASS styles instead.
+    // for every other already existing picker variant (PeoplePicker, TagPicker)
+    // so that we can use the CSS-in-JS styles. If the check fails (ex: custom picker),
+    // then we just use the old SASS styles instead.
     const classNames: Partial<IProcessedStyleSet<IBasePickerStyles>> = styles
       ? getClassNames(styles, {
           theme,

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -210,15 +210,15 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
         >
           {this.getSuggestionsAlert()}
           <SelectionZone selection={this.selection} selectionMode={SelectionMode.multiple}>
-            <div className={css('ms-BasePicker-text', stylesSASS.pickerText, isFocused && stylesSASS.inputFocused)}>
-              <span id={this._ariaMap.selectedItems} className={stylesSASS.pickerItems} role={'list'}>
+            <div className={this._classNames.text}>
+              <span id={this._ariaMap.selectedItems} className={this._classNames.itemsWrapper} role={'list'}>
                 {this.renderItems()}
               </span>
               {this.canAddItems() && (
                 <Autofill
                   spellCheck={false}
                   {...inputProps as any}
-                  className={css('ms-BasePicker-input', stylesSASS.pickerInput, inputProps && inputProps.className)}
+                  className={this._classNames.input}
                   ref={this.input}
                   onFocus={this.onInputFocus}
                   onBlur={this.onInputBlur}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -157,7 +157,7 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  styles?: IStyleFunctionOrObject<IBasePickerStyleProps<T>, IBasePickerStyles>;
+  styles?: IStyleFunctionOrObject<IBasePickerStyleProps, IBasePickerStyles>;
 
   /**
    * Theme provided by styled() function
@@ -258,7 +258,7 @@ export interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement>
 /**
  * The props needed to construct styles.
  */
-export type IBasePickerStyleProps<TItem> = Pick<IBasePickerProps<TItem>, 'theme' | 'className'> & {
+export type IBasePickerStyleProps = Pick<IBasePickerProps<any>, 'theme' | 'className'> & {
   /** Whether text style area is focused */
   isFocused?: boolean;
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { IPickerItemProps } from './PickerItem.types';
 import { IPersonaProps } from '../Persona/Persona.types';
-import { IRefObject, IRenderFunction } from '../../Utilities';
+import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { ISuggestionModel } from './Suggestions/SuggestionsController';
 import { BaseAutoFill } from './AutoFill/BaseAutoFill';
 import { ICalloutProps } from '../../Callout';
+import { ITheme, IStyle } from '../../Styling';
 
 export interface IBasePicker<T> {
   /** Gets the current value of the input. */
@@ -21,6 +22,10 @@ export interface IBasePicker<T> {
 // and searched for by the people picker. For example, if the picker is
 // displaying persona's than type T could either be of Persona or Ipersona props
 export interface IBasePickerProps<T> extends React.Props<any> {
+  /**
+   * Optional callback to access the IBasePicker interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
   componentRef?: IRefObject<IBasePicker<T>>;
 
   /**
@@ -148,6 +153,16 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * @defaultvalue false
    */
   enableSelectedSuggestionAlert?: boolean;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<IBasePickerStyleProps<T>, IBasePickerStyles>;
+
+  /**
+   * Theme provided by styled() function
+   */
+  theme?: ITheme;
 }
 
 export interface IBasePickerSuggestionsProps {
@@ -238,4 +253,26 @@ export interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement>
    * text persists until deleted or changed.
    */
   defaultVisibleValue?: string;
+}
+
+/**
+ * The props needed to construct styles.
+ */
+export type IBasePickerStyleProps<TItem> = Pick<IBasePickerProps<TItem>, 'theme' | 'className'> & {
+  /** Whether text style area is focused */
+  isFocused?: boolean;
+
+  /** Optional pickerInput className */
+  inputClassName?: string;
+};
+
+/**
+ * Represents the stylable areas of the control.
+ */
+export interface IBasePickerStyles {
+  root: IStyle;
+  text: IStyle;
+  itemsWrapper: IStyle;
+  input: IStyle;
+  screenReaderText: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -270,9 +270,18 @@ export type IBasePickerStyleProps = Pick<IBasePickerProps<any>, 'theme' | 'class
  * Represents the stylable areas of the control.
  */
 export interface IBasePickerStyles {
+  /** Root element of any picker extending from BasePicker (wraps all the elements)*/
   root: IStyle;
+
+  /** Refers to the elements already selected(picked) wrapped by `itemsWrapper` along with the input to type new selection */
   text: IStyle;
+
+  /** Refers to the items already selected(picked). */
   itemsWrapper: IStyle;
+
+  /** Refers to the input were to type new selections(picks). */
   input: IStyle;
+
+  /** Refers to helper element used for accessibility tools (hidden from view on screen). */
   screenReaderText: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx
@@ -65,11 +65,7 @@ export interface IGenericItem {
   ValidationState: ValidationState;
 }
 
-export function createGenericItem(
-  name: string,
-  currentValidationState: ValidationState,
-  allowPhoneInitials?: boolean // TODO: how does this gets passed to PeoplePicker
-): IGenericItem & { key: React.Key } {
+export function createGenericItem(name: string, currentValidationState: ValidationState): IGenericItem & { key: React.Key } {
   const personaToConvert = {
     key: name,
     primaryText: name,
@@ -78,7 +74,7 @@ export function createGenericItem(
   };
 
   if (currentValidationState !== ValidationState.warning) {
-    personaToConvert.imageInitials = getInitials(name, getRTL(), allowPhoneInitials);
+    personaToConvert.imageInitials = getInitials(name, getRTL());
   }
 
   return personaToConvert;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx
@@ -1,14 +1,21 @@
 /* tslint:disable */
 import * as React from 'react';
 /* tslint:enable */
-import { getRTL, getInitials } from '../../../Utilities';
+import { getRTL, getInitials, styled } from '../../../Utilities';
 import { BasePicker, BasePickerListBelow } from '../BasePicker';
-import { IBasePickerProps, IBasePickerSuggestionsProps, ValidationState } from '../BasePicker.types';
+import {
+  IBasePickerProps,
+  IBasePickerSuggestionsProps,
+  ValidationState,
+  IBasePickerStyleProps,
+  IBasePickerStyles
+} from '../BasePicker.types';
 import { SelectedItemDefault } from './PeoplePickerItems/SelectedItemDefault';
 import { IPersonaProps } from '../../../Persona';
 import { SuggestionItemSmall, SuggestionItemNormal } from './PeoplePickerItems/SuggestionItemDefault';
 import './PeoplePicker.scss';
 import { IPeoplePickerItemProps } from './PeoplePickerItems/PeoplePickerItem.types';
+import { getStyles } from '../BasePicker.styles';
 
 export interface IPeoplePickerProps extends IBasePickerProps<IPersonaProps> {}
 
@@ -19,7 +26,7 @@ export class MemberListPeoplePicker extends BasePickerListBelow<IPersonaProps, I
 /**
  * Standard People Picker.
  */
-export class NormalPeoplePicker extends BasePeoplePicker {
+export class NormalPeoplePickerBase extends BasePeoplePicker {
   public static defaultProps = {
     onRenderItem: (props: IPeoplePickerItemProps) => <SelectedItemDefault {...props} />,
     onRenderSuggestionsItem: (props: IPersonaProps, itemProps?: IBasePickerSuggestionsProps) =>
@@ -31,7 +38,7 @@ export class NormalPeoplePicker extends BasePeoplePicker {
 /**
  * Compact layout. It uses small personas when displaying search results.
  */
-export class CompactPeoplePicker extends BasePeoplePicker {
+export class CompactPeoplePickerBase extends BasePeoplePicker {
   public static defaultProps = {
     onRenderItem: (props: IPeoplePickerItemProps) => <SelectedItemDefault {...props} />,
     onRenderSuggestionsItem: (props: IPersonaProps, itemProps?: IBasePickerSuggestionsProps) =>
@@ -43,7 +50,7 @@ export class CompactPeoplePicker extends BasePeoplePicker {
 /**
  * MemberList layout. The selected people show up below the search box.
  */
-export class ListPeoplePicker extends MemberListPeoplePicker {
+export class ListPeoplePickerBase extends MemberListPeoplePicker {
   public static defaultProps = {
     onRenderItem: (props: IPeoplePickerItemProps) => <SelectedItemDefault {...props} />,
     onRenderSuggestionsItem: (props: IPersonaProps, itemProps?: IBasePickerSuggestionsProps) =>
@@ -61,7 +68,7 @@ export interface IGenericItem {
 export function createGenericItem(
   name: string,
   currentValidationState: ValidationState,
-  allowPhoneInitials: boolean
+  allowPhoneInitials?: boolean // TODO: how does this gets passed to PeoplePicker
 ): IGenericItem & { key: React.Key } {
   const personaToConvert = {
     key: name,
@@ -76,3 +83,30 @@ export function createGenericItem(
 
   return personaToConvert;
 }
+
+export const NormalPeoplePicker = styled<IPeoplePickerProps, IBasePickerStyleProps, IBasePickerStyles>(
+  NormalPeoplePickerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'NormalPeoplePicker'
+  }
+);
+
+export const CompactPeoplePicker = styled<IPeoplePickerProps, IBasePickerStyleProps, IBasePickerStyles>(
+  CompactPeoplePickerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'CompactPeoplePicker'
+  }
+);
+
+export const ListPeoplePicker = styled<IPeoplePickerProps, IBasePickerStyleProps, IBasePickerStyles>(
+  ListPeoplePickerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'ListPeoplePickerBase'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.tsx
@@ -1,9 +1,10 @@
 /* tslint:disable */
 import * as React from 'react';
-import { css } from '../../../Utilities';
+import { css, styled } from '../../../Utilities';
 /* tslint:enable */
 import { BasePicker } from '../BasePicker';
-import { IBasePickerProps } from '../BasePicker.types';
+import { IBasePickerProps, IBasePickerStyleProps, IBasePickerStyles } from '../BasePicker.types';
+import { getStyles } from '../BasePicker.styles';
 import { TagItem, ITagItemProps } from './TagItem';
 import * as stylesImport from './TagItem.scss';
 const styles: any = stylesImport;
@@ -15,8 +16,8 @@ export interface ITag {
 
 export interface ITagPickerProps extends IBasePickerProps<ITag> {}
 
-export class TagPicker extends BasePicker<ITag, ITagPickerProps> {
-  protected static defaultProps = {
+export class TagPickerBase extends BasePicker<ITag, ITagPickerProps> {
+  public static defaultProps = {
     onRenderItem: (props: ITagItemProps) => {
       return <TagItem {...props}>{props.item.name}</TagItem>;
     },
@@ -25,3 +26,7 @@ export class TagPicker extends BasePicker<ITag, ITagPickerProps> {
     )
   };
 }
+
+export const TagPicker = styled<ITagPickerProps, IBasePickerStyleProps, IBasePickerStyles>(TagPickerBase, getStyles, undefined, {
+  scope: 'TagPicker'
+});

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -124,7 +124,9 @@ exports[`Pickers BasePicker renders BasePicker with inputProps supply classnames
 
 exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
 <div
-  className="ms-BasePicker"
+  className=
+      ms-BasePicker
+
   onKeyDown={[Function]}
 >
   <div
@@ -148,9 +150,28 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
       role="presentation"
     >
       <div
-        className="ms-BasePicker-text"
+        className=
+            ms-BasePicker-text
+            {
+              align-items: center;
+              border: 1px solid #a6a6a6;
+              box-sizing: border-box;
+              display: flex;
+              flex-wrap: wrap;
+              min-height: 30px;
+              min-width: 180px;
+            }
+            &:hover {
+              border-color: #333333;
+            }
       >
         <span
+          className=
+              ms-BasePicker-itemsWrapper
+              {
+                display: flex;
+                flex-wrap: wrap;
+              }
           id="selected-items-id__0"
           role="list"
         />
@@ -162,7 +183,19 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
           aria-haspopup="true"
           autoCapitalize="off"
           autoComplete="off"
-          className="ms-BasePicker-input"
+          className=
+              ms-BasePicker-input
+              {
+                align-self: flex-end;
+                border: none;
+                flex-grow: 1;
+                height: 34px;
+                outline: none;
+                padding-bottom: 0;
+                padding-left: 6px;
+                padding-right: 6px;
+                padding-top: 0;
+              }
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -124,9 +124,7 @@ exports[`Pickers BasePicker renders BasePicker with inputProps supply classnames
 
 exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
 <div
-  className=
-      ms-BasePicker
-
+  className="ms-BasePicker"
   onKeyDown={[Function]}
 >
   <div
@@ -150,28 +148,9 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
       role="presentation"
     >
       <div
-        className=
-            ms-BasePicker-text
-            {
-              align-items: center;
-              border: 1px solid #a6a6a6;
-              box-sizing: border-box;
-              display: flex;
-              flex-wrap: wrap;
-              min-height: 30px;
-              min-width: 180px;
-            }
-            &:hover {
-              border-color: #333333;
-            }
+        className="ms-BasePicker-text"
       >
         <span
-          className=
-              ms-BasePicker-itemsWrapper
-              {
-                display: flex;
-                flex-wrap: wrap;
-              }
           id="selected-items-id__0"
           role="list"
         />
@@ -183,19 +162,7 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
           aria-haspopup="true"
           autoCapitalize="off"
           autoComplete="off"
-          className=
-              ms-BasePicker-input
-              {
-                align-self: flex-end;
-                border: none;
-                flex-grow: 1;
-                height: 34px;
-                outline: none;
-                padding-bottom: 0;
-                padding-left: 6px;
-                padding-right: 6px;
-                padding-top: 0;
-              }
+          className="ms-BasePicker-input"
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/ITagPickerDemoPageState.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/ITagPickerDemoPageState.tsx
@@ -1,3 +1,0 @@
-export interface ITagPickerDemoPageState {
-  isPickerDisabled?: boolean;
-}

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import { TagPicker, TagPickerBase } from 'office-ui-fabric-react/lib/components/pickers/TagPicker/TagPicker';
+import { TagPicker, IBasePicker, ITag } from 'office-ui-fabric-react/lib/Pickers';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { ITagPickerDemoPageState } from 'office-ui-fabric-react/lib/components/pickers/examples/ITagPickerDemoPageState';
 import * as exampleStylesImport from 'office-ui-fabric-react/lib/common/_exampleStyles.scss';
 const exampleStyles: any = exampleStylesImport;
 
-const _testTags = [
+const _testTags: ITag[] = [
   'black',
   'blue',
   'brown',
@@ -24,8 +23,12 @@ const _testTags = [
   'yellow'
 ].map(item => ({ key: item, name: item }));
 
+export interface ITagPickerDemoPageState {
+  isPickerDisabled?: boolean;
+}
+
 export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageState> {
-  private _picker: TagPickerBase;
+  private _picker = React.createRef<IBasePicker<ITag>>();
 
   constructor(props: {}) {
     super(props);
@@ -62,7 +65,7 @@ export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageS
         <br />
         Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
         <TagPicker
-          componentRef={this._resolveRef('_picker')}
+          componentRef={this._picker}
           onResolveSuggestions={this._onFilterChangedNoFilter}
           onItemSelected={this._onItemSelected}
           getTextFromItem={this._getTextFromItem}
@@ -82,7 +85,7 @@ export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageS
     );
   }
 
-  private _getTextFromItem(item: any): any {
+  private _getTextFromItem(item: ITag): string {
     return item.name;
   }
 
@@ -92,7 +95,7 @@ export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageS
     });
   };
 
-  private _onFilterChanged = (filterText: string, tagList: { key: string; name: string }[]): { key: string; name: string }[] => {
+  private _onFilterChanged = (filterText: string, tagList: ITag[]): ITag[] => {
     return filterText
       ? _testTags
           .filter(tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0)
@@ -100,18 +103,18 @@ export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageS
       : [];
   };
 
-  private _onFilterChangedNoFilter = (filterText: string, tagList: { key: string; name: string }[]): { key: string; name: string }[] => {
+  private _onFilterChangedNoFilter = (filterText: string, tagList: ITag[]): ITag[] => {
     return filterText ? _testTags.filter(tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0) : [];
   };
 
-  private _onItemSelected = (item: { key: string; name: string }): { key: string; name: string } | null => {
-    if (this._listContainsDocument(item, this._picker.items)) {
+  private _onItemSelected = (item: ITag): ITag | null => {
+    if (this._picker.current && this._listContainsDocument(item, this._picker.current.items)) {
       return null;
     }
     return item;
   };
 
-  private _listContainsDocument(tag: { key: string; name: string }, tagList: { key: string; name: string }[]) {
+  private _listContainsDocument(tag: ITag, tagList?: ITag[]) {
     if (!tagList || !tagList.length || tagList.length === 0) {
       return false;
     }

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
@@ -23,7 +23,7 @@ const _testTags: ITag[] = [
   'yellow'
 ].map(item => ({ key: item, name: item }));
 
-interface ITagPickerDemoPageState {
+export interface ITagPickerDemoPageState {
   isPickerDisabled?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
@@ -28,6 +28,7 @@ export interface ITagPickerDemoPageState {
 }
 
 export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageState> {
+  // All pickers extend from BasePicker specifying the item type.
   private _picker = React.createRef<IBasePicker<ITag>>();
 
   constructor(props: {}) {

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
@@ -23,7 +23,7 @@ const _testTags: ITag[] = [
   'yellow'
 ].map(item => ({ key: item, name: item }));
 
-export interface ITagPickerDemoPageState {
+interface ITagPickerDemoPageState {
   isPickerDisabled?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/TagPicker.Basic.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import { TagPicker } from 'office-ui-fabric-react/lib/components/pickers/TagPicker/TagPicker';
+import { TagPicker, TagPickerBase } from 'office-ui-fabric-react/lib/components/pickers/TagPicker/TagPicker';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { ITagPickerDemoPageState } from 'office-ui-fabric-react/lib/components/pickers/examples/ITagPickerDemoPageState';
 import * as exampleStylesImport from 'office-ui-fabric-react/lib/common/_exampleStyles.scss';
@@ -25,7 +25,7 @@ const _testTags = [
 ].map(item => ({ key: item, name: item }));
 
 export class TagPickerBasicExample extends BaseComponent<{}, ITagPickerDemoPageState> {
-  private _picker: TagPicker;
+  private _picker: TagPickerBase;
 
   constructor(props: {}) {
     super(props);


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #5411
- [X] Include a change request file using `$ npm run change`

#### Description of changes

This PR brings the first part of the pickers' conversion to use CSS-in-JS. Things that were done in this part:

1. Add `BasePicker.styles.ts` to provide CSS-in-JS styling for the already existing pickers (TagPicker, PeoplePicker) and still leave support for Sass styles for custom pickers implemented by extending from `BasePicker` class without injecting the default styles.
2. Added comments on explaining why the above is needed.
3. Add `styles` and `theme` optional props to `IBasePickerProps` interface.
4. Changed tests in `BasePicker.test.ts` to use correctly a public method on the component instance by accessing its `componentRef` (this surfaced after wrapping the pickers with the `styled` function and the linter giving me red lines).

5. Removing this parameter in the `PeoplePicker`'s `createGenericItem` default prop added by #4376
https://github.com/OfficeDev/office-ui-fabric-react/blob/31783e67b172c645d15e169b54c84e8bfed5d6ca/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx#L64
It was never actually working and for some reason, this was not caught by types because this prop is only allowing to pass 2 arguments:
https://github.com/OfficeDev/office-ui-fabric-react/blob/31783e67b172c645d15e169b54c84e8bfed5d6ca/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts#L120
... and later is called only with those 2 arguments in here:
https://github.com/OfficeDev/office-ui-fabric-react/blob/31783e67b172c645d15e169b54c84e8bfed5d6ca/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx#L795
After wrapping the Base classes with the `styled` function I started to get type errors. So I discussed it with @joschect and I consider it's safe to be removed. If later this functionality needs to be added (it was never actually working in the first place) this should be done in a separate PR with more changes than the initial mentioned PR introduced. @cliffkoh would appreciate your input with this surface API change as this function was exported even though it's just a default prop provided by `PeoplePicker`. Even if someone did import to use it I don't see a way to pass that argument in it.
6. A little cleanup of the TagPicker example by moving a state interface into the same file as the example for user visibility and some more type fixes. Plus fixing the same issue as in tests file with the improper use of the public method of the component instance. This was causing the linter to complain that property `items` does not exist on `TagPicker`. Changing it to `TagPickerBase` was solving the errors but user should not care about the Base and use the `componentRef` prop instead.
7. Updated the API file and snapshots to reflect the current changes

Part 2 PR will consist of converting the picker items (Tags, Personas).

#### Focus areas to test

Need some feedback on moving the string classNames from being always on the component elements to the styles file, where in case globalClassNames are disabled in the Theme, might break some already existing custom Sass overrides in consumers apps. Should I skip the step of `getGlobalClassNames(GlobalClassNames, theme)`?

Also, regarding the number 6 in my list above, because we had this example displayed for a long time for users to see, now that accessing those methods is not working that way, we might get into breaking someone's app with this change in case they used this example. Should we still go with this change?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7353)

