### PR TITLE
Relax property value requirements for the autoComplete property on the TextField component.

### DIFF
--- a/common/changes/office-ui-fabric-react/Issue-7593_2019-01-10-12-50.json
+++ b/common/changes/office-ui-fabric-react/Issue-7593_2019-01-10-12-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Relaxed type restrictions on possible values for 'autoComplete' attribute on TextField component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "patrik@themediaexchange.nl"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10745,7 +10745,7 @@ interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElement | HTM
   addonString?: string;
   ariaLabel?: string;
   autoAdjustHeight?: boolean;
-  autoComplete?: 'on' | 'off';
+  autoComplete?: string;
   borderless?: boolean;
   className?: string;
   // @deprecated (undocumented)

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -254,8 +254,11 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   /**
    * Whether the input field should have autocomplete enabled.
    * This tells the browser to display options based on earlier typed values.
+   * Common values are 'on' and 'off' but for all possible values see the following links:
+   * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values
+   * https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill
    */
-  autoComplete?: 'on' | 'off';
+  autoComplete?: string;
 
   /**
    * The masking string that defines the mask's behavior.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7593 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Added ` | string` to the property definition. We could also remove the `'on' | 'off'` part but I left it for now.

#### Focus areas to test
I had to run `npm run update-api` so perhaps the api change has to be reviewed? 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7594)

