### PR TITLE
Dropdown: Screen reader now reads out required for required dropdowns

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdownRequired_2018-12-11-19-58.json
+++ b/common/changes/office-ui-fabric-react/dropdownRequired_2018-12-11-19-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: only select aria-activedescendant when open to fix screen reader output for required dropdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -244,7 +244,8 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
               aria-label={ariaLabel}
               aria-labelledby={label && !ariaLabel ? id + '-label' : undefined}
               aria-describedby={mergeAriaAttributeValues(optionId, keytipAttributes['aria-describedby'])}
-              aria-activedescendant={ariaAttrs.ariaActiveDescendant}
+              aria-activedescendant={isOpen ? ariaAttrs.ariaActiveDescendant : undefined}
+              aria-required={required}
               aria-disabled={disabled}
               aria-owns={isOpen ? id + '-list' : undefined}
               {...divProps}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.doc.tsx
@@ -4,12 +4,14 @@ import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
 import { IDocPageProps } from '../../common/DocPage.types';
 import { DropdownCustomExample } from './examples/Dropdown.Custom.Example';
 import { DropdownErrorExample } from './examples/Dropdown.Error.Example';
+import { DropdownRequiredExample } from './examples/Dropdown.Required.Example';
 import { DropdownStatus } from './Dropdown.checklist';
 
 const DropdownBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx') as string;
 const DropdownBasicExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Dropdown/Dropdown.Basic.Example.Codepen.txt') as string;
 const DropdownCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx') as string;
 const DropdownErrorExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx') as string;
