### PR TITLE
SearchBox: fix handling of null value

### DIFF
--- a/common/changes/office-ui-fabric-react/searchbox-null-value_2019-01-01-16-22.json
+++ b/common/changes/office-ui-fabric-react/searchbox-null-value_2019-01-01-16-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SearchBox: fix handling of null value",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -43,8 +43,10 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
   public componentWillReceiveProps(newProps: ISearchBoxProps): void {
     if (newProps.value !== undefined) {
       this._latestValue = newProps.value;
+      // If the user passes in null, substitute an empty string
+      // (passing null is not allowed per typings, but users might do it anyway)
       this.setState({
-        value: newProps.value
+        value: newProps.value || ''
       });
     }
   }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.test.tsx
@@ -1,21 +1,37 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import { SearchBox } from './SearchBox';
 import { KeyCodes } from '../../Utilities';
+import { ISearchBoxProps } from './SearchBox.types';
+import { ISearchBoxState, SearchBoxBase } from './SearchBox.base';
 
 // tslint:disable:jsx-no-lambda
 
 describe('SearchBox', () => {
+  let component: renderer.ReactTestRenderer | undefined;
+  let wrapper: ReactWrapper<ISearchBoxProps, ISearchBoxState, SearchBoxBase> | undefined;
+
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+      component = undefined;
+    }
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
   it('renders SearchBox correctly', () => {
-    const component = renderer.create(<SearchBox />);
+    component = renderer.create(<SearchBox />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('can execute an onClick on clear button', () => {
     let clickExecuted = false;
-    const component = mount(
+    wrapper = mount(
       <SearchBox
         clearButtonProps={{
           onClick: () => (clickExecuted = true)
@@ -23,41 +39,41 @@ describe('SearchBox', () => {
       />
     );
 
-    expect(component.find('input').prop('value')).toEqual('');
+    expect(wrapper.find('input').prop('value')).toEqual('');
 
-    component.find('input').simulate('change', { target: { value: 'New value' } });
+    wrapper.find('input').simulate('change', { target: { value: 'New value' } });
 
-    expect(component.find('input').prop('value')).toEqual('New value');
+    expect(wrapper.find('input').prop('value')).toEqual('New value');
 
-    component.find('button').simulate('click');
+    wrapper.find('button').simulate('click');
 
     expect(clickExecuted).toEqual(true);
 
-    expect(component.find('input').prop('value')).toEqual('');
+    expect(wrapper.find('input').prop('value')).toEqual('');
   });
 
   it('renders SearchBox without animation correctly', () => {
-    const component = renderer.create(<SearchBox disableAnimation={true} />);
+    component = renderer.create(<SearchBox disableAnimation={true} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('can execute search when SearchBox is empty', () => {
     let searchExecuted = false;
-    const component = mount(<SearchBox onSearch={() => (searchExecuted = true)} />);
+    wrapper = mount(<SearchBox onSearch={() => (searchExecuted = true)} />);
 
-    component.find('input').simulate('keydown', { which: KeyCodes.enter });
+    wrapper.find('input').simulate('keydown', { which: KeyCodes.enter });
     expect(searchExecuted).toEqual(true);
   });
 
   it('has a default icon with empty iconProps', () => {
-    const component = mount(<SearchBox iconProps={{}} />);
+    wrapper = mount(<SearchBox iconProps={{}} />);
     const searchIcon = '';
-    expect(component.find('i').text()).toEqual(searchIcon);
+    expect(wrapper.find('i').text()).toEqual(searchIcon);
   });
 
   it('supports overriding the icon iconName', () => {
-    const component = mount(
+    wrapper = mount(
       <SearchBox
         iconProps={{
           iconName: 'Filter'
@@ -66,12 +82,12 @@ describe('SearchBox', () => {
     );
 
     const filterIcon = '';
-    expect(component.find('i').text()).toEqual(filterIcon);
+    expect(wrapper.find('i').text()).toEqual(filterIcon);
   });
 
   it('supports native props on inner input', () => {
-    const component = mount(<SearchBox autoComplete="on" />);
-    const inputEl = component.find('input').getDOMNode();
+    wrapper = mount(<SearchBox autoComplete="on" />);
+    const inputEl = wrapper.find('input').getDOMNode();
     const autocompleteVal = inputEl.getAttribute('autocomplete');
 
     expect(autocompleteVal).toBe('on');
@@ -79,8 +95,8 @@ describe('SearchBox', () => {
 
   it('supports setting a placeholder value', () => {
     const placeholder = 'Search';
-    const component = mount(<SearchBox placeholder={placeholder} />);
-    const inputEl = component.find('input').getDOMNode();
+    wrapper = mount(<SearchBox placeholder={placeholder} />);
+    const inputEl = wrapper.find('input').getDOMNode();
     const placeholderVal = inputEl.getAttribute('placeholder');
 
     expect(placeholderVal).toBe(placeholder);
@@ -88,33 +104,57 @@ describe('SearchBox', () => {
 
   it('only invokes onFocus callback once per focus event', () => {
     const onFocus = jest.fn();
-    const component = mount(<SearchBox onFocus={onFocus} />);
-    component.simulate('focus');
+    wrapper = mount(<SearchBox onFocus={onFocus} />);
+    wrapper.simulate('focus');
 
     expect(onFocus.mock.calls.length).toBe(1);
   });
 
-  it('id is generated internally and cannot be set via props', () => {
-    const component = mount(<SearchBox id={'foo'} />);
-    const inputEl = component.find('input').getDOMNode();
+  it('generates id internally and cannot be set via props', () => {
+    wrapper = mount(<SearchBox id={'foo'} />);
+    const inputEl = wrapper.find('input').getDOMNode();
     const idVal = inputEl.getAttribute('id');
 
     expect(idVal).toBe('SearchBox12');
   });
 
-  it('disable state can be set via props', () => {
-    const component = mount(<SearchBox disabled />);
-    const inputEl = component.find('input').getDOMNode();
+  it('can be disabled via props', () => {
+    wrapper = mount(<SearchBox disabled />);
+    const inputEl = wrapper.find('input').getDOMNode();
     const disabledVal = inputEl.getAttribute('disabled');
 
     expect(disabledVal).toBe('');
   });
 
-  it('disable is false by default', () => {
-    const component = mount(<SearchBox />);
-    const inputEl = component.find('input').getDOMNode();
+  it('is not disabled by default', () => {
+    wrapper = mount(<SearchBox />);
+    const inputEl = wrapper.find('input').getDOMNode();
     const disabledVal = inputEl.getAttribute('disabled');
 
     expect(disabledVal).toBeFalsy();
+  });
+
+  it('handles setting value', () => {
+    wrapper = mount(<SearchBox value="test" />);
+    expect(wrapper.find('input').prop('value')).toBe('test');
+  });
+
+  it('handles setting null value', () => {
+    // this is not allowed per typings, but users might do it anyway
+    wrapper = mount(<SearchBox value={null as any} />);
+    expect(wrapper.find('input').prop('value')).toBe('');
+  });
+
+  it('handles updating value to empty string', () => {
+    wrapper = mount(<SearchBox value="test" />);
+    wrapper.setProps({ value: '' });
+    expect(wrapper.find('input').prop('value')).toBe('');
+  });
+
+  it('handles updating value to null', () => {
+    wrapper = mount(<SearchBox value="test" />);
+    // this is not allowed per typings, but users might do it anyway
+    wrapper.setProps({ value: null as any });
+    expect(wrapper.find('input').prop('value')).toBe('');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -67,9 +67,9 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
 
   /**
    * The default value of the text in the SearchBox, in the case of an uncontrolled component.
-   * Up till now, this has not been implemented, deprecating. Will re-implement if uncontrolled
+   * Deprecating prop since so far, this has not been implemented. Will un-deprecate if uncontrolled
    * component behavior is implemented.
-   * @deprecated Not implmented.
+   * @deprecated Not implemented.
    */
   defaultValue?: string;
 
@@ -101,7 +101,7 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
   underlined?: boolean;
 
   /**
-   * Theme (provided through customization.)
+   * Theme (provided through customization).
    */
   theme?: ITheme;
 

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -67,8 +67,7 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
 
   /**
    * The default value of the text in the SearchBox, in the case of an uncontrolled component.
-   * Deprecating prop since so far, this has not been implemented. Will un-deprecate if uncontrolled
-   * component behavior is implemented.
+   * This prop is being deprecated since so far, uncontrolled behavior has not been implemented.
    * @deprecated Not implemented.
    */
   defaultValue?: string;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7449
- [x] Include a change request file using `$ npm run change`

#### Description of changes

If the component consumer passes in `null` as the `value` prop for the SearchBox, we should substitute an empty string to prevent exceptions.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7501)

