### PR TITLE
Update buttons in OverflowSet and ResizeGroup examples

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-update-example-buttons_2019-01-17-23-00.json
+++ b/common/changes/office-ui-fabric-react/miwhea-update-example-buttons_2019-01-17-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update two examples to use CommandBarButton",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseComponent, css } from 'office-ui-fabric-react/lib/Utilities';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
 
@@ -126,12 +126,12 @@ export class OverflowSetCustomExample extends BaseComponent<any, any> {
     if (item.onRender) {
       return item.onRender(item);
     }
-    return <DefaultButton iconProps={{ iconName: item.icon }} menuProps={item.subMenuProps} text={item.name} />;
+    return <CommandBarButton iconProps={{ iconName: item.icon }} menuProps={item.subMenuProps} text={item.name} />;
   }
 
   private _onRenderOverflowButton(overflowItems: any[] | undefined): JSX.Element {
     return (
-      <DefaultButton className={css(styles.overflowButton)} menuIconProps={{ iconName: 'More' }} menuProps={{ items: overflowItems! }} />
+      <CommandBarButton className={css(styles.overflowButton)} menuIconProps={{ iconName: 'More' }} menuProps={{ items: overflowItems! }} />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
 import { OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
@@ -87,12 +87,13 @@ export class ResizeGroupOverflowSetExample extends BaseComponent<{}, IResizeGrou
                 overflowItems={data.overflow.length ? data.overflow : null}
                 onRenderItem={item => {
                   return (
-                    <DefaultButton text={item.name} iconProps={{ iconName: item.icon }} onClick={item.onClick} checked={item.checked} />
+                    <CommandBarButton text={item.name} iconProps={{ iconName: item.icon }} onClick={item.onClick} checked={item.checked} />
                   );
                 }}
                 onRenderOverflowButton={overflowItems => {
-                  return <DefaultButton menuProps={{ items: overflowItems! }} />;
+                  return <CommandBarButton menuProps={{ items: overflowItems! }} />;
                 }}
+                styles={{ root: { height: 40 } }}
               />
             );
           }}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -164,7 +164,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       aria-owns={null}
       className=
           ms-Button
-          ms-Button--default
+          ms-Button--commandBar
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -178,12 +178,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            height: 32px;
-            min-width: 80px;
+            min-width: 40px;
             outline: transparent;
             padding-bottom: 0;
-            padding-left: 16px;
-            padding-right: 16px;
+            padding-left: 4px;
+            padding-right: 4px;
             padding-top: 0;
             position: relative;
             text-align: center;
@@ -207,28 +206,30 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
             border: none;
-            bottom: -2px;
-            left: -2px;
+            bottom: 4px;
+            left: 4px;
             outline-color: ButtonText;
