### PR TITLE
Fix precommit hook

### DIFF
--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -3,16 +3,15 @@
 # exit with non-zero status after issuing an appropriate message if
 # it wants to stop the commit.
 
-COMMAND=node scripts/node_modules/lint-staged/index.js
-
 echo --------------------------------------------
 echo Starting Git hook: pre-commit
 
-if [ -f $COMMAND ]; then
-  echo Invoking $COMMAND
-  $COMMAND
-else
-  echo Command not installed: $COMMAND
+echo Invoking node scripts/node_modules/lint-staged/index.js
+node scripts/node_modules/lint-staged/index.js
+
+if [ $? -ne 0 ]; then
+  # the lint-staged script above will print out appropriate errors
+  exit 1
 fi
 
 echo Finished Git hook: pre-commit


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The pre-commit hook was printing out an error message, but not actually stopping the commit if it caused a tslint error as it should be. If the exit status of "node scripts/node_modules/lint-staged/index.js" is non-zero, the script now exits with a non-zero status.

@pgonzal FYI

#### Focus areas to test

(optional)
