### PR TITLE
PeoplePicker: Reduce height to 32px

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-people-picker-height_2019-01-17-20-32.json
+++ b/common/changes/office-ui-fabric-react/miwhea-people-picker-height_2019-01-17-20-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "PeoplePicker: Reduce height to match other inputs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -71,7 +71,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
                   align-self: flex-end;
                   border: none;
                   flex-grow: 1;
-                  height: 34px;
+                  height: 30px;
                   outline: none;
                   padding-bottom: 0;
                   padding-left: 6px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -210,7 +210,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                   align-self: flex-end;
                   border: none;
                   flex-grow: 1;
-                  height: 34px;
+                  height: 30px;
                   outline: none;
                   padding-bottom: 0;
                   padding-left: 6px;
@@ -305,7 +305,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                   align-self: flex-end;
                   border: none;
                   flex-grow: 1;
-                  height: 34px;
+                  height: 30px;
                   outline: none;
                   padding-bottom: 0;
                   padding-left: 6px;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -53,7 +53,7 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
     input: [
       classNames.input,
       {
-        height: 34,
+        height: 30,
         border: 'none',
         flexGrow: 1,
         outline: 'none',

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -9,7 +9,7 @@ const GlobalClassNames = {
   isInvalid: 'is-invalid'
 };
 
-const REMOVE_BUTTON_SIZE = 28;
+const REMOVE_BUTTON_SIZE = 24;
 
 export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePickerItemSelectedStyles {
   const { className, theme, selected, invalid } = props;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.tsx
@@ -43,7 +43,7 @@ export const PeoplePickerItemBase = (props: IPeoplePickerItemSelectedProps) => {
       aria-labelledby={'selectedItemPersona-' + itemId}
     >
       <div className={classNames.itemContent} id={'selectedItemPersona-' + itemId}>
-        <Persona size={PersonaSize.size28} styles={personaStyles} coinProps={{ styles: personaCoinStyles }} {...item} />
+        <Persona size={PersonaSize.size24} styles={personaStyles} coinProps={{ styles: personaCoinStyles }} {...item} />
       </div>
       <IconButton
         onClick={onRemoveItem}

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
                 align-self: flex-end;
                 border: none;
                 flex-grow: 1;
-                height: 34px;
+                height: 30px;
                 outline: none;
                 padding-bottom: 0;
                 padding-left: 6px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6675
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Reduces the PeoplePicker's height to 32px (border included) to match similar inputs like TextField, Dropdown, and SearchBox.

![image](https://user-images.githubusercontent.com/1382445/51347071-17c6f280-1a54-11e9-8b26-c79544596920.png)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7703)

