### PR TITLE
Fixes #7303 - Panel: When IsHiddenOnDismiss is true, Focus does not automatically enter Panel and is not returned when Panel is dismissed

### DIFF
--- a/common/changes/office-ui-fabric-react/yubojia-focusTrapZone_2018-12-11-22-54.json
+++ b/common/changes/office-ui-fabric-react/yubojia-focusTrapZone_2018-12-11-22-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusTrapZone - Make forceFocusInsideTrap prop changes modify focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "yubojia@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1294,6 +1294,8 @@ class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}>, implements I
   // (undocumented)
   componentDidMount(): void;
   // (undocumented)
+  componentDidUpdate(prevProps: IFocusTrapZoneProps): void;
+  // (undocumented)
   componentWillMount(): void;
   // (undocumented)
   componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1296,8 +1296,6 @@ class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}>, implements I
   // (undocumented)
   componentDidUpdate(prevProps: IFocusTrapZoneProps): void;
   // (undocumented)
-  componentWillMount(): void;
-  // (undocumented)
   componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void;
   // (undocumented)
   componentWillUnmount(): void;

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -21,8 +21,6 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   private _hasFocusHandler: boolean;
   private _hasClickHandler: boolean;
 
-  public componentWillMount(): void {}
-
   public componentDidMount(): void {
     this._bringFocusIntoZone();
     this._updateEventHandlers(this.props);

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -21,9 +21,7 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   private _hasFocusHandler: boolean;
   private _hasClickHandler: boolean;
 
-  public componentWillMount(): void {
-    FocusTrapZone._focusStack.push(this);
-  }
+  public componentWillMount(): void {}
 
   public componentDidMount(): void {
     this._bringFocusIntoZone();
@@ -45,23 +43,15 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
 
     if (!prevForceFocusInsideTrap && newForceFocusInsideTrap) {
       // Transition from forceFocusInsideTrap disabled to enabled. Emulate what happens when a FocusTrapZone gets mounted
-      FocusTrapZone._focusStack.push(this);
       this._bringFocusIntoZone();
     } else if (prevForceFocusInsideTrap && !newForceFocusInsideTrap) {
       // Transition from forceFocusInsideTrap enabled to disabled. Emulate what happens when a FocusTrapZone gets unmounted
-      FocusTrapZone._focusStack = FocusTrapZone._focusStack.filter((value: FocusTrapZone) => {
-        return this !== value;
-      });
       this._returnFocusToInitiator();
     }
   }
 
   public componentWillUnmount(): void {
     this._events.dispose();
-    FocusTrapZone._focusStack = FocusTrapZone._focusStack.filter((value: FocusTrapZone) => {
-      return this !== value;
-    });
-
     this._returnFocusToInitiator();
   }
 
@@ -116,6 +106,8 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   private _bringFocusIntoZone(): void {
     const { elementToFocusOnDismiss, disableFirstFocus = false } = this.props;
 
+    FocusTrapZone._focusStack.push(this);
+
     this._previouslyFocusedElementOutsideTrapZone = elementToFocusOnDismiss
       ? elementToFocusOnDismiss
       : (document.activeElement as HTMLElement);
@@ -126,6 +118,10 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
 
   private _returnFocusToInitiator(): void {
     const { ignoreExternalFocusing } = this.props;
+
+    FocusTrapZone._focusStack = FocusTrapZone._focusStack.filter((value: FocusTrapZone) => {
+      return this !== value;
+    });
 
     const activeElement = document.activeElement as HTMLElement;
     if (

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -95,7 +95,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       elementToFocusOnDismiss,
       firstFocusableSelector,
       focusTrapZoneProps,
-      forceFocusInsideTrap,
+      forceFocusInsideTrap = true,
       hasCloseButton,
       headerText,
       headerClassName = '',

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -95,7 +95,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       elementToFocusOnDismiss,
       firstFocusableSelector,
       focusTrapZoneProps,
-      forceFocusInsideTrap = true,
+      forceFocusInsideTrap,
       hasCloseButton,
       headerText,
       headerClassName = '',

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -129,9 +129,9 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   ignoreExternalFocusing?: boolean;
 
   /**
-   * Indicates whether Panel should force focus inside the focus trap zone
+   * Indicates whether Panel should force focus inside the focus trap zone.
+   * If not explicitly specified, behavior aligns with FocusTrapZone's default behavior.
    * Deprecated, use `focusTrapZoneProps`.
-   * @defaultvalue true
    * @deprecated Use `focusTrapZoneProps`.
    */
   forceFocusInsideTrap?: boolean;


### PR DESCRIPTION
#### Description of changes
Please see [Issue#7303](https://github.com/OfficeDev/office-ui-fabric-react/issues/7303) for full background explanation of the issue.

FocusTrapZone already has a "forceFocusInsideTrap" property, which the Panel sets and unsets to implement isHiddenOnDismiss. However, the feature is incomplete.
This change adds logic so that when the forceFocusInsideTrap property transitions from false to true, then bring focus into the FocusTrapZone just like if we were mounting the FocusTrapZone.
Conversely, when the forceFocusInsideTrap property transitions from true to false, return focus back outside the FocusTrapZone just like we are unmounting the FocusTrapZone.

There is also a minor change to Panel to default forceFocusInsideTrap to true like the description claims it should be.

#### Focus areas to test
Panel when isHiddenOnDismiss is set
FocusTrapZone

#### Known issues observed, but NOT being addressed by this change
- Having forceFocusInsideTrap set to false will NOT prevent focus from being brought into the FocusTrapZone when the zone is mounted. The "disableFirstFocus" property can do that
- If "disableFirstFocus" is set to true, then transitioning forceFocusInsideTrap from false to true will not bring focus into the trap zone.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7362)

