### PR TITLE
fix ordering of the codepen generation

### DIFF
--- a/scripts/just-task.js
+++ b/scripts/just-task.js
@@ -39,12 +39,9 @@ task(
       condition('jest', () => !argv().min && !argv().prdeploy),
       series(
         'ts',
+        'build-codepen-examples',
         condition('lint-imports', () => !argv().min && !argv().prdeploy),
-        parallel(
-          condition('webpack', () => !argv().min),
-          condition('verify-api-extractor', () => !argv().min && !argv().prdeploy),
-          'build-codepen-examples'
-        )
+        parallel(condition('webpack', () => !argv().min), condition('verify-api-extractor', () => !argv().min && !argv().prdeploy))
       )
     )
   )


### PR DESCRIPTION
#### Description of changes

Technically the order of operation in the build task is wrong with the codepen codegen step. It is "okay" because we all run an `npm install` which builds the codepen examples and skips webpack. So this fixes the order so it does it universally correct even without the extra npm install (in preparation for when OUFR is no longer the uber package)

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7698)

