### PR TITLE
Fix : DetailsList dragDropEvents doesn't update when changed

### DIFF
--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -201,6 +201,15 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     if (this.props.onDidUpdate) {
       this.props.onDidUpdate(this);
     }
+
+    if (prevProps.dragDropEvents !== this.props.dragDropEvents) {
+      this._dragDropHelper = this.props.dragDropEvents
+        ? new DragDropHelper({
+            selection: this.props.selection || new Selection({ onSelectionChanged: undefined, getKey: this.props.getKey }),
+            minimumPixelsForDrag: this.props.minimumPixelsForDrag
+          })
+        : null;
+    }
   }
 
   public componentWillReceiveProps(newProps: IDetailsListProps): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7503 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

In the constructor, this._dragDropHelper = props.dragDropEvents is set. So any future updates to props.dragDropEvents are not used.
Check object reference and update this._dragDropHelper if dragDropEvents has changed in componentDidUpdate() lifecycle method.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7578)

