### PR TITLE
MessageBar: aria-expanded and aria-controls

### DIFF
--- a/common/changes/office-ui-fabric-react/messageBarAria_2018-12-17-19-28.json
+++ b/common/changes/office-ui-fabric-react/messageBarAria_2018-12-17-19-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: add aria-expanded and aria-controls to See More button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -88,6 +88,8 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
             onClick={this._onClick}
             iconProps={{ iconName: this.state.expandSingleLine ? 'DoubleChevronUp' : 'DoubleChevronDown' }}
             ariaLabel={this.props.overflowButtonAriaLabel}
+            aria-expanded={this.state.expandSingleLine}
+            aria-controls={this.state.labelId}
           />
         </div>
       );
@@ -118,10 +120,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
 
   private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
     return (
-      <div
-        className={this._classNames.root}
-        aria-expanded={!this.props.actions && this.props.truncated ? this.state.expandSingleLine : undefined}
-      >
+      <div className={this._classNames.root}>
         <div className={this._classNames.content}>
           {this._getIconSpan()}
           {this._renderInnerText()}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -529,7 +529,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     Blocked MessageBar - single line, with dismiss button and truncated text. Truncation is not available if you use action buttons or multiline and should be used sparingly.
   </label>
   <div
-    aria-expanded={false}
     className=
         ms-MessageBar
         ms-MessageBar--blocked
@@ -697,6 +696,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
       >
         <button
+          aria-controls="MessageBar5"
+          aria-expanded={false}
           aria-label="See more"
           className=
               ms-Button
@@ -3385,7 +3386,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
     Blocked, single line, with dismiss button and truncated text - custom styles
   </label>
   <div
-    aria-expanded={false}
     className=
         ms-MessageBar
         ms-MessageBar--blocked
@@ -3555,6 +3555,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
       >
         <button
+          aria-controls="MessageBar48"
+          aria-expanded={false}
           aria-label="See more"
           className=
               ms-Button


### PR DESCRIPTION
### Pull request checklist

- [X] Addresses an existing issue: Fixes #5717
- [X] Include a change request file using `$ npm run change`

### Description of changes

These changes place `aria-expanded` and `aria-controls` on the "See more" button element instead of the entirety of the message bar (which is a change I originally made here: #5775). This makes more sense, as the button is what is actionable, not the entire message bar.

`aria-controls` is set to the id of the text that is expanded when the "See more" button is clicked.

With focus on the "See more" button, Narrator used to only read out the following, even after clicking or pressing Space/Enter to activate the button

**See more, button,**

Now, it reads out

**See more, button collapsed,
See more, button expanded,**

### Focus areas to test

Turn on Narrator and go to the MessageBar demo page. Tab "See more" button in the "Blocked MessageBar" example. Activate the button by pressing Space or Enter. Narrator should read out the following

**See more, button collapsed,
See more, button expanded,**

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7423)

