### PR TITLE
Show tooltip

### DIFF
--- a/common/changes/office-ui-fabric-react/show-tooltip_2019-01-03-01-07.json
+++ b/common/changes/office-ui-fabric-react/show-tooltip_2019-01-03-01-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TooltipHost: add show method",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10891,6 +10891,7 @@ interface ITooltip {
 // @public (undocumented)
 interface ITooltipHost {
   dismiss: () => void;
+  show: () => void;
 }
 
 // @public
@@ -12434,6 +12435,8 @@ class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHostState
   dismiss: () => void;
   // (undocumented)
   render(): JSX.Element;
+  // (undocumented)
+  show: () => void;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -111,6 +111,10 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
     }
   }
 
+  public show = (): void => {
+    this._toggleTooltip(true);
+  };
+
   public dismiss = (): void => {
     this._hideTooltip();
   };

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
@@ -8,7 +8,12 @@ import { IStyle, ITheme } from '../../Styling';
 
 export interface ITooltipHost {
   /**
-   * Dismisses the tooltip
+   * Shows the tooltip.
+   */
+  show: () => void;
+
+  /**
+   * Dismisses the tooltip.
    */
   dismiss: () => void;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7510 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Tooltip exposes a `dismiss` method, but there was no equivalent method to show the tooltip. The new `show` method provides a workaround for #7510, since the Dropdown can now call `show` on TooltipHost when the user selects an option.

Codepen showing the issue (tooltip not shown on option selection): https://codepen.io/kkjeer/pen/RExvWR?editors=1010#0

Codepen showing the workaround using the new `show` method (tooltip shown on option selection): https://codepen.io/kkjeer/pen/gZoqPg?editors=1010#0

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7511)

