### PR TITLE
Setting aria-modal flag on Panel

### DIFF
--- a/common/changes/office-ui-fabric-react/focus_panel_2019-01-15-18-11.json
+++ b/common/changes/office-ui-fabric-react/focus_panel_2019-01-15-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Setting the aria-modal flag to true on Panel because it's considered modal and currently, focus is going outside the Panel component while Narrator's in scan mode. This alone will not solve this problem fully because we're still waiting on Narrator to support aria-modal.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/focus_panel_2019-01-15-18-11.json
+++ b/common/changes/office-ui-fabric-react/focus_panel_2019-01-15-18-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Setting the aria-modal flag to true on Panel because it's considered modal and currently, focus is going outside the Panel component while Narrator's in scan mode. This alone will not solve this problem fully because we're still waiting on Narrator to support aria-modal.",
+      "comment": "Panel: setting the aria-modal to true to prevent loosing focus when using Narrator in scan mode.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -155,6 +155,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       <Layer {...layerProps}>
         <Popup
           role="dialog"
+          aria-modal="true"
           ariaLabelledBy={header ? headerTextId : undefined}
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`Panel renders Panel correctly 1`] = `
   >
     <div
       aria-labelledby="Panel0-headerText"
+      aria-modal="true"
       className=
 
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -177,6 +177,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
     >
       <div
         aria-labelledby="Panel3-headerText"
+        aria-modal="true"
         className=
 
             {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #6800
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Setting the aria-modal flag to true on Panel because it's considered modal and currently, focus is going outside the Panel component while Narrator's in scan mode. This alone will not solve this problem fully because we're still waiting on Narrator to support aria-modal.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7654)

