### PR TITLE
Fix Selected Nav item's pseudo element

### DIFF
--- a/common/changes/office-ui-fabric-react/Nav-selectedItem-event_2018-12-28-21-40.json
+++ b/common/changes/office-ui-fabric-react/Nav-selectedItem-event_2018-12-28-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix Nav selected item's pseudo element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -127,7 +127,8 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
             top: 0,
             right: 0,
             bottom: 0,
-            left: 0
+            left: 0,
+            pointerEvents: 'none'
           }
         }
       },
@@ -199,7 +200,8 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
             top: 0,
             right: 0,
             bottom: 0,
-            left: 0
+            left: 0,
+            pointerEvents: 'none'
           }
         }
       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -775,6 +775,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         bottom: 0px;
                         content: "";
                         left: 0px;
+                        pointer-events: none;
                         position: absolute;
                         right: 0px;
                         top: 0px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7476
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Nav selected item's pseudo element doesn't pass events hence hindering `onRenderLink` functionalities. Setting its `pointer-events` as `none`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7495)

