### PR TITLE
Pickers: Fix so controlled pickers will only focus when it has focus

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-controlledpicker-focus_2019-01-09-20-12.json
+++ b/common/changes/office-ui-fabric-react/fix-controlledpicker-focus_2019-01-09-20-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pickers: Fix so controlled pickers will only focus when it has focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -118,8 +118,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           items: newProps.selectedItems
         },
         () => {
-          // Only update the focus if this component is currently focused. If the items are managed by another component,
-          // then that component should control focus
+          // Only update the focus if this component is currently focused to ensure that the basepicker
+          // doesn't steal focus from something else.
           if (this.state.isFocused) {
             // Need to reset focus in the same that way that we do if an item is selected by a non-controlled component
             // See _onSelectedItemsUpdated.

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -118,9 +118,13 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           items: newProps.selectedItems
         },
         () => {
-          // Need to reset focus in the same that way that we do if an item is selected by a non-controlled component
-          // See _onSelectedItemsUpdated.
-          this.resetFocus(focusIndex);
+          // Only update the focus if this component is currently focused. If the items are managed by another component,
+          // then that component should control focus
+          if (this.state.isFocused) {
+            // Need to reset focus in the same that way that we do if an item is selected by a non-controlled component
+            // See _onSelectedItemsUpdated.
+            this.resetFocus(focusIndex);
+          }
         }
       );
     }


### PR DESCRIPTION
…focus

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #7543
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix it so the controlled picker will only focus when it has focus. This ensures that it won't steal focus whenever it gets new props.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7587)

