### PR TITLE
Fluent theme: Export animations as strings

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-animation-fix_2018-12-21-18-15.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-animation-fix_2018-12-21-18-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Export animations as strings instead of objects",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentMotion.ts
+++ b/packages/fluent-theme/src/fluent/FluentMotion.ts
@@ -1,73 +1,64 @@
-import { IRawStyle, keyframes } from '@uifabric/merge-styles';
+import { keyframes } from '@uifabric/merge-styles';
 
-const fadeInKeyframes: string = keyframes({
+const fadeInAnimationName: string = keyframes({
   from: { opacity: 0 },
   to: { opacity: 1 }
 });
 
-const fadeOutKeyframes: string = keyframes({
+const fadeOutAnimationName: string = keyframes({
   from: { opacity: 1 },
   to: { opacity: 0 }
 });
 
-const scaleDownInKeyframes: string = keyframes({
+const scaleDownInAnimationName: string = keyframes({
   from: { transform: 'scale3d(1.15, 1.15, 1)' },
   to: { transform: 'scale3d(1, 1, 1)' }
 });
 
-const scaleDownOutKeyframes: string = keyframes({
+const scaleDownOutAnimationName: string = keyframes({
   from: { transform: 'scale3d(1, 1, 1)' },
   to: { transform: 'scale3d(0.9, 0.9, 1)' }
 });
 
-const slideLeftOutKeyframes: string = keyframes({
+const slideLeftOutAnimationName: string = keyframes({
   from: { transform: 'translate3d(0, 0, 0)' },
   to: { transform: 'translate3d(-48px, 0, 0)' }
 });
 
-const slideRightOutKeyframes: string = keyframes({
+const slideRightOutAnimationName: string = keyframes({
   from: { transform: 'translate3d(0, 0, 0)' },
   to: { transform: 'translate3d(48px, 0, 0)' }
 });
 
-const slideLeftInKeyframes: string = keyframes({
+const slideLeftInAnimationName: string = keyframes({
   from: { transform: 'translate3d(48px, 0, 0)' },
   to: { transform: 'translate3d(0, 0, 0)' }
 });
 
-const slideRightInKeyframes: string = keyframes({
+const slideRightInAnimationName: string = keyframes({
   from: { transform: 'translate3d(-48px, 0, 0)' },
   to: { transform: 'translate3d(0, 0, 0)' }
 });
 
-const slideUpOutKeyframes: string = keyframes({
+const slideUpOutAnimationName: string = keyframes({
   from: { transform: 'translate3d(0, 0, 0)' },
   to: { transform: 'translate3d(0, -48px, 0)' }
 });
 
-const slideDownOutKeyframes: string = keyframes({
+const slideDownOutAnimationName: string = keyframes({
   from: { transform: 'translate3d(0, 0, 0)' },
   to: { transform: 'translate3d(0, 48px, 0)' }
 });
 
-const slideUpInKeyframes: string = keyframes({
+const slideUpInAnimationName: string = keyframes({
   from: { transform: 'translate3d(0, 48px, 0)' },
   to: { transform: 'translate3d(0, 0, 0)' }
 });
 
-const slideDownInKeyframes: string = keyframes({
+const slideDownInAnimationName: string = keyframes({
   from: { transform: 'translate3d(0, -48px, 0)' },
   to: { transform: 'translate3d(0, 0, 0)' }
 });
-
-function _createAnimation(animationName: string, animationDuration: string, animationTimingFunction: string): IRawStyle {
-  return {
-    animationName,
-    animationDuration,
-    animationTimingFunction,
-    animationFillMode: 'both'
-  };
-}
 
 export namespace MotionDurations {
   export const duration1 = '100ms';
@@ -83,17 +74,21 @@ export namespace MotionTimings {
   export const standard = 'cubic-bezier(0.8, 0, 0.2, 1)';
 }
 
+function _createAnimation(animationName: string, animationDuration: string, animationTimingFunction: string): string {
+  return `${animationName} ${animationDuration} ${animationTimingFunction}`;
+}
+
 export namespace MotionAnimations {
-  export const fadeIn = _createAnimation(fadeInKeyframes, MotionDurations.duration1, MotionTimings.linear);
-  export const fadeOut = _createAnimation(fadeOutKeyframes, MotionDurations.duration1, MotionTimings.linear);
-  export const scaleDownIn = _createAnimation(scaleDownInKeyframes, MotionDurations.duration3, MotionTimings.decelerate);
-  export const scaleDownOut = _createAnimation(scaleDownOutKeyframes, MotionDurations.duration3, MotionTimings.decelerate);
-  export const slideLeftOut = _createAnimation(slideLeftOutKeyframes, MotionDurations.duration1, MotionTimings.accelerate);
-  export const slideRightOut = _createAnimation(slideRightOutKeyframes, MotionDurations.duration1, MotionTimings.accelerate);
-  export const slideLeftIn = _createAnimation(slideLeftInKeyframes, MotionDurations.duration1, MotionTimings.decelerate);
-  export const slideRightIn = _createAnimation(slideRightInKeyframes, MotionDurations.duration1, MotionTimings.decelerate);
-  export const slideUpOut = _createAnimation(slideUpOutKeyframes, MotionDurations.duration1, MotionTimings.accelerate);
-  export const slideDownOut = _createAnimation(slideDownOutKeyframes, MotionDurations.duration1, MotionTimings.accelerate);
-  export const slideUpIn = _createAnimation(slideUpInKeyframes, MotionDurations.duration1, MotionTimings.decelerate);
-  export const slideDownIn = _createAnimation(slideDownInKeyframes, MotionDurations.duration1, MotionTimings.decelerate);
+  export const fadeIn = _createAnimation(fadeInAnimationName, MotionDurations.duration1, MotionTimings.linear);
+  export const fadeOut = _createAnimation(fadeOutAnimationName, MotionDurations.duration1, MotionTimings.linear);
+  export const scaleDownIn = _createAnimation(scaleDownInAnimationName, MotionDurations.duration3, MotionTimings.decelerate);
+  export const scaleDownOut = _createAnimation(scaleDownOutAnimationName, MotionDurations.duration3, MotionTimings.decelerate);
+  export const slideLeftOut = _createAnimation(slideLeftOutAnimationName, MotionDurations.duration1, MotionTimings.accelerate);
+  export const slideRightOut = _createAnimation(slideRightOutAnimationName, MotionDurations.duration1, MotionTimings.accelerate);
+  export const slideLeftIn = _createAnimation(slideLeftInAnimationName, MotionDurations.duration1, MotionTimings.decelerate);
+  export const slideRightIn = _createAnimation(slideRightInAnimationName, MotionDurations.duration1, MotionTimings.decelerate);
+  export const slideUpOut = _createAnimation(slideUpOutAnimationName, MotionDurations.duration1, MotionTimings.accelerate);
+  export const slideDownOut = _createAnimation(slideDownOutAnimationName, MotionDurations.duration1, MotionTimings.accelerate);
+  export const slideUpIn = _createAnimation(slideUpInAnimationName, MotionDurations.duration1, MotionTimings.decelerate);
+  export const slideDownIn = _createAnimation(slideDownInAnimationName, MotionDurations.duration1, MotionTimings.decelerate);
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`MotionAnimations` currently has an object for each animation. This isn't useful, as merge-styles expects a string of animation properties. I've updated the `_createAnimation()` function to return that string. See [this sandbox](https://codesandbox.io/s/pjk70rzk4m) for a demo of generating these strings and applying them to an element.

I've also renamed variables like `fadeInKeyframes` to `fadeInAnimationName` for clarity.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7458)

