### PR TITLE
Fix VirtualizedList usage of componentDidUpdate

### DIFF
--- a/common/changes/@uifabric/experiments/virtualized-list_2019-01-08-00-23.json
+++ b/common/changes/@uifabric/experiments/virtualized-list_2019-01-08-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "VirtualizedList: fix componentDidUpdate usage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/virtualized-list_2019-01-08-00-34.json
+++ b/common/changes/@uifabric/utilities/virtualized-list_2019-01-08-00-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "BaseComponent: when updating componentRef, handle case where current or previous props are not given",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/experiments/src/components/VirtualizedList/VirtualizedList.test.tsx
+++ b/packages/experiments/src/components/VirtualizedList/VirtualizedList.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { VirtualizedListBasicExample } from './examples/VirtualizedList.Basic.Example';
+
+describe('VirtualizedList', () => {
+  let component: renderer.ReactTestRenderer | undefined;
+
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+      component = undefined;
+    }
+  });
+
+  it('renders', () => {
+    component = renderer.create(<VirtualizedListBasicExample />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
@@ -54,16 +54,11 @@ export class VirtualizedList<TItem extends IObjectWithKey> extends BaseComponent
       this._render(scrollTop);
     });
 
-    this.componentDidUpdate();
+    this._updateObservedElements();
   }
 
   public componentDidUpdate(): void {
-    // (Re-)register with the observer after every update, this way we'll get an intersection event immediately if one of the spacer
-    // elements is visible right now.
-    for (const key of Object.keys(this._spacerElements)) {
-      const ref = this._spacerElements[key];
-      this.context.scrollContainer.observe(ref);
-    }
+    this._updateObservedElements();
   }
 
   public componentWillUpdate(): void {
@@ -82,6 +77,15 @@ export class VirtualizedList<TItem extends IObjectWithKey> extends BaseComponent
         {items}
       </div>
     );
+  }
+
+  private _updateObservedElements(): void {
+    // (Re-)register with the observer after every update, so we'll get an intersection event immediately if one of the spacer
+    // elements is visible right now.
+    for (const key of Object.keys(this._spacerElements)) {
+      const ref = this._spacerElements[key];
+      this.context.scrollContainer.observe(ref);
+    }
   }
 
   private _renderItems(scrollTop: number, viewportHeight: number): (JSX.Element | null)[] {

--- a/packages/experiments/src/components/VirtualizedList/__snapshots__/VirtualizedList.test.tsx.snap
+++ b/packages/experiments/src/components/VirtualizedList/__snapshots__/VirtualizedList.test.tsx.snap
@@ -1,0 +1,283 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VirtualizedList renders 1`] = `
+<div>
+  <div
+    className="ms-ScrollContainer"
+    data-is-scrollable={true}
+  >
+    <div
+      className="ms-VirtualizedList"
+    >
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 0
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 1
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 2
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 3
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 4
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 5
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 6
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 7
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 8
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 9
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 10
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 11
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 12
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 13
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 14
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 15
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 16
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 17
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 18
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 19
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 20
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 21
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 22
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 23
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 24
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 25
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 26
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 27
+      </div>
+      <div
+        style={
+          Object {
+            "height": 30,
+          }
+        }
+      >
+        Item 28
+      </div>
+      <div
+        style={
+          Object {
+            "height": 59160,
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -179,7 +179,9 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
    * Updates the componentRef (by calling it with "this" when necessary.)
    */
   protected _updateComponentRef(currentProps: IBaseProps, newProps: IBaseProps = {}): void {
-    if (currentProps.componentRef !== newProps.componentRef) {
+    // currentProps *should* always be defined, but verify that just in case a subclass is manually
+    // calling a lifecycle method with no parameters (which has happened) or other odd usage.
+    if (currentProps && newProps && currentProps.componentRef !== newProps.componentRef) {
       this._setComponentRef(currentProps.componentRef, null);
       this._setComponentRef(newProps.componentRef, this);
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

VirtualizedList was calling `componentDidUpdate` (with no arguments) from `componentDidMount`, essentially using it as a helper method containing logic both lifecycles needed to use. The change to BaseComponent in #7393 added its own implementation of `componentDidUpdate` which assumed that the first argument `prevProps` would always be defined, causing an exception when rendering VirtualizedList.

Fix is to move the logic in VirtualizedList to a proper helper method and make `BaseComponent._updateComponentRef` (called by `componentDidUpdate`) verify that its arguments are defined.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7553)

