### PR TITLE
Fluent theme: Add Facepile styles

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-facepile_2018-12-20-18-35.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-facepile_2018-12-20-18-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Update Facepile overflow button color",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -14,6 +14,7 @@ import { DefaultButtonStyles } from './styles/DefaultButton.styles';
 import { DialogContentStyles, DialogFooterStyles } from './styles/Dialog.styles';
 import { DropdownStyles } from './styles/Dropdown.styles';
 import { ExpandingCardStyles, PlainCardStyles } from './styles/HoverCard.styles';
+import { FacepileStyles } from './styles/Facepile.styles';
 import { IconButtonStyles } from './styles/IconButton.styles';
 import { LabelStyles } from './styles/Label.styles';
 import { LinkStyles } from './styles/Link.styles';
@@ -97,6 +98,9 @@ export const FluentStyles: any = {
   },
   ExpandingCard: {
     styles: ExpandingCardStyles
+  },
+  Facepile: {
+    styles: FacepileStyles
   },
   IconButton: {
     styles: IconButtonStyles

--- a/packages/fluent-theme/src/fluent/styles/Facepile.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Facepile.styles.ts
@@ -1,0 +1,15 @@
+import { IFacepileStyleProps, IFacepileStyles } from 'office-ui-fabric-react/lib/Facepile';
+
+export const FacepileStyles = (props: IFacepileStyleProps): Partial<IFacepileStyles> => {
+  const { theme } = props;
+  const { palette } = theme;
+
+  return {
+    overflowButton: {
+      backgroundColor: palette.neutralLighter
+    },
+    descriptiveOverflowButton: {
+      backgroundColor: palette.neutralLighter
+    }
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7284
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds styles for Facepile to the Fluent theme. The only change at this time is making the overflow button lighter.

Before:
![image](https://user-images.githubusercontent.com/1382445/50303920-6bd5bb80-0443-11e9-93fd-fb785f9cfdfa.png)

After:
![image](https://user-images.githubusercontent.com/1382445/50303906-5c567280-0443-11e9-8b50-c9f98274b3eb.png)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7447)

