### PR TITLE
CommandBar: Add ARIA labels to overflow buttons in examples

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-commandbar-examples-overflow-aria_2019-01-17-16-48.json
+++ b/common/changes/office-ui-fabric-react/miwhea-commandbar-examples-overflow-aria_2019-01-17-16-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Add ARIA labels to the overflow buttons in examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -9,6 +9,7 @@ export class CommandBarBasicExample extends React.Component<{}, {}> {
         <CommandBar
           items={this.getItems()}
           overflowItems={this.getOverlflowItems()}
+          overflowButtonProps={{ ariaLabel: 'More commands' }}
           farItems={this.getFarItems()}
           ariaLabel={'Use left and right arrow keys to navigate between commands'}
         />

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
@@ -25,6 +25,7 @@ export class CommandBarButtonAsExample extends React.Component<{}, {}> {
       <div>
         <CommandBar
           overflowButtonProps={{
+            ariaLabel: 'More commands',
             menuProps: {
               items: [], // Items must be passed for typesafety, but commandBar will determine items rendered in overflow
               isBeakVisible: true,

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
@@ -67,6 +67,7 @@ export class IndividualCommandBarButtonAsExample extends React.Component<IIndivi
     return (
       <CommandBar
         overflowButtonProps={{
+          ariaLabel: 'More commands',
           menuProps: {
             items: [], // Items must be passed for typesafety, but commandBar will determine items rendered in overflow
             isBeakVisible: true,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -729,6 +729,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               <button
                 aria-expanded={false}
                 aria-haspopup={true}
+                aria-label="More commands"
                 aria-owns={null}
                 className=
                     ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -733,6 +733,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               <button
                 aria-expanded={false}
                 aria-haspopup={true}
+                aria-label="More commands"
                 aria-owns={null}
                 className=
                     ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -730,6 +730,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
             <button
               aria-expanded={false}
               aria-haspopup={true}
+              aria-label="More commands"
               aria-owns={null}
               className=
                   ms-Button
@@ -2511,6 +2512,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
             <button
               aria-expanded={false}
               aria-haspopup={true}
+              aria-label="More commands"
               aria-owns={null}
               className=
                   ms-Button


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7668
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds ARIA labels to the overflow buttons in the CommandBar examples.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7694)

