### PR TITLE
DetailsList: Fix custom footer example's footer row not full width

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-dl-custom-footer-example_2018-12-18-22-31.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-dl-custom-footer-example_2018-12-18-22-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Fix custom footer example's footer row not full width.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
@@ -147,6 +147,7 @@ export class DetailsListCustomFooterExample extends React.Component<
   ): JSX.Element {
     return (
       <DetailsRow
+        {...detailsFooterProps}
         columns={detailsFooterProps!.columns as IColumn[]}
         item={{}}
         itemIndex={-1}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Discovered this visual glitch while profiling `DetailsList`. The [DetailsList Custom Footer Example](https://developer.microsoft.com/en-us/fabric#/components/detailslist/customfooter) currently _does not_ render its footer row as full width.

This fix Object spreads the default `IDetailsFooterProps` on the footer row to fix that styling glitch.

**Note:** I ran `npm run update-snapshots`, but it did not produce output.

#### Focus areas to test

**Before**

![image](https://user-images.githubusercontent.com/706967/50187168-175efe80-02d2-11e9-8769-440b6f05d93d.png)

**After**

![image](https://user-images.githubusercontent.com/706967/50187185-2776de00-02d2-11e9-8b24-1fa726ca58a2.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7431)

