### PR TITLE
Fabric site: fix best practices linking

### DIFF
--- a/common/changes/@uifabric/example-app-base/fixBestPracticesLinkingOnSite_2019-01-16-23-23.json
+++ b/common/changes/@uifabric/example-app-base/fixBestPracticesLinkingOnSite_2019-01-16-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "ComponentPage: add id to dos and donts section to fix linking on site",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -301,7 +301,7 @@ export class ComponentPage extends React.Component<IComponentPageProps, {}> {
 
     if (this.props.dos && this.props.donts) {
       dosAndDonts.push(
-        <div className="ComponentPage-doSections" key="do-sections">
+        <div className="ComponentPage-doSections" key="do-sections" id={!this.props.bestPractices ? 'BestPractices' : undefined}>
           <div className="ComponentPage-doSection">
             <div className="ComponentPage-doSectionHeader">
               <h3>Do</h3>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

These changes fix the broken "Best Practices" link. Now it takes you to the "Dos and Don'ts" section, which is the expected behavior as confirmed by Peter.

Before:

![bestpracticeslinknotworking](https://user-images.githubusercontent.com/14134000/51285422-9a43a980-19a3-11e9-9265-bc58341e27ee.gif)

After:

![best practices link working](https://user-images.githubusercontent.com/14134000/51285318-4769f200-19a3-11e9-9e54-2953b98f0f19.gif)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7683)

