### PR TITLE
ComboBox: revert change to aria label

### DIFF
--- a/common/changes/office-ui-fabric-react/combobox-revert_2019-01-10-20-20.json
+++ b/common/changes/office-ui-fabric-react/combobox-revert_2019-01-10-20-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CombBox: revert change to aria label",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -379,8 +379,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 aria-autocomplete={this._getAriaAutoCompleteValue()}
                 role="combobox"
                 readOnly={disabled || !allowFreeform}
-                aria-labelledby={label && !ariaLabel ? id + '-label' : undefined}
-                aria-label={ariaLabel}
+                aria-labelledby={label && id + '-label'}
+                aria-label={ariaLabel && !label ? ariaLabel : undefined}
                 aria-describedby={keytipAttributes['aria-describedby']}
                 aria-activedescendant={this._getAriaActiveDescentValue()}
                 aria-disabled={disabled}
@@ -1186,7 +1186,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           onMouseLeave={this._onOptionMouseLeave}
           role="option"
           aria-selected={isSelected ? 'true' : 'false'}
-          ariaLabel={item.ariaLabel}
+          ariaLabel={this._getPreviewText(item)}
           disabled={item.disabled}
           title={title}
         >
@@ -1200,7 +1200,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       ) : (
         <Checkbox
           id={id + '-list' + item.index}
-          ariaLabel={item.ariaLabel}
+          ariaLabel={this._getPreviewText(item)}
           key={item.key}
           data-index={item.index}
           styles={checkboxStyles}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Reverting the ComboBox portion of #7409 per @jspurlin's request. Rationale below, copied from an email:

> [When rev'ing fabric in another repo] our ComboBox snapshot test was being updated to remove the `aria-label`.
>  
> Digging in, I found that this was introduced in 6.118.0 by #7409 - Dropdown & ComboBox options screen reader fix. That PR changed the setting of `aria-label` to only be the `ariaLabel` prop instead of setting it to either the `ariaLabel` prop or the `item.text`. It states that it’s fixing a bug where NVDA with Chrome reads both the `aria-label` and `item.text`. Up front, from looking at the W3C spec for Accessible Name and Description Computation, if an `aria-label` is provided then it should be used as the accessible name (assuming an `aria-labelledby` is not also provided) so this is a bug with NVDA/Chrome (note did not repro this with Edge/Narrator, NVDA/FF, JAWS/Chrome, or JAWS/FF (although a subset would reread the text for the initially focused item but not reread any item after that)).
>  
> Additionally, setting the `aria-label` to be the `ariaLabel` (when `item.useAriaLabelAsText` is true) or to the `item.text` (when use `item.useAriaLabelAsText` is false) ensures:
> - That the `aria-label` (e.g. what a screen reader user hears at the “option”) is what will be used when querying in the comboBox
>     - This means the user will not get an “option” that they cannot query for which can be achieve if:
>         - A creator sets an `aria-label` without `useAriaLabelAsText` and that value doesn’t align with the value of `item.text` (`item.text` is used to query)
>         - A creator uses a custom render function and the contents don’t align with the value item.text
>  
> The behavior before 7409 guaranteed that if a creator provides an `ariaLabel` for an item that it is only used if it is also used as the queryable  text, otherwise it would set `aria-label` to `item.text` so that the value that is conveyed to ATs aligns with what the user can query for. After this change, a creator can easily build an option who’s AT representation does not align with what is queryable.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7605)

