### PR TITLE
Dropdown: refactor styles for Panel to use subComponentStyles

### DIFF
--- a/common/changes/office-ui-fabric-react/shield-PanelMediaQ_2019-01-17-04-46.json
+++ b/common/changes/office-ui-fabric-react/shield-PanelMediaQ_2019-01-17-04-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: refactor styles of Panel to `subComponentStyles` pattern.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7636,6 +7636,7 @@ interface IDropdownStyles {
 // @public (undocumented)
 interface IDropdownSubComponentStyles {
   label: IStyleFunctionOrObject<ILabelStyleProps, any>;
+  panel: IStyleFunctionOrObject<IPanelStyleProps, any>;
 }
 
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -28,7 +28,7 @@ import { ILabelStyleProps, ILabelStyles, Label } from '../../Label';
 import { IProcessedStyleSet } from '../../Styling';
 import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { KeytipData } from '../../KeytipData';
-import { Panel } from '../../Panel';
+import { Panel, IPanelStyleProps, IPanelStyles } from '../../Panel';
 import { ResponsiveMode, withResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import { SelectableOptionMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
 
@@ -422,15 +422,12 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
 
     const isSmall = responsiveMode! <= ResponsiveMode.medium;
 
+    const panelStyles = this._classNames.subComponentStyles
+      ? (this._classNames.subComponentStyles.panel as IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>)
+      : undefined;
+
     return isSmall ? (
-      <Panel
-        className={this._classNames.panel}
-        isOpen={true}
-        isLightDismiss={true}
-        onDismissed={this._onDismiss}
-        hasCloseButton={false}
-        {...panelProps}
-      >
+      <Panel isOpen={true} isLightDismiss={true} onDismissed={this._onDismiss} hasCloseButton={false} styles={panelStyles} {...panelProps}>
         {this._renderFocusableList(props)}
       </Panel>
     ) : (
@@ -527,11 +524,11 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
     const id = this._id;
     const isItemSelected = item.index !== undefined && selectedIndices ? selectedIndices.indexOf(item.index) > -1 : false;
 
-    // select the right classname based on the combination of selected/disabled
+    // select the right className based on the combination of selected/disabled
     const itemClassName =
-      isItemSelected && item.disabled === true // preciate: both selected and disabled
+      isItemSelected && item.disabled === true // predicate: both selected and disabled
         ? this._classNames.dropdownItemSelectedAndDisabled
-        : isItemSelected // preciate: selected only
+        : isItemSelected // predicate: selected only
         ? this._classNames.dropdownItemSelected
         : item.disabled === true // predicate: disabled only
         ? this._classNames.dropdownItemDisabled

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -279,7 +279,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
           // Force drop shadow even under medium breakpoint
           boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)'
         },
-        contentInner: { padding: '0 0 40px' }
+        contentInner: { padding: '0 0 20px' }
       }
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -21,7 +21,7 @@ const GlobalClassNames = {
 };
 
 const DROPDOWN_HEIGHT = 32;
-const DROPDOWN_ITEMHEIGHT = 32;
+const DROPDOWN_ITEM_HEIGHT = 32;
 
 const highContrastAdjustMixin = {
   // highContrastAdjust mixin
@@ -85,7 +85,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       display: 'block',
       padding: '4px 16px',
       width: '100%',
-      minHeight: DROPDOWN_ITEMHEIGHT,
+      minHeight: DROPDOWN_ITEM_HEIGHT,
       lineHeight: 20,
       height: 'auto',
       position: 'relative',
@@ -215,20 +215,6 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       },
       calloutClassName
     ],
-    panel: [
-      globalClassnames.panel,
-      {
-        // #5689: use subcomponentstyles when panel is converted to use js styling.
-        selectors: {
-          '& .ms-Panel-main': {
-            // Force drop shadow even under medium breakpoint
-            boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)'
-          },
-          '& .ms-Panel-contentInner': { padding: '0 0 20px' }
-        }
-      },
-      panelClassName
-    ],
     dropdownItemsWrapper: { selectors: { '&:focus': { outline: 0 } } },
     dropdownItems: [globalClassnames.dropdownItems, { display: 'block' }],
     dropdownItem: [
@@ -277,14 +263,24 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         background: 'none',
         backgroundColor: 'transparent',
         border: 'none',
-        height: DROPDOWN_ITEMHEIGHT,
-        lineHeight: DROPDOWN_ITEMHEIGHT,
+        height: DROPDOWN_ITEM_HEIGHT,
+        lineHeight: DROPDOWN_ITEM_HEIGHT,
         cursor: 'default',
         padding: '0px 16px',
         userSelect: 'none',
         textAlign: 'left'
       }
     ],
