### PR TITLE
Pivot slot updates

### DIFF
--- a/common/changes/office-ui-fabric-react/pivotSlotUpdates_2018-12-28-22-18.json
+++ b/common/changes/office-ui-fabric-react/pivotSlotUpdates_2018-12-28-22-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "update pivot component to use semantic slots from design redlines",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jescla@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/pivotSlotUpdates_2018-12-28-22-18.json
+++ b/common/changes/office-ui-fabric-react/pivotSlotUpdates_2018-12-28-22-18.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "update pivot component to use semantic slots from design redlines",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -28,7 +28,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
   const { palette, semanticColors } = props.theme;
   return [
     {
-      color: palette.neutralPrimary,
+      color: semanticColors.actionLink,
       display: 'inline-block',
       fontSize: FontSizes.medium,
       fontWeight: FontWeights.regular,
@@ -60,7 +60,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
           visibility: 'hidden'
         },
         ':hover': {
-          color: palette.neutralPrimary,
+          color: semanticColors.actionLinkHovered,
           cursor: 'pointer'
         },
         ':focus': {
@@ -100,7 +100,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
 
 export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
   const { className, rootIsLarge, rootIsTabs, theme } = props;
-  const { palette } = theme;
+  const { palette, semanticColors } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
@@ -151,7 +151,7 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
         selectors: {
           ':before': {
             boxSizing: 'border-box',
-            borderBottom: `2px solid ${palette.themePrimary}`,
+            borderBottom: `2px solid ${semanticColors.inputBackgroundChecked}`,
             selectors: {
               [HighContrastSelector]: {
                 borderBottomColor: 'Highlight'

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -253,7 +253,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -451,7 +451,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -605,7 +605,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -767,7 +767,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -990,7 +990,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -1143,7 +1143,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -1341,7 +1341,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -1507,7 +1507,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -1713,7 +1713,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -1866,7 +1866,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -2063,7 +2063,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -2229,7 +2229,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
               top: 0px;
             }
             &:hover {
-              color: #333333;
+              color: #212121;
               cursor: pointer;
             }
             @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -103,7 +103,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -259,7 +259,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -411,7 +411,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -99,7 +99,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -254,7 +254,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -403,7 +403,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -99,7 +99,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -252,7 +252,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -401,7 +401,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -99,7 +99,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -291,7 +291,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -467,7 +467,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -630,7 +630,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -818,7 +818,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -100,7 +100,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -253,7 +253,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -402,7 +402,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -267,7 +267,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -426,7 +426,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -585,7 +585,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -99,7 +99,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -252,7 +252,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -401,7 +401,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -267,7 +267,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -426,7 +426,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -585,7 +585,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -111,7 +111,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -264,7 +264,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -413,7 +413,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -100,7 +100,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -266,7 +266,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -425,7 +425,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -584,7 +584,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -267,7 +267,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -426,7 +426,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
@@ -585,7 +585,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 top: 0px;
               }
               &:hover {
-                color: #333333;
+                color: #212121;
                 cursor: pointer;
               }
               @media screen and (-ms-high-contrast: active){&:hover {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7496
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates the Pivot fabric component with semantic slots from these redlines:

https://microsoft.sharepoint.com/teams/WebPartTheming/Shared%20Documents/Forms/AllItems.aspx?id=/teams/WebPartTheming/Shared%20Documents/Redlines/Navigation/navigation-pivot-redlines.pdf&parent=/teams/WebPartTheming/Shared%20Documents/Redlines/Navigation&p=true&slrid=64fdad9e-f0be-0000-b690-3dfab39cf474

NOTE: On the redlines, one of the states is labeled "Pressed", and it has a 2px line with `inputBackgroundChecked` color value under it. Unsure if supposed to be for the non-selected option pressed state, or for the selected pressed state. Have sent message to designer to verify but I think she's OOF today, and today is the last day on my contract. So maybe someone else can follow up with her, or maybe this PR can be accepted as is and that particular item can be addressed separately?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7497)

