### PR TITLE
Rating: Use palette colors

### DIFF
--- a/common/changes/@uifabric/fluent-theme/miwhea-rating-palette-colors_2019-01-09-18-00.json
+++ b/common/changes/@uifabric/fluent-theme/miwhea-rating-palette-colors_2019-01-09-18-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Rating: Use palette colors where possible",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
@@ -3,7 +3,7 @@ import { NeutralColors } from '../FluentColors';
 
 export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> => {
   const { disabled, readOnly, theme } = props;
-  const { semanticColors } = theme;
+  const { palette, semanticColors } = theme;
 
   return {
     root: [
@@ -13,7 +13,7 @@ export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> =
             // This is part 1 of highlighting all stars up to the one the user is hovering over
             '&:hover': {
               selectors: {
-                '.ms-RatingStar-back': { color: NeutralColors.gray160 }
+                '.ms-RatingStar-back': { color: palette.neutralPrimary }
               }
             }
           }
@@ -28,7 +28,7 @@ export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> =
       }
     ],
     ratingStarFront: {
-      color: NeutralColors.gray160
+      color: palette.neutralPrimary
     },
     ratingButton: [
       !disabled &&


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

While doing an audit of the neutrals in the Fluent theme, I found two instances where we had hard-coded values that can instead be pulled from the theme palette.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7583)

