### PR TITLE
DetailsList: Fix validation error with column header aria-describedby when onRenderColumnHeaderTooltip used

### DIFF
--- a/common/changes/office-ui-fabric-react/ariaDescribedByDetailsListHeader_2018-12-14-01-11.json
+++ b/common/changes/office-ui-fabric-react/ariaDescribedByDetailsListHeader_2018-12-14-01-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: fix conditional rendering of aria-describedby",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -93,7 +93,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                       : undefined
                   }
                   aria-describedby={
-                    this.props.onRenderColumnHeaderTooltip || this._hasAccessibleLabel() ? `${parentId}-${column.key}-tooltip` : undefined
+                    !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleLabel() ? `${parentId}-${column.key}-tooltip` : undefined
                   }
                   onContextMenu={this._onColumnContextMenu.bind(this, column)}
                   onClick={this._onColumnClick.bind(this, column)}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -146,7 +146,7 @@ describe('DetailsColumn', () => {
       />
     );
 
-    expect(component.find('[aria-describedby]').length).toBe(1);
+    expect(component.find('[aria-describedby]')).toHaveLength(1);
   });
 
   it("by default, has a node present in the DOM referenced by the column's aria-describedby attribute", () => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { DetailsColumn } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
-import { IColumn, ColumnActionsMode } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList.types';
+import { IColumn, ColumnActionsMode, IDetailsHeaderProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList.types';
 import { mount } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
-import { assign } from '@uifabric/utilities';
+import { assign, IRenderFunction } from '@uifabric/utilities';
+import { ITooltipHostProps, TooltipHost } from '../..';
 
 let mockOnColumnClick: jest.Mock<{}>;
 let baseColumn: IColumn;
@@ -174,5 +175,35 @@ describe('DetailsColumn', () => {
     const referenceId = ariaDescribedByEl.getAttribute('aria-describedby');
 
     expect(component.exists(`#${referenceId}`)).toBe(true);
+  });
+
+  it('if custom DetailsHeader has optional onRenderColumnHeaderTooltip, do not render invalid aria-describedby attribute', () => {
+    const column = assign({}, baseColumn, { ariaLabel: 'Foo' });
+    let component: any;
+    const columns = [column];
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        onRenderDetailsHeader={(props: IDetailsHeaderProps, defaultRenderer?: IRenderFunction<IDetailsHeaderProps>) => {
+          return defaultRenderer!({
+            ...props,
+            onRenderColumnHeaderTooltip: (tooltipProps: ITooltipHostProps, tooltipRenderer?: IRenderFunction<ITooltipHostProps>) => {
+              return <TooltipHost {...tooltipProps} />;
+            }
+          });
+        }}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    expect(component.exists('[aria-describedby]')).toBe(false);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -4,7 +4,6 @@ import { IColumn, ColumnActionsMode } from 'office-ui-fabric-react/lib/component
 import { mount } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
 import { assign } from '@uifabric/utilities';
-import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 
 let mockOnColumnClick: jest.Mock<{}>;
 let baseColumn: IColumn;
@@ -147,5 +146,33 @@ describe('DetailsColumn', () => {
     );
 
     expect(component.find('[aria-describedby]').length).toBe(1);
+  });
+
+  it("by default, has a node present in the DOM referenced by the column's aria-describedby attribute", () => {
+    const column = assign({}, baseColumn, { ariaLabel: 'Foo' });
+    let component: any;
+    const columns = [column];
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    const ariaDescribedByEl = component
+      .find('[aria-describedby]')
+      .first()
+      .getDOMNode();
+    const referenceId = ariaDescribedByEl.getAttribute('aria-describedby');
+
+    expect(component.exists(`#${referenceId}`)).toBe(true);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -4,7 +4,7 @@ import { IColumn, ColumnActionsMode, IDetailsHeaderProps } from 'office-ui-fabri
 import { mount } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
 import { assign, IRenderFunction } from '@uifabric/utilities';
-import { ITooltipHostProps, TooltipHost } from '../..';
+import { ITooltipHostProps, TooltipHost } from '../Tooltip';
 
 let mockOnColumnClick: jest.Mock<{}>;
 let baseColumn: IColumn;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -4,6 +4,7 @@ import { IColumn, ColumnActionsMode } from 'office-ui-fabric-react/lib/component
 import { mount } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
 import { assign } from '@uifabric/utilities';
+import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 
 let mockOnColumnClick: jest.Mock<{}>;
 let baseColumn: IColumn;
@@ -124,5 +125,27 @@ describe('DetailsColumn', () => {
     columnHeaderTitle.simulate('click');
 
     expect(mockOnColumnClick.mock.calls.length).toBe(0);
+  });
+
+  it('by default, has aria-describedby set for columns which provide an ariaLabel value', () => {
+    const column = assign({}, baseColumn, { ariaLabel: 'Foo' });
+    let component: any;
+    const columns = [column];
+
+    component = mount(
+      <DetailsList
+        items={[]}
+        setKey={'key1'}
+        initialFocusedIndex={0}
+        skipViewportMeasures={true}
+        columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
+        componentRef={ref => (component = ref)}
+        // tslint:disable-next-line:jsx-no-lambda
+        onShouldVirtualize={() => false}
+      />
+    );
+
+    expect(component.find('[aria-describedby]').length).toBe(1);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -4,7 +4,7 @@ import { IColumn, ColumnActionsMode, IDetailsHeaderProps } from 'office-ui-fabri
 import { mount } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
 import { assign, IRenderFunction } from '@uifabric/utilities';
-import { ITooltipHostProps, TooltipHost } from '../Tooltip';
+import { ITooltipHostProps, TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 
 let mockOnColumnClick: jest.Mock<{}>;
 let baseColumn: IColumn;
@@ -189,6 +189,7 @@ describe('DetailsColumn', () => {
         initialFocusedIndex={0}
         skipViewportMeasures={true}
         columns={columns}
+        // tslint:disable-next-line:jsx-no-lambda
         onRenderDetailsHeader={(props: IDetailsHeaderProps, defaultRenderer?: IRenderFunction<IDetailsHeaderProps>) => {
           return defaultRenderer!({
             ...props,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7142
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This is a collaborative effort with @natalieethell to address #7142. To summarize:

When the _optional_ `onRenderColumnHeaderTooltip` is absent, we render labels per column header for accessibility read-out. These labels are referenced by their identifier via `aria-describedby`.

In #7013, we added support for consumers to _optionally_ provide `onRenderColumnHeaderTooltip`. When this _optional_ prop is used, the rendering of the DOM that by default would render the accessible labels is left up to the developer. However, we _currently_ reference the absent DOM nodes via `aria-describedby` attributes which results in ARIA validation error(s) (the bug).

The fix is to _only_ render the `aria-describedby` attribute when the _optional_ `onRenderColumnHeaderTooltip` prop absent, i.e. the default case.

#### Focus areas to test

As part of this PR, I've added unit tests which account for this regression and confirmed by running them against `master`.

1. Verify the test logic is correct

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7410)

