### PR TITLE
Users/chhil/add restricted dates

### DIFF
--- a/common/changes/office-ui-fabric-react/Users-Chhil-AddRestrictedDates_2019-01-03-18-23.json
+++ b/common/changes/office-ui-fabric-react/Users-Chhil-AddRestrictedDates_2019-01-03-18-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Allow disabling specific dates on the calendar in addition to the max and min dates.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "chhil@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2275,6 +2275,7 @@ interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttributes<HTM
   navigationIcons?: ICalendarIconStrings;
   onDismiss?: () => void;
   onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
+  restrictedDates?: Date[];
   selectDateOnClick?: boolean;
   // @deprecated
   shouldFocusOnMount?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
@@ -78,7 +78,7 @@ export const CalendarPageProps: IDocPageProps = {
       )
     },
     {
-      title: `Inline Calendar with week selection, date boundary (minDate, maxDate), disabled dates (restrictedDates)
+      title: `Inline Calendar with week selection, date boundary (minDate, maxDate), disabled dates (restrictedDates),
         and overlaid year picker when month header is clicked`,
       code: CalendarInlineExampleCode,
 

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
@@ -32,7 +32,7 @@ export const CalendarPageProps: IDocPageProps = {
         />
       ),
       codepenJS: CalendarInlineExampleCodepen
-   },
+    },
     {
       title: 'Inline Calendar with overlaid month picker when header is clicked',
       code: CalendarInlineExampleCode,
@@ -47,7 +47,7 @@ export const CalendarPageProps: IDocPageProps = {
           showGoToToday={false}
         />
       )
-   },
+    },
     {
       title: 'Inline Calendar with month picker and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -61,7 +61,7 @@ export const CalendarPageProps: IDocPageProps = {
           showGoToToday={true}
         />
       )
-   },
+    },
     {
       title: 'Inline Calendar with week selection and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -76,10 +76,10 @@ export const CalendarPageProps: IDocPageProps = {
           showNavigateButtons={true}
         />
       )
-   },
+    },
     {
-      title: `Inline Calendar with week selection, date boundary (minDate, maxDate), disabled dates (restrictedDates) and overlaid year picker when
-        month header is clicked`,
+      title: `Inline Calendar with week selection, date boundary (minDate, maxDate), disabled dates (restrictedDates)
+        and overlaid year picker when month header is clicked`,
       code: CalendarInlineExampleCode,
 
       view: (
@@ -95,7 +95,7 @@ export const CalendarPageProps: IDocPageProps = {
           restrictedDates={[addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)]}
         />
       )
-   },
+    },
     {
       title: 'Inline Calendar with month selection and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -110,7 +110,7 @@ export const CalendarPageProps: IDocPageProps = {
           showNavigateButtons={true}
         />
       )
-   },
+    },
     {
       title: 'Inline Calendar with week numbers',
       code: CalendarInlineExampleCode,
@@ -124,7 +124,7 @@ export const CalendarPageProps: IDocPageProps = {
           showWeekNumbers={true}
         />
       )
-   },
+    },
     {
       title: 'Inline Calendar with 6 weeks display by default',
       code: CalendarInlineExampleCode,
@@ -138,7 +138,7 @@ export const CalendarPageProps: IDocPageProps = {
           showSixWeeksByDefault={true}
         />
       )
-   },
+    },
     {
       title: 'Inline Calendar with month picker, no day picker, and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -153,9 +153,10 @@ export const CalendarPageProps: IDocPageProps = {
           isDayPickerVisible={false}
         />
       )
-   },
+    },
     {
-      title: 'Inline Calendar with date boundary (minDate, maxDate), disabled dates (restrictedDates), and overlaid year picker when month header is clicked',
+      title: `Inline Calendar with date boundary (minDate, maxDate), disabled dates (restrictedDates),
+        and overlaid year picker when month header is clicked`,
       code: CalendarInlineExampleCode,
 
       view: (
@@ -170,7 +171,7 @@ export const CalendarPageProps: IDocPageProps = {
           restrictedDates={[addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)]}
         />
       )
-   },
+    },
     {
       title: `Calendar with workWeekDays = [T W, F, Sa] provided, first day of week = M, and overlaid year picker when
       month header is clicked`,
@@ -187,14 +188,14 @@ export const CalendarPageProps: IDocPageProps = {
           workWeekDays={[DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Friday, DayOfWeek.Saturday]}
         />
       )
-   },
+    },
     {
       title: 'Calendar launched from a button',
       code: CalendarButtonExampleCode,
 
       view: <CalendarButtonExample highlightCurrentMonth={true} />,
       codepenJS: CalendarButtonExampleCodepen
-   },
+    },
     {
       title: 'Month picker launched from a button',
       code: CalendarButtonExampleCode,
@@ -207,7 +208,7 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for Month Picker'}
         />
       )
-   },
+    },
     {
       title: 'Calendar with overlaid month picker launched from a button',
       code: CalendarButtonExampleCode,
@@ -220,7 +221,7 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for overlaid Day Picker and Month Picker'}
         />
       )
-   },
+    },
     {
       title: 'Calendar with overlaid month picker launched from a button without show go to today button',
       code: CalendarButtonExampleCode,
@@ -234,7 +235,7 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for overlaid Day Picker and Month Picker without go to today button'}
         />
       )
-   }
+    }
   ],
   propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/Calendar.types.ts')],
   overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/docs/CalendarOverview.md'),

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
@@ -4,7 +4,7 @@ import { IDocPageProps } from '../../common/DocPage.types';
 import { CalendarButtonExample } from './examples/Calendar.Button.Example';
 import { CalendarInlineExample } from './examples/Calendar.Inline.Example';
 import { CalendarStatus } from './Calendar.checklist';
-import { addMonths, addYears, addWeeks } from '../../utilities/dateMath/DateMath';
+import { addMonths, addYears, addWeeks, addDays } from '../../utilities/dateMath/DateMath';
 
 const CalendarButtonExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx') as string;
 const CalendarButtonExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Calendar/Calendar.Button.Example.Codepen.txt') as string;
@@ -32,7 +32,7 @@ export const CalendarPageProps: IDocPageProps = {
         />
       ),
       codepenJS: CalendarInlineExampleCodepen
-    },
+   },
     {
       title: 'Inline Calendar with overlaid month picker when header is clicked',
       code: CalendarInlineExampleCode,
@@ -47,7 +47,7 @@ export const CalendarPageProps: IDocPageProps = {
           showGoToToday={false}
         />
       )
-    },
+   },
     {
       title: 'Inline Calendar with month picker and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -61,7 +61,7 @@ export const CalendarPageProps: IDocPageProps = {
           showGoToToday={true}
         />
       )
-    },
+   },
     {
       title: 'Inline Calendar with week selection and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -76,9 +76,9 @@ export const CalendarPageProps: IDocPageProps = {
           showNavigateButtons={true}
         />
       )
-    },
+   },
     {
-      title: `Inline Calendar with week selection, date boundary (minDate, maxDate), and overlaid year picker when
+      title: `Inline Calendar with week selection, date boundary (minDate, maxDate), disabled dates (restrictedDates) and overlaid year picker when
         month header is clicked`,
       code: CalendarInlineExampleCode,
 
@@ -92,9 +92,10 @@ export const CalendarPageProps: IDocPageProps = {
           showNavigateButtons={true}
           minDate={addWeeks(today, -2)}
           maxDate={addWeeks(today, 2)}
+          restrictedDates={[addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)]}
         />
       )
