### PR TITLE
Add index based key to ContextualMenu sections

### DIFF
--- a/common/changes/office-ui-fabric-react/contextualmenu-section_2019-01-17-03-35.json
+++ b/common/changes/office-ui-fabric-react/contextualmenu-section_2019-01-17-03-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Fixes #7686",
+      "comment": "ContextualMenu: fixes issue #7686 when items of type `section` are given the same key and later are rendered as list items causing a React warning. Change the example having this issue.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/contextualmenu-section_2019-01-17-03-35.json
+++ b/common/changes/office-ui-fabric-react/contextualmenu-section_2019-01-17-03-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixes #7686",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "danmar@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -531,7 +531,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
 
     if (sectionProps.items && sectionProps.items.length > 0) {
       return (
-        <li role="presentation" key={sectionItem.key}>
+        <li role="presentation" key={sectionProps.key || sectionItem.key || `section-${index}`}>
           <div role="group">
             <ul className={this._classNames.list}>
               {sectionProps.topDivider && this._renderSeparator(index, menuClassNames, true, true)}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -234,9 +234,9 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     this._classNames = getMenuClassNames
       ? getMenuClassNames(theme!, className)
       : getClassNames(styles, {
-          theme: theme!,
-          className: className
-        });
+        theme: theme!,
+        className: className
+      });
 
     const hasIcons = itemsHaveIcons(items);
 
@@ -508,38 +508,38 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   }
 
   private _renderSectionItem(
-    item: IContextualMenuItem,
+    sectionItem: IContextualMenuItem,
     menuClassNames: IMenuItemClassNames,
     index: number,
     hasCheckmarks: boolean,
     hasIcons: boolean
   ) {
-    const section = item.sectionProps;
-    if (!section) {
+    const sectionProps = sectionItem.sectionProps;
+    if (!sectionProps) {
       return;
     }
 
     let headerItem;
-    if (section.title) {
+    if (sectionProps.title) {
       const headerContextualMenuItem: IContextualMenuItem = {
-        key: `section-${section.title}-title`,
+        key: `section-${sectionProps.title}-title`,
         itemType: ContextualMenuItemType.Header,
-        text: section.title
+        text: sectionProps.title
       };
       headerItem = this._renderHeaderMenuItem(headerContextualMenuItem, menuClassNames, index, hasCheckmarks, hasIcons);
     }
 
-    if (section.items && section.items.length > 0) {
+    if (sectionProps.items && sectionProps.items.length > 0) {
       return (
-        <li role="presentation" key={`section-${index}`}>
+        <li role="presentation" key={sectionItem.key}>
           <div role="group">
             <ul className={this._classNames.list}>
-              {section.topDivider && this._renderSeparator(index, menuClassNames, true, true)}
-              {headerItem && this._renderListItem(headerItem, item.key || index, menuClassNames, item.title)}
-              {section.items.map((contextualMenuItem, itemsIndex) =>
-                this._renderMenuItem(contextualMenuItem, itemsIndex, itemsIndex, section.items.length, hasCheckmarks, hasIcons)
+              {sectionProps.topDivider && this._renderSeparator(index, menuClassNames, true, true)}
+              {headerItem && this._renderListItem(headerItem, sectionItem.key || index, menuClassNames, sectionItem.title)}
+              {sectionProps.items.map((contextualMenuItem, itemsIndex) =>
+                this._renderMenuItem(contextualMenuItem, itemsIndex, itemsIndex, sectionProps.items.length, hasCheckmarks, hasIcons)
               )}
-              {section.bottomDivider && this._renderSeparator(index, menuClassNames, false, true)}
+              {sectionProps.bottomDivider && this._renderSeparator(index, menuClassNames, false, true)}
             </ul>
           </div>
         </li>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -531,7 +531,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
 
     if (section.items && section.items.length > 0) {
       return (
-        <li role="presentation" key={section.key}>
+        <li role="presentation" key={`section-${index}`}>
           <div role="group">
             <ul className={this._classNames.list}>
               {section.topDivider && this._renderSeparator(index, menuClassNames, true, true)}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
@@ -13,7 +13,7 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
           menuProps={{
             items: [
               {
-                key: 'section',
+                key: 'section1',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
                   topDivider: true,
@@ -32,7 +32,7 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
                 }
               },
               {
-                key: 'section',
+                key: 'section2',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
                   title: 'Social',
@@ -53,7 +53,7 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
                 }
               },
               {
-                key: 'section',
+                key: 'section3',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
                   title: 'Navigation',


### PR DESCRIPTION
Prevents React's unique key warning.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7686 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Uses an index iterator to name React keys for list items. Previous key was undefined - accessing what would be "section.sectionProps.key" which does not exist in the schema.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7687)

