### PR TITLE
Add card panel re-render fix in onLayoutchange method which is getting called twice.

### DIFF
--- a/common/changes/@uifabric/dashboard/AddCardPanelRerenderFix_2019-01-17-14-23.json
+++ b/common/changes/@uifabric/dashboard/AddCardPanelRerenderFix_2019-01-17-14-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Fixed Add card panel re-render issue in onLayoutChange method in DashboardGridLayoutWithAddCardPanel.tsx",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "vamshidharenumula@gmail.com"
+}

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutWithAddCardPanel/DashboardGridLayoutWithAddCardPanel.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutWithAddCardPanel/DashboardGridLayoutWithAddCardPanel.tsx
@@ -216,7 +216,9 @@ export class DashboardGridLayoutWithAddCardPanel extends BaseComponent<
         };
         newLayout.lg!.push(itemLayout);
       });
-      if (newLayout !== this.state.layout) {
+
+      // for object comparision using JSON stringify
+      if (JSON.stringify(newLayout) !== JSON.stringify(this.state.layout)) {
         if (this.props.onLayoutChange) {
           this.props.onLayoutChange(newLayout);
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Add card panel re-render fix in onLayoutchange method which is getting called twice.

(give an overview)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7691)

