### PR TITLE
Adding option to prevent the Coachmark from automatically setting focus on itself upon mounting

### DIFF
--- a/common/changes/office-ui-fabric-react/nidurak-focusOnMount_2018-12-21-21-51.json
+++ b/common/changes/office-ui-fabric-react/nidurak-focusOnMount_2018-12-21-21-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding option to prevent focus on Coachmark mount",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nidurak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2655,6 +2655,7 @@ interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
   onMouseMove?: (e: MouseEvent) => void;
   positioningContainerProps?: IPositioningContainerProps;
   preventDismissOnLostFocus?: boolean;
+  preventFocusOnMount?: boolean;
   styles?: IStyleFunctionOrObject<ICoachmarkStyleProps, ICoachmarkStyles>;
   target: HTMLElement | string | null;
   // @deprecated

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
@@ -332,11 +332,14 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
             }
           }, 0);
         }
-        this._async.setTimeout(() => {
-          if (this._entityHost.current) {
-            this._entityHost.current.focus();
-          }
-        }, 1000);
+
+        if (!this.props.preventFocusOnMount) {
+          this._async.setTimeout(() => {
+            if (this._entityHost.current) {
+              this._entityHost.current.focus();
+            }
+          }, 1000);
+        }
       }
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -166,6 +166,13 @@ export interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
   preventDismissOnLostFocus?: boolean;
 
   /**
+   * If true then focus will not be set to the Coachmark when it mounts. Useful in cases where focus on coachmark
+   * is causing other components in page to dismiss upon losing focus.
+   * @default false
+   */
+  preventFocusOnMount?: boolean;
+
+  /**
    * Callback when the Coachmark tries to close.
    */
   onDismiss?: (ev?: any) => void;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -168,7 +168,7 @@ export interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
   /**
    * If true then focus will not be set to the Coachmark when it mounts. Useful in cases where focus on coachmark
    * is causing other components in page to dismiss upon losing focus.
-   * @default false
+   * @defaultvalue false
    */
   preventFocusOnMount?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adding option to prevent the Coachmark from automatically setting focus on itself upon mounting. This was causing other components to dismiss on loss of focus. For example, a contextual menu would dismiss when the Coachmark first mounts.

#### Focus areas to test

Coachmark

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7459)