+const DropdownRequiredExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx') as string;
 
 export const DropdownPageProps: IDocPageProps = {
   title: 'Dropdown',
@@ -32,6 +34,11 @@ export const DropdownPageProps: IDocPageProps = {
       title: 'Dropdown with Error Message',
       code: DropdownErrorExampleCode,
       view: <DropdownErrorExample />
+    },
+    {
+      title: 'Required Dropdown',
+      code: DropdownRequiredExampleCode,
+      view: <DropdownRequiredExample />
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -180,7 +180,6 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
 
 >
   <div
-    aria-activedescendant="Dropdown0-option"
     aria-describedby="Dropdown0-option"
     aria-expanded="false"
     className=

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
@@ -13,8 +13,6 @@ export class DropdownRequiredExample extends BaseComponent<{}, {}> {
         <Dropdown
           placeholder="Select an Option"
           label="Required dropdown example:"
-          id="Requireddrop1"
-          ariaLabel="Required dropdown example"
           options={[
             { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
             { key: 'A', text: 'Option a', title: 'I am option a.' },

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Dropdown, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import './Dropdown.Basic.Example.scss';
 
 export class DropdownRequiredExample extends BaseComponent<{}, {}> {
   constructor(props: {}) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Dropdown, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
+import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
+import './Dropdown.Basic.Example.scss';
+
+export class DropdownRequiredExample extends BaseComponent<{}, {}> {
+  constructor(props: {}) {
+    super(props);
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div className="docs-DropdownExample">
+        <Dropdown
+          placeholder="Select an Option"
+          label="Required dropdown example:"
+          id="Requireddrop1"
+          ariaLabel="Required dropdown example"
+          options={[
+            { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
+            { key: 'A', text: 'Option a', title: 'I am option a.' },
+            { key: 'B', text: 'Option b' },
+            { key: 'C', text: 'Option c', disabled: true },
+            { key: 'D', text: 'Option d' },
+            { key: 'E', text: 'Option e' },
+            { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
+            { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
+            { key: 'F', text: 'Option f' },
+            { key: 'G', text: 'Option g' },
+            { key: 'H', text: 'Option h' },
+            { key: 'I', text: 'Option i' },
+            { key: 'J', text: 'Option j' }
+          ]}
+          required={true}
+        />
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -43,7 +43,6 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
         Directional hint
       </label>
       <div
-        aria-activedescendant="Dropdown0-option"
         aria-describedby="Dropdown0-option"
         aria-expanded="false"
         aria-labelledby="Dropdown0-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -700,7 +700,6 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
         Directional hint
       </label>
       <div
-        aria-activedescendant="Dropdown3-option"
         aria-describedby="Dropdown3-option"
         aria-expanded="false"
         aria-labelledby="Dropdown3-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -182,7 +182,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
 
               >
                 <div
-                  aria-activedescendant="Dropdown2-option"
                   aria-describedby="Dropdown2-option"
                   aria-disabled={false}
                   aria-expanded="false"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -45,7 +45,6 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
         Coachmark position
       </label>
       <div
-        aria-activedescendant="Dropdown0-option"
         aria-describedby="Dropdown0-option"
         aria-expanded="false"
         aria-labelledby="Dropdown0-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -196,7 +196,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         Directional hint
       </label>
       <div
-        aria-activedescendant="Dropdown1-option"
         aria-describedby="Dropdown1-option"
         aria-expanded="false"
         aria-labelledby="Dropdown1-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -209,7 +209,6 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
       Select the first day of the week
     </label>
     <div
-      aria-activedescendant="Dropdown3-option"
       aria-describedby="Dropdown3-option"
       aria-expanded="false"
       aria-labelledby="Dropdown3-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -209,7 +209,6 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
       Select the first day of the week
     </label>
     <div
-      aria-activedescendant="Dropdown3-option"
       aria-describedby="Dropdown3-option"
       aria-expanded="false"
       aria-labelledby="Dropdown3-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -40,7 +40,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example:
     </label>
     <div
-      aria-activedescendant="Basicdrop1-option"
       aria-describedby="Basicdrop1-option"
       aria-expanded="false"
       aria-label="Basic dropdown example"
@@ -578,7 +577,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       Controlled example:
     </label>
     <div
-      aria-activedescendant="Dropdown4-option"
       aria-describedby="Dropdown4-option"
       aria-expanded="false"
       aria-labelledby="Dropdown4-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -40,7 +40,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       Custom example:
     </label>
     <div
-      aria-activedescendant="Customdrop1-option"
       aria-describedby="Customdrop1-option"
       aria-expanded="false"
       aria-label="Custom dropdown example"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
+exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] = `
 <div
   className="docs-DropdownExample"
 >
@@ -34,17 +34,25 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Errormessagedrop1"
-      id="Errormessagedrop1-label"
+          &::after {
+            color: #a80000;
+            content: ' *';
+            padding-right: 12px;
+          }
+      htmlFor="Requireddrop1"
+      id="Requireddrop1-label"
+      required={true}
     >
-      Error message example:
+      Required dropdown example:
     </label>
     <div
-      aria-describedby="Errormessagedrop1-option"
+      aria-describedby="Requireddrop1-option"
       aria-expanded="false"
-      aria-label="Error message dropdown example"
+      aria-label="Required dropdown example"
+      aria-required={true}
       className=
           ms-Dropdown
+          is-required
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -129,13 +137,14 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Errormessagedrop1"
+      id="Requireddrop1"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       placeholder="Select an Option"
+      required={true}
       role="listbox"
       tabIndex={0}
     >
@@ -143,14 +152,13 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
         aria-atomic={true}
         aria-label="Select an Option"
         aria-live="off"
-        aria-setsize={5}
+        aria-setsize={10}
         className=
             ms-Dropdown-title
             ms-Dropdown-titleIsPlaceHolder
-            ms-Dropdown-title--hasError
             {
               background-color: #ffffff;
-              border-color: #a80000;
+              border-color: #a6a6a6;
               border-style: solid;
               border-width: 1px;
               box-shadow: none;
@@ -173,7 +181,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Errormessagedrop1-option"
+        id="Requireddrop1-option"
         role="option"
       >
         <span>
@@ -213,21 +221,6 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
           
         </i>
       </span>
-    </div>
-    <div
-      className=
-
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #a80000;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-            padding-top: 5px;
-          }
-    >
-      Error message
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -39,16 +39,16 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             content: ' *';
             padding-right: 12px;
           }
-      htmlFor="Requireddrop1"
-      id="Requireddrop1-label"
+      htmlFor="Dropdown0"
+      id="Dropdown0-label"
       required={true}
     >
       Required dropdown example:
     </label>
     <div
-      aria-describedby="Requireddrop1-option"
+      aria-describedby="Dropdown0-option"
       aria-expanded="false"
-      aria-label="Required dropdown example"
+      aria-labelledby="Dropdown0-label"
       aria-required={true}
       className=
           ms-Dropdown
@@ -137,7 +137,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Requireddrop1"
+      id="Dropdown0"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -181,7 +181,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Requireddrop1-option"
+        id="Dropdown0-option"
         role="option"
       >
         <span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -744,7 +744,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
         Persona Size:
       </label>
       <div
-        aria-activedescendant="Dropdown5-option"
         aria-describedby="Dropdown5-option"
         aria-expanded="false"
         aria-labelledby="Dropdown5-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -936,7 +936,6 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
         Overflow Button Type:
       </label>
       <div
-        aria-activedescendant="Dropdown5-option"
         aria-describedby="Dropdown5-option"
         aria-expanded="false"
         aria-labelledby="Dropdown5-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -99,7 +99,6 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         Select People Picker Type
       </label>
       <div
-        aria-activedescendant="Dropdown2-option"
         aria-describedby="Dropdown2-option"
         aria-expanded="false"
         aria-labelledby="Dropdown2-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3580,7 +3580,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           Number of items to render
         </label>
         <div
-          aria-activedescendant="Dropdown64-option"
           aria-describedby="Dropdown64-option"
           aria-expanded="false"
           aria-labelledby="Dropdown64-label"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #5162
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Narrator wasn't reading out "required" for required dropdowns. There was a long discussion figuring out why "aria-required" was not being read out for the listbox element, and we found out it was because the focus was jumping to the list item inside it (which is not keyboard-focusable, but comes to Narrator as having keyboard focus). So, this fix involves only maintaining aria-activedescendant when the listbox is open, and unsetting the attribute when closed. This gives us the desired behavior.

We do lose just part of what used to be read out, but reading out "required" seems more important than reading out the selected item's index when the dropdown is closed.

**Edge + Narrator**

**Before:**
Basic dropdown example, Option a, <say-as interpret-as="spell">1</say-as> of 10, selected

**After:**
Basic dropdown example, Option a selected, requires selection contains 10 items,Required,
Option a, collapsed,

**Edge + NVDA
Chrome + NVDA**

**Before:**
Basic dropdown example list collapsed required Option a
Option a, 1 of 10

**After:**
Basic dropdown example list collapsed required Option a

#### Focus areas to test

Turn on Narrator and the Dropdown demo page in Edge. Navigate to the Required Dropdown example using the keyboard and ensure that the following is read out:

Basic dropdown example, Option a selected, requires selection contains 10 items,Required,
Option a, collapsed,

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7357)

