### PR TITLE
BaseComponent: Remove componentWillReceiveProps usage

### DIFF
--- a/common/changes/@uifabric/utilities/deprecations2_2018-12-14-02-23.json
+++ b/common/changes/@uifabric/utilities/deprecations2_2018-12-14-02-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "BaseComponent: Remove componentWillReceiveProps usage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/deprecations2_2018-12-14-02-23.json
+++ b/common/changes/office-ui-fabric-react/deprecations2_2018-12-14-02-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BaseComponent: Remove componentWillReceiveProps usage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -142,7 +142,7 @@ class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends React.C
   protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<TProps>): void;
   readonly className: string;
   componentDidMount(): void;
-  componentWillReceiveProps(newProps: Readonly<TProps>, newContext: any): void;
+  componentDidUpdate(prevProps: TProps, prevState: TState): void;
   componentWillUnmount(): void;
   // @deprecated (undocumented)
   static onError: ((errorMessage?: string, ex?: any) => void);

--- a/packages/utilities/etc/utilities.api.ts
+++ b/packages/utilities/etc/utilities.api.ts
@@ -74,7 +74,7 @@ class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends React.C
   protected _warnMutuallyExclusive(mutuallyExclusiveMap: ISettingsMap<TProps>): void;
   readonly className: string;
   componentDidMount(): void;
-  componentWillReceiveProps(newProps: Readonly<TProps>, newContext: any): void;
+  componentDidUpdate(prevProps: TProps, prevState: TState): void;
   componentWillUnmount(): void;
   // @deprecated (undocumented)
   static onError: ((errorMessage?: string, ex?: any) => void);

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -58,11 +58,9 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
     initializeDir();
 
     _makeAllSafe(this, BaseComponent.prototype, [
-      'componentWillMount',
       'componentDidMount',
       'shouldComponentUpdate',
-      'componentWillUpdate',
-      'componentWillReceiveProps',
+      'getSnapshotBeforeUpdate',
       'render',
       'componentDidUpdate',
       'componentWillUnmount'
@@ -70,11 +68,10 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
   }
 
   /**
-   * When the component will receive props, make sure the componentRef is updated.
+   * When the component receives props, make sure the componentRef is updated.
    */
-  // tslint:disable-next-line:no-any
-  public componentWillReceiveProps(newProps: Readonly<TProps>, newContext: any): void {
-    this._updateComponentRef(this.props, newProps);
+  public componentDidUpdate(prevProps: TProps, prevState: TState): void {
+    this._updateComponentRef(prevProps, this.props);
   }
 
   /**

--- a/packages/utilities/src/hoist.ts
+++ b/packages/utilities/src/hoist.ts
@@ -2,10 +2,14 @@ const REACT_LIFECYCLE_EXCLUSIONS = [
   'setState',
   'render',
   'componentWillMount',
+  'UNSAFE_componentWillMount',
   'componentDidMount',
   'componentWillReceiveProps',
+  'UNSAFE_componentWillReceiveProps',
   'shouldComponentUpdate',
   'componentWillUpdate',
+  'getSnapshotBeforeUpdate',
+  'UNSAFE_componentWillUpdate',
   'componentDidUpdate',
   'componentWillUnmount'
 ];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #4613
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As discussed in [this issue comment](https://github.com/OfficeDev/office-ui-fabric-react/issues/4613#issuecomment-446461869), until BaseComponent stops using `componentWillReceiveProps`, nothing extending BaseComponent can use `getDerivedStateFromProps`. React gives a console warning if the old and new lifecycles are used in combination, and it doesn't call the old lifecycles.

BaseComponent uses `componentWillReceiveProps` to update the componentRef. Based on [the blog post](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#invoking-external-callbacks), it appears that the recommended alternative is moving the logic to `componentDidUpdate`--which this PR does.

The change seems to work on initial inspection, but I'd VERY much appreciate input from others more experienced with React on whether they see any potential problems (also recommended ways to test).
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7393)

