### PR TITLE
Add FocusTrapCallout Component

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-trapfocus_2018-12-28-02-01.json
+++ b/common/changes/office-ui-fabric-react/callout-trapfocus_2018-12-28-02-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add FocusTrapCallout component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1289,6 +1289,12 @@ export function focusClear(): IRawStyle;
 export function focusFirstChild(rootElement: HTMLElement): boolean;
 
 // @public (undocumented)
+class FocusTrapCallout extends BaseComponent<IFocusTrapCalloutProps, {}> {
+  // (undocumented)
+  render(): JSX.Element;
+}
+
+// @public (undocumented)
 class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}>, implements IFocusTrapZone {
   // (undocumented)
   componentDidMount(): void;
@@ -7709,6 +7715,12 @@ interface IFitContentToBoundsOptions {
   contentSize: ISize;
   maxScale?: number;
   mode: FitMode;
+}
+
+// @public (undocumented)
+interface IFocusTrapCalloutProps extends ICalloutProps {
+  // (undocumented)
+  focusTrapProps?: IFocusTrapZoneProps;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.doc.tsx
@@ -5,12 +5,14 @@ import { IDocPageProps } from '../../common/DocPage.types';
 
 import { CalloutBasicExample } from './examples/Callout.Basic.Example';
 import { CalloutNestedExample } from './examples/Callout.Nested.Example';
+import { CalloutFocusTrapExample } from './examples/Callout.FocusTrap.Example';
 import { CalloutDirectionalExample } from './examples/Callout.Directional.Example';
 import { CalloutCoverExample } from './examples/Callout.Cover.Example';
 import { CalloutStatus } from './Callout.checklist';
 
 const CalloutBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Basic.Example.tsx') as string;
 const CalloutNestedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Nested.Example.tsx') as string;
+const CalloutFocusTrapExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx') as string;
 const CalloutDirectionalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Directional.Example.tsx') as string;
 const CalloutCoverExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Callout/examples/Callout.Cover.Example.tsx') as string;
 
@@ -31,6 +33,11 @@ export const CalloutPageProps: IDocPageProps = {
       title: 'Nested Callout... Callout with a commandbar with a sub menu',
       code: CalloutNestedExampleCode,
       view: <CalloutNestedExample {...cmdBarParamsTextAndIcons} />
+    },
+    {
+      title: 'Focus Trap Callout',
+      code: CalloutFocusTrapExampleCode,
+      view: <CalloutFocusTrapExample {...cmdBarParamsTextAndIcons} />
     },
     {
       title: 'Callout with directional hint',

--- a/packages/office-ui-fabric-react/src/components/Callout/FocusTrapCallout.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/FocusTrapCallout.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { BaseComponent } from '../../Utilities';
+import { Callout } from './Callout';
+import { ICalloutProps } from './Callout.types';
+import { FocusTrapZone, IFocusTrapZoneProps } from '../FocusTrapZone';
+
+export interface IFocusTrapCalloutProps extends ICalloutProps {
+  /*
+   * Optional props to be passed on to FocusTrapZone
+   */
+  focusTrapProps?: IFocusTrapZoneProps;
+}
+
+export class FocusTrapCallout extends BaseComponent<IFocusTrapCalloutProps, {}> {
+  public render() {
+    return (
+      <Callout {...this.props}>
+        <FocusTrapZone {...this.props.focusTrapProps}>{this.props.children}</FocusTrapZone>
+      </Callout>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { FocusTrapCallout } from 'office-ui-fabric-react/lib/Callout';
+import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
+import './CalloutExample.scss';
+
+export interface ICalloutFocusTrapExampleProps {
+  items: ICommandBarItemProps[];
+}
+
+export class CalloutFocusTrapExample extends React.Component<
+  ICalloutFocusTrapExampleProps,
+  {
+    isCalloutVisible: boolean;
+  }
+> {
+  private _menuButtonElement: HTMLElement | null;
+
+  public constructor(props: ICalloutFocusTrapExampleProps) {
+    super(props);
+
+    this._onDismiss = this._onDismiss.bind(this);
+
+    this.state = {
+      isCalloutVisible: false
+    };
+  }
+
+  public render(): JSX.Element {
+    const { isCalloutVisible } = this.state;
+
+    return (
+      <div className="ms-CalloutExample">
+        <div className="ms-CalloutBasicExample-buttonArea" ref={menuButton => (this._menuButtonElement = menuButton)}>
+          <DefaultButton onClick={this._onDismiss} text={isCalloutVisible ? 'Hide callout' : 'Show callout'} />
+        </div>
+        {isCalloutVisible ? (
+          <div>
+            <FocusTrapCallout
+              role={'alertdialog'}
+              ariaLabelledBy={'callout-label-2'}
+              className="ms-CalloutExample-callout"
+              gapSpace={0}
+              target={this._menuButtonElement}
+              onDismiss={this._onDismiss}
+              setInitialFocus={true}
+            >
+              <div className="ms-CalloutExample-header">
+                <p className="ms-CalloutExample-title" id={'callout-label-2'}>
+                  Callout title here
+                </p>
+              </div>
+              <div className="ms-CalloutExample-inner">
+                <div className="ms-CalloutExample-content">
+                  <p className="ms-CalloutExample-subText">
+                    Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
+                  </p>
+                </div>
+              </div>
+              <CommandBar items={this.props.items} />
+            </FocusTrapCallout>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  private _onDismiss(ev: any): void {
+    this.setState({
+      isCalloutVisible: !this.state.isCalloutVisible
+    });
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/index.ts
@@ -1,3 +1,4 @@
 export * from './Callout';
 export * from './Callout.types';
+export * from './FocusTrapCallout';
 export * from '../../common/DirectionalHint';

--- a/packages/office-ui-fabric-react/src/components/HoverCard/CardCallout/CardCallout.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/CardCallout/CardCallout.tsx
@@ -5,6 +5,7 @@ import { Callout } from '../../../Callout';
 import { DirectionalHint } from '../../../common/DirectionalHint';
 import { FocusTrapZone } from '../../../FocusTrapZone';
 import { IBaseCardProps } from '../BaseCard.types';
+import { FocusTrapCallout, ICalloutProps } from '../../Callout';
 
 export interface ICardCalloutProps extends IBaseCardProps<{}, {}, {}> {
   finalHeight?: number;
@@ -25,26 +26,35 @@ export const CardCallout = (props: ICardCalloutProps) => {
     content
   } = props;
 
+  const calloutProps: ICalloutProps = {
+    ...getNativeProps(props, divProperties),
+    className: className,
+    target: targetElement,
+    isBeakVisible: false,
+    directionalHint: directionalHint,
+    directionalHintFixed: directionalHintFixed,
+    finalHeight: finalHeight,
+    minPagePadding: 24,
+    onDismiss: onLeave,
+    gapSpace: gapSpace
+  };
+
   return (
-    <Callout
-      {...getNativeProps(props, divProperties)}
-      className={className}
-      target={targetElement}
-      isBeakVisible={false}
-      directionalHint={directionalHint}
-      directionalHintFixed={directionalHintFixed}
-      finalHeight={finalHeight}
-      minPagePadding={24}
-      onDismiss={onLeave}
-      gapSpace={gapSpace}
-    >
+    <React.Fragment>
       {trapFocus ? (
-        <FocusTrapZone forceFocusInsideTrap={false} isClickableOutsideFocusTrap={true} disableFirstFocus={!firstFocus}>
+        <FocusTrapCallout
+          {...calloutProps}
+          focusTrapProps={{
+            forceFocusInsideTrap: false,
+            isClickableOutsideFocusTrap: true,
+            disableFirstFocus: !firstFocus
+          }}
+        >
           {content}
-        </FocusTrapZone>
+        </FocusTrapCallout>
       ) : (
-        content
+        <Callout {...calloutProps}>{content}</Callout>
       )}
-    </Callout>
+    </React.Fragment>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1597
- [x] Include a change request file using `$ npm run change`

#### Description of changes

 - Added a composite component called `FocusTrapCallout` to allow ability to trap focus in a `Callout`. Consumers can pass in the props as they would have in a regular `Callout` in addition they can pass `FocusTrapZone` props via `focusTrapProps` to customize the trap.
- Updated `CardCallout` in HoverCard to use the above component