-    },
+   },
     {
       title: 'Inline Calendar with month selection and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -109,7 +110,7 @@ export const CalendarPageProps: IDocPageProps = {
           showNavigateButtons={true}
         />
       )
-    },
+   },
     {
       title: 'Inline Calendar with week numbers',
       code: CalendarInlineExampleCode,
@@ -123,7 +124,7 @@ export const CalendarPageProps: IDocPageProps = {
           showWeekNumbers={true}
         />
       )
-    },
+   },
     {
       title: 'Inline Calendar with 6 weeks display by default',
       code: CalendarInlineExampleCode,
@@ -137,7 +138,7 @@ export const CalendarPageProps: IDocPageProps = {
           showSixWeeksByDefault={true}
         />
       )
-    },
+   },
     {
       title: 'Inline Calendar with month picker, no day picker, and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
@@ -152,9 +153,9 @@ export const CalendarPageProps: IDocPageProps = {
           isDayPickerVisible={false}
         />
       )
-    },
+   },
     {
-      title: 'Inline Calendar with date boundary (minDate, maxDate) and overlaid year picker when month header is clicked',
+      title: 'Inline Calendar with date boundary (minDate, maxDate), disabled dates (restrictedDates), and overlaid year picker when month header is clicked',
       code: CalendarInlineExampleCode,
 
       view: (
@@ -166,9 +167,10 @@ export const CalendarPageProps: IDocPageProps = {
           showGoToToday={false}
           minDate={addMonths(today, -1)}
           maxDate={addYears(today, 1)}
+          restrictedDates={[addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)]}
         />
       )
-    },
+   },
     {
       title: `Calendar with workWeekDays = [T W, F, Sa] provided, first day of week = M, and overlaid year picker when
       month header is clicked`,
@@ -185,14 +187,14 @@ export const CalendarPageProps: IDocPageProps = {
           workWeekDays={[DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Friday, DayOfWeek.Saturday]}
         />
       )
-    },
+   },
     {
       title: 'Calendar launched from a button',
       code: CalendarButtonExampleCode,
 
       view: <CalendarButtonExample highlightCurrentMonth={true} />,
       codepenJS: CalendarButtonExampleCodepen
-    },
+   },
     {
       title: 'Month picker launched from a button',
       code: CalendarButtonExampleCode,
@@ -205,7 +207,7 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for Month Picker'}
         />
       )
