### PR TITLE
Fluent Default Button: Update hover background color

### DIFF
--- a/common/changes/@uifabric/fluent-theme/edwl-2018-12-fixButtonHoverFluent_2018-12-11-22-57.json
+++ b/common/changes/@uifabric/fluent-theme/edwl-2018-12-fixButtonHoverFluent_2018-12-11-22-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Default Button: Update hover background color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -15,6 +15,7 @@ export const DefaultButtonStyles: Partial<IButtonStyles> = {
     ...getFocusStyle(FluentTheme, 1)
   },
   rootHovered: {
+    backgroundColor: NeutralColors.gray20,
     selectors: {
       '.ms-Button--primary': {
         backgroundColor: CommunicationColors.shade10


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update incorrect hover background color of Default Button from Gray30 to Gray20.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7360)

