### PR TITLE
ChoiceGroup: Makes first option focusable, even with invalid defaultSelectedKey

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-choicegroup-invalid-default-key_2019-01-15-20-32.json
+++ b/common/changes/office-ui-fabric-react/miwhea-choicegroup-invalid-default-key_2019-01-15-20-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: Sets the first enabled option to focusable, even with an invalid defaultSelectedKey",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -33,8 +33,11 @@ export class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGro
       selectedKey: 'defaultSelectedKey'
     });
 
+    const validDefaultSelectedKey: boolean = !!props.options && props.options.some(option => option.key === props.defaultSelectedKey);
+
     this.state = {
-      keyChecked: props.defaultSelectedKey === undefined ? this._getKeyChecked(props)! : props.defaultSelectedKey,
+      keyChecked:
+        props.defaultSelectedKey === undefined || !validDefaultSelectedKey ? this._getKeyChecked(props)! : props.defaultSelectedKey,
       keyFocused: undefined
     };
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -7,7 +7,7 @@ import * as renderer from 'react-test-renderer';
 
 import { ChoiceGroup } from './ChoiceGroup';
 import { IChoiceGroupOption, IChoiceGroup } from './ChoiceGroup.types';
-import { resetIds } from '../../Utilities';
+import { merge, resetIds } from '../../Utilities';
 
 const TEST_OPTIONS: IChoiceGroupOption[] = [
   { key: '1', text: '1', 'data-automation-id': 'auto1' } as IChoiceGroupOption,
@@ -77,10 +77,10 @@ describe('ChoiceGroup', () => {
   });
 
   it('An individual choice option can be disabled', () => {
-    const options = { ...TEST_OPTIONS };
+    const options = merge([], TEST_OPTIONS);
     options[0].disabled = true;
 
-    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS} required={true} />);
+    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={options} required={true} />);
 
     const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
 
@@ -191,5 +191,11 @@ describe('ChoiceGroup', () => {
     ReactTestUtils.Simulate.change(choiceOptions[0]);
     expect(choiceGroupRef.current!.checkedOption).toBeDefined();
     expect(choiceGroupRef.current!.checkedOption).toEqual(TEST_OPTIONS[0]);
+  });
+
+  it('sets the first enabled option to focusable, even with an invalid defaultSelectedKey', () => {
+    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS} defaultSelectedKey="X" />);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    expect((choiceOptions[0] as HTMLInputElement).getAttribute('data-is-focusable')).toEqual('true');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -77,7 +77,7 @@ describe('ChoiceGroup', () => {
   });
 
   it('An individual choice option can be disabled', () => {
-    const options = merge([], TEST_OPTIONS);
+    const options: IChoiceGroupOption[] = merge([], TEST_OPTIONS) as IChoiceGroupOption[];
     options[0].disabled = true;
 
     const choiceGroup = mount(<ChoiceGroup label="testgroup" options={options} required={true} />);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7644
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This change handles the case where the `defaultSelectedKey` prop does not exist within the `options` provided. In this case, the first enabled option should be focusable.

Also fixes a separate ChoiceGroup test that was making a shallow copy, mutating the shared test options and resulting in unexpected errors in later tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7656)

