### PR TITLE
Fix broken modal snapshot in master branch

### DIFF
--- a/common/changes/office-ui-fabric-react/fixSnapshots_2019-01-05-10-00.json
+++ b/common/changes/office-ui-fabric-react/fixSnapshots_2019-01-05-10-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`Modal renders Modal correctly 1`] = `
                 box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
                 box-sizing: border-box;
                 max-height: 100%;
-                outline: 3px solid tranparent;
+                outline: 3px solid transparent;
                 overflow-y: auto;
                 position: relative;
                 text-align: left;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

It appears that the new just build is not breaking the build when there are snapshot test failures.
 
This breakage happened in PR https://github.com/OfficeDev/office-ui-fabric-react/pull/7523

The corresponding Travis CI build (and also all builds on Azure Pipelines) have the same snapshot errors but all failed to break the build on the error.

https://travis-ci.org/OfficeDev/office-ui-fabric-react/builds/475305588?utm_source=github_status&utm_medium=notification

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7536)

