### PR TITLE
Fix DatePicker firing two onSelectDate events when allowTextInput is true

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker-onSelectDate_2019-01-08-07-06.json
+++ b/common/changes/office-ui-fabric-react/datepicker-onSelectDate_2019-01-08-07-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix DatePicker firing two onSelectDate events when allowTextInput is true",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -420,7 +420,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
         // not be able to come up with the exact same date.
         if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
-          date = this.state.selectedDate;
+          return;
         } else {
           date = parseDateFromString!(inputValue);
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { Calendar, ICalendarStrings } from '../../Calendar';
 import { DatePicker } from './DatePicker';
@@ -51,6 +52,18 @@ describe('DatePicker', () => {
     textField.simulate('change', { target: { value: '' } }).simulate('blur');
 
     expect(onSelectDate).toHaveBeenCalledTimes(2);
+
+    datePicker.unmount();
+  });
+
+  it('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
+    const onSelectDate = jest.fn();
+    const datePicker = mount(<DatePickerBase allowTextInput={true} onSelectDate={onSelectDate} />);
+
+    datePicker.setState({ isDatePickerShown: true });
+    ReactTestUtils.Simulate.click(document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement);
+
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
 
     datePicker.unmount();
   });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7473
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There is no need to set `date` send it via `onSelectDate` callback, when we have detected  that "selected date has the same formatted string as what we're about to parse".

Original formatting fix here: https://github.com/OfficeDev/office-ui-fabric-react/pull/3168

#### Focus areas to test

Other DatePicker scenarios when  `allowTextInput` is `true`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7559)

