### PR TITLE
ContextualMenu: Move keys in example

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2019-01-17-23-35.json
+++ b/common/changes/office-ui-fabric-react/master_2019-01-17-23-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Adds keys to sections in the header example",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
@@ -13,9 +13,9 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
           menuProps={{
             items: [
               {
-                key: 'section',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
+                  key: 'section1',
                   topDivider: true,
                   bottomDivider: true,
                   title: 'Actions',
@@ -32,9 +32,9 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
                 }
               },
               {
-                key: 'section',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
+                  key: 'section2',
                   title: 'Social',
                   items: [
                     {
@@ -53,9 +53,9 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
                 }
               },
               {
-                key: 'section',
                 itemType: ContextualMenuItemType.Section,
                 sectionProps: {
+                  key: 'section3',
                   title: 'Navigation',
                   items: [
                     {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7686
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Moves the `key` properties from the arrays of items down into the props for each section. This fixes the warning about an iterator without unique keys.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7709)

