### PR TITLE
Thumbnail list aria and alt text

### DIFF
--- a/common/changes/@uifabric/dashboard/thumbnailListAriaAndAltText_2018-12-13-16-35.json
+++ b/common/changes/@uifabric/dashboard/thumbnailListAriaAndAltText_2018-12-13-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding aria-hidden and alt property for the image of Thumbnail item in ThumbnailList component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "nulikarthik@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailItem.tsx
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailItem.tsx
@@ -13,11 +13,11 @@ export class ThumbnailItem extends React.Component<IThumbnailItemProps> {
     const getClassNames = classNamesFunction<IThumbnailItemProps, IThumbnailItemStyles>();
     const classNames = getClassNames(getThumbnailItemStyles);
     const customStyles = getCustomCommandBarStyles();
-    const { imageSource, subheaderText, description } = this.props;
+    const { altImageText, imageAriaHidden, imageSource, subheaderText, description } = this.props;
     return (
       <div className={classNames.root}>
         <div className={classNames.image}>
-          <Image src={imageSource} />
+          <Image src={imageSource} aria-hidden={imageAriaHidden} alt={altImageText} />
           <CompoundButton secondaryText={description} styles={customStyles} onClick={this.props.handleThumbnailItemClick}>
             {subheaderText}
           </CompoundButton>

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.tsx
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.tsx
@@ -22,6 +22,8 @@ export class ThumbnailList extends React.Component<IThumbnailListProps> {
           description={thumbnailItem.description}
           subheaderText={thumbnailItem.subheaderText}
           handleThumbnailItemClick={thumbnailItem.handleThumbnailItemClick}
+          imageAriaHidden={thumbnailItem.imageAriaHidden}
+          altImageText={thumbnailItem.altImageText}
         />
       );
     });

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.types.ts
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.types.ts
@@ -17,6 +17,16 @@ export interface IThumbnailItemProps {
   description?: string;
 
   /**
+   * alternate text for the image of the thumbnail item
+   */
+  altImageText?: string;
+
+  /**
+   * aria hidden for the image of the thumbnail item
+   */
+  imageAriaHidden?: boolean;
+
+  /**
    * Callback function to handle click on thumbnail item
    */
   handleThumbnailItemClick?: () => void;

--- a/packages/dashboard/src/components/Card/examples/Card.MediumWide.Basic.Example.tsx
+++ b/packages/dashboard/src/components/Card/examples/Card.MediumWide.Basic.Example.tsx
@@ -28,7 +28,9 @@ export class MediumWideCardBasicExample extends React.Component<{}, {}> {
         description: 'This is the first thumbnail item',
         handleThumbnailItemClick: () => {
           alert('First Item clicked');
-        }
+        },
+        altImageText: 'First item',
+        imageAriaHidden: true
       },
       {
         imageSource: '../../../public/images/download.jpg',
@@ -36,7 +38,8 @@ export class MediumWideCardBasicExample extends React.Component<{}, {}> {
         description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor',
         handleThumbnailItemClick: () => {
           alert('Second Item clicked');
-        }
+        },
+        altImageText: 'Second item'
       }
     ];
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Adding aria-hidden and alt property for the image of Thumbnail item in ThumbnailList component
![image](https://user-images.githubusercontent.com/22408128/49953113-403a5a80-feb2-11e8-9e63-667450dfc5de.png)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7382)