-    },
+   },
     {
       title: 'Calendar with overlaid month picker launched from a button',
       code: CalendarButtonExampleCode,
@@ -218,7 +220,7 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for overlaid Day Picker and Month Picker'}
         />
       )
-    },
+   },
     {
       title: 'Calendar with overlaid month picker launched from a button without show go to today button',
       code: CalendarButtonExampleCode,
@@ -232,7 +234,7 @@ export const CalendarPageProps: IDocPageProps = {
           buttonString={'Click for overlaid Day Picker and Month Picker without go to today button'}
         />
       )
-    }
+   }
   ],
   propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/Calendar.types.ts')],
   overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Calendar/docs/CalendarOverview.md'),

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -131,6 +131,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
       navigationIcons,
       minDate,
       maxDate,
+      restrictedDates,
       className,
       showCloseButton,
       allFocusable,
@@ -195,6 +196,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
                     showSixWeeksByDefault={this.props.showSixWeeksByDefault}
                     minDate={minDate}
                     maxDate={maxDate}
+                    restrictedDates={restrictedDates}
                     workWeekDays={this.props.workWeekDays}
                     componentRef={this._dayPicker}
                     showCloseButton={showCloseButton}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -143,6 +143,11 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
   maxDate?: Date;
 
   /**
+   * If set the Calendar will not allow selection of dates in this array.
+   */
+  restrictedDates?: Date[];
+
+  /**
    * Whether the calendar should show 6 weeks by default.
    * @defaultvalue false
    */

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -58,6 +58,7 @@ export interface ICalendarDayProps extends React.ClassAttributes<CalendarDay> {
   showSixWeeksByDefault?: boolean;
   minDate?: Date;
   maxDate?: Date;
+  restrictedDates?: Date[];
   workWeekDays?: DayOfWeek[];
   showCloseButton?: boolean;
   allFocusable?: boolean;
@@ -662,6 +663,9 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     if (dateRangeType !== DateRangeType.Day) {
       dateRange = this._getBoundedDateRange(dateRange, minDate, maxDate);
     }
+    dateRange = dateRange.filter(d => {
+      return !this._getIsRestrictedDate(d);
+    });
 
     if (onSelectDate) {
       onSelectDate(selectedDate, dateRange);
@@ -772,7 +776,10 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
           isToday: compareDates(todaysDate, date),
           isSelected: isInDateRangeArray(date, selectedDates),
           onSelected: this._onSelectDate.bind(this, originalDate),
-          isInBounds: (minDate ? compareDatePart(minDate, date) < 1 : true) && (maxDate ? compareDatePart(date, maxDate) < 1 : true)
+          isInBounds:
+            (minDate ? compareDatePart(minDate, date) < 1 : true) &&
+            (maxDate ? compareDatePart(date, maxDate) < 1 : true) &&
+            !this._getIsRestrictedDate(date)
         };
 
         week.push(dayInfo);
@@ -792,6 +799,17 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     }
 
     return weeks;
+  }
+
+  private _getIsRestrictedDate(date: Date): boolean {
+    const { restrictedDates } = this.props;
+    if (!restrictedDates) {
+      return false;
+    }
+    const restrictedDate = restrictedDates.find(rd => {
+      return rd.getDate() === date.getDate() && rd.getMonth() === date.getMonth() && rd.getFullYear() === date.getFullYear();
+    });
+    return restrictedDate ? true : false;
   }
 
   private _getBoundedDateRange(dateRange: Date[], minDate?: Date, maxDate?: Date): Date[] {

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -807,7 +807,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       return false;
     }
     const restrictedDate = restrictedDates.find(rd => {
-      return rd.getDate() === date.getDate() && rd.getMonth() === date.getMonth() && rd.getFullYear() === date.getFullYear();
+      return compareDates(rd, date);
     });
     return restrictedDate ? true : false;
   }

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -72,15 +72,6 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
       dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
     }
 
