### PR TITLE
DetailsList: Add test for optional headerClassName prop

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-add-headerclassname-tests_2019-01-10-19-39.json
+++ b/common/changes/office-ui-fabric-react/keco-add-headerclassname-tests_2019-01-10-19-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Add test for existance of headerClassName if provided",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/keco-add-headerclassname-tests_2019-01-10-19-39.json
+++ b/common/changes/office-ui-fabric-react/keco-add-headerclassname-tests_2019-01-10-19-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "DetailsList: Add test for existance of headerClassName if provided",
+      "comment": "DetailsList: Add test for existence of headerClassName if provided",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -684,4 +684,29 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(Number.MIN_SAFE_INTEGER);
     expect(_sourceIndex).toBe(2);
   });
+
+  it('should set optional headerClassName on header if provided', () => {
+    const headerClassName: string = 'foo';
+    const column: IColumn = {
+      key: 'a',
+      name: 'a',
+      fieldName: 'a',
+      minWidth: 200,
+      maxWidth: 400,
+      calculatedWidth: 200,
+      isResizable: true,
+      headerClassName
+    };
+
+    const component = mount(
+      <DetailsHeader
+        selection={_selection}
+        selectionMode={SelectionMode.multiple}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        columns={[column]}
+      />
+    );
+
+    expect(component.find(`.${headerClassName}`).exists()).toBe(true);
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

#7555 brought to my attention that there currently is no test for the existence of the _optional_ `headerClassName` when provided on `IColumn`. This adds such a test.

#### Focus areas to test

Tests should succeed on CI and locally.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7602)

