### PR TITLE
git U/jehell/calendar griditem

### DIFF
--- a/common/changes/office-ui-fabric-react/u-jehell-cal-griditem_2019-01-02-21-59.json
+++ b/common/changes/office-ui-fabric-react/u-jehell-cal-griditem_2019-01-02-21-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix calendar accessibility edge bug preventing row and column info from being populated correctly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jehell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -121,7 +121,6 @@ $Calendar-dayPicker-margin: 10px;
   @include ms-font-m-plus;
   color: $ms-color-neutralPrimary;
   box-sizing: border-box;
-  display: inline-flex;
   justify-content: center;
   align-items: center;
   cursor: default;


### PR DESCRIPTION
#### Description of changes

The row and column accessibly properties are not being populated (currently set to 0) for the table cells (td) causing screen readers to not read the row and column numbers.  This is due to an edge bug when the "inline-flex" is used as a display value.  

This change removes the display value causing the row and column properties to be set properly.

#### Focus areas to test

- Narrator row and column info should now be read by narrator
- No other changes are expected.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7507)

