### PR TITLE
Rorezend/backport v5 disable selection

### DIFF
--- a/common/changes/office-ui-fabric-react/rorezend-backport-v5-disable-selection_2018-12-15-00-13.json
+++ b/common/changes/office-ui-fabric-react/rorezend-backport-v5-disable-selection_2018-12-15-00-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "backport to v5: Add the ability to disable the built-in SelectionMode in DetailsList (PR #6140)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rorezend@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/rorezend-backport-v5-disable-selection_2018-12-15-00-13.json
+++ b/common/changes/office-ui-fabric-react/rorezend-backport-v5-disable-selection_2018-12-15-00-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "backport to v5: Add the ability to disable the built-in SelectionMode in DetailsList (PR #6140)",
+      "comment": "DetailsList: Add the ability to disable the built-in SelectionMode.",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -131,7 +131,11 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     };
 
     this._selection = props.selection || new Selection({ onSelectionChanged: undefined, getKey: props.getKey });
-    this._selection.setItems(props.items as IObjectWithKey[], false);
+
+    if (!this.props.disableSelectionZone) {
+      this._selection.setItems(props.items as IObjectWithKey[], false);
+    }
+
     this._dragDropHelper = props.dragDropEvents
       ? new DragDropHelper({
         selection: this._selection,
@@ -214,7 +218,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       checkboxVisibility,
       items,
       setKey,
-      selectionMode,
+      selectionMode = this._selection.mode,
       columns,
       viewport,
       compact
@@ -234,7 +238,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       });
     }
 
