### PR TITLE
Foundation API improvements

### DIFF
--- a/common/changes/@uifabric/experiments/jg-foundation-api_2019-01-16-23-13.json
+++ b/common/changes/@uifabric/experiments/jg-foundation-api_2019-01-16-23-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Foundation API improvements.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/experiments/src/components/Accordion/Accordion.tsx
+++ b/packages/experiments/src/components/Accordion/Accordion.tsx
@@ -1,9 +1,9 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { withSlots, getSlots } from '../../Foundation';
-import { createStatelessComponent } from '../../Foundation';
+import { createComponent } from '../../Foundation';
 import { CollapsibleSection, ICollapsibleSectionProps } from '../../CollapsibleSection';
-import { IAccordionComponent, IAccordionProps, IAccordionSlots, IAccordionStyles, IAccordionTokens } from './Accordion.types';
+import { IAccordionComponent, IAccordionProps, IAccordionSlots } from './Accordion.types';
 import { styles } from './Accordion.styles';
 
 const AccordionItemType = (<CollapsibleSection /> as React.ReactElement<ICollapsibleSectionProps>).type;
@@ -40,11 +40,10 @@ const AccordionStatics = {
   Item: CollapsibleSection,
   defaultProps: {}
 };
-type IAccordionStatics = typeof AccordionStatics;
 
 export const Accordion: React.StatelessComponent<IAccordionProps> & {
   Item: React.StatelessComponent<ICollapsibleSectionProps>;
-} = createStatelessComponent<IAccordionProps, IAccordionStyles, IAccordionTokens, IAccordionStatics>({
+} = createComponent({
   displayName: 'Accordion',
   styles,
   view,

--- a/packages/experiments/src/components/Accordion/Accordion.types.ts
+++ b/packages/experiments/src/components/Accordion/Accordion.types.ts
@@ -1,7 +1,7 @@
 import { IStyle } from '../../Styling';
-import { IHTMLDivSlot, IStatelessComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IHTMLDivSlot, IStyleableComponentProps } from '../../Foundation';
 
-export type IAccordionComponent = IStatelessComponent<IAccordionProps, IAccordionTokens, IAccordionStyles>;
+export type IAccordionComponent = IComponent<IAccordionProps, IAccordionTokens, IAccordionStyles>;
 
 export interface IAccordionSlots {
   root?: IHTMLDivSlot;

--- a/packages/experiments/src/components/Button/Button.tsx
+++ b/packages/experiments/src/components/Button/Button.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { createComponent } from '../../Foundation';
-import { IButtonProps, IButtonTokens, IButtonViewProps, IButtonStyles } from './Button.types';
+import { IButtonProps } from './Button.types';
 import { ButtonState as state } from './Button.state';
 import { ButtonView as view } from './Button.view';
 import { ButtonStyles as styles, ButtonTokens as tokens } from './Button.styles';
 
-export const Button: React.StatelessComponent<IButtonProps> = createComponent<IButtonProps, IButtonViewProps, IButtonTokens, IButtonStyles>(
-  {
-    displayName: 'Button',
-    styles,
-    state,
-    tokens,
-    view
-  }
-);
+export const Button: React.StatelessComponent<IButtonProps> = createComponent({
+  displayName: 'Button',
+  styles,
+  state,
+  tokens,
+  view
+});
 
 export default Button;

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -5,7 +5,7 @@ import { IStackSlot } from '../../Stack';
 import { ITextSlot } from '../../Text';
 import { IBaseProps } from '../../Utilities';
 
-export type IButtonComponent = IComponent<IButtonProps, IButtonViewProps, IButtonTokens, IButtonStyles>;
+export type IButtonComponent = IComponent<IButtonProps, IButtonTokens, IButtonStyles, IButtonViewProps>;
 
 export type IButtonSlot = ISlotProp<IButtonProps>;
 

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
@@ -1,20 +1,10 @@
 import { CollapsibleSectionView } from './CollapsibleSection.view';
 import { collapsibleSectionStyles } from './CollapsibleSection.styles';
 import { CollapsibleSectionState } from './CollapsibleSection.state';
-import {
-  ICollapsibleSectionProps,
-  ICollapsibleSectionViewProps,
-  ICollapsibleSectionStyles,
-  ICollapsibleSectionTokens
-} from './CollapsibleSection.types';
-import { createComponent, createStatelessComponent } from '../../Foundation';
+import { ICollapsibleSectionProps } from './CollapsibleSection.types';
+import { createComponent } from '../../Foundation';
 
-export const CollapsibleSection: React.StatelessComponent<ICollapsibleSectionProps> = createComponent<
-  ICollapsibleSectionProps,
-  ICollapsibleSectionViewProps,
-  ICollapsibleSectionStyles,
-  ICollapsibleSectionTokens
->({
+export const CollapsibleSection: React.StatelessComponent<ICollapsibleSectionProps> = createComponent({
   displayName: 'CollapsibleSection',
   view: CollapsibleSectionView,
   state: CollapsibleSectionState,
@@ -22,11 +12,7 @@ export const CollapsibleSection: React.StatelessComponent<ICollapsibleSectionPro
 });
 
 // TODO: This is only here for testing createComponent and should be removed before promoting to production
-export const CollapsibleSectionStateless: React.StatelessComponent<ICollapsibleSectionProps> = createStatelessComponent<
-  ICollapsibleSectionProps,
-  ICollapsibleSectionStyles,
-  ICollapsibleSectionTokens
->({
+export const CollapsibleSectionStateless: React.StatelessComponent<ICollapsibleSectionProps> = createComponent({
   displayName: 'CollapsibleSection',
   view: CollapsibleSectionView,
   styles: collapsibleSectionStyles

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
@@ -5,9 +5,9 @@ import { ICollapsibleSectionTitleSlot } from './CollapsibleSectionTitle.types';
 
 export type ICollapsibleSectionComponent = IComponent<
   ICollapsibleSectionProps,
-  ICollapsibleSectionViewProps,
+  ICollapsibleSectionTokens,
   ICollapsibleSectionStyles,
-  ICollapsibleSectionTokens
+  ICollapsibleSectionViewProps
 >;
 
 export interface ICollapsibleSectionSlots {

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
@@ -1,17 +1,9 @@
-import { createFactory, createStatelessComponent, ISlottableComponentType } from '../../Foundation';
+import { createComponent, createFactory, ISlottableComponentType } from '../../Foundation';
 import { CollapsibleSectionTitleView as view } from './CollapsibleSectionTitle.view';
 import { getStyles as styles } from './CollapsibleSectionTitle.styles';
-import {
-  ICollapsibleSectionTitleProps,
-  ICollapsibleSectionTitleStyles,
-  ICollapsibleSectionTitleTokens
-} from './CollapsibleSectionTitle.types';
+import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
 
-export const CollapsibleSectionTitle: ISlottableComponentType<ICollapsibleSectionTitleProps> = createStatelessComponent<
-  ICollapsibleSectionTitleProps,
-  ICollapsibleSectionTitleTokens,
-  ICollapsibleSectionTitleStyles
->({
+export const CollapsibleSectionTitle: ISlottableComponentType<ICollapsibleSectionTitleProps> = createComponent({
   displayName: 'CollapsibleSectionTitle',
   view,
   styles

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -1,9 +1,9 @@
 import { IRefObject } from '../../Utilities';
-import { IComponentStyles, IHTMLButtonSlot, ISlotProp, IStatelessComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLButtonSlot, ISlotProp, IStyleableComponentProps } from '../../Foundation';
 import { ITextSlot } from '../../Text';
 import { IIconSlot } from '../../utilities/factoryComponents.types';
 
-export type ICollapsibleSectionTitleComponent = IStatelessComponent<
+export type ICollapsibleSectionTitleComponent = IComponent<
   ICollapsibleSectionTitleProps,
   ICollapsibleSectionTitleTokens,
   ICollapsibleSectionTitleStyles

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
@@ -1,13 +1,9 @@
 import { VerticalPersonaView } from './VerticalPersona.view';
 import { VerticalPersonaStyles } from './VerticalPersona.styles';
-import { IVerticalPersonaProps, IVerticalPersonaStyles, IVerticalPersonaTokens } from './VerticalPersona.types';
-import { createStatelessComponent } from '../../../Foundation';
+import { IVerticalPersonaProps } from './VerticalPersona.types';
+import { createComponent } from '../../../Foundation';
 
-export const VerticalPersona: React.StatelessComponent<IVerticalPersonaProps> = createStatelessComponent<
-  IVerticalPersonaProps,
-  IVerticalPersonaTokens,
-  IVerticalPersonaStyles
->({
+export const VerticalPersona: React.StatelessComponent<IVerticalPersonaProps> = createComponent({
   displayName: 'VerticalPersona',
   view: VerticalPersonaView,
   styles: VerticalPersonaStyles

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
@@ -1,9 +1,9 @@
 import { IStyle, IFontWeight } from '@uifabric/styling';
-import { IHTMLDivSlot, IStatelessComponent, IStyleableComponentProps } from '../../../Foundation';
+import { IComponent, IHTMLDivSlot, IStyleableComponentProps } from '../../../Foundation';
 import { ITextSlot } from '../../../Text';
 import { IPersonaCoinSlot } from '../../PersonaCoin/PersonaCoin.types';
 
-export type IVerticalPersonaComponent = IStatelessComponent<IVerticalPersonaProps, IVerticalPersonaTokens, IVerticalPersonaStyles>;
+export type IVerticalPersonaComponent = IComponent<IVerticalPersonaProps, IVerticalPersonaTokens, IVerticalPersonaStyles>;
 
 export interface IVerticalPersonaSlots {
   root?: IHTMLDivSlot;

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.view.tsx
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.view.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+/** @jsx withSlots */
 import { PersonaCoin } from '../../PersonaCoin/PersonaCoin';
-import { getSlots } from '../../../Foundation';
+import { getSlots, withSlots } from '../../../Foundation';
 import { IVerticalPersonaComponent, IVerticalPersonaProps, IVerticalPersonaSlots } from './VerticalPersona.types';
 import { PersonaText } from '../PersonaText/PersonaText';
 

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
@@ -1,13 +1,9 @@
 import { PersonaCoinView } from './PersonaCoin.view';
 import { PersonaCoinStyles } from './PersonaCoin.styles';
-import { IPersonaCoinProps, IPersonaCoinStyles, IPersonaCoinTokens } from './PersonaCoin.types';
-import { createStatelessComponent } from '../../Foundation';
+import { IPersonaCoinProps } from './PersonaCoin.types';
+import { createComponent } from '../../Foundation';
 
-export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps> = createStatelessComponent<
-  IPersonaCoinProps,
-  IPersonaCoinTokens,
-  IPersonaCoinStyles
->({
+export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps> = createComponent({
   displayName: 'PersonaCoin',
   view: PersonaCoinView,
   styles: PersonaCoinStyles

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.types.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.types.ts
@@ -1,9 +1,9 @@
 import { ImageLoadState } from 'office-ui-fabric-react';
-import { IComponentStyles, IHTMLDivSlot, ISlotProp, IStatelessComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLDivSlot, ISlotProp, IStyleableComponentProps } from '../../Foundation';
 import { IPersonaPresenceSlot } from '../../utilities/factoryComponents.types';
 import { IPersonaCoinImageSlot } from './PersonaCoinImage/PersonaCoinImage.types';
 
-export type IPersonaCoinComponent = IStatelessComponent<IPersonaCoinProps, IPersonaCoinTokens, IPersonaCoinStyles>;
+export type IPersonaCoinComponent = IComponent<IPersonaCoinProps, IPersonaCoinTokens, IPersonaCoinStyles>;
 
 export type IPersonaCoinSlot = ISlotProp<IPersonaCoinProps> | string;
 

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Image, ImageFit } from 'office-ui-fabric-react';
-import { createStatelessComponent } from '../../../Foundation';
+import { createComponent } from '../../../Foundation';
 import { IPersonaCoinImageProps } from './PersonaCoinImage.types';
-import { IPersonaCoinComponent, IPersonaCoinStyles, IPersonaCoinTokens } from '../PersonaCoin.types';
+import { IPersonaCoinComponent } from '../PersonaCoin.types';
 import { DEFAULT_PERSONA_COIN_SIZE } from '../PersonaCoin.styles';
 
 const personaCoinImageStyles: IPersonaCoinComponent['styles'] = {
@@ -41,11 +41,7 @@ const PersonaCoinImageView = (props: IPersonaCoinImageProps): JSX.Element | null
   );
 };
 
-export const PersonaCoinImage: React.StatelessComponent<IPersonaCoinImageProps> = createStatelessComponent<
-  IPersonaCoinImageProps,
-  IPersonaCoinTokens,
-  IPersonaCoinStyles
->({
+export const PersonaCoinImage: React.StatelessComponent<IPersonaCoinImageProps> = createComponent({
   displayName: 'PersonaCoinImage',
   view: PersonaCoinImageView,
   styles: personaCoinImageStyles

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -1,9 +1,9 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { withSlots, createStatelessComponent, getSlots } from '../../Foundation';
+import { withSlots, createComponent, getSlots } from '../../Foundation';
 import StackItem from './StackItem/StackItem';
 import { IStackItemProps } from './StackItem/StackItem.types';
-import { IStackComponent, IStackProps, IStackSlots, IStackStyles } from './Stack.types';
+import { IStackComponent, IStackProps, IStackSlots } from './Stack.types';
 import { styles } from './Stack.styles';
 import { mergeStyles } from '../../Styling';
 import { getNativeProps, htmlElementProperties } from '../../Utilities';
@@ -71,11 +71,10 @@ const StackStatics = {
   Item: StackItem,
   defaultProps: {}
 };
-type IStackStatics = typeof StackStatics;
 
 export const Stack: React.StatelessComponent<IStackProps> & {
   Item: React.StatelessComponent<IStackItemProps>;
-} = createStatelessComponent<IStackProps, IStackStyles, {}, IStackStatics>({
+} = createComponent({
   displayName: 'Stack',
   styles,
   view,

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -1,8 +1,9 @@
-import { IComponentStyles, IHTMLDivSlot, ISlotProp, IStatelessComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponentStyles, IHTMLDivSlot, ISlotProp, IComponent, IStyleableComponentProps } from '../../Foundation';
 
 export type Alignment = 'start' | 'end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'baseline' | 'stretch';
 
-export type IStackComponent = IStatelessComponent<IStackProps, IStackStyles, IStackTokens>;
+// TODO: why isn't token/styles type swap resulting in any type errors?
+export type IStackComponent = IComponent<IStackProps, IStackTokens, IStackStyles>;
 
 export type IStackSlot = ISlotProp<IStackProps>;
 

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -2,7 +2,6 @@ import { IComponentStyles, IHTMLDivSlot, ISlotProp, IComponent, IStyleableCompon
 
 export type Alignment = 'start' | 'end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'baseline' | 'stretch';
 
-// TODO: why isn't token/styles type swap resulting in any type errors?
 export type IStackComponent = IComponent<IStackProps, IStackTokens, IStackStyles>;
 
 export type IStackSlot = ISlotProp<IStackProps>;

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { withSlots, createStatelessComponent, getSlots } from '../../../Foundation';
-import { IStackItemComponent, IStackItemProps, IStackItemSlots, IStackItemStyles, IStackItemTokens } from './StackItem.types';
+import { withSlots, createComponent, getSlots } from '../../../Foundation';
+import { IStackItemComponent, IStackItemProps, IStackItemSlots } from './StackItem.types';
 import { styles } from './StackItem.styles';
 
 const view: IStackItemComponent['view'] = props => {
@@ -18,11 +18,7 @@ const view: IStackItemComponent['view'] = props => {
   return <Slots.root>{first}</Slots.root>;
 };
 
-export const StackItem: React.StatelessComponent<IStackItemProps> = createStatelessComponent<
-  IStackItemProps,
-  IStackItemTokens,
-  IStackItemStyles
->({
+export const StackItem: React.StatelessComponent<IStackItemProps> = createComponent({
   displayName: 'StackItem',
   styles,
   view

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -1,6 +1,6 @@
-import { IComponentStyles, IHTMLSpanSlot, IStatelessComponent, IStyleableComponentProps } from '../../../Foundation';
+import { IComponentStyles, IHTMLSpanSlot, IComponent, IStyleableComponentProps } from '../../../Foundation';
 
-export type IStackItemComponent = IStatelessComponent<IStackItemProps, IStackItemTokens, IStackItemStyles>;
+export type IStackItemComponent = IComponent<IStackItemProps, IStackItemTokens, IStackItemStyles>;
 
 export interface IStackItemSlots {
   root?: IHTMLSpanSlot;

--- a/packages/experiments/src/components/Text/Text.ts
+++ b/packages/experiments/src/components/Text/Text.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { createStatelessComponent } from '../../Foundation';
-import { ITextProps, ITextStyles, ITextTokens } from './Text.types';
+import { createComponent } from '../../Foundation';
+import { ITextProps } from './Text.types';
 import { TextView as view } from './Text.view';
 import { TextStyles as styles } from './Text.styles';
 
-export const Text: React.StatelessComponent<ITextProps> = createStatelessComponent<ITextProps, ITextTokens, ITextStyles>({
+export const Text: React.StatelessComponent<ITextProps> = createComponent({
   displayName: 'Text',
   styles,
   view

--- a/packages/experiments/src/components/Text/Text.types.tsx
+++ b/packages/experiments/src/components/Text/Text.types.tsx
@@ -1,7 +1,7 @@
-import { IComponentStyles, IHTMLSpanSlot, ISlotProp, IStatelessComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponentStyles, IHTMLSpanSlot, ISlotProp, IComponent, IStyleableComponentProps } from '../../Foundation';
 import { IFontStyles } from '../../Styling';
 
-export type ITextComponent = IStatelessComponent<ITextProps, ITextTokens, ITextStyles>;
+export type ITextComponent = IComponent<ITextProps, ITextTokens, ITextStyles>;
 
 export type ITextSlot = ISlotProp<ITextProps, 'children'>;
 

--- a/packages/experiments/src/components/Text/examples/Text.Ramp.Example.tsx
+++ b/packages/experiments/src/components/Text/examples/Text.Ramp.Example.tsx
@@ -3,12 +3,12 @@ import { Text, Stack, IStackProps } from '@uifabric/experiments';
 import { IFontStyles } from '@uifabric/experiments/lib/Styling';
 import {
   withSlots,
-  createStatelessComponent,
+  createComponent,
   getSlots,
+  IComponent,
   IComponentStyles,
   ISlotProp,
-  IStyleableComponentProps,
-  IStatelessComponent
+  IStyleableComponentProps
 } from '@uifabric/experiments/lib/Foundation';
 
 const TestText = 'The quick brown fox jumped over the lazy dog.';
@@ -48,7 +48,7 @@ interface ITableProps extends ITableSlots, IStyleableComponentProps<ITableProps,
   title: string;
 }
 
-type ITableComponent = IStatelessComponent<ITableProps, {}, ITableStyles>;
+type ITableComponent = IComponent<ITableProps, {}, ITableStyles>;
 
 const TableView: ITableComponent['view'] = props => {
   const Slots = getSlots<ITableProps, ITableSlots>(props, {
@@ -76,7 +76,7 @@ const TableView: ITableComponent['view'] = props => {
   );
 };
 
-const Table = createStatelessComponent<ITableProps, {}, ITableStyles>({
+const Table: React.StatelessComponent<ITableProps> = createComponent({
   view: TableView,
   displayName: 'Table',
   styles: {

--- a/packages/experiments/src/components/Toggle/Toggle.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.ts
@@ -1,15 +1,13 @@
 import { ToggleView as view } from './Toggle.view';
 import { ToggleStyles as styles, ToggleTokens as tokens } from './Toggle.styles';
 import { ToggleState as state } from './Toggle.state';
-import { IToggleProps, IToggleViewProps, IToggleStyles, IToggleTokens } from './Toggle.types';
+import { IToggleProps } from './Toggle.types';
 import { createComponent } from '../../Foundation';
 
-export const Toggle: React.StatelessComponent<IToggleProps> = createComponent<IToggleProps, IToggleViewProps, IToggleTokens, IToggleStyles>(
-  {
-    displayName: 'Toggle',
-    view,
-    state,
-    styles,
-    tokens
-  }
-);
+export const Toggle: React.StatelessComponent<IToggleProps> = createComponent({
+  displayName: 'Toggle',
+  view,
+  state,
+  styles,
+  tokens
+});

--- a/packages/experiments/src/components/Toggle/Toggle.types.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.types.ts
@@ -5,7 +5,7 @@ import { IBaseProps, IComponentAs } from '../../Utilities';
 import { IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';
 import { ILabelSlot } from '../../utilities/factoryComponents.types';
 
-export type IToggleComponent = IComponent<IToggleProps, IToggleViewProps, IToggleTokens, IToggleStyles>;
+export type IToggleComponent = IComponent<IToggleProps, IToggleTokens, IToggleStyles, IToggleViewProps>;
 
 export interface IToggleSlots {
   /**

--- a/packages/experiments/src/utilities/BaseComponentMin.ts
+++ b/packages/experiments/src/utilities/BaseComponentMin.ts
@@ -16,6 +16,8 @@ export interface IBaseProps<T = any> {
  *
  * @public
  */
+// TODO: rename, BaseComponentMin is ambiguous. BaseComponent? BaseComponentRef?
+// TODO: will probably need lifecycle deprecation changes before promotion similar to BaseComponent
 export class BaseComponentMin<TComponentProps extends IBaseProps = {}, TState = {}> extends React.Component<TComponentProps, TState> {
   /**
    * Controls whether the componentRef prop will be resolved by this component instance. If you are

--- a/packages/experiments/src/utilities/IComponent.ts
+++ b/packages/experiments/src/utilities/IComponent.ts
@@ -8,25 +8,51 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 //        export const styles: IStackComponent['styles'] = props => {
 //        Existing issue: https://github.com/Microsoft/TypeScript/issues/241
 
+/**
+ * Helper type defining style sections, one for each component slot.
+ */
+export type IComponentStyles<TSlots> = { [key in keyof TSlots]?: IStyle };
+
+/**
+ * Function declaration for component styles functions.
+ */
 export type IStylesFunction<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> = (
   props: TViewProps,
   theme: ITheme,
   tokens: TTokens
 ) => TStyleSet;
 
+/**
+ * Composite type for component styles functions and objects.
+ */
 export type IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> =
   | IStylesFunction<TViewProps, TTokens, TStyleSet>
   | TStyleSet;
 
-export type ITokenBase<TViewProps, TTokens> = ITokenFunctionOrObject<TViewProps, TTokens> | false | null | undefined;
-
-export interface ITokenBaseArray<TViewProps, TTokens> extends Array<IToken<TViewProps, TTokens>> {}
-
+/**
+ * Tokens can be defined as an object, function, or an array of objects and functions.
+ */
 export type IToken<TViewProps, TTokens> = ITokenBase<TViewProps, TTokens> | ITokenBaseArray<TViewProps, TTokens>;
 
+/**
+ * Function declaration for component token functions.
+ */
 export type ITokenFunction<TViewProps, TTokens> = (props: TViewProps, theme: ITheme) => IToken<TViewProps, TTokens>;
 
+/**
+ * Composite type for component token functions and objects.
+ */
 export type ITokenFunctionOrObject<TViewProps, TTokens> = ITokenFunction<TViewProps, TTokens> | TTokens;
+
+/**
+ * Composite base type that includes all possible resolutions of token functions in an array.
+ */
+export type ITokenBase<TViewProps, TTokens> = ITokenFunctionOrObject<TViewProps, TTokens> | false | null | undefined;
+
+/**
+ * Composite token base array type allowing for token objects, functions, and function resolutions.
+ */
+export interface ITokenBaseArray<TViewProps, TTokens> extends Array<IToken<TViewProps, TTokens>> {}
 
 /**
  * Optional props for styleable components. If these props are present, they will automatically be
@@ -63,7 +89,8 @@ export type IStateComponentType<TComponentProps, TViewProps> = React.ComponentTy
  * Component used by foundation to tie elements together.
  * @see createComponent for generic type documentation.
  */
-export interface IComponentOptions<TComponentProps, TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TStatics = {}> {
+// TODO: any way to rename 'view' looking forward to React Hooks components? or just leave as view?
+export interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
   /**
    * Display name to identify component in React hierarchy.
    */
@@ -77,9 +104,9 @@ export interface IComponentOptions<TComponentProps, TViewProps, TTokens, TStyleS
    */
   styles?: IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet>;
   /**
-   * React view stateless component.
+   * React view component.
    */
-  view: React.StatelessComponent<TViewProps>;
+  view: React.ComponentType<TViewProps>;
   /**
    * Optional state component that processes TComponentProps into TViewProps.
    */
@@ -93,25 +120,3 @@ export interface IComponentOptions<TComponentProps, TViewProps, TTokens, TStyleS
    */
   tokens?: ITokenFunctionOrObject<TViewProps, TTokens>;
 }
-
-/**
- * Variant of IComponentOptions for stateful components with appropriate typing and required properties.
- */
-export type IComponent<TComponentProps, TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TStatics = {}> = IComponentOptions<
-  TComponentProps,
-  TViewProps,
-  TTokens,
-  TStyleSet,
-  TStatics
-> &
-  Required<Pick<IComponentOptions<TComponentProps, TComponentProps, TTokens, TStyleSet, TStatics>, 'state'>>;
-
-/**
- * Variant of IComponentOptions for stateless components with appropriate typing and required properties.
- */
-export type IStatelessComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TStatics = {}> = Omit<
-  IComponentOptions<TComponentProps, TComponentProps, TTokens, TStyleSet, TStatics>,
-  'state'
->;
-
-export type IComponentStyles<TSlots> = { [key in keyof TSlots]?: IStyle };

--- a/packages/experiments/src/utilities/IComponent.ts
+++ b/packages/experiments/src/utilities/IComponent.ts
@@ -89,7 +89,6 @@ export type IStateComponentType<TComponentProps, TViewProps> = React.ComponentTy
  * Component used by foundation to tie elements together.
  * @see createComponent for generic type documentation.
  */
-// TODO: any way to rename 'view' looking forward to React Hooks components? or just leave as view?
 export interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
   /**
    * Display name to identify component in React hierarchy.

--- a/packages/experiments/src/utilities/createComponent.tsx
+++ b/packages/experiments/src/utilities/createComponent.tsx
@@ -3,14 +3,7 @@ import { concatStyleSets, IStyleSet, ITheme } from '@uifabric/styling';
 import { Customizations, CustomizerContext, ICustomizerContext } from '@uifabric/utilities';
 import { assign } from './utilities';
 
-import {
-  IComponent,
-  ICustomizationProps,
-  IStatelessComponent,
-  IStyleableComponentProps,
-  IStylesFunctionOrObject,
-  IToken
-} from './IComponent';
+import { IComponent, ICustomizationProps, IStyleableComponentProps, IStylesFunctionOrObject, IToken } from './IComponent';
 import { IDefaultSlotProps } from './ISlots';
 
 /**
@@ -27,18 +20,22 @@ import { IDefaultSlotProps } from './ISlots';
  * State component is optional. If state is not provided, created component is essentially a functional stateless component.
  *
  * TComponentProps: A styleable props interface for the created component.
+ * TTokens: The type for tokens props.
+ * TStyleSet: The type for styles properties.
  * TViewProps: The props specific to the view, including processed properties outputted by optional state component. If state
  * component is not provided, TComponentProps is the same as TViewProps.
- * TStyleSet: The type for styles properties.
- * TTokens: The type for tokens props.
  * TStatics: Static type for statics applied to created component object.
  *
  * @param {IComponent} component
  * @param {IComponentProviders} providers
  */
-export function createComponent<TComponentProps, TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TStatics = {}>(
-  component: IComponent<TComponentProps, TViewProps, TTokens, TStyleSet, TStatics>
-): React.StatelessComponent<TComponentProps> & TStatics {
+export function createComponent<
+  TComponentProps,
+  TTokens,
+  TStyleSet extends IStyleSet<TStyleSet>,
+  TViewProps = TComponentProps,
+  TStatics = {}
+>(component: IComponent<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React.StatelessComponent<TComponentProps> & TStatics {
   const result: React.StatelessComponent<TComponentProps> = (componentProps: TComponentProps) => {
     return (
       // TODO: createComponent is also affected by https://github.com/OfficeDev/office-ui-fabric-react/issues/6603
@@ -81,7 +78,7 @@ export function createComponent<TComponentProps, TViewProps, TTokens, TStyleSet 
               _defaultStyles: styles
             };
 
-            return component.view(viewComponentProps);
+            return <component.view {...viewComponentProps} />;
           };
           return component.state ? <component.state {...componentProps} renderView={renderView} /> : renderView();
         }}
@@ -95,17 +92,6 @@ export function createComponent<TComponentProps, TViewProps, TTokens, TStyleSet 
 
   // Later versions of TypeSript should allow us to merge objects in a type safe way and avoid this cast.
   return result as React.StatelessComponent<TComponentProps> & TStatics;
-}
-
-/**
- * A wrapper function around createComponent to confine generics and component properties for stateless components.
- *
- * @see {@link createComponent} for more information.
- */
-export function createStatelessComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TStatics = {}>(
-  component: IStatelessComponent<TComponentProps, TTokens, TStyleSet, TStatics>
-): React.StatelessComponent<TComponentProps> & TStatics {
-  return createComponent(component as IComponent<TComponentProps, TComponentProps, TTokens, TStyleSet, TStatics>);
 }
 
 /**
@@ -124,6 +110,9 @@ function _resolveStyles<TProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>>
   );
 }
 
+/**
+ * Resolve all tokens functions with props flatten results along with all tokens objects.
+ */
 function _resolveTokens<TViewProps, TTokens>(
   props: TViewProps,
   theme: ITheme,

--- a/packages/experiments/src/utilities/slots.tsx
+++ b/packages/experiments/src/utilities/slots.tsx
@@ -159,6 +159,7 @@ export function getSlots<TProps extends TSlots, TSlots extends ISlotProps<TProps
       //  each closure as a different component (since it is a new instance) from the previous one and then forces a rerender of the entire
       //  slot subtree. For now, the only way to avoid this is to use withSlots, which bypasses the call to React.createElement.
       const slot: ISlot<keyof TSlots> = componentProps => {
+        // TODO: detect withSlots usage here or elsewhere (via existence of type property?) and warn if withSlots is not used
         return renderSlot(
           slots[name],
           // TODO: this cast to any is hiding a relationship issue between the first two args

--- a/packages/experiments/src/utilities/slots.tsx
+++ b/packages/experiments/src/utilities/slots.tsx
@@ -158,8 +158,12 @@ export function getSlots<TProps extends TSlots, TSlots extends ISlotProps<TProps
       // This closure method requires the use of withSlots to prevent unnecessary rerenders. This is because React detects
       //  each closure as a different component (since it is a new instance) from the previous one and then forces a rerender of the entire
       //  slot subtree. For now, the only way to avoid this is to use withSlots, which bypasses the call to React.createElement.
-      const slot: ISlot<keyof TSlots> = componentProps => {
-        // TODO: detect withSlots usage here or elsewhere (via existence of type property?) and warn if withSlots is not used
+      const slot: ISlot<keyof TSlots> = (componentProps, ...args: any[]) => {
+        if (args.length > 0) {
+          // If React.createElement is being incorrectly used with slots, there will be additional arguments.
+          // We can detect these additional arguments and error on their presence.
+          throw new Error('Any module using getSlots must use withSlots. Please see withSlots javadoc for more info.');
+        }
         return renderSlot(
           slots[name],
           // TODO: this cast to any is hiding a relationship issue between the first two args

--- a/scripts/templates/create-component/slots/EmptyComponent.mustache
+++ b/scripts/templates/create-component/slots/EmptyComponent.mustache
@@ -1,21 +1,10 @@
 import { {{componentName}}View } from './{{componentName}}.view';
 import { {{componentName}}Styles, {{componentName}}Tokens } from './{{componentName}}.styles';
 import { {{componentName}}State } from './{{componentName}}.state';
-import {
-  I{{componentName}}Props,
-  I{{componentName}}ViewProps,
-  I{{componentName}}Styles,
-  I{{componentName}}Tokens
-} from './{{componentName}}.types';
+import { I{{componentName}}Props } from './{{componentName}}.types';
 import { createComponent } from '../../Foundation';
 
-export const {{componentName}}: React.StatelessComponent< I{{componentName}}Props> =
-  createComponent<
-  I{{componentName}}Props,
-  I{{componentName}}ViewProps,
-  I{{componentName}}Tokens,
-  I{{componentName}}Styles
->({
+export const {{componentName}}: React.StatelessComponent< I{{componentName}}Props> = createComponent({
   displayName: '{{componentName}}',
   view: {{componentName}}View,
   state: {{componentName}}State,

--- a/scripts/templates/create-component/slots/EmptyComponentStateless.mustache
+++ b/scripts/templates/create-component/slots/EmptyComponentStateless.mustache
@@ -1,18 +1,9 @@
 import { {{componentName}}View } from './{{componentName}}.view';
 import { {{componentName}}Styles, {{componentName}}Tokens } from './{{componentName}}.styles';
-import {
-  I{{componentName}}Props,
-  I{{componentName}}Styles,
-  I{{componentName}}Tokens
-} from './{{componentName}}.types';
-import { createStatelessComponent } from '../../Foundation';
+import { I{{componentName}}Props } from './{{componentName}}.types';
+import { createComponent } from '../../Foundation';
 
-export const {{componentName}}: React.StatelessComponent< I{{componentName}}Props> =
-  createStatelessComponent<
-  I{{componentName}}Props,
-  I{{componentName}}Tokens,
-  I{{componentName}}Styles
->({
+export const {{componentName}}: React.StatelessComponent< I{{componentName}}Props> = createComponent({
   displayName: '{{componentName}}',
   view: {{componentName}}View,
   styles: {{componentName}}Styles,

--- a/scripts/templates/create-component/slots/EmptyTypes.mustache
+++ b/scripts/templates/create-component/slots/EmptyTypes.mustache
@@ -3,7 +3,7 @@ import { ITextSlot } from '../../Text';
 import { IBaseProps } from '../../Utilities';
 
 export type I{{componentName}}Component =
-  IComponent< I{{componentName}}Props, I{{componentName}}ViewProps, I{{componentName}}Tokens, I{{componentName}}Styles>;
+  IComponent< I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles, I{{componentName}}ViewProps>;
 
 // Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
 export interface I{{componentName}} { }

--- a/scripts/templates/create-component/slots/EmptyTypesStateless.mustache
+++ b/scripts/templates/create-component/slots/EmptyTypesStateless.mustache
@@ -1,9 +1,8 @@
-import { IComponentStyles, IHTMLDivSlot, IStatelessComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLDivSlot, IStyleableComponentProps } from '../../Foundation';
 import { ITextSlot } from '../../Text';
 import { IBaseProps } from '../../Utilities';
 
-export type I{{componentName}}Component =
-  IStatelessComponent< I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles>;
+export type I{{componentName}}Component = IComponent< I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles>;
 
 // Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
 export interface I{{componentName}} { }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I wanted to make changes to the Foundation API that would continue to work as React evolves, particularly for React Hooks. While widening up the typings for `view` I also found that TS is now automatically inferring all of the types for `createComponent` and, as a result, I've removed explicit generics wherever `createComponent` is called. I've also removed `createStatelessComponent` and have unified all calls into one `createComponent` signature.

I've also added a check for `withSlots` usage in `getSlots` that throws an error if `withSlots` is not used.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7682)

