### PR TITLE
Add ability to override prettier options per-project

### DIFF
--- a/scripts/exec-sync.js
+++ b/scripts/exec-sync.js
@@ -1,24 +1,29 @@
+// @ts-check
 const path = require('path');
-const execSync = require('child_process').execSync;
-const chalk = require('chalk');
+const child_process = require('child_process');
+const chalk = require('chalk').default;
 const { logStatus } = require('./logging');
 
-const SEPARATOR = process.platform === 'win32' ? ';' : ':',
-  env = Object.assign({}, process.env);
+const SEPARATOR = process.platform === 'win32' ? ';' : ':';
+const env = Object.assign({}, process.env);
 
 env.PATH = path.resolve('./node_modules/.bin') + SEPARATOR + env.PATH;
 
-function myExecSync(cmd, displayName, cwd = process.cwd()) {
-  let returnValue = 0;
-  let start = new Date().getTime();
-
+/**
+ * Execute a command synchronously.
+ *
+ * @param {string} cmd  Command to execute
+ * @param {string} [displayName] Display name for the command
+ * @param {string} [cwd] Working directory in which to run the command
+ */
+function execSync(cmd, displayName, cwd = process.cwd()) {
   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
 
-  const output = execSync(cmd, {
+  child_process.execSync(cmd, {
     cwd,
     env: env,
     stdio: 'inherit'
   });
 }
 
-module.exports = myExecSync;
+module.exports = execSync;

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -1,7 +1,7 @@
+// @ts-check
 const path = require('path');
-const exec = require('child_process').exec;
-const chalk = require('chalk');
-const stream = require('stream');
+const child_process = require('child_process');
+const chalk = require('chalk').default;
 const { logStatus } = require('./logging');
 
 const SEPARATOR = process.platform === 'win32' ? ';' : ':',
@@ -9,7 +9,15 @@ const SEPARATOR = process.platform === 'win32' ? ';' : ':',
 
 env.PATH = path.resolve('./node_modules/.bin') + SEPARATOR + env.PATH;
 
-module.exports = function(cmd, displayName, cwd = process.cwd(), opts = {}) {
+/**
+ * Execute a command.
+ *
+ * @param {string} cmd Command to execute
+ * @param {string} [displayName] Display name for the command
+ * @param {string} [cwd] Working directory in which to run the command
+ * @param {{ stdout?: any; stderr?: any; }} [opts] Pipe stdout/stderr somewhere. Can pass `process` global.
+ */
+function exec(cmd, displayName, cwd = process.cwd(), opts = {}) {
   logStatus(chalk.gray('Executing: ') + chalk.cyan(displayName || cmd));
 
   const execOptions = {
@@ -19,7 +27,7 @@ module.exports = function(cmd, displayName, cwd = process.cwd(), opts = {}) {
   };
 
   return new Promise((resolve, reject) => {
-    const child = exec(cmd, execOptions, (error, stdout, stderr) =>
+    const child = child_process.exec(cmd, execOptions, (error, stdout, stderr) =>
       error
         ? reject({
             error,
@@ -39,4 +47,6 @@ module.exports = function(cmd, displayName, cwd = process.cwd(), opts = {}) {
       child.stderr.pipe(opts.stderr);
     }
   });
-};
+}
+
+module.exports = exec;

--- a/scripts/lint-staged/prettier.js
+++ b/scripts/lint-staged/prettier.js
@@ -1,30 +1,6 @@
-const prettier = require('prettier');
-const path = require('path');
-const execSync = require('../exec-sync');
+// @ts-check
+
+const { runPrettierMultiProject } = require('../prettier/prettier-helpers');
 
 const files = process.argv.slice(2);
-
-runPrettierOnStagedFiles(files);
-
-/**
- *  Gets the prettier config path from the tslint package
- */
-function getPrettierConfigPath() {
-  return path.join(process.cwd(), 'packages', 'prettier-rules', 'prettier.config.js');
-}
-
-/**
- * Runs prettier on the files that are staged and need formatting.
- * The need for formatting is checked by prettier by calling prettier.check()
- *
- * @param {string[]} files Staged files passed in by lint-staged
- */
-function runPrettierOnStagedFiles(files) {
-  const prettierPath = 'node ' + path.resolve(path.join(__dirname, '..', 'node_modules', 'prettier', 'bin-prettier.js'));
-  const prettierIgnorePath = path.resolve(path.join(__dirname, '..', '..', '.prettierignore'));
-
-  // Get the config from @uifabric/prettier-rules
-  const prettierConfigPath = getPrettierConfigPath();
-
-  execSync(`${prettierPath} --config ${prettierConfigPath} --ignore-path "${prettierIgnorePath}" --write ${files.join(' ')}`);
-}
+runPrettierMultiProject(files);

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -1,7 +1,8 @@
+// @ts-check
 const { execSync } = require('child_process');
-const exec = require('./exec');
 const path = require('path');
 const { EOL, cpus } = require('os');
+const { runPrettierMultiProject } = require('./prettier/prettier-helpers');
 
 const prettierIntroductionCommit = 'HEAD~1';
 const passedDiffTarget = process.argv.slice(2).length ? process.argv.slice(2)[0] : prettierIntroductionCommit;
@@ -15,24 +16,17 @@ const filesChangedSinceLastRun = gitDiffOutput
   .split(EOL)
   .filter(fileName => /\.(ts|tsx|js)$/.test(fileName));
 
-const prettierPath = path.resolve(__dirname, './node_modules/prettier/bin-prettier.js');
-const prettierIgnorePath = path.resolve(path.join(__dirname, '..', '.prettierignore'));
-const prettierConfigPath = path.join(__dirname, '..', 'packages', 'prettier-rules', 'prettier.config.js');
-
+/**
+ * Run prettier for some files.
+ * @param {string[]} filePaths Run for these file paths
+ */
 function runPrettierForFiles(filePaths) {
   if (filePaths.length === 0) {
     return Promise.resolve();
   }
 
   console.log(`Running for ${filePaths.length} files!`);
-
-  const sources = filePaths.join(' ');
-  return exec(
-    `node ${prettierPath} --config ${prettierConfigPath} --ignore-path ${prettierIgnorePath} --write ${sources}`,
-    undefined,
-    undefined,
-    process
-  );
+  return runPrettierMultiProject(filePaths, true /*async*/);
 }
 
 const numberOfCpus = cpus().length / 2;

--- a/scripts/prettier/prettier-helpers.js
+++ b/scripts/prettier/prettier-helpers.js
@@ -95,15 +95,18 @@ function runPrettierMultiProject(files, runAsync) {
   }
 
   const configPaths = Object.keys(configMap);
-  console.log('CONFIG PATHS: ' + configPaths);
-  console.log(JSON.stringify(configMap));
-  let promise = Promise.resolve();
   // Run all the prettier commands in sequence
-  for (const configPath of configPaths) {
-    promise = runPrettier(configMap[configPath], configPath, runAsync);
+  if (runAsync) {
+    let promise = Promise.resolve();
+    for (const configPath of configPaths) {
+      promise = promise.then(() => runPrettier(configMap[configPath], configPath, true));
+    }
+    return promise;
+  } else {
+    for (const configPath of configPaths) {
+      runPrettier(configMap[configPath], configPath);
+    }
   }
-
-  return runAsync ? promise : undefined;
 }
 
 module.exports = { runPrettierForProject, runPrettierMultiProject };

--- a/scripts/prettier/prettier-helpers.js
+++ b/scripts/prettier/prettier-helpers.js
@@ -1,0 +1,109 @@
+// @ts-check
+const path = require('path');
+const fs = require('fs');
+const execSync = require('../exec-sync');
+const exec = require('../exec');
+const readConfig = require('../read-config');
+
+const prettierConfig = 'prettier.config.js';
+const prettierIgnore = '.prettierignore';
+const repoRoot = path.resolve(__dirname, '..', '..');
+const prettierRulesConfig = path.join(repoRoot, 'packages', 'prettier-rules', prettierConfig);
+const prettierIgnorePath = path.join(repoRoot, prettierIgnore);
+const prettierBin = path.join(__dirname, '..', 'node_modules', 'prettier', 'bin-prettier.js');
+let projectsWithPrettierConfig;
+
+function init() {
+  if (projectsWithPrettierConfig) {
+    return;
+  }
+
+  projectsWithPrettierConfig = [];
+  const rushJson = readConfig('rush.json');
+  if (rushJson) {
+    // Check the root of each project for a custom prettier config, and save the project paths that have one
+    for (const project of rushJson.projects) {
+      const packagePath = path.resolve(repoRoot, project.projectFolder);
+      if (fs.existsSync(path.join(packagePath, prettierConfig))) {
+        projectsWithPrettierConfig.push(packagePath);
+      }
+    }
+  }
+}
+
+/**
+ * Run prettier for a given set of files with the given config.
+ *
+ * @param {string[]} files List of files for which to run prettier
+ * @param {string} configPath Path to relevant prettier.config.js.
+ * @param {boolean} [runAsync] Whether to run the command synchronously or asynchronously
+ * @returns A promise if run asynchronously, or nothing if run synchronously
+ */
+function runPrettier(files, configPath, runAsync) {
+  const cmd = `node ${prettierBin} --config ${configPath} --ignore-path "${prettierIgnorePath}" --write ${files.join(' ')}`;
+  if (runAsync) {
+    return exec(cmd, undefined, undefined, process);
+  } else {
+    execSync(cmd);
+  }
+}
+
+/**
+ * Runs prettier on all ts/tsx/json/js files in a project.
+ *
+ * @param {string} projectPath Path to the project root for which to run prettier
+ */
+function runPrettierForProject(projectPath) {
+  init();
+
+  const sourcePath = path.join(projectPath, '**', '*.{ts,tsx,json,js}');
+  const configPath = projectsWithPrettierConfig[projectPath] || prettierRulesConfig;
+  runPrettier([sourcePath], configPath);
+}
+
+/**
+ * Runs prettier on the given list of files.
+ *
+ * @param {string[]} files Staged files passed in by lint-staged
+ * @param {boolean} [runAsync] Whether to run the command synchronously or asynchronously
+ * @returns A promise if run asynchronously, or nothing if run synchronously
+ */
+function runPrettierMultiProject(files, runAsync) {
+  if (files.length === 0) {
+    return runAsync ? Promise.resolve() : undefined;
+  }
+
+  init();
+
+  // Buid a mapping from config file name to files for which that config applies
+  const configMap = {};
+  for (const file of files) {
+    // Default to the repo-wide config
+    let configPath = prettierRulesConfig;
+    const absPath = path.resolve(repoRoot, file);
+    for (const projectPath of projectsWithPrettierConfig) {
+      // Check if this file is inside any of the projects with a custom config
+      if (absPath.startsWith(projectPath)) {
+        configPath = path.join(projectPath, prettierConfig);
+        break;
+      }
+    }
+    if (!configMap[configPath]) {
+      configMap[configPath] = [];
+    }
+    configMap[configPath].push(file);
+  }
+
+  const configPaths = Object.keys(configMap);
+  console.log('CONFIG PATHS: ' + configPaths);
+  console.log(JSON.stringify(configMap));
+  let promise = Promise.resolve();
+  // Run all the prettier commands in sequence
+  for (const configPath of configPaths) {
+    promise = runPrettier(configMap[configPath], configPath, runAsync);
+  }
+
+  return runAsync ? promise : undefined;
+}
+
+module.exports = { runPrettierForProject, runPrettierMultiProject };

--- a/scripts/tasks/prettier.js
+++ b/scripts/tasks/prettier.js
@@ -1,21 +1,7 @@
+// @ts-check
+
+const { runPrettierForProject } = require('../prettier/prettier-helpers');
+
 module.exports = function() {
-  const childProcess = require('child_process');
-  const path = require('path');
-  const fs = require('fs');
-  const sourcePath = path.join(process.cwd(), '**', '*.{ts,tsx,json,js}');
-  const prettierPath = 'node ' + path.resolve(__dirname, '../node_modules/prettier/bin-prettier.js');
-  const prettierIgnorePath = path.resolve(path.join(__dirname, '..', '..', '.prettierignore'));
-
-  const prettierConfigPath = path.join(process.cwd(), '..', '..', 'packages', 'prettier-rules', 'prettier.config.js');
-
-  try {
-    fs.accessSync(prettierConfigPath, fs.constants.R_OK);
-  } catch (err) {
-    console.error('Can not find prettier.config.js');
-
-    process.exit(1);
-  }
-
-  const prettierCommand = `${prettierPath} --config ${prettierConfigPath} --ignore-path "${prettierIgnorePath}" --write "${sourcePath}"`;
-  childProcess.execSync(prettierCommand);
+  runPrettierForProject(process.cwd());
 };


### PR DESCRIPTION
#### Description of changes

Add ability to have a per-project prettier.config.js which can import then override the default rules. 

Motivation was that I'd like the vr-tests project to have a lower maximum line length, because with the current 140, prettier tends to squish test cases together and make them unreadable.

Also adds a single file with all the logic for invoking prettier (rather than having it duplicated three times) and adds documentation and type checking to some related scripts.

#### Focus areas to test

To test:
1. Modify a file in some project
2. In that project, add a prettier.config.js with a very small `printWidth`
3. `npm run prettier` and verify that the modified file has been reformatted
4. Change the `printWidth` setting to something bigger
5. Temporarily commit the changed file and verify that it's reformatted again

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7630)

