### PR TITLE
Adding focus for action bar overflow button

### DIFF
--- a/common/changes/@uifabric/dashboard/bugfix_2741374_2018-12-24-10-10.json
+++ b/common/changes/@uifabric/dashboard/bugfix_2741374_2018-12-24-10-10.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@uifabric/dashboard",
-  "email": "gorigarajesh@gmail.com"
+  "email": "v-ragor@microsoft.com"
 }

--- a/common/changes/@uifabric/dashboard/bugfix_2741374_2018-12-24-10-10.json
+++ b/common/changes/@uifabric/dashboard/bugfix_2741374_2018-12-24-10-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Adding focus for action bar overflow button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "gorigarajesh@gmail.com"
+}

--- a/packages/dashboard/src/components/Card/ActionBar/ActionBar.styles.ts
+++ b/packages/dashboard/src/components/Card/ActionBar/ActionBar.styles.ts
@@ -31,6 +31,12 @@ export const overflowButtonStyles: IButtonStyles = {
       },
       ':hover::after': {
         display: 'none'
+      },
+      ':focus': {
+        border: 'solid black 0.5px'
+      },
+      ':focus::after': {
+        display: 'none'
       }
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adding focus for action bar overflow button



#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7468)


####screenshot
<img width="944" alt="overflowfocus" src="https://user-images.githubusercontent.com/13463251/50399115-12eb8780-07a3-11e9-8966-0d35ed656c2a.PNG">

