### PR TITLE
Commandbar: Fixed so it won't flicker on resize

### DIFF
--- a/common/changes/office-ui-fabric-react/commandbar_2019-01-08-04-31.json
+++ b/common/changes/office-ui-fabric-react/commandbar_2019-01-08-04-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed: the commandbar will no longer flicker when resized",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -189,26 +189,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     return <OverflowButtonType {...overflowProps as IButtonProps} />;
   };
 
-  private _prepareDataForCacheKey(data: ICommandBarData): ICommandBarData {
-    const setSize = data.primaryItems.length + (data.overflowItems.length > 0 ? 1 : 0);
-
-    data.primaryItems = data.primaryItems.map((item, i) => {
-      item.posinset = i + 1;
-      item.setsize = setSize;
-      return item;
-    });
-
-    if (data.farItems) {
-      data.farItems = data.farItems.map((item, i, array) => {
-        item.posinset = i + 1;
-        item.setsize = array.length;
-        return item;
-      });
-    }
-
-    return data;
-  }
-
   private _computeCacheKey(data: ICommandBarData): string {
     const { primaryItems, farItems = [], overflowItems } = data;
     const returnKey = (acc: string, current: ICommandBarItemProps): string => {
@@ -236,7 +216,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       overflowItems = [movedItem, ...overflowItems];
       primaryItems = shiftOnReduce ? primaryItems.slice(1) : primaryItems.slice(0, -1);
 
-      const newData = this._prepareDataForCacheKey({ ...data, primaryItems, overflowItems });
+      const newData = { ...data, primaryItems, overflowItems };
       cacheKey = this._computeCacheKey(newData);
 
       if (onDataReduced) {
@@ -263,7 +243,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       // if shiftOnReduce, movedItem goes first, otherwise, last.
       primaryItems = shiftOnReduce ? [movedItem, ...primaryItems] : [...primaryItems, movedItem];
 
-      const newData = this._prepareDataForCacheKey({ ...data, primaryItems, overflowItems });
+      const newData = { ...data, primaryItems, overflowItems };
       cacheKey = this._computeCacheKey(newData);
 
       if (onDataGrown) {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -189,6 +189,26 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     return <OverflowButtonType {...overflowProps as IButtonProps} />;
   };
 
+  private _prepareDataForCacheKey(data: ICommandBarData): ICommandBarData {
+    const setSize = data.primaryItems.length + (data.overflowItems.length > 0 ? 1 : 0);
+
+    data.primaryItems = data.primaryItems.map((item, i) => {
+      item['posinset'] = i + 1;
+      item['setsize'] = setSize;
+      return item;
+    });
+
+    if (data.farItems) {
+      data.farItems = data.farItems.map((item, i, array) => {
+        item['posinset'] = i + 1;
+        item['setsize'] = array.length;
+        return item;
+      });
+    }
+
+    return data;
+  }
+
   private _computeCacheKey(data: ICommandBarData): string {
     const { primaryItems, farItems = [], overflowItems } = data;
     const returnKey = (acc: string, current: ICommandBarItemProps): string => {
@@ -216,15 +236,14 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       overflowItems = [movedItem, ...overflowItems];
       primaryItems = shiftOnReduce ? primaryItems.slice(1) : primaryItems.slice(0, -1);
 
-      data.primaryItems = primaryItems;
-      data.overflowItems = overflowItems;
-      cacheKey = this._computeCacheKey(data);
+      const newData = this._prepareDataForCacheKey({ ...data, primaryItems, overflowItems });
+      cacheKey = this._computeCacheKey(newData);
 
       if (onDataReduced) {
         onDataReduced(movedItem);
       }
 
-      return { ...data, cacheKey };
+      return { ...newData, cacheKey };
     }
 
     return undefined;
@@ -244,15 +263,14 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       // if shiftOnReduce, movedItem goes first, otherwise, last.
       primaryItems = shiftOnReduce ? [movedItem, ...primaryItems] : [...primaryItems, movedItem];
 
-      data.primaryItems = primaryItems;
-      data.overflowItems = overflowItems;
-      cacheKey = this._computeCacheKey(data);
+      const newData = this._prepareDataForCacheKey({ ...data, primaryItems, overflowItems });
+      cacheKey = this._computeCacheKey(newData);
 
       if (onDataGrown) {
         onDataGrown(movedItem);
       }
 
-      return { ...data, cacheKey };
+      return { ...newData, cacheKey };
     }
 
     return undefined;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -193,15 +193,15 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     const setSize = data.primaryItems.length + (data.overflowItems.length > 0 ? 1 : 0);
 
     data.primaryItems = data.primaryItems.map((item, i) => {
-      item['posinset'] = i + 1;
-      item['setsize'] = setSize;
+      item.posinset = i + 1;
+      item.setsize = setSize;
       return item;
     });
 
     if (data.farItems) {
       data.farItems = data.farItems.map((item, i, array) => {
-        item['posinset'] = i + 1;
-        item['setsize'] = array.length;
+        item.posinset = i + 1;
+        item.setsize = array.length;
         return item;
       });
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7532
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I removed the cachekey logic which accounted for overflow, etc. erroneously and this adds back the cache key calculation to commandbar. The line in question:

https://github.com/OfficeDev/office-ui-fabric-react/commit/cc7f252b7f921c8f2ba79551ea82fa6f93e36dda#diff-b7ad51933f12bb1d434bb4dd8cc5a969

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7557)

