### PR TITLE
[Just] Migrates start-test to just

### DIFF
--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -20,7 +20,7 @@
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/tasks/build-codepen-examples.js && node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/common/changes/@uifabric/charting/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/charting/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/charting",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/dashboard/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/dashboard/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/dashboard",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/date-time/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/date-time/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/date-time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/experiments/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/fabric-website-resources/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website-resources",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/foundation/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/foundation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/jest-serializer-merge-styles/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/jest-serializer-merge-styles/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/jest-serializer-merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/merge-styles/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/styling/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/test-utilities/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/test-utilities/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/test-utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/test-utilities",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/utilities/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/starttest_2019-01-08-23-10.json
+++ b/common/changes/@uifabric/variants/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/variants",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/starttest_2019-01-08-23-10.json
+++ b/common/changes/office-ui-fabric-react/starttest_2019-01-08-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -26,7 +26,7 @@
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "test": "react-scripts-ts test --env=jsdom",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -18,7 +18,7 @@
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/packages/foundation-scenarios/package.json
+++ b/packages/foundation-scenarios/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
-    "start-test": "node ../../scripts/start-test.js"
+    "start-test": "node ../../scripts/just.js jest-watch"
   },
   "disabledTasks": [
     "copy",

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-api": "node ../../scripts/update-api.js"
   },
   "disabledTasks": [

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -21,7 +21,7 @@
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "cd ../../apps/fabric-website-resources && npm start",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/just.js jest -u",
     "update-api": "node ../../scripts/update-api.js",
     "codepen": "node ../../scripts/local-codepen.js"

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -16,7 +16,7 @@
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-api": "node ../../scripts/update-api.js",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-api": "node ../../scripts/update-api.js"
   },
   "devDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "code-style": "node ../../scripts/just.js code-style",
     "clean": "node ../../scripts/just.js clean",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-api": "node ../../scripts/update-api.js",
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/just.js build",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
-    "start-test": "node ../../scripts/start-test.js"
+    "start-test": "node ../../scripts/just.js jest-watch"
   },
   "disabledTasks": [
     "copy",

--- a/scripts/start-test.js
+++ b/scripts/start-test.js
@@ -1,5 +1,0 @@
-const customArgs = process && process.argv ? process.argv.slice(2).join(' ') : '';
-
-require('./tasks/jest')({
-  args: `--watch -i ${customArgs}`
-});

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -9,3 +9,11 @@ exports.jest = () =>
     ...(process.env.TRAVIS || argv().production ? { coverage: true } : undefined),
     ...(argv().u || argv().updateSnapshot ? { updateSnapshot: true } : undefined)
   });
+
+exports.jestWatch = () =>
+  jestTask({
+    ...(process.env.TRAVIS && { runInBand: true }),
+    ...(process.env.TRAVIS || argv().production ? { coverage: true } : undefined),
+    ...(argv().u || argv().updateSnapshot ? { updateSnapshot: true } : undefined),
+    _: ['--watch', '-i', ...(argv()._ ? argv()._.filter(arg => arg !== 'jest-watch') : [])]
+  });

--- a/scripts/tasks/rig.js
+++ b/scripts/tasks/rig.js
@@ -2,7 +2,7 @@
 
 const { clean } = require('./clean');
 const { copy } = require('./copy');
-const { jest } = require('./jest');
+const { jest, jestWatch } = require('./jest');
 const { sass } = require('./sass');
 const { ts } = require('./ts');
 const { tslint } = require('./tslint');
@@ -20,6 +20,7 @@ exports.rig = {
   clean,
   copy,
   jest,
+  jestWatch,
   sass,
   ts,
   tslint,

--- a/scripts/templates/create-package/EmptyPackageJson.mustache
+++ b/scripts/templates/create-package/EmptyPackageJson.mustache
@@ -17,7 +17,7 @@
     "build": "node ../../scripts/build.js",
     "clean": "node ../../scripts/clean.js",
     "start": "node ../../scripts/start.js",
-    "start-test": "node ../../scripts/start-test.js",
+    "start-test": "node ../../scripts/just.js jest-watch",
     "update-snapshots": "node ../../scripts/build.js jest -u"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

One of the left over tasks that hadn't been migrated is start-test. This moves it to use just.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7574)