-    subComponentStyles: { label: { root: { display: 'inline-block' } } }
+    subComponentStyles: {
+      label: { root: { display: 'inline-block' } },
+      panel: {
+        root: [panelClassName],
+        main: {
+          // Force drop shadow even under medium breakpoint
+          boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)'
+        },
+        contentInner: { padding: '0 0 40px' }
+      }
+    }
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -232,7 +232,7 @@ export interface IDropdownStyles {
   /** Refers to the callout that hosts Dropdown options in larger viewports. */
   callout: IStyle;
 
-  /** SubComponent styles. */
+  /** Subcomponent styles. */
   subComponentStyles: IDropdownSubComponentStyles;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -6,6 +6,7 @@ import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import { IKeytipProps } from '../../Keytip';
 import { ILabelStyleProps } from '../../Label';
 import { RectangleEdge } from '../../utilities/positioning';
+import { IPanelStyleProps, IPanelStyles } from '../Panel/Panel.types';
 
 export { SelectableOptionMenuItemType as DropdownMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
 
@@ -150,13 +151,13 @@ export type IDropdownStyleProps = Pick<IDropdownProps, 'theme' | 'className' | '
   isRenderingPlaceholder: boolean;
 
   /**
-   * Optional custom classname for the panel that displays in small viewports, hosting the Dropdown options.
+   * Optional custom className for the panel that displays in small viewports, hosting the Dropdown options.
    * This is primarily provided for backwards compatibility.
    */
   panelClassName?: string;
 
   /**
-   * Optional custom classname for the callout that displays in larger viewports, hosting the Dropdown options.
+   * Optional custom className for the callout that displays in larger viewports, hosting the Dropdown options.
    * This is primarily provided for backwards compatibility.
    */
   calloutClassName?: string;
@@ -216,7 +217,7 @@ export interface IDropdownStyles {
    */
   dropdownOptionText: IStyle;
 
-  /** Refers to the dropdown seperator. */
+  /** Refers to the dropdown separator. */
   dropdownDivider: IStyle;
 
   /** Refers to the individual dropdown items that are being rendered as a header. */
@@ -231,13 +232,13 @@ export interface IDropdownStyles {
   /** Refers to the callout that hosts Dropdown options in larger viewports. */
   callout: IStyle;
 
-  /** Subcomponent styles. */
+  /** SubComponent styles. */
   subComponentStyles: IDropdownSubComponentStyles;
 }
 
 export interface IDropdownSubComponentStyles {
   /** Refers to the panel that hosts the Dropdown options in small viewports. */
-  // panel: IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>; // #5689: this relies on Panel supporting JS styling.
+  panel: IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>;
 
   /** Refers to the primary label for the Dropdown. */
   label: IStyleFunctionOrObject<ILabelStyleProps, any>;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -6,7 +6,7 @@ import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import { IKeytipProps } from '../../Keytip';
 import { ILabelStyleProps } from '../../Label';
 import { RectangleEdge } from '../../utilities/positioning';
-import { IPanelStyleProps, IPanelStyles } from '../Panel/Panel.types';
+import { IPanelStyleProps } from '../Panel/Panel.types';
 
 export { SelectableOptionMenuItemType as DropdownMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
 
@@ -238,7 +238,8 @@ export interface IDropdownStyles {
 
 export interface IDropdownSubComponentStyles {
   /** Refers to the panel that hosts the Dropdown options in small viewports. */
-  panel: IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>;
+  panel: IStyleFunctionOrObject<IPanelStyleProps, any>;
+  // #5690: replace any with ILabelStyles in TS 2.9
 
   /** Refers to the primary label for the Dropdown. */
   label: IStyleFunctionOrObject<ILabelStyleProps, any>;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-395:hover + .headerDividerBar-396 {
+      & .headerDivider-394:hover + .headerDividerBar-395 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #5689
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Refactors the styles for `Panel` in `Dropdown` to use `subComponentStyles`. Also, repurposing the issue it fixes for a different issue which had comments pointing to it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7688)

