### PR TITLE
ContextualMenu: fix hovering on items in IE

### DIFF
--- a/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
+++ b/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from 'office-ui-fabric-react';
@@ -80,7 +80,7 @@ const itemsWithIcons: IContextualMenuItem[] = [
     iconProps: {
       iconName: 'MusicInCollectionFill'
     },
-    text: 'Music',
+    text: 'Music'
   }
 ];
 
@@ -132,9 +132,9 @@ const itemsWithSubmenu: IContextualMenuItem[] = [
         {
           key: 'calendarEvent',
           text: 'Calendar event',
-          title: 'Create a calendar event',
+          title: 'Create a calendar event'
         }
-      ],
+      ]
     },
     text: 'New'
   },
@@ -144,11 +144,11 @@ const itemsWithSubmenu: IContextualMenuItem[] = [
       items: [
         {
           key: 'sharetotwitter',
-          text: 'Share to Twitter',
+          text: 'Share to Twitter'
         },
         {
           key: 'sharetofacebook',
-          text: 'Share to Facebook',
+          text: 'Share to Facebook'
         },
         {
           key: 'sharetoemail',
@@ -158,17 +158,17 @@ const itemsWithSubmenu: IContextualMenuItem[] = [
               {
                 key: 'sharetooutlook_1',
                 text: 'Share to Outlook',
-                title: 'Share to Outlook',
+                title: 'Share to Outlook'
               },
               {
                 key: 'sharetogmail_1',
                 text: 'Share to Gmail',
-                title: 'Share to Gmail',
+                title: 'Share to Gmail'
               }
-            ],
-          },
-        },
-      ],
+            ]
+          }
+        }
+      ]
     },
     text: 'Share'
   }
@@ -185,11 +185,11 @@ const itemsWithHeaders: IContextualMenuItem[] = [
       items: [
         {
           key: 'newItem',
-          text: 'New',
+          text: 'New'
         },
         {
           key: 'deleteItem',
-          text: 'Delete',
+          text: 'Delete'
         }
       ]
     }
@@ -217,40 +217,82 @@ const itemsWithSplitButtonSubmenu: IContextualMenuItem[] = [
   {
     key: 'share',
     split: true,
-    onClick: () => { },
+    onClick: () => undefined,
     subMenuProps: {
       items: [
         {
           key: 'sharetotwitter',
-          text: 'Share to Twitter',
+          text: 'Share to Twitter'
         },
         {
           key: 'sharetofacebook',
-          text: 'Share to Facebook',
+          text: 'Share to Facebook'
         },
         {
           key: 'sharetoemail',
           split: true,
-          onClick: () => { },
+          onClick: () => undefined,
           text: 'Share to Email',
           subMenuProps: {
             items: [
               {
                 key: 'sharetooutlook_1',
                 text: 'Share to Outlook',
-                title: 'Share to Outlook',
+                title: 'Share to Outlook'
               },
               {
                 key: 'sharetogmail_1',
                 text: 'Share to Gmail',
-                title: 'Share to Gmail',
+                title: 'Share to Gmail'
               }
-            ],
-          },
-        },
-      ],
+            ]
+          }
+        }
+      ]
     },
     text: 'Share'