-    if (newProps.items !== items) {
+    if (!this.props.disableSelectionZone && newProps.items !== items) {
       this._selection.setItems(newProps.items, shouldResetSelection);
     }
 
@@ -340,6 +344,36 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
     const detailsFooterProps = this._getDetailsFooterProps();
     const columnReorderProps = this._getColumnReorderProps();
     const rowCount = (isHeaderVisible ? 1 : 0) + GetGroupCount(groups) + (items ? items.length : 0);
+
+    const list = groups ? (
+      <GroupedList
+        ref={ this._groupedList }
+        groups={ groups }
+        groupProps={ groupProps ? this._getGroupProps(groupProps) : undefined }
+        items={ items }
+        onRenderCell={ this._onRenderCell }
+        selection={ selection }
+        selectionMode={ selectionMode }
+        dragDropEvents={ dragDropEvents }
+        dragDropHelper={ dragDropHelper as DragDropHelper }
+        eventsToRegister={ rowElementEventMap }
+        listProps={ additionalListProps }
+        onGroupExpandStateChanged={ this._onGroupExpandStateChanged }
+        usePageCache={ usePageCache }
+        onShouldVirtualize={ onShouldVirtualize }
+      />
+    ) : (
+        <List
+          ref={ this._list }
+          role='presentation'
+          items={ enableShimmer && !items.length ? SHIMMER_ITEMS : items }
+          onRenderCell={ this._onRenderListCell(0) }
+          usePageCache={ usePageCache }
+          onShouldVirtualize={ onShouldVirtualize }
+          { ...additionalListProps }
+        />
+      );
+
     return (
       // If shouldApplyApplicationRole is true, role application will be applied to make arrow keys work
       // with JAWS.
@@ -403,45 +437,22 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
               onActiveElementChanged={ this._onActiveRowChanged }
               onBlur={ this._onBlur }
             >
-              <SelectionZone
-                ref={ this._selectionZone }
-                selection={ selection }
-                selectionPreservedOnEmptyClick={ selectionPreservedOnEmptyClick }
-                selectionMode={ selectionMode }
-                onItemInvoked={ onItemInvoked }
-                onItemContextMenu={ onItemContextMenu }
-                enterModalOnTouch={ this.props.enterModalSelectionOnTouch }
-                { ...(selectionZoneProps || {}) }
-              >
-                { groups ? (
-                  <GroupedList
-                    ref={ this._groupedList }
-                    groups={ groups }
-                    groupProps={ groupProps ? this._getGroupProps(groupProps) : undefined }
-                    items={ items }
-                    onRenderCell={ this._onRenderCell }
-                    selection={ selection }
-                    selectionMode={ selectionMode }
-                    dragDropEvents={ dragDropEvents }
-                    dragDropHelper={ dragDropHelper as DragDropHelper }
-                    eventsToRegister={ rowElementEventMap }
-                    listProps={ additionalListProps }
-                    onGroupExpandStateChanged={ this._onGroupExpandStateChanged }
-                    usePageCache={ usePageCache }
-                    onShouldVirtualize={ onShouldVirtualize }
-                  />
-                ) : (
-                    <List
-                      ref={ this._list }
-                      role='presentation'
-                      items={ enableShimmer && !items.length ? SHIMMER_ITEMS : items }
-                      onRenderCell={ this._onRenderListCell(0) }
-                      usePageCache={ usePageCache }
-                      onShouldVirtualize={ onShouldVirtualize }
-                      { ...additionalListProps }
-                    />
-                  ) }
-              </SelectionZone>
+              { !this.props.disableSelectionZone ? (
+                <SelectionZone
+                  ref={ this._selectionZone }
+                  selection={ selection }
+                  selectionPreservedOnEmptyClick={ selectionPreservedOnEmptyClick }
+                  selectionMode={ selectionMode }
+                  onItemInvoked={ onItemInvoked }
+                  onItemContextMenu={ onItemContextMenu }
+                  enterModalOnTouch={ this.props.enterModalSelectionOnTouch }
+                  { ...selectionZoneProps || {} }
+                >
+                  { list }
+                </SelectionZone>
+              ) : (
+                  list
+                ) }
             </FocusZone>
           </div>
           { onRenderDetailsFooter(
@@ -490,7 +501,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       onRenderMissingItem,
       onRenderItemColumn,
       onRenderRow = this._onRenderRow,
-      selectionMode,
+      selectionMode = this._selection.mode,
       viewport,
       checkboxVisibility,
       getRowAriaLabel,
@@ -512,7 +523,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
       compact: compact,
       columns: columns as IColumn[],
       groupNestingDepth: nestingDepth,
-      selectionMode: selectionMode!,
+      selectionMode: selectionMode,
       selection: selection,
       onDidMount: this._onRowDidMount,
       onWillUnmount: this._onRowWillUnmount,
@@ -753,7 +764,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
   /** Builds a set of columns to fix within the viewport width. */
   private _getJustifiedColumns(newColumns: IColumn[], viewportWidth: number, props: IDetailsListProps, firstIndex: number): IColumn[] {
     const {
-      selectionMode,
+      selectionMode = this._selection.mode,
       checkboxVisibility,
       groups
     } = props;
@@ -959,7 +970,8 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
             ...props,
             columns: columns,
             groupNestingDepth: groupNestingDepth,
-            selection: this._selection
+            selection: this._selection,
+            selectionMode: this._selection.mode
           },
           defaultRender
         );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.tsx
@@ -970,8 +970,7 @@ export class DetailsList extends BaseComponent<IDetailsListProps, IDetailsListSt
             ...props,
             columns: columns,
             groupNestingDepth: groupNestingDepth,
-            selection: this._selection,
-            selectionMode: this._selection.mode
+            selection: this._selection
           },
           defaultRender
         );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -258,6 +258,11 @@ export interface IDetailsListProps extends React.Props<DetailsList>, IWithViewpo
    *
    */
   columnReorderOptions?: IColumnReorderOptions;
+
+  /**
+   * Whether or not to disable the built-in SelectionZone, so the host component can provide its own.
+   */
+  disableSelectionZone?: boolean;
 }
 
 export interface IColumn {


### PR DESCRIPTION
This change backports PR #6140 to v5 (Add the ability to disable the built-in SelectionZone in DetailsList)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7412)

