### PR TITLE
Theming: fix createTheme

### DIFF
--- a/common/changes/@uifabric/styling/fixCreateTheme_2019-01-11-20-13.json
+++ b/common/changes/@uifabric/styling/fixCreateTheme_2019-01-11-20-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "fix createTheme so that it cannot mutate DefaultFontStyles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/styling/src/styles/theme.test.ts
+++ b/packages/styling/src/styles/theme.test.ts
@@ -85,5 +85,15 @@ describe('loadTheme', () => {
       expect(newTheme.fonts.mega.fontSize).toEqual('10px');
       expect(newTheme.fonts.mega.fontWeight).toEqual(DefaultFontStyles.mega.fontWeight);
     });
+    it('applies fonts to theme and does not mutate the DefaultFontStyles object', () => {
+      const defaultFontStyles = { ...DefaultFontStyles };
+
+      const userTheme = { fonts: { small: { fontSize: '20px' } } };
+      loadTheme(userTheme);
+      const newTheme = getTheme();
+
+      expect(newTheme.fonts.small.fontSize).toEqual('20px');
+      expect(defaultFontStyles.small.fontSize).toEqual(DefaultFontStyles.small.fontSize);
+    });
   });
 });

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -107,16 +107,17 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     ...theme.semanticColors
   };
 
-  let defaultFontStyles: IFontStyles = DefaultFontStyles;
+  let defaultFontStyles: IFontStyles = { ...DefaultFontStyles };
+
   if (theme.defaultFontStyle) {
-    for (const fontStyle of Object.keys(DefaultFontStyles)) {
-      defaultFontStyles[fontStyle] = { ...defaultFontStyles[fontStyle], ...theme.defaultFontStyle };
+    for (const fontStyle of Object.keys(defaultFontStyles)) {
+      defaultFontStyles[fontStyle] = merge({}, defaultFontStyles[fontStyle], theme.defaultFontStyle);
     }
   }
 
   if (theme.fonts) {
     for (const fontStyle of Object.keys(theme.fonts)) {
-      defaultFontStyles[fontStyle] = merge(defaultFontStyles[fontStyle], theme.fonts[fontStyle]);
+      defaultFontStyles[fontStyle] = merge({}, defaultFontStyles[fontStyle], theme.fonts[fontStyle]);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This fix prevents createTheme from mutating the DefaultFontStyles object, which was happening in the experiments package as a result of my recent changes. I'll add a test for this as well.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7616)

