### PR TITLE
#7601 - Facepile: maxDisplayablePersonas not being accepted when 0

### DIFF
--- a/common/changes/office-ui-fabric-react/tabrumle-FacepileMaxCoauthors_2019-01-11-17-12.json
+++ b/common/changes/office-ui-fabric-react/tabrumle-FacepileMaxCoauthors_2019-01-11-17-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix issue with Facepile not using maxDisplayablePersonas prop if its value is 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tabrumle@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -41,7 +41,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     const { _classNames } = this;
 
     // Add a check to make sure maxDisplayalePersonas is defined to cover the edge case of it being 0.
-    const numPersonasToShow: number = typeof maxDisplayablePersonas !== 'undefined' ?
+    const numPersonasToShow: number = typeof maxDisplayablePersonas === 'number' ?
       Math.min(personas.length, maxDisplayablePersonas ) : personas.length;
 
     // Added for deprecating chevronButtonProps.  Can remove after v1.0

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -40,7 +40,8 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
 
     const { _classNames } = this;
 
-    const numPersonasToShow: number = Math.min(personas.length, maxDisplayablePersonas || personas.length);
+    // Add a check to make sure maxDisplayalePersonas is defined to cover the edge case of it being 0.
+    const numPersonasToShow: number = typeof maxDisplayablePersonas !== 'undefined' ? Math.min(personas.length, maxDisplayablePersonas ) : personas.length;
 
     // Added for deprecating chevronButtonProps.  Can remove after v1.0
     if (chevronButtonProps && !overflowButtonProps) {

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -41,7 +41,8 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     const { _classNames } = this;
 
     // Add a check to make sure maxDisplayalePersonas is defined to cover the edge case of it being 0.
-    const numPersonasToShow: number = typeof maxDisplayablePersonas !== 'undefined' ? Math.min(personas.length, maxDisplayablePersonas ) : personas.length;
+    const numPersonasToShow: number = typeof maxDisplayablePersonas !== 'undefined' ?
+      Math.min(personas.length, maxDisplayablePersonas ) : personas.length;
 
     // Added for deprecating chevronButtonProps.  Can remove after v1.0
     if (chevronButtonProps && !overflowButtonProps) {

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
@@ -202,4 +202,11 @@ describe('Facepile', () => {
     expect(wrapper.find(PersonaCoin).length).toEqual(1);
     expect(wrapper.find(Persona).length).toEqual(1);
   });
+
+  it('renders no Persona or PersonaCoin if 0 is passed in for maxDisplayablePersonas', () => {
+    const wrapper = mount(<Facepile personas={facepilePersonas} maxDisplayablePersonas={0} />);
+
+    expect(wrapper.find(PersonaCoin).length).toEqual(0);
+    expect(wrapper.find(Persona).length).toEqual(0);
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #7601 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix an issue where maxDisplayablePersonas was not being used if it had a 0 passed in for its value.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7613)

