### PR TITLE
Persona: change type of the 'coinProps' prop to IPersonaCoinProps

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-PersonaPropFix_2018-12-13-22-54.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-PersonaPropFix_2018-12-13-22-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Persona: change type of the 'coinProps' type to IPersonaCoinProps.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9086,9 +9086,9 @@ interface IPersonaProps extends IPersonaSharedProps {
 }
 
 // @public (undocumented)
-interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase> {
+interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | HTMLDivElement> {
   allowPhoneInitials?: boolean;
-  coinProps?: React.HTMLAttributes<HTMLDivElement>;
+  coinProps?: IPersonaCoinProps;
   coinSize?: number;
   hidePersonaDetails?: boolean;
   imageAlt?: string;

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -7,7 +7,7 @@ import { IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IPersona {}
 
-export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase> {
+export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | HTMLDivElement> {
   /**
    * Primary text to display, usually the name of the person.
    */
@@ -127,7 +127,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase> {
   /**
    * Optional HTML element props for Persona coin.
    */
-  coinProps?: React.HTMLAttributes<HTMLDivElement>;
+  coinProps?: IPersonaCoinProps;
 
   /**
    * Theme provided by High-Order Component.


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Changes `coinProps` type to the correct one as in #7216 which was unfortunately closed without a merge. This blocks some of the pickers css-in-js conversion so I would appreciate a quick review and merge.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7386)

