### PR TITLE
Added: adding a prdeploy flag so that PR Deploy job can build faster

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -151,6 +151,12 @@
       "parameterKind": "flag",
       "description": "Skips tasks that are irrelevant during npm install",
       "associatedCommands": ["build", "rebuild"]
+    },
+    {
+      "longName": "--prdeploy",
+      "parameterKind": "flag",
+      "description": "Skips tasks that are irrelevant during PR Deploy",
+      "associatedCommands": ["build", "rebuild"]
     }
     // {
     //   "parameterKind": "choice",

--- a/scripts/just-task.js
+++ b/scripts/just-task.js
@@ -12,6 +12,8 @@ option('production');
 // Adds an alias for 'npm-install-mode' for backwards compatibility
 option('min', { alias: 'npm-install-mode' });
 
+option('prdeploy');
+
 option('webpackConfig', { alias: 'w' });
 
 Object.keys(rig).forEach(taskFunction => {
@@ -24,7 +26,7 @@ Object.keys(rig).forEach(taskFunction => {
   }
 });
 
-task('ts', parallel('ts:commonjs', 'ts:esm', condition('ts:amd', () => argv().production && !argv().min)));
+task('ts', parallel('ts:commonjs', 'ts:esm', condition('ts:amd', () => argv().production && !argv().min && !argv().prdeploy)));
 
 task(
   'build',
@@ -33,12 +35,16 @@ task(
     'copy',
     'sass',
     parallel(
-      condition('tslint', () => !argv().min),
-      condition('jest', () => !argv().min),
+      condition('tslint', () => !argv().min && !argv().prdeploy),
+      condition('jest', () => !argv().min && !argv().prdeploy),
       series(
         'ts',
-        condition('lint-imports', () => !argv().min),
-        parallel(condition('webpack', () => !argv().min), condition('verify-api-extractor', () => !argv().min), 'build-codepen-examples')
+        condition('lint-imports', () => !argv().min && !argv().prdeploy),
+        parallel(
+          condition('webpack', () => !argv().min),
+          condition('verify-api-extractor', () => !argv().min && !argv().prdeploy),
+          'build-codepen-examples'
+        )
       )
     )
   )


### PR DESCRIPTION
#### Pull request checklist
- [x] Include a change request file using `$ npm run change` - not needed

#### Description of changes

This change adds a new flag to be run like this:

`npm run build -- --prdeploy` 

It is for making it so that tests, linting and non-essential tasks are skipped during build when creating a PR deploy site. This will conserve the resources (time, compute cycle) on the Azure DevOps pipeline. 

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7632)

