### PR TITLE
Add className attribute to TextField of DatePicker

### DIFF
--- a/common/changes/office-ui-fabric-react/datePicker_textField_className_2019-01-17-19-21.json
+++ b/common/changes/office-ui-fabric-react/datePicker_textField_className_2019-01-17-19-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "added className attribute to TextField of DatePicker",
+      "comment": "DatePicker: adds missing className attribute to the `TextField` of the control.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/datePicker_textField_className_2019-01-17-19-21.json
+++ b/common/changes/office-ui-fabric-react/datePicker_textField_className_2019-01-17-19-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "added className attribute to TextField of DatePicker",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phtucker@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -191,6 +191,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         >
           <TextField
             id={this._id + '-label'}
+            className={classNames.textField}
             label={label}
             ariaLabel={ariaLabel}
             aria-controls={isDatePickerShown ? calloutId : undefined}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -43,6 +43,12 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
             padding-top: 0px;
             position: relative;
           }
+          & input[readonly] {
+            cursor: pointer;
+          }
+          & input::-ms-clear {
+            display: none;
+          }
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -47,6 +47,12 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
               padding-top: 0px;
               position: relative;
             }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
+            }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -52,6 +52,12 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
               padding-top: 0px;
               position: relative;
             }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
+            }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -49,6 +49,12 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
               padding-top: 0px;
               position: relative;
             }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
+            }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -49,6 +49,12 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
               padding-top: 0px;
               position: relative;
             }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
+            }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -51,6 +51,12 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
               padding-top: 0px;
               position: relative;
             }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
+            }
       >
         <div
           className=
@@ -249,6 +255,12 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
               padding-right: 0px;
               padding-top: 0px;
               position: relative;
+            }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
             }
       >
         <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -47,6 +47,12 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
               padding-top: 0px;
               position: relative;
             }
+            & input[readonly] {
+              cursor: pointer;
+            }
+            & input::-ms-clear {
+              display: none;
+            }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -3,7 +3,8 @@
 exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1`] = `
 <div
   className=
-      & .headerDivider-396:hover + .headerDividerBar-397 {
+
+      & .headerDivider-395:hover + .headerDividerBar-396 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-395:hover + .headerDividerBar-396 {
+      & .headerDivider-396:hover + .headerDividerBar-397 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

TextField element of DatePicker was not picking up styles. This was due to the className attribute not being present on the TextField. This PR adds the className attribute and appropriate value and has been verified as solving the aforementioned issue.

#### Focus areas to test

DatePicker

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7697)