-            right: -2px;
-            top: -2px;
+            right: 4px;
+            top: 4px;
           }
           &:active > * {
             left: 0px;
             position: relative;
             top: 0px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
           &:hover {
             background-color: #eaeaea;
             color: #212121;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
             color: Highlight;
           }
           &:active {
-            background-color: #c8c8c8;
-            color: #212121;
+            background-color: #dadada;
+            color: #000000;
           }
       data-is-focusable={true}
       onClick={[Function]}
@@ -256,6 +257,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
+                color: #106ebe;
                 display: inline-block;
                 flex-shrink: 0;
                 font-family: "FabricMDL2Icons";
@@ -288,7 +290,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             className=
                 ms-Button-label
                 {
-                  font-weight: 600;
+                  font-weight: normal;
                   line-height: 100%;
                   margin-bottom: 0;
                   margin-left: 4px;
@@ -306,6 +308,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
+                color: #666666;
                 display: inline-block;
                 flex-shrink: 0;
                 font-family: "FabricMDL2Icons";
@@ -341,7 +344,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
     <button
       className=
           ms-Button
-          ms-Button--default
+          ms-Button--commandBar
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -355,12 +358,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            height: 32px;
-            min-width: 80px;
+            min-width: 40px;
             outline: transparent;
             padding-bottom: 0;
-            padding-left: 16px;
-            padding-right: 16px;
+            padding-left: 4px;
+            padding-right: 4px;
             padding-top: 0;
             position: relative;
             text-align: center;
@@ -384,28 +386,30 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
             border: none;
-            bottom: -2px;
-            left: -2px;
+            bottom: 4px;
+            left: 4px;
             outline-color: ButtonText;
-            right: -2px;
-            top: -2px;
+            right: 4px;
+            top: 4px;
           }
           &:active > * {
             left: 0px;
             position: relative;
             top: 0px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
           &:hover {
             background-color: #eaeaea;
             color: #212121;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
             color: Highlight;
           }
           &:active {
-            background-color: #c8c8c8;
-            color: #212121;
+            background-color: #dadada;
+            color: #000000;
           }
       data-is-focusable={true}
       onClick={[Function]}
@@ -433,6 +437,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
+                color: #106ebe;
                 display: inline-block;
                 flex-shrink: 0;
                 font-family: "FabricMDL2Icons";
@@ -465,7 +470,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             className=
                 ms-Button-label
                 {
-                  font-weight: 600;
+                  font-weight: normal;
                   line-height: 100%;
                   margin-bottom: 0;
                   margin-left: 4px;
@@ -491,7 +496,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
     <button
       className=
           ms-Button
-          ms-Button--default
+          ms-Button--commandBar
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -505,12 +510,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            height: 32px;
-            min-width: 80px;
+            min-width: 40px;
             outline: transparent;
             padding-bottom: 0;
-            padding-left: 16px;
-            padding-right: 16px;
+            padding-left: 4px;
+            padding-right: 4px;
             padding-top: 0;
             position: relative;
             text-align: center;
@@ -534,28 +538,30 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
             border: none;
-            bottom: -2px;
-            left: -2px;
+            bottom: 4px;
+            left: 4px;
             outline-color: ButtonText;
-            right: -2px;
-            top: -2px;
+            right: 4px;
+            top: 4px;
           }
           &:active > * {
             left: 0px;
             position: relative;
             top: 0px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
           &:hover {
             background-color: #eaeaea;
             color: #212121;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
             color: Highlight;
           }
           &:active {
-            background-color: #c8c8c8;
-            color: #212121;
+            background-color: #dadada;
+            color: #000000;
           }
       data-is-focusable={true}
       onClick={[Function]}
@@ -583,6 +589,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
+                color: #106ebe;
                 display: inline-block;
                 flex-shrink: 0;
                 font-family: "FabricMDL2Icons";
@@ -615,7 +622,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             className=
                 ms-Button-label
                 {
-                  font-weight: 600;
+                  font-weight: normal;
                   line-height: 100%;
                   margin-bottom: 0;
                   margin-left: 4px;
@@ -644,7 +651,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       aria-owns={null}
       className=
           ms-Button
-          ms-Button--default
+          ms-Button--commandBar
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -658,12 +665,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            height: 32px;
-            min-width: 80px;
+            min-width: 40px;
             outline: transparent;
             padding-bottom: 0;
-            padding-left: 16px;
-            padding-right: 16px;
+            padding-left: 4px;
+            padding-right: 4px;
             padding-top: 0;
             position: relative;
             text-align: center;
@@ -687,28 +693,30 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
             border: none;
-            bottom: -2px;
-            left: -2px;
+            bottom: 4px;
+            left: 4px;
             outline-color: ButtonText;
-            right: -2px;
-            top: -2px;
+            right: 4px;
+            top: 4px;
           }
           &:active > * {
             left: 0px;
             position: relative;
             top: 0px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border: none;
+          }
           &:hover {
             background-color: #eaeaea;
             color: #212121;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
             color: Highlight;
           }
           &:active {
-            background-color: #c8c8c8;
-            color: #212121;
+            background-color: #dadada;
+            color: #000000;
           }
       data-is-focusable={true}
       onClick={[Function]}
@@ -736,6 +744,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
+                color: #666666;
                 display: inline-block;
                 flex-shrink: 0;
                 font-family: "FabricMDL2Icons";

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -31,6 +31,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               {
                 display: flex;
                 flex-wrap: nowrap;
+                height: 40px;
                 position: relative;
               }
           data-focuszone-id="FocusZone0"
@@ -51,7 +52,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -65,12 +66,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -94,28 +94,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -143,6 +145,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -175,7 +178,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -202,7 +205,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -216,12 +219,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -245,28 +247,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -294,6 +298,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -326,7 +331,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -353,7 +358,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -367,12 +372,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -396,28 +400,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -445,6 +451,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -477,7 +484,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -504,7 +511,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -518,12 +525,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -547,28 +553,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -596,6 +604,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -628,7 +637,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -655,7 +664,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -669,12 +678,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -698,28 +706,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -747,6 +757,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -779,7 +790,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -806,7 +817,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -820,12 +831,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -849,28 +859,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -898,6 +910,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -930,7 +943,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -957,7 +970,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -971,12 +984,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1000,28 +1012,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1049,6 +1063,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1081,7 +1096,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -1108,7 +1123,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1122,12 +1137,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1151,28 +1165,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1200,6 +1216,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1232,7 +1249,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -1259,7 +1276,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1273,12 +1290,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1302,28 +1318,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1351,6 +1369,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1383,7 +1402,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -1410,7 +1429,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1424,12 +1443,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1453,28 +1471,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1502,6 +1522,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1534,7 +1555,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -1561,7 +1582,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1575,12 +1596,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1604,28 +1624,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1653,6 +1675,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1685,7 +1708,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -1712,7 +1735,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1726,12 +1749,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1755,28 +1777,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1804,6 +1828,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1836,7 +1861,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -1863,7 +1888,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1877,12 +1902,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -1906,28 +1930,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -1955,6 +1981,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -1987,7 +2014,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2014,7 +2041,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2028,12 +2055,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2057,28 +2083,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2106,6 +2134,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -2138,7 +2167,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2165,7 +2194,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2179,12 +2208,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2208,28 +2236,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2257,6 +2287,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -2289,7 +2320,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2316,7 +2347,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2330,12 +2361,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2359,28 +2389,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2408,6 +2440,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -2440,7 +2473,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2467,7 +2500,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2481,12 +2514,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2510,28 +2542,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2559,6 +2593,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -2591,7 +2626,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2618,7 +2653,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2632,12 +2667,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2661,28 +2695,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2710,6 +2746,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -2742,7 +2779,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2769,7 +2806,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2783,12 +2820,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2812,28 +2848,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2861,6 +2899,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -2893,7 +2932,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;
@@ -2920,7 +2959,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               checked={false}
               className=
                   ms-Button
-                  ms-Button--default
+                  ms-Button--commandBar
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -2934,12 +2973,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
+                    min-width: 40px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
@@ -2963,28 +3001,30 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
-                    bottom: -2px;
-                    left: -2px;
+                    bottom: 4px;
+                    left: 4px;
                     outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
+                    right: 4px;
+                    top: 4px;
                   }
                   &:active > * {
                     left: 0px;
                     position: relative;
                     top: 0px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border: none;
+                  }
                   &:hover {
                     background-color: #eaeaea;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #c8c8c8;
-                    color: #212121;
+                    background-color: #dadada;
+                    color: #000000;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -3012,6 +3052,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        color: #106ebe;
                         display: inline-block;
                         flex-shrink: 0;
                         font-family: "FabricMDL2Icons";
@@ -3044,7 +3085,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     className=
                         ms-Button-label
                         {
-                          font-weight: 600;
+                          font-weight: normal;
                           line-height: 100%;
                           margin-bottom: 0;
                           margin-left: 4px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7662 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates examples for OverflowSet and ResizeGroup to use CommandBarButton instead of DefaultButton. Previously these looked much the same, but with the Fluent style updates, there is a difference that makes DefaultButtons not look right directly against each other.

#### Before
![image](https://user-images.githubusercontent.com/1382445/51354710-574c0980-1a69-11e9-998f-15cead6755fe.png)
![image](https://user-images.githubusercontent.com/1382445/51354721-6468f880-1a69-11e9-8055-6308e4169fa8.png)

#### After
![image](https://user-images.githubusercontent.com/1382445/51354614-05a37f00-1a69-11e9-97c5-0e7aca1facfc.png)
![image](https://user-images.githubusercontent.com/1382445/51354637-13f19b00-1a69-11e9-8675-0318a67f6efb.png)
