### PR TITLE
ActionButton: Fix focus outline getting clipped when the action button sits within a container with `overflow:'hidden'`.

### DIFF
--- a/common/changes/office-ui-fabric-react/issue7528_2019-01-05-10-33.json
+++ b/common/changes/office-ui-fabric-react/issue7528_2019-01-05-10-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ActionButton: Fix focus outline getting clipped when the action button sits within a container with `overflow:'hidden'`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ActionButton/ActionButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ActionButton/ActionButton.styles.ts
@@ -15,7 +15,7 @@ export const getStyles = memoizeFunction(
         height: DEFAULT_BUTTON_HEIGHT,
         color: theme.palette.neutralPrimary,
         backgroundColor: 'transparent',
-        border: 'none'
+        border: '1px solid transparent'
       },
 
       rootHovered: {

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Button renders ActionButton correctly 1`] = `
         -webkit-font-smoothing: antialiased;
         background-color: transparent;
         border-radius: 0px;
-        border: none;
+        border: 1px solid transparent;
         box-sizing: border-box;
         color: #333333;
         cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`Modal renders Modal correctly 1`] = `
                 box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
                 box-sizing: border-box;
                 max-height: 100%;
-                outline: 3px solid tranparent;
+                outline: 3px solid transparent;
                 overflow-y: auto;
                 position: relative;
                 text-align: left;

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Nav renders Nav correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -206,7 +206,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -349,7 +349,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -492,7 +492,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -639,7 +639,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -782,7 +782,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -925,7 +925,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1068,7 +1068,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1215,7 +1215,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1358,7 +1358,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1501,7 +1501,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1644,7 +1644,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   -webkit-font-smoothing: antialiased;
                   background-color: #ffffff;
                   border-radius: 100%;
-                  border: none;
+                  border: 1px solid transparent;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
@@ -21,7 +21,7 @@ exports[`Component Examples renders Button.Action.Example.tsx correctly 1`] = `
           -webkit-font-smoothing: antialiased;
           background-color: transparent;
           border-radius: 0px;
-          border: none;
+          border: 1px solid transparent;
           box-sizing: border-box;
           color: #333333;
           cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
@@ -24,7 +24,7 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
             -webkit-font-smoothing: antialiased;
             background-color: transparent;
             border-radius: 0px;
-            border: none;
+            border: 1px solid transparent;
             box-sizing: border-box;
             color: #333333;
             cursor: pointer;
@@ -200,7 +200,7 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
             -webkit-font-smoothing: antialiased;
             background-color: transparent;
             border-radius: 0px;
-            border: none;
+            border: 1px solid transparent;
             box-sizing: border-box;
             color: #333333;
             cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -179,7 +179,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
                         border-radius: 0px;
-                        border: none;
+                        border: 1px solid transparent;
                         box-sizing: border-box;
                         color: #333333;
                         cursor: pointer;
@@ -358,7 +358,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             -webkit-font-smoothing: antialiased;
                             background-color: transparent;
                             border-radius: 0px;
-                            border: none;
+                            border: 1px solid transparent;
                             box-sizing: border-box;
                             color: #333333;
                             cursor: pointer;
@@ -526,7 +526,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             -webkit-font-smoothing: antialiased;
                             background-color: transparent;
                             border-radius: 0px;
-                            border: none;
+                            border: 1px solid transparent;
                             box-sizing: border-box;
                             color: #333333;
                             cursor: pointer;
@@ -698,7 +698,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         -webkit-font-smoothing: antialiased;
                         background-color: #f4f4f4;
                         border-radius: 0px;
-                        border: none;
+                        border: 1px solid transparent;
                         box-sizing: border-box;
                         color: #0078d4;
                         cursor: pointer;
@@ -876,7 +876,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
                         border-radius: 0px;
-                        border: none;
+                        border: 1px solid transparent;
                         box-sizing: border-box;
                         color: #333333;
                         cursor: pointer;
@@ -1044,7 +1044,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
                         border-radius: 0px;
-                        border: none;
+                        border: 1px solid transparent;
                         box-sizing: border-box;
                         color: #333333;
                         cursor: pointer;
@@ -1212,7 +1212,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
                         border-radius: 0px;
-                        border: none;
+                        border: 1px solid transparent;
                         box-sizing: border-box;
                         color: #333333;
                         cursor: pointer;
@@ -1381,7 +1381,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
                         border-radius: 0px;
-                        border: none;
+                        border: 1px solid transparent;
                         box-sizing: border-box;
                         color: #333333;
                         cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
@@ -87,7 +87,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;
@@ -255,7 +255,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;
@@ -423,7 +423,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;
@@ -591,7 +591,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -90,7 +90,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;
@@ -258,7 +258,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -174,7 +174,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;
@@ -429,7 +429,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                       -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border-radius: 0px;
-                      border: none;
+                      border: 1px solid transparent;
                       box-sizing: border-box;
                       color: #333333;
                       cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -67,7 +67,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -210,7 +210,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -353,7 +353,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -496,7 +496,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -639,7 +639,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #eaeaea;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -828,7 +828,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 0px;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -969,7 +969,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 0px;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1110,7 +1110,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 0px;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1251,7 +1251,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 0px;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1392,7 +1392,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #eaeaea;
                     border-radius: 0px;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1589,7 +1589,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1732,7 +1732,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -1875,7 +1875,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2018,7 +2018,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2165,7 +2165,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2308,7 +2308,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2451,7 +2451,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2594,7 +2594,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2741,7 +2741,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -2884,7 +2884,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3027,7 +3027,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3170,7 +3170,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: #ffffff;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
@@ -3362,7 +3362,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -3511,7 +3511,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -3660,7 +3660,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -3809,7 +3809,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;
@@ -3958,7 +3958,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     -webkit-font-smoothing: antialiased;
                     background-color: transparent;
                     border-radius: 100%;
-                    border: none;
+                    border: 1px solid transparent;
                     box-sizing: border-box;
                     color: #a6a6a6;
                     cursor: default;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -138,7 +138,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -249,7 +249,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -360,7 +360,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -471,7 +471,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -582,7 +582,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -693,7 +693,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -804,7 +804,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -915,7 +915,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1026,7 +1026,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1137,7 +1137,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1248,7 +1248,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1359,7 +1359,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1470,7 +1470,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1581,7 +1581,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1709,7 +1709,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1820,7 +1820,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -1931,7 +1931,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2042,7 +2042,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2153,7 +2153,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2264,7 +2264,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2375,7 +2375,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2486,7 +2486,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2597,7 +2597,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2708,7 +2708,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2819,7 +2819,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -2930,7 +2930,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -3041,7 +3041,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -3152,7 +3152,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;
@@ -3263,7 +3263,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
                 border-radius: 0px;
-                border: none;
+                border: 1px solid transparent;
                 box-sizing: border-box;
                 color: #333333;
                 cursor: pointer;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7528 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix the issue where action button gets clipped if contained like in this codepen repro: https://codepen.io/avenezia/pen/YdexRm

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7538)

