### PR TITLE
List: Remove usage of string refs for List pages

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-list-ref_2019-01-17-20-52.json
+++ b/common/changes/office-ui-fabric-react/keco-list-ref_2019-01-17-20-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Remove usage of string refs used for List pages",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -89,7 +89,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
 
   private _root = React.createRef<HTMLDivElement>();
   private _surface = React.createRef<HTMLDivElement>();
-  private _pageRefs: { [key: string]: HTMLDivElement | null } = {};
+  private _pageRefs: { [pageKey: string]: React.RefObject<HTMLDivElement> };
 
   private _estimatedPageHeight: number;
   private _totalEstimates: number;
@@ -157,6 +157,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       leading: false
     });
 
+    this._pageRefs = {};
     this._cachedPageHeights = {};
     this._estimatedPageHeight = 0;
     this._focusedIndex = -1;
@@ -400,13 +401,16 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     const pageStyle = this._getPageStyle(page);
 
     const { onRenderPage = this._onRenderPage } = this.props;
+    const pageRef = React.createRef<HTMLDivElement>();
+
+    this._pageRefs[page.key] = pageRef;
 
     const pageElement = onRenderPage(
       {
         page: page,
         className: css('ms-List-page'),
         key: page.key,
-        ref: el => (this._pageRefs[page.key] = el),
+        ref: pageRef,
         style: pageStyle,
         role: 'presentation'
       },
@@ -660,7 +664,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
    */
   private _measurePage(page: IPage): boolean {
     let hasChangedHeight = false;
-    const pageElement = this._pageRefs[page.key];
+    const pageElement = this._pageRefs[page.key].current;
     const cachedHeight = this._cachedPageHeights[page.startIndex];
 
     // console.log('   * measure attempt', page.startIndex, cachedHeight);

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -87,12 +87,9 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     renderedWindowsBehind: DEFAULT_RENDERED_WINDOWS_BEHIND
   };
 
-  public refs: {
-    [key: string]: React.ReactInstance;
-  };
-
   private _root = React.createRef<HTMLDivElement>();
   private _surface = React.createRef<HTMLDivElement>();
+  private _pageRefs: { [key: string]: HTMLDivElement | null } = {};
 
   private _estimatedPageHeight: number;
   private _totalEstimates: number;
@@ -409,7 +406,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
         page: page,
         className: css('ms-List-page'),
         key: page.key,
-        ref: page.key,
+        ref: el => (this._pageRefs[page.key] = el),
         style: pageStyle,
         role: 'presentation'
       },
@@ -663,7 +660,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
    */
   private _measurePage(page: IPage): boolean {
     let hasChangedHeight = false;
-    const pageElement = this.refs[page.key] as HTMLElement;
+    const pageElement = this._pageRefs[page.key];
     const cachedHeight = this._cachedPageHeights[page.startIndex];
 
     // console.log('   * measure attempt', page.startIndex, cachedHeight);

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -87,6 +87,10 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     renderedWindowsBehind: DEFAULT_RENDERED_WINDOWS_BEHIND
   };
 
+  public refs: {
+    [key: string]: React.ReactInstance;
+  };
+
   private _root = React.createRef<HTMLDivElement>();
   private _surface = React.createRef<HTMLDivElement>();
   private _pageRefs: { [pageKey: string]: React.RefObject<HTMLDivElement> };

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -405,16 +405,15 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     const pageStyle = this._getPageStyle(page);
 
     const { onRenderPage = this._onRenderPage } = this.props;
-    const pageRef = React.createRef<HTMLDivElement>();
 
-    this._pageRefs[page.key] = pageRef;
+    this._pageRefs[page.key] = this._pageRefs[page.key] || React.createRef();
 
     const pageElement = onRenderPage(
       {
         page: page,
         className: css('ms-List-page'),
         key: page.key,
-        ref: pageRef,
+        ref: this._pageRefs[page.key],
         style: pageStyle,
         role: 'presentation'
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7690
- [x] Include a change request file using `$ npm run change`

#### Description of changes

String refs are deprecated in React `16.x` and their usage emits a warning when React's "Strict Mode" is enabled. This removes the usage of string refs within `List` and replaces the string ref lookup hash.

Reference: https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7704)

