### PR TITLE
Ensure coachmark layers behind header on example page

### DIFF
--- a/common/changes/office-ui-fabric-react/bekaise-fixcalloutlayering_2019-01-10-23-15.json
+++ b/common/changes/office-ui-fabric-react/bekaise-fixcalloutlayering_2019-01-10-23-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Ensure coachmark layers under header",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "bekaise@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.doc.tsx
@@ -12,7 +12,8 @@ export const CoachmarkPageProps: IDocPageProps = {
     {
       title: 'Coachmark Basic',
       code: CoachmarkBasicExampleCode,
-      view: <CoachmarkBasicExample />
+      view: <CoachmarkBasicExample />,
+      isScrollable: false
     }
   ],
   propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts')],

--- a/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
@@ -99,7 +99,8 @@ export class CoachmarkBasicExample extends BaseComponent<{}, ICoachmarkBasicExam
           <Coachmark
             target={this._targetButton.current}
             positioningContainerProps={{
-              directionalHint: this.state.coachmarkPosition
+              directionalHint: this.state.coachmarkPosition,
+              doNotLayer: true
             }}
             ariaAlertText="A Coachmark has appeared"
             ariaDescribedBy={'coachmark-desc1'}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7221
- [x] Include a change request file using `$ npm run change`

#### Description of changes

On the example page for the coachmark we can see the coachmark appearing above the header if we scroll down far enough. This change makes the coachmark layer on the same layer as the button it is attached to, ensuring that it displays on the same layer underneath the floating header.

#### Focus areas to test

Coachmark examples page. See #7221 for more info.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7607)

