### PR TITLE
Just: adds a `npm run just` script for convenience 

### DIFF
--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/tasks/build-codepen-examples.js && node ../../scripts/start.js",

--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js",

--- a/apps/server-rendered-app/package.json
+++ b/apps/server-rendered-app/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js"
   },

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js"

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js"

--- a/common/changes/@uifabric/charting/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/charting/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/charting",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/dashboard/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/dashboard/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/dashboard",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/date-time/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/date-time/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/date-time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/example-app-base/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/example-app-base/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/experiments/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/fabric-website-resources/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website-resources",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/fabric-website/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/file-type-icons/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/file-type-icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/fluent-theme/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/fluent-theme/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fluent-theme",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/foundation/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/foundation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/icons/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/jest-serializer-merge-styles/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/jest-serializer-merge-styles/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/jest-serializer-merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/merge-styles/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/styling/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/test-utilities/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/test-utilities/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/test-utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/test-utilities",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/theme-samples/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/theme-samples/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/theme-samples",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/theme-samples",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/utilities/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/just_2019-01-10-17-17.json
+++ b/common/changes/@uifabric/variants/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/variants",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/just_2019-01-10-17-17.json
+++ b/common/changes/office-ui-fabric-react/just_2019-01-10-17-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean"
   },
   "disabledTasks": [

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -23,6 +23,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "test": "react-scripts-ts test --env=jsdom",

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js"

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js",

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style"
   },

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean"
   },
   "disabledTasks": [

--- a/packages/foundation-scenarios/package.json
+++ b/packages/foundation-scenarios/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style"
   },

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start-test": "node ../../scripts/just.js jest-watch"

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "cd ../../apps/fabric-website-resources && npm start",

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -13,6 +13,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start": "node ../../scripts/start.js",

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "start": "node ../../scripts/start.js",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean"
   },
   "disabledTasks": [

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "code-style": "node ../../scripts/just.js code-style",
     "clean": "node ../../scripts/just.js clean",
     "start-test": "node ../../scripts/just.js jest-watch",

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ../../scripts/just.js build",
+    "just": "node ../../scripts/just.js",
     "clean": "node ../../scripts/just.js clean",
     "code-style": "node ../../scripts/just.js code-style",
     "start-test": "node ../../scripts/just.js jest-watch"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Before `just` was integrated, folks used to be able to run individual steps of the build by running it like this:

`npm run build ts`

This PR adds back that capability slightly differently:

`npm run just ts`

Since these are `just` tasks, you can be specific as well (to save time!):

`npm run just ts:esm`

You can even do things like

`npm run just jest-watch`

All the tasks are defined under `/scripts/tasks`. I will add descriptions to those in a separate PR. This PR backfills a workflow that was lost in translation.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7600)

