### PR TITLE
ChoiceGroup: add `optionChecked` getter to IChoiceGroup

### DIFF
--- a/common/changes/office-ui-fabric-react/shield-ChiceGroupRef_2019-01-08-23-07.json
+++ b/common/changes/office-ui-fabric-react/shield-ChiceGroupRef_2019-01-08-23-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: adds a getter method to IChoiceGroup to allow grabbing the current checked option through the componentRef.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -586,6 +586,7 @@ class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGroupState
   static defaultProps: IChoiceGroupProps;
   // (undocumented)
   focus(): void;
+  readonly optionChecked: IChoiceGroupOption | undefined;
   // (undocumented)
   render(): JSX.Element;
 }
@@ -2497,6 +2498,7 @@ interface ICheckStyles {
 // @public (undocumented)
 interface IChoiceGroup {
   focus: () => void;
+  optionChecked: IChoiceGroupOption | undefined;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -42,6 +42,15 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
     this._labelId = getId('ChoiceGroupLabel');
   }
 
+  /**
+   * Gets the current checked option.
+   */
+  public get optionChecked(): IChoiceGroupOption | undefined {
+    const { options = [] } = this.props;
+    const { keyChecked: key } = this.state;
+    return find(options, (value: IChoiceGroupOption) => value.key === key);
+  }
+
   public componentWillReceiveProps(newProps: IChoiceGroupProps): void {
     const newKeyChecked = this._getKeyChecked(newProps);
     const oldKeyChecked = this._getKeyChecked(this.props);

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -6,7 +6,7 @@ import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 
 import { ChoiceGroup } from './ChoiceGroup';
-import { IChoiceGroupOption } from './ChoiceGroup.types';
+import { IChoiceGroupOption, IChoiceGroup } from './ChoiceGroup.types';
 import { resetIds } from '../../Utilities';
 
 const TEST_OPTIONS: IChoiceGroupOption[] = [
@@ -183,5 +183,17 @@ describe('ChoiceGroup', () => {
     expect((choiceOptions[1] as HTMLInputElement).getAttribute('aria-label')).toBeNull();
     expect((choiceOptions[2] as HTMLInputElement).getAttribute('aria-label')).toBeNull();
     expect((choiceOptions[3] as HTMLInputElement).getAttribute('aria-label')).toEqual('Custom aria label');
+  });
+
+  it('can be accessed to get the current checked option', () => {
+    const choiceGroupRef = React.createRef<IChoiceGroup>();
+    const choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} role="" componentRef={choiceGroupRef} />);
+
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+
+    expect(choiceGroupRef.current!.optionChecked).toBeUndefined();
+    ReactTestUtils.Simulate.change(choiceOptions[0]);
+    expect(choiceGroupRef.current!.optionChecked).toBeDefined();
+    expect(choiceGroupRef.current!.optionChecked).toEqual(TEST_OPTIONS[0]);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -6,6 +6,11 @@ import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utili
 
 export interface IChoiceGroup {
   /**
+   * Gets the current checked option.
+   */
+  optionChecked: IChoiceGroupOption | undefined;
+
+  /**
    * Sets focus to the choiceGroup.
    */
   focus: () => void;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7539
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adding this method to allow access to the current checked option through the `componetRef` prop.
Also adding a test to make sure it works as expected.
