### PR TITLE
DocumentCard: add optional aria role property to allow override the default aria role.

### DIFF
--- a/common/changes/office-ui-fabric-react/yimwu-documentcardariarole_2019-01-04-00-09.json
+++ b/common/changes/office-ui-fabric-react/yimwu-documentcardariarole_2019-01-04-00-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCard: add optional aria role property to allow override the default aria role.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "yimwu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7397,6 +7397,7 @@ interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
   componentRef?: IRefObject<IDocumentCard>;
   onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
   onClickHref?: string;
+  role?: string;
   type?: DocumentCardType;
 }
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.tsx
@@ -32,7 +32,7 @@ export class DocumentCard extends BaseComponent<IDocumentCardProps, any> impleme
     }
 
     // if this element is actionable it should have an aria role
-    const role = actionable ? (onClick ? 'button' : 'link') : undefined;
+    const role = this.props.role || (actionable ? (onClick ? 'button' : 'link') : undefined);
     const tabIndex = actionable ? 0 : undefined;
 
     return (

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -49,6 +49,13 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
   className?: string;
 
   /**
+   * Aria role assigned to the documentCard (Eg. button, link).
+   * Use this to override the default assignment.
+   * When onClick is provided, default role will be 'button'. When onClickHref is provided, default role will be 'link'.
+   */
+  role?: string;
+
+  /**
    * Hex color value of the line below the card, which should correspond to the document type.
    * This should only be supplied when using the 'compact' card layout.
    *

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -51,7 +51,7 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
   /**
    * Aria role assigned to the documentCard (Eg. button, link).
    * Use this to override the default assignment.
-   * When onClick is provided, default role will be 'button'. When onClickHref is provided, default role will be 'link'.
+   * @defaultvalue When `onClick` is provided, default role will be 'button'. When `onClickHref` is provided, default role will be 'link'.
    */
   role?: string;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ X] Include a change request file using `$ npm run change`

#### Description of changes

DocumentCard: add optional aria role property to allow override the default aria role.

By default doucmentCard will have role set to 'button' when onClick is provided. But in some case, we still want to set role to 'link' even though onClick is provided.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7517)