+  }
+];
+
+const itemsWithSubmenuHrefs: IContextualMenuItem[] = [
+  {
+    key: 'parent',
+    id: 'parent',
+    name: 'Parent',
+    subMenuProps: {
+      items: [
+        {
+          key: 'item1',
+          id: 'item1',
+          name: 'Item 1',
+          href: 'http://bing.com',
+          subMenuProps: {
+            items: [
+              {
+                key: 'sub1',
+                name: 'Sub-item 1',
+                href: 'http://bing.com'
+              }
+            ]
+          }
+        },
+        {
+          key: 'item2',
+          id: 'item2',
+          name: 'Item 2',
+          href: 'http://bing.com',
+          subMenuProps: {
+            items: [
+              {
+                key: 'sub2',
+                name: 'Sub-item 2',
+                href: 'http://bing.com'
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ];
 
@@ -265,39 +307,30 @@ storiesOf('ContextualMenu', module)
         .click('.ms-ContextualMenu-linkContent')
         .hover('.ms-ContextualMenu-linkContent')
         .snapshot('click', { cropTo: '.ms-Layer' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
   ))
-  .addStory('Root', () => (
-    <ContextualMenu
-      items={items}
-    />
+  .addStory('Root', () => <ContextualMenu items={items} />)
+  .addStory('With icons', () => <ContextualMenu items={itemsWithIcons} />)
+  .addStory('With secondaryText', () => <ContextualMenu items={itemsWithSecondaryText} />, { rtl: true })
+  .addStory('With submenu', () => <ContextualMenu items={itemsWithSubmenu} />, { rtl: true })
+  .addStory('With headers', () => <ContextualMenu items={itemsWithHeaders} />)
+  .addStory('With split button submenu', () => <ContextualMenu items={itemsWithSplitButtonSubmenu} />)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default2', { cropTo: '.ms-Layer' })
+        .hover('#parent')
+        .snapshot('parent hovered', { cropTo: '.ms-Layer' })
+        .hover('#item1')
+        .snapshot('item1 hovered', { cropTo: '.ms-Layer' })
+        .hover('#item2')
+        .snapshot('item2 hovered', { cropTo: '.ms-Layer' })
+        .end()}
+    >
+      {story()}
+    </Screener>
   ))
-  .addStory('With icons', () => (
-    <ContextualMenu
-      items={itemsWithIcons}
-    />
-  ))
-  .addStory('With secondaryText', () => (
-    <ContextualMenu
-      items={itemsWithSecondaryText}
-    />
-  ), { rtl: true })
-  .addStory('With submenu', () => (
-    <ContextualMenu
-      items={itemsWithSubmenu}
-    />
-  ), { rtl: true })
-  .addStory('With headers', () => (
-    <ContextualMenu
-      items={itemsWithHeaders}
-    />
-  ))
-  .addStory('With split button submenu', () => (
-    <ContextualMenu
-      items={itemsWithSplitButtonSubmenu}
-    />
-  ));
+  .addStory('With submenus with hrefs', () => <ContextualMenu items={itemsWithSubmenuHrefs} />);

--- a/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
+++ b/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from 'office-ui-fabric-react';
+import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem, DefaultButton } from 'office-ui-fabric-react';
 
 const items: IContextualMenuItem[] = [
   {
@@ -321,7 +321,8 @@ storiesOf('ContextualMenu', module)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
-        .snapshot('default2', { cropTo: '.ms-Layer' })
+        .click('#button')
+        .snapshot('menu opened', { cropTo: '.ms-Layer' })
         .hover('#parent')
         .snapshot('parent hovered', { cropTo: '.ms-Layer' })
         .hover('#item1')
@@ -333,4 +334,6 @@ storiesOf('ContextualMenu', module)
       {story()}
     </Screener>
   ))
-  .addStory('With submenus with hrefs', () => <ContextualMenu items={itemsWithSubmenuHrefs} />);
+  .addStory('With submenus with hrefs', () => (
+    <DefaultButton id="button" text="Click for ContextualMenu" menuProps={{ items: itemsWithSubmenuHrefs }} />
+  ));

--- a/common/changes/office-ui-fabric-react/contextmenu_2019-01-10-03-06.json
+++ b/common/changes/office-ui-fabric-react/contextmenu_2019-01-10-03-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: fix hovering on items in IE",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -1490,7 +1490,7 @@ export function getScrollbarWidth(): number;
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
 
 // @public (undocumented)
-export function getSubmenuItems(item: IContextualMenuItem): any;
+export function getSubmenuItems(item: IContextualMenuItem): IContextualMenuItem[] | undefined;
 
 // @public
 export function getTheme(depComments?: boolean): ITheme;
@@ -6651,7 +6651,6 @@ interface IContextualMenuState {
   contextualMenuTarget?: Element;
   // (undocumented)
   dismissedMenuItemKey?: string;
-  // (undocumented)
   expandedByMouseClick?: boolean;
   // (undocumented)
   expandedMenuItemKey?: string;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -721,8 +721,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     if (!ev.defaultPrevented) {
       // When Edge + Narrator are used together (regardless of if the button is in a form or not), pressing
       // "Enter" fires this method and not _onMenuKeyDown. Checking ev.nativeEvent.detail differentiates
-      // between a real click event and a keypress event.
-      const shouldFocusOnContainer = ev.nativeEvent.detail !== 0;
+      // between a real click event and a keypress event (detail should be the number of mouse clicks).
+      // ...Plot twist! For a real click event in IE 11, detail is always 0 (Edge sets it properly to 1).
+      // So we also check the pointerType property, which both Edge and IE set to "mouse" for real clicks
+      // and "" for pressing "Enter" with Narrator on.
+      const shouldFocusOnContainer = ev.nativeEvent.detail !== 0 || (ev.nativeEvent as PointerEvent).pointerType === 'mouse';
       this._onToggleMenu(shouldFocusOnContainer);
       ev.preventDefault();
       ev.stopPropagation();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -41,7 +41,6 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
 
     return (
       <DefaultButton
-        id="ContextualMenuButton2"
         text="Click for ContextualMenu"
         menuProps={{
           shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
@@ -22,7 +22,6 @@ export class ContextualMenuIconExample extends React.Component<{}, { showCallout
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuButton2"
           text="Click for ContextualMenu"
           menuProps={{
             shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx
@@ -13,7 +13,6 @@ export class ContextualMenuIconSecondaryTextExample extends React.Component<{}, 
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuButton2"
           text="Click for ContextualMenu"
           menuProps={{
             shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -19,9 +19,20 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
   public render(): JSX.Element {
     return (
       <div>
-        <TextField value={String(this.state.hoverDelay)} label="Hover delay (ms)" type="number" onChange={this._onHoverDelayChanged} />
+        <TextField
+          value={String(this.state.hoverDelay)}
+          label="Hover delay (ms)"
+          type="number"
+          onChange={this._onHoverDelayChanged}
+          styles={{
+            subComponentStyles: {
+              label: { root: { display: 'inline-block', marginRight: '10px' } }
+            },
+            fieldGroup: { display: 'inline-flex', maxWidth: '100px' },
+            wrapper: { display: 'block', marginBottom: '10px' }
+          }}
+        />
         <DefaultButton
-          id="ContextualMenuButton2"
           text="Click for ContextualMenu"
           menuProps={{
             shouldFocusOnMount: true,
@@ -82,7 +93,6 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
               },
               {
                 key: 'shareSplit',
-                onClick: () => alert('Split buttons!'),
                 split: true,
                 'aria-roledescription': 'split button',
                 subMenuProps: {
@@ -126,7 +136,7 @@ export class ContextualMenuSubmenuExample extends React.Component<any, IContextu
 
   private _onHoverDelayChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string) => {
     this.setState({
-      hoverDelay: +newValue
+      hoverDelay: Number(newValue) || 0
     });
   };
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
@@ -74,7 +74,6 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
         color: #212121;
       }
   data-is-focusable={true}
-  id="ContextualMenuButton2"
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuButton2"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuButton2"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -25,7 +25,10 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
     <div
       className=
           ms-TextField-wrapper
-
+          {
+            display: block;
+            margin-bottom: 10px;
+          }
     >
       <label
         className=
@@ -36,13 +39,13 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               box-shadow: none;
               box-sizing: border-box;
               color: #333333;
-              display: block;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
               margin-bottom: 0px;
               margin-left: 0px;
-              margin-right: 0px;
+              margin-right: 10px;
               margin-top: 0px;
               overflow-wrap: break-word;
               padding-bottom: 5px;
@@ -64,13 +67,14 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               border: 1px solid #a6a6a6;
               box-shadow: none;
               box-sizing: border-box;
-              display: flex;
+              display: inline-flex;
               flex-direction: row;
               height: 32px;
               margin-bottom: 0px;
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
+              max-width: 100px;
               padding-bottom: 0px;
               padding-left: 0px;
               padding-right: 0px;
@@ -208,7 +212,6 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuButton2"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7419
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This change fixes a bug in IE where if the first item in a context menu has children, it's only expanded after the second hover event (move cursor in, back out, and in again). 

The issue was that the context menu's container element was getting marked as non-focusable in IE, due to some logic added for Edge+Narrator to correctly handle when the menu was opened with the enter key (that special combination calls the click handler rather than key handlers). This means the first focusable child inside the context menu is the first item, so it receives focus when the menu opens instead of the container receiving focus. When the user hovers the first item, the mouse move handler sees that the item is already `document.activeElement` and concludes there's nothing to be done.

Fix is to refine detection of the special Edge+Narrator+enter key case when opening the menu from BaseButton. Previously it assumed that `nativeEvent.detail` (which should be the number of mouse clicks) would be 0 only in the special case where the "click" is actually a key press--but `detail` is always 0 in IE. So I added an additional check for `nativeEvent.pointerType`, which in both IE and Edge is `"mouse"` for click events and `""` in the special case. (Requesting review from @rebeccaballantyne since she appears to have added the special case awhile back.)

#### Focus areas to test

Test context menu with and without narrator in various browsers using example "ContextualMenu with submenus" from demo site

Try to add screener test to cover this case (not as useful since we don't run screener against IE or Edge...)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7592)