### PR TITLE
Rtl layout issue and thumbnail alt text

### DIFF
--- a/common/changes/@uifabric/dashboard/rtlLayoutIssueAndThumbnailAltText_2018-12-12-00-54.json
+++ b/common/changes/@uifabric/dashboard/rtlLayoutIssueAndThumbnailAltText_2018-12-12-00-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding LTR wrapper for RGL. This will prevent the cards from overflowing to the right most end. Although the layout of cards are displayed in LTR their content is shown in RTL when the mode is RTL. Added alt text for thumbnail item in thumbnail list",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailItem.tsx
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailItem.tsx
@@ -13,11 +13,11 @@ export class ThumbnailItem extends React.Component<IThumbnailItemProps> {
     const getClassNames = classNamesFunction<IThumbnailItemProps, IThumbnailItemStyles>();
     const classNames = getClassNames(getThumbnailItemStyles);
     const customStyles = getCustomCommandBarStyles();
-    const { imageSource, subheaderText, description } = this.props;
+    const { altImageText, imageSource, subheaderText, description } = this.props;
     return (
       <div className={classNames.root}>
         <div className={classNames.image}>
-          <Image src={imageSource} />
+          <Image src={imageSource} alt={altImageText} />
           <CompoundButton secondaryText={description} styles={customStyles} onClick={this.props.handleThumbnailItemClick}>
             {subheaderText}
           </CompoundButton>

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.tsx
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.tsx
@@ -22,6 +22,7 @@ export class ThumbnailList extends React.Component<IThumbnailListProps> {
           description={thumbnailItem.description}
           subheaderText={thumbnailItem.subheaderText}
           handleThumbnailItemClick={thumbnailItem.handleThumbnailItemClick}
+          altImageText={thumbnailItem.altImageText}
         />
       );
     });

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.types.ts
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.types.ts
@@ -17,6 +17,11 @@ export interface IThumbnailItemProps {
   description?: string;
 
   /**
+   * alternate text for the image of the thumbnail item
+   */
+  altImageText: string;
+
+  /**
    * Callback function to handle click on thumbnail item
    */
   handleThumbnailItemClick?: () => void;

--- a/packages/dashboard/src/components/Card/examples/Card.MediumWide.Basic.Example.tsx
+++ b/packages/dashboard/src/components/Card/examples/Card.MediumWide.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Card, CardContentType, CardSize, IAction, ICardProps, IThumbnailItemProps, Priority } from '../../../index';
+import { Card, CardContentType, CardSize, IAction, ICardProps, IThumbnailItemProps, Priority } from '@uifabric/dashboard';
 export class MediumWideCardBasicExample extends React.Component<{}, {}> {
   constructor(props: ICardProps) {
     super(props);

--- a/packages/dashboard/src/components/Card/examples/Card.MediumWide.Basic.Example.tsx
+++ b/packages/dashboard/src/components/Card/examples/Card.MediumWide.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Card, CardContentType, CardSize, IAction, ICardProps, IThumbnailItemProps, Priority } from '@uifabric/dashboard';
+import { Card, CardContentType, CardSize, IAction, ICardProps, IThumbnailItemProps, Priority } from '../../../index';
 export class MediumWideCardBasicExample extends React.Component<{}, {}> {
   constructor(props: ICardProps) {
     super(props);
@@ -28,7 +28,8 @@ export class MediumWideCardBasicExample extends React.Component<{}, {}> {
         description: 'This is the first thumbnail item',
         handleThumbnailItemClick: () => {
           alert('First Item clicked');
-        }
+        },
+        altImageText: 'first image'
       },
       {
         imageSource: '../../../public/images/download.jpg',
@@ -36,7 +37,8 @@ export class MediumWideCardBasicExample extends React.Component<{}, {}> {
         description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor',
         handleThumbnailItemClick: () => {
           alert('Second Item clicked');
-        }
+        },
+        altImageText: 'second image'
       }
     ];
 

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
@@ -69,28 +69,32 @@ export class DashboardGridLayoutBase extends React.Component<IDashboardGridLayou
     const { layouts } = this.state;
 
     return (
-      <ResponsiveReactGridLayout
-        isDraggable={this.props.isDraggable || true}
-        breakpoints={this.props.breakpoints}
-        cols={this.props.cols}
-        className={classNames.root}
-        margin={this.props.margin}
-        containerPadding={[0, 0]}
-        isResizable={this.props.isResizable || false}
-        rowHeight={this.props.rowHeight}
-        layouts={layouts}
-        verticalCompact={true}
-        onDrag={this.props.onDrag}
-        onDragStart={this.props.onDragStart}
-        onDragStop={this.props.onDragStop}
-        onBreakpointChange={this.props.onBreakPointChange}
-        dragApiRef={this.props.dragApi}
-        onWidthChange={this.props.onWidthChange}
-        {...this.props}
-        onLayoutChange={this._onLayoutChanged}
-      >
-        {this.props.children}
-      </ResponsiveReactGridLayout>
+      // Adding ltr explicitly as the cards in the dashboard shift to the right(out of view) when rtl direction is experienced
+      // Although the cards now appear in ltr their content is still in rtl in rtl mode
+      <div dir="ltr">
+        <ResponsiveReactGridLayout
+          isDraggable={this.props.isDraggable || true}
+          breakpoints={this.props.breakpoints}
+          cols={this.props.cols}
+          className={classNames.root}
+          margin={this.props.margin}
+          containerPadding={[0, 0]}
+          isResizable={this.props.isResizable || false}
+          rowHeight={this.props.rowHeight}
+          layouts={layouts}
+          verticalCompact={true}
+          onDrag={this.props.onDrag}
+          onDragStart={this.props.onDragStart}
+          onDragStop={this.props.onDragStop}
+          onBreakpointChange={this.props.onBreakPointChange}
+          dragApiRef={this.props.dragApi}
+          onWidthChange={this.props.onWidthChange}
+          {...this.props}
+          onLayoutChange={this._onLayoutChanged}
+        >
+          {this.props.children}
+        </ResponsiveReactGridLayout>
+      </div>
     );
   }
 

--- a/packages/dashboard/src/components/DashboardGridLayout/examples/DGLWithAddCardPanel.Example.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/examples/DGLWithAddCardPanel.Example.tsx
@@ -34,7 +34,8 @@ const thumbnailItems: IThumbnailItemProps[] = [
     description: 'This is the first thumbnail item',
     handleThumbnailItemClick: () => {
       alert('First Item clicked');
-    }
+    },
+    altImageText: 'First item'
   },
   {
     imageSource: './src/images/download.jpg',
@@ -42,7 +43,8 @@ const thumbnailItems: IThumbnailItemProps[] = [
     description: 'Lorem ipsum dolor sit amet, ',
     handleThumbnailItemClick: () => {
       alert('Second Item clicked');
-    }
+    },
+    altImageText: 'Second item'
   }
 ];
 

--- a/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.Card.Example.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.Card.Example.tsx
@@ -35,7 +35,8 @@ export class DashboardGridLayoutCardExample extends React.Component<{}, {}> {
         description: 'This is the first thumbnail item',
         handleThumbnailItemClick: () => {
           alert('First Item clicked');
-        }
+        },
+        altImageText: 'First item'
       },
       {
         imageSource: './src/images/download.jpg',
@@ -43,7 +44,8 @@ export class DashboardGridLayoutCardExample extends React.Component<{}, {}> {
         description: 'Lorem ipsum dolor sit amet, ',
         handleThumbnailItemClick: () => {
           alert('Second Item clicked');
-        }
+        },
+        altImageText: 'Second item'
       }
     ];
 

--- a/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.Sections.Example.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.Sections.Example.tsx
@@ -40,7 +40,8 @@ const thumbnailItems: IThumbnailItemProps[] = [
     description: 'This is the first thumbnail item',
     handleThumbnailItemClick: () => {
       alert('First Item clicked');
-    }
+    },
+    altImageText: 'First Item'
   },
   {
     imageSource: './src/images/download.jpg',
@@ -48,7 +49,8 @@ const thumbnailItems: IThumbnailItemProps[] = [
     description: 'Lorem ipsum dolor sit amet, ',
     handleThumbnailItemClick: () => {
       alert('Second Item clicked');
-    }
+    },
+    altImageText: 'Second Item'
   }
 ];
 

--- a/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.SectionsNonCollapse.Example.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/examples/DashboardGridLayout.SectionsNonCollapse.Example.tsx
@@ -39,7 +39,8 @@ const thumbnailItems: IThumbnailItemProps[] = [
     description: 'This is the first thumbnail item',
     handleThumbnailItemClick: () => {
       alert('First Item clicked');
-    }
+    },
+    altImageText: 'First Item'
   },
   {
     imageSource: './src/images/download.jpg',
@@ -47,7 +48,8 @@ const thumbnailItems: IThumbnailItemProps[] = [
     description: 'Lorem ipsum dolor sit amet, ',
     handleThumbnailItemClick: () => {
       alert('Second Item clicked');
-    }
+    },
+    altImageText: 'Second Item'
   }
 ];
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adding LTR wrapper for RGL. This will prevent the cards from overflowing to the rightmost end. Although the layout of cards are displayed in LTR their content is shown in RTL when the mode is RTL. Added alt text for thumbnail item in the thumbnail list.

#### Focus areas to test

(optional)
