### PR TITLE
Ios scroll fix

### DIFF
--- a/common/changes/@uifabric/utilities/ios-scroll_2019-01-08-19-23.json
+++ b/common/changes/@uifabric/utilities/ios-scroll_2019-01-08-19-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Scroll: use scrollableParent in _preventOverscrolling, allow EventGroup.on to take event options",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "kakje@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/ios-scroll_2019-01-08-19-23.json
+++ b/common/changes/office-ui-fabric-react/ios-scroll_2019-01-08-19-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Modal, Dialog: Update styling to work with changes to allowScrollOnElement (change overflowY from auto to hidden)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1113,7 +1113,7 @@ class EventGroup {
   // (undocumented)
   static isObserved(target: any, eventName: string): boolean;
   // (undocumented)
-  off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
+  off(target?: any, eventName?: string, callback?: (args?: any) => void, options?: boolean | AddEventListenerOptions): void;
   on(target: any, eventName: string, callback: (args?: any) => void, options?: boolean | AddEventListenerOptions): void;
   onAll(target: any, events: {
           [key: string]: (args?: any) => void;
@@ -7538,11 +7538,11 @@ interface IEventRecord {
   // (undocumented)
   objectCallback?: (args?: any) => void;
   // (undocumented)
+  options?: boolean | AddEventListenerOptions;
+  // (undocumented)
   parent: any;
   // (undocumented)
   target: any;
-  // (undocumented)
-  useCapture: boolean;
 }
 
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1114,7 +1114,7 @@ class EventGroup {
   static isObserved(target: any, eventName: string): boolean;
   // (undocumented)
   off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
-  on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void;
+  on(target: any, eventName: string, callback: (args?: any) => void, options?: boolean | AddEventListenerOptions): void;
   onAll(target: any, events: {
           [key: string]: (args?: any) => void;
       }, useCapture?: boolean): void;

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
@@ -26,7 +26,7 @@ export const getStyles = (props: IDialogContentStyleProps): IDialogContentStyles
       isClose && classNames.close,
       {
         flexGrow: 1,
-        overflowY: 'auto' // required for IE11
+        overflowY: 'hidden' // required for allowScrollOnElement
       },
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Dialog renders Dialog correctly 1`] = `
 
       {
         flex-grow: 1;
-        overflow-y: auto;
+        overflow-y: hidden;
       }
 >
   <div

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -169,7 +169,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
                 forceFocusInsideTrap={forceFocusInsideTrap}
                 firstFocusableSelector={firstFocusableSelector}
               >
-                <div ref={this._allowScrollOnModal} className={classNames.scrollableContent}>
+                <div ref={this._allowScrollOnModal} className={classNames.scrollableContent} data-is-scrollable={true}>
                   {this.props.children}
                 </div>
               </FocusTrapZone>

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`Modal renders Modal correctly 1`] = `
                   flex-grow: 1;
                   overflow-y: auto;
                 }
+            data-is-scrollable={true}
           >
             Test Content
           </div>

--- a/packages/office-ui-fabric-react/src/components/Modal/examples/Modal.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Modal/examples/Modal.Basic.Example.scss
@@ -23,7 +23,7 @@
     .ms-modalExample-body {
       flex: 4 4 auto;
       padding: 5px 28px;
-      overflow-y: auto;
+      overflow-y: hidden;
     }
   }
 }

--- a/packages/utilities/etc/utilities.api.ts
+++ b/packages/utilities/etc/utilities.api.ts
@@ -164,7 +164,7 @@ class EventGroup {
   // (undocumented)
   static isObserved(target: any, eventName: string): boolean;
   // (undocumented)
-  off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
+  off(target?: any, eventName?: string, callback?: (args?: any) => void, options?: boolean | AddEventListenerOptions): void;
   on(target: any, eventName: string, callback: (args?: any) => void, options?: boolean | AddEventListenerOptions): void;
   onAll(target: any, events: {
           [key: string]: (args?: any) => void;
@@ -405,11 +405,11 @@ interface IEventRecord {
   // (undocumented)
   objectCallback?: (args?: any) => void;
   // (undocumented)
+  options?: boolean | AddEventListenerOptions;
+  // (undocumented)
   parent: any;
   // (undocumented)
   target: any;
-  // (undocumented)
-  useCapture: boolean;
 }
 
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name

--- a/packages/utilities/etc/utilities.api.ts
+++ b/packages/utilities/etc/utilities.api.ts
@@ -165,7 +165,7 @@ class EventGroup {
   static isObserved(target: any, eventName: string): boolean;
   // (undocumented)
   off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void;
-  on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void;
+  on(target: any, eventName: string, callback: (args?: any) => void, options?: boolean | AddEventListenerOptions): void;
   onAll(target: any, events: {
           [key: string]: (args?: any) => void;
       }, useCapture?: boolean): void;

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -14,7 +14,7 @@ export interface IEventRecord {
   callback: (args?: any) => void;
   elementCallback?: (...args: any[]) => void;
   objectCallback?: (args?: any) => void;
-  useCapture: boolean;
+  options?: boolean | AddEventListenerOptions;
 }
 // tslint:enable:no-any
 
@@ -200,7 +200,7 @@ export class EventGroup {
         eventName: eventName,
         parent: parent,
         callback: callback,
-        useCapture: options !== undefined && typeof options === 'boolean'
+        options
       };
 
       // Initialize and wire up the record on the target, so that it can call the callback if the event fires.
@@ -273,14 +273,14 @@ export class EventGroup {
   }
 
   // tslint:disable-next-line:no-any
-  public off(target?: any, eventName?: string, callback?: (args?: any) => void, useCapture?: boolean): void {
+  public off(target?: any, eventName?: string, callback?: (args?: any) => void, options?: boolean | AddEventListenerOptions): void {
     for (let i = 0; i < this._eventRecords.length; i++) {
       let eventRecord = this._eventRecords[i];
       if (
         (!target || target === eventRecord.target) &&
         (!eventName || eventName === eventRecord.eventName) &&
         (!callback || callback === eventRecord.callback) &&
-        (typeof useCapture !== 'boolean' || useCapture === eventRecord.useCapture)
+        (typeof options !== 'boolean' || options === eventRecord.options)
       ) {
         let events = <IEventRecordsByName>eventRecord.target.__events__;
         let targetArrayLookup = events[eventRecord.eventName];
@@ -303,7 +303,7 @@ export class EventGroup {
 
         if (eventRecord.elementCallback) {
           if (eventRecord.target.removeEventListener) {
-            eventRecord.target.removeEventListener(eventRecord.eventName, eventRecord.elementCallback, eventRecord.useCapture);
+            eventRecord.target.removeEventListener(eventRecord.eventName, eventRecord.elementCallback, eventRecord.options);
           } else if (eventRecord.target.detachEvent) {
             // IE8
             eventRecord.target.detachEvent('on' + eventRecord.eventName, eventRecord.elementCallback);

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -186,12 +186,12 @@ export class EventGroup {
    * of this instance of EventGroup.
    */
   // tslint:disable-next-line:no-any
-  public on(target: any, eventName: string, callback: (args?: any) => void, useCapture?: boolean): void {
+  public on(target: any, eventName: string, callback: (args?: any) => void, options?: boolean | AddEventListenerOptions): void {
     if (eventName.indexOf(',') > -1) {
       let events = eventName.split(/[ ,]+/);
 
       for (let i = 0; i < events.length; i++) {
-        this.on(target, events[i], callback, useCapture);
+        this.on(target, events[i], callback, options);
       }
     } else {
       let parent = this._parent;
@@ -200,7 +200,7 @@ export class EventGroup {
         eventName: eventName,
         parent: parent,
         callback: callback,
-        useCapture: useCapture || false
+        useCapture: options !== undefined && typeof options === 'boolean'
       };
 
       // Initialize and wire up the record on the target, so that it can call the callback if the event fires.
@@ -248,7 +248,7 @@ export class EventGroup {
 
         if (target.addEventListener) {
           /* tslint:disable:ban-native-functions */
-          (<EventTarget>target).addEventListener(eventName, processElementEvent, useCapture);
+          (<EventTarget>target).addEventListener(eventName, processElementEvent, options);
           /* tslint:enable:ban-native-functions */
         } else if (target.attachEvent) {
           // IE8

--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -70,8 +70,8 @@ const _makeElementScrollAllower = () => {
       return;
     }
 
-    events.on(element, 'touchstart', _saveClientY);
-    events.on(element, 'touchmove', _preventOverscrolling);
+    events.on(element, 'touchstart', _saveClientY, { passive: false });
+    events.on(element, 'touchmove', _preventOverscrolling, { passive: false });
 
     _element = element;
   };

--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -47,6 +47,11 @@ const _makeElementScrollAllower = () => {
 
     const clientY = event.targetTouches[0].clientY - _previousClientY;
 
+    const scrollableParent = findScrollableParent(event.target as HTMLElement);
+    if (scrollableParent) {
+      _element = scrollableParent;
+    }
+
     // if the element is scrolled to the top,
     // prevent the user from scrolling up
     if (_element.scrollTop === 0 && clientY > 0) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6315 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Before this fix, custom scrolling inside a Modal component was not scrollable on iOS Safari. The reason was in the `_preventOverscrolling` function in scroll.ts - the _element variable used to detect scrolling events was the "scrollableContent" element rather than the child element within the Modal. Since the scrollableContent element has an equal scrollHeight and clientHeight if custom scrolling is used, `_preventOverscrolling` calculated that the element had been scrolled to the bottom and prevented further scrolling. This change calls `findScrollableParent` on the event target to get the correct element to perform calculations on.

Examples of custom scrolling with Modals with this fix (using mobile device simulator on Chrome):

Basic custom scrolling (fixed header, cyan scrollable area):
![modal-custom-scrolling](https://user-images.githubusercontent.com/6687333/50854178-3b45bb00-1339-11e9-8b45-90693aa4650b.gif)

Nested custom scrolling (fixed header, cyan scrollable area with yellow scrollable children):
![modal-nested-scrolling](https://user-images.githubusercontent.com/6687333/50854210-53b5d580-1339-11e9-8f7e-cd6b201eb594.gif)

#### Question for discussion: should the "scrollableContent" div have `data-is-scrollable=true` set?
Calling `findScrollableParent` is more performant if scrollable divs have the `data-is-scrollable` attribute since it avoids expensive `getComputedStyle` calls. However, in a scenario such as the custom Modal scrolling examples above, where the scrollableContent div has a scrollable child that does not have `data-is-scrollable` set, then scrollableContent will be returned as the scrollable parent, and its child div will not be scrollable.

Possible options here:
1. Do not set `data-is-scrollable` on the scrollableContent.
a. Pros: If the user has scrollable divs inside scrollableContent, they will be correctly identified as the scrollable element even if they do not have the `data-is-scrollable` attribute.
b. Cons: If the user does not have any custom scrollable divs inside scrollableContent, unnecessary expensive `getComputedStyle` calls will be made in order to determine that scrollableContent is the scrollable div.
2. Set `data-is-scrollable` on the scrollableContent (current approach - updated after offline discussion).
a. This would require the user to set `data-is-scrollable` on any custom scrollable children of scrollableContent.
3. Allow the user to set the `data-is-scrollable` attribute on scrollableContent via a Modal prop.

#### Focus areas to test

(optional)