-    const today: Date = new Date();
-    const restrictedDates: Date[] = [
-      new Date(today.getFullYear(), today.getMonth(), 15),
-      new Date(today.getFullYear(), today.getMonth(), 27),
-      new Date(today.getFullYear(), today.getMonth(), 12),
-      new Date(today.getFullYear(), today.getMonth(), 18),
-      new Date(today.getFullYear(), today.getMonth(), 15)
-    ];
-
     return (
       <div style={divStyle}>
         {
@@ -119,7 +110,6 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           showWeekNumbers={this.props.showWeekNumbers}
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
-          restrictedDates={restrictedDates}
           showSixWeeksByDefault={this.props.showSixWeeksByDefault}
           workWeekDays={this.props.workWeekDays}
         />

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -36,6 +36,7 @@ export interface ICalendarInlineExampleProps {
   showWeekNumbers?: boolean;
   minDate?: Date;
   maxDate?: Date;
+  restrictedDates?: Date[];
   showSixWeeksByDefault?: boolean;
   workWeekDays?: DayOfWeek[];
   firstDayOfWeek?: DayOfWeek;
@@ -58,7 +59,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
 
   public render(): JSX.Element {
     const divStyle: React.CSSProperties = {
-      height: '340px'
+      height: 'auto'
     };
 
     const buttonStyle: React.CSSProperties = {
@@ -93,6 +94,15 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
             </span>
           </div>
         )}
+        {(this.props.restrictedDates) && (
+          <div>
+            Disabled date(s):
+            <span>
+              {' '}
+              {this.props.restrictedDates.map((d) => d.toLocaleDateString()).join(', ')}
+            </span>
+          </div>
+        )}
         <Calendar
           onSelectDate={this._onSelectDate}
           onDismiss={this._onDismiss}
@@ -110,6 +120,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           showWeekNumbers={this.props.showWeekNumbers}
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
+          restrictedDates={this.props.restrictedDates}
           showSixWeeksByDefault={this.props.showSixWeeksByDefault}
           workWeekDays={this.props.workWeekDays}
         />

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -72,6 +72,15 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
       dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
     }
 
+    const today: Date = new Date();
+    const restrictedDates: Date[] = [
+      new Date(today.getFullYear(), today.getMonth(), 15),
+      new Date(today.getFullYear(), today.getMonth(), 27),
+      new Date(today.getFullYear(), today.getMonth(), 12),
+      new Date(today.getFullYear(), today.getMonth(), 18),
+      new Date(today.getFullYear(), today.getMonth(), 15)
+    ];
+
     return (
       <div style={divStyle}>
         {
@@ -110,6 +119,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           showWeekNumbers={this.props.showWeekNumbers}
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
+          restrictedDates={restrictedDates}
           showSixWeeksByDefault={this.props.showSixWeeksByDefault}
           workWeekDays={this.props.workWeekDays}
         />

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -94,12 +94,12 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
             </span>
           </div>
         )}
-        {(this.props.restrictedDates) && (
+        {this.props.restrictedDates && (
           <div>
             Disabled date(s):
             <span>
               {' '}
-              {this.props.restrictedDates.map((d) => d.toLocaleDateString()).join(', ')}
+              {this.props.restrictedDates.length > 0 ? this.props.restrictedDates.map(d => d.toLocaleDateString()).join(', ') : 'Not set'}
             </span>
           </div>
         )}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6684
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Allow disabling specific dates on the calendar in addition to the max and min dates.
Example Usage:
  ```
    const today: Date = new Date();
    const restrictedDates: Date[] = [
      new Date(today.getFullYear(), today.getMonth(), 15),
      new Date(today.getFullYear(), today.getMonth(), 27),
      new Date(today.getFullYear(), today.getMonth(), 12),
      new Date(today.getFullYear(), today.getMonth(), 18),
      new Date(today.getFullYear(), today.getMonth(), 15)
    ];

    <Calendar
    .../* other props */
    restrictedDates={restrictedDates}
     />
```
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7509)

