### PR TITLE
DetailsHeader Test: Assert drag and drop hint elements are non-null

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-assert-dnd-hint-tests_2018-12-11-21-45.json
+++ b/common/changes/office-ui-fabric-react/keco-assert-dnd-hint-tests_2018-12-11-21-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsHeader Test: Assert elements in test are non-null to reduce IDE noise.",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -510,8 +510,8 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(1);
     let dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     let dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     // dragover b/w b&c and c&d -> dead zone b/w 370 and 810
     _RaiseEvent(detailsColSourceC, _DRAGOVER, 400);
@@ -525,13 +525,13 @@ describe('DetailsHeader', () => {
     // dead zone : idx 2 and 3 -> no hint shown
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual(null);
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual(null);
 
     dropHintElement = component.find('#columnDropHint_3').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual(null);
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual(null);
 
     // dragover e
     _RaiseEvent(detailsColTargetE, _DRAGOVER, 811);
@@ -539,8 +539,8 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(4);
     dropHintElement = component.find('#columnDropHint_4').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     // raise dragend on column c
     _RaiseEvent(detailsColSourceC, _DRAGEND, 490);
@@ -548,8 +548,8 @@ describe('DetailsHeader', () => {
     // drop hint should be hidden on doing a dragend
     dropHintElement = component.find('#columnDropHint_4').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: none;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // do a mousedown and dragstart on source column c
     _RaiseEvent(detailsColSourceC, _MOUSEDOWN, 490);
@@ -562,8 +562,8 @@ describe('DetailsHeader', () => {
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
 
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     // dragover outside f's zone (frozen) -> should get last valid drop hint
     _RaiseEvent(detailsColTargetF, _DRAGOVER, 1169);
@@ -571,8 +571,8 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(5);
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
   });
 
   it('should set source and target index correctly on drop', () => {
@@ -624,8 +624,8 @@ describe('DetailsHeader', () => {
 
     let dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     let dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     _RaiseEvent(detailsColTarget, _DROP, 160);
     expect(_sourceIndex).toBe(4);
@@ -633,8 +633,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: none;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // try moving column c after frozen column f (abcdef -> abdecf)
     let detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
@@ -651,8 +651,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: inline-block;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     _RaiseEvent(detailsColTarget, _DROP, 1169);
     expect(_sourceIndex).toBe(2);
@@ -660,8 +660,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual('display: none;');
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // source and target column are the same
     detailsColSourceC = component.find('[aria-colindex=4]').getDOMNode();
@@ -676,8 +676,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0).getAttribute('style')).toEqual(null);
-    expect(dropHintElementChildren.item(1).getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual(null);
 
     // drop on source column itself -> drophintindex should not be set and hence target index not updated
     _RaiseEvent(detailsColTarget, _DROP, 500);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The `DetailsHeader` drag & drop hint element access LoC in test are warning that they are _nullable_. We know they are present and therefore can assert _non-null_. This will reduce errors reported by IDE particularly VS Code, which will help authors of tests to see _actual_ errors (myself).

#### Focus areas to test

None.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7359)

