### PR TITLE
Foundation: Styles/Tokens Typing Improvements

### DIFF
--- a/common/changes/@uifabric/example-app-base/jg-typing-improvements_2019-01-17-23-52.json
+++ b/common/changes/@uifabric/example-app-base/jg-typing-improvements_2019-01-17-23-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Fix bug where customizations apply to theme and scheme dropdowns.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/jg-typing-improvements_2019-01-17-23-52.json
+++ b/common/changes/@uifabric/experiments/jg-typing-improvements_2019-01-17-23-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add helper return types to mitigate TS function return type widening.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -156,9 +156,11 @@ export class ExampleCard extends React.Component<IExampleCardProps, IExampleCard
               <div className="ExampleCard-code">{isCodeVisible && <Highlight>{code}</Highlight>}</div>
 
               {activeCustomizations ? (
-                <ThemeProvider scheme={_schemes[schemeIndex]}>
-                  <ExampleCardComponent styles={regionStyles}>{exampleCardContent}</ExampleCardComponent>
-                </ThemeProvider>
+                <Customizer {...activeCustomizations}>
+                  <ThemeProvider scheme={_schemes[schemeIndex]}>
+                    <ExampleCardComponent styles={regionStyles}>{exampleCardContent}</ExampleCardComponent>
+                  </ThemeProvider>
+                </Customizer>
               ) : (
                 exampleCardContent
               )}
@@ -167,7 +169,7 @@ export class ExampleCard extends React.Component<IExampleCardProps, IExampleCard
             </div>
           );
 
-          return activeCustomizations ? <Customizer {...activeCustomizations}>{exampleCard}</Customizer> : exampleCard;
+          return exampleCard;
         }}
       </AppCustomizationsContext.Consumer>
     );

--- a/packages/experiments/src/components/Button/Button.styles.ts
+++ b/packages/experiments/src/components/Button/Button.styles.ts
@@ -1,4 +1,4 @@
-import { IButtonComponent } from './Button.types';
+import { IButtonComponent, IButtonStylesReturnType, IButtonTokenReturnType } from './Button.types';
 import { getFocusStyle, getGlobalClassNames } from '../../Styling';
 
 const baseTokens: IButtonComponent['tokens'] = {
@@ -22,7 +22,7 @@ const circularTokens: IButtonComponent['tokens'] = {
   contentPadding: ''
 };
 
-const enabledTokens: IButtonComponent['tokens'] = (props, theme) => {
+const enabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.buttonBackground,
@@ -43,7 +43,7 @@ const enabledTokens: IButtonComponent['tokens'] = (props, theme) => {
   };
 };
 
-const disabledTokens: IButtonComponent['tokens'] = (props, theme) => {
+const disabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
   const { semanticColors } = theme;
   return {
     backgroundColor: theme.semanticColors.buttonBackgroundDisabled,
@@ -64,7 +64,7 @@ const disabledTokens: IButtonComponent['tokens'] = (props, theme) => {
   };
 };
 
-const expandedTokens: IButtonComponent['tokens'] = (props, theme) => {
+const expandedTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.buttonBackgroundPressed,
@@ -77,7 +77,7 @@ const expandedTokens: IButtonComponent['tokens'] = (props, theme) => {
   };
 };
 
-const primaryEnabledTokens: IButtonComponent['tokens'] = (props, theme) => {
+const primaryEnabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.primaryButtonBackground,
@@ -96,7 +96,7 @@ const primaryEnabledTokens: IButtonComponent['tokens'] = (props, theme) => {
   };
 };
 
-const primaryExpandedTokens: IButtonComponent['tokens'] = (props, theme) => {
+const primaryExpandedTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.primaryButtonBackgroundPressed,
@@ -109,7 +109,7 @@ const primaryExpandedTokens: IButtonComponent['tokens'] = (props, theme) => {
   };
 };
 
-export const ButtonTokens: IButtonComponent['tokens'] = (props, theme) => [
+export const ButtonTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => [
   baseTokens,
   !props.disabled && enabledTokens,
   props.expanded && expandedTokens,
@@ -119,7 +119,7 @@ export const ButtonTokens: IButtonComponent['tokens'] = (props, theme) => [
   props.disabled && disabledTokens
 ];
 
-export const ButtonStyles: IButtonComponent['styles'] = (props, theme, tokens) => {
+export const ButtonStyles: IButtonComponent['styles'] = (props, theme, tokens): IButtonStylesReturnType => {
   const { className } = props;
 
   const globalClassNames = getGlobalClassNames(
@@ -197,21 +197,22 @@ export const ButtonStyles: IButtonComponent['styles'] = (props, theme, tokens) =
     ],
     content: {
       overflow: 'visible'
-    },
-    splitContainer: {
-      height: '100%',
-      position: 'relative',
-      width: '36px'
-    },
-    divider: {
-      background: tokens.color,
-      bottom: 6,
-      display: 'inline-block',
-      left: 0,
-      opacity: 0.7,
-      position: 'absolute',
-      top: 6,
-      width: 1
     }
+    // TODO: test with split button approach.
+    // splitContainer: {
+    //   height: '100%',
+    //   position: 'relative',
+    //   width: '36px'
+    // },
+    // divider: {
+    //   background: tokens.color,
+    //   bottom: 6,
+    //   display: 'inline-block',
+    //   left: 0,
+    //   opacity: 0.7,
+    //   position: 'absolute',
+    //   top: 6,
+    //   width: 1
+    // }
   };
 };

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -7,6 +7,12 @@ import { IBaseProps } from '../../Utilities';
 
 export type IButtonComponent = IComponent<IButtonProps, IButtonTokens, IButtonStyles, IButtonViewProps>;
 
+// These types are redundant with IButtonComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type IButtonTokenReturnType = ReturnType<Extract<IButtonComponent['tokens'], Function>>;
+export type IButtonStylesReturnType = ReturnType<Extract<IButtonComponent['styles'], Function>>;
+
 export type IButtonSlot = ISlotProp<IButtonProps>;
 
 export interface IButtonSlots {

--- a/packages/experiments/src/components/Button/examples/Button.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Example.tsx
@@ -16,6 +16,7 @@ const ButtonStack = (props: { children: JSX.Element[] | JSX.Element }) => (
   </Stack>
 );
 
+// tslint:disable:jsx-no-lambda
 export class ButtonExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
@@ -38,7 +39,8 @@ export class ButtonExample extends React.Component<{}, {}> {
               <ButtonStack>
                 <Button icon="Upload" content="Button with string icon" />
                 <Button icon={{ iconName: 'Share' }} content="Button with iconProps" />
-                <Button icon={<Icon iconName="Download" />} content="Button with custom icon" />
+                <Button icon={() => <Icon iconName="Download" />} content="Button with icon render function" />
+                <Button icon={<Icon iconName="Download" />} content="Button with icon JSX" />
               </ButtonStack>
               <ButtonStack>
                 <Button>

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.styles.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.styles.ts
@@ -1,4 +1,4 @@
-import { ICollapsibleSectionComponent } from './CollapsibleSection.types';
+import { ICollapsibleSectionComponent, ICollapsibleSectionStylesReturnType } from './CollapsibleSection.types';
 import { getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
@@ -6,7 +6,7 @@ const GlobalClassNames = {
   body: 'ms-CollapsibleSection-body'
 };
 
-export const collapsibleSectionStyles: ICollapsibleSectionComponent['styles'] = (props, theme) => {
+export const collapsibleSectionStyles: ICollapsibleSectionComponent['styles'] = (props, theme): ICollapsibleSectionStylesReturnType => {
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
@@ -10,6 +10,12 @@ export type ICollapsibleSectionComponent = IComponent<
   ICollapsibleSectionViewProps
 >;
 
+// These types are redundant with ICollapsibleSectionComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type ICollapsibleSectionTokenReturnType = ReturnType<Extract<ICollapsibleSectionComponent['tokens'], Function>>;
+export type ICollapsibleSectionStylesReturnType = ReturnType<Extract<ICollapsibleSectionComponent['styles'], Function>>;
+
 export interface ICollapsibleSectionSlots {
   root?: IHTMLDivSlot;
   title?: ICollapsibleSectionTitleSlot;

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.styles.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.styles.ts
@@ -1,8 +1,8 @@
 import { merge } from 'office-ui-fabric-react/lib/Utilities';
 import { isSingleLineText } from '../../../utilities/textHelpers';
-import { IVerticalPersonaComponent, IVerticalPersonaStyleVariableTypes } from './VerticalPersona.types';
+import { IVerticalPersonaComponent, IVerticalPersonaStyleVariableTypes, IVerticalPersonaStylesReturnType } from './VerticalPersona.types';
 
-export const VerticalPersonaStyles: IVerticalPersonaComponent['styles'] = (props, theme) => {
+export const VerticalPersonaStyles: IVerticalPersonaComponent['styles'] = (props, theme): IVerticalPersonaStylesReturnType => {
   const baseVariables: IVerticalPersonaStyleVariableTypes = {
     verticalPersonaWidth: 122,
     text: {

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
@@ -5,6 +5,12 @@ import { IPersonaCoinSlot } from '../../PersonaCoin/PersonaCoin.types';
 
 export type IVerticalPersonaComponent = IComponent<IVerticalPersonaProps, IVerticalPersonaTokens, IVerticalPersonaStyles>;
 
+// These types are redundant with IVerticalPersonaComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type IVerticalPersonaTokenReturnType = ReturnType<Extract<IVerticalPersonaComponent['tokens'], Function>>;
+export type IVerticalPersonaStylesReturnType = ReturnType<Extract<IVerticalPersonaComponent['styles'], Function>>;
+
 export interface IVerticalPersonaSlots {
   root?: IHTMLDivSlot;
   primaryText?: ITextSlot;

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -1,4 +1,4 @@
-import { IStackComponent, IStackStyles, IStackProps } from './Stack.types';
+import { IStackComponent, IStackStyles, IStackProps, IStackStylesReturnType } from './Stack.types';
 import { getVerticalAlignment, parseGap, parsePadding } from './StackUtils';
 import { getGlobalClassNames } from '../../Styling';
 
@@ -12,7 +12,7 @@ const GlobalClassNames = {
   inner: 'ms-Stack-inner'
 };
 
-export const styles: IStackComponent['styles'] = (props, theme) => {
+export const styles: IStackComponent['styles'] = (props, theme): IStackStylesReturnType => {
   const {
     horizontalFill,
     verticalFill,

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -4,6 +4,12 @@ export type Alignment = 'start' | 'end' | 'center' | 'space-between' | 'space-ar
 
 export type IStackComponent = IComponent<IStackProps, IStackTokens, IStackStyles>;
 
+// These types are redundant with IStackComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type IStackTokenReturnType = ReturnType<Extract<IStackComponent['tokens'], Function>>;
+export type IStackStylesReturnType = ReturnType<Extract<IStackComponent['styles'], Function>>;
+
 export type IStackSlot = ISlotProp<IStackProps>;
 
 export interface IStackSlots {

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
@@ -1,5 +1,5 @@
 import { getGlobalClassNames } from '../../../Styling';
-import { IStackItemComponent, IStackItemStyles } from './StackItem.types';
+import { IStackItemComponent, IStackItemStyles, IStackItemStylesReturnType } from './StackItem.types';
 
 const GlobalClassNames = {
   root: 'ms-StackItem'
@@ -10,7 +10,7 @@ const alignMap: { [key: string]: string } = {
   end: 'flex-end'
 };
 
-export const styles: IStackItemComponent['styles'] = (props, theme) => {
+export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemStylesReturnType => {
   const { grow, shrink, preventShrink, align, fillHorizontal, fillVertical, className } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -6,6 +6,12 @@ export interface IStackItemSlots {
   root?: IHTMLSpanSlot;
 }
 
+// These types are redundant with IStackItemComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type IStackItemTokenReturnType = ReturnType<Extract<IStackItemComponent['tokens'], Function>>;
+export type IStackItemStylesReturnType = ReturnType<Extract<IStackItemComponent['styles'], Function>>;
+
 export interface IStackItemProps extends IStackItemSlots, IStyleableComponentProps<IStackItemProps, IStackItemTokens, IStackItemStyles> {
   /**
    * How to render the StackItem.

--- a/packages/experiments/src/components/Text/Text.styles.ts
+++ b/packages/experiments/src/components/Text/Text.styles.ts
@@ -1,6 +1,6 @@
-import { ITextComponent } from './Text.types';
+import { ITextComponent, ITextStyles, ITextStylesReturnType } from './Text.types';
 
-export const TextStyles: ITextComponent['styles'] = (props, theme) => {
+export const TextStyles: ITextComponent['styles'] = (props, theme): ITextStylesReturnType => {
   const { as, className, inline, wrap, variant } = props;
   const { fonts } = theme;
   const variantObject = variant && fonts[variant] ? fonts[variant] : fonts.medium;
@@ -24,5 +24,5 @@ export const TextStyles: ITextComponent['styles'] = (props, theme) => {
       },
       className
     ]
-  };
+  } as ITextStyles;
 };

--- a/packages/experiments/src/components/Text/Text.types.tsx
+++ b/packages/experiments/src/components/Text/Text.types.tsx
@@ -3,6 +3,12 @@ import { IFontStyles } from '../../Styling';
 
 export type ITextComponent = IComponent<ITextProps, ITextTokens, ITextStyles>;
 
+// These types are redundant with ITextComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type ITextTokenReturnType = ReturnType<Extract<ITextComponent['tokens'], Function>>;
+export type ITextStylesReturnType = ReturnType<Extract<ITextComponent['styles'], Function>>;
+
 export type ITextSlot = ISlotProp<ITextProps, 'children'>;
 
 export interface ITextSlots {

--- a/packages/experiments/src/components/Toggle/Toggle.styles.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.styles.ts
@@ -1,4 +1,4 @@
-import { IToggleComponent } from './Toggle.types';
+import { IToggleComponent, IToggleStylesReturnType, IToggleTokenReturnType } from './Toggle.types';
 import { getFocusStyle, getGlobalClassNames, HighContrastSelector, IStyle } from '../../Styling';
 
 const GlobalClassNames = {
@@ -10,7 +10,7 @@ const GlobalClassNames = {
   text: 'ms-Toggle-stateText'
 };
 
-const toggleEnabledTokens: IToggleComponent['tokens'] = (props, theme) => {
+const toggleEnabledTokens: IToggleComponent['tokens'] = (props, theme): IToggleTokenReturnType => {
   const { semanticColors } = theme;
   return {
     pillBackground: semanticColors.bodyBackground,
@@ -23,7 +23,7 @@ const toggleEnabledTokens: IToggleComponent['tokens'] = (props, theme) => {
   };
 };
 
-const toggleDisabledTokens: IToggleComponent['tokens'] = (props, theme) => {
+const toggleDisabledTokens: IToggleComponent['tokens'] = (props, theme): IToggleTokenReturnType => {
   const { semanticColors } = theme;
   return {
     pillBackground: semanticColors.bodyBackground,
@@ -41,7 +41,7 @@ const toggleCheckedVariables: IToggleComponent['tokens'] = {
   pillJustifyContent: 'flex-end'
 };
 
-const toggleCheckedEnabledTokens: IToggleComponent['tokens'] = (props, theme) => {
+const toggleCheckedEnabledTokens: IToggleComponent['tokens'] = (props, theme): IToggleTokenReturnType => {
   const { semanticColors } = theme;
   return {
     pillBackground: semanticColors.inputBackgroundChecked,
@@ -57,7 +57,7 @@ const toggleCheckedEnabledTokens: IToggleComponent['tokens'] = (props, theme) =>
   };
 };
 
-const toggleCheckedDisabledTokens: IToggleComponent['tokens'] = (props, theme) => {
+const toggleCheckedDisabledTokens: IToggleComponent['tokens'] = (props, theme): IToggleTokenReturnType => {
   const { semanticColors } = theme;
   return {
     pillBackground: semanticColors.disabledBodySubtext,
@@ -65,13 +65,13 @@ const toggleCheckedDisabledTokens: IToggleComponent['tokens'] = (props, theme) =
   };
 };
 
-export const ToggleTokens: IToggleComponent['tokens'] = props => [
+export const ToggleTokens: IToggleComponent['tokens'] = (props): IToggleTokenReturnType => [
   props.checked && toggleCheckedVariables,
   props.disabled && [toggleDisabledTokens, props.checked && toggleCheckedDisabledTokens],
   !props.disabled && [toggleEnabledTokens, props.checked && toggleCheckedEnabledTokens]
 ];
 
-export const ToggleStyles: IToggleComponent['styles'] = (props, theme, tokens) => {
+export const ToggleStyles: IToggleComponent['styles'] = (props, theme, tokens): IToggleStylesReturnType => {
   const { className, disabled, checked } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);

--- a/packages/experiments/src/components/Toggle/Toggle.types.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.types.ts
@@ -7,6 +7,12 @@ import { ILabelSlot } from '../../utilities/factoryComponents.types';
 
 export type IToggleComponent = IComponent<IToggleProps, IToggleTokens, IToggleStyles, IToggleViewProps>;
 
+// These types are redundant with IToggleComponent but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+export type IToggleTokenReturnType = ReturnType<Extract<IToggleComponent['tokens'], Function>>;
+export type IToggleStylesReturnType = ReturnType<Extract<IToggleComponent['styles'], Function>>;
+
 export interface IToggleSlots {
   /**
    * Root element.

--- a/scripts/templates/create-component/slots/EmptyStyles.mustache
+++ b/scripts/templates/create-component/slots/EmptyStyles.mustache
@@ -1,4 +1,8 @@
-import { I{{componentName}}Component } from './{{componentName}}.types';
+import {
+  I{{componentName}}Component,
+  I{{componentName}}StylesReturnType,
+  I{{componentName}}TokenReturnType
+} from './{{componentName}}.types';
 import { getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
@@ -14,12 +18,12 @@ const warningTokens: I{{componentName}}Component['tokens'] = {
   textColor: 'red'
 };
 
-export const {{componentName}}Tokens: I{{componentName}}Component['tokens'] = (props, theme) => [
+export const {{componentName}}Tokens: I{{componentName}}Component['tokens'] = (props, theme): I{{componentName}}TokenReturnType => [
   baseTokens,
   props.warning && warningTokens
 ];
 
-export const {{componentName}}Styles: I{{componentName}}Component['styles'] = (props, theme, tokens) => {
+export const {{componentName}}Styles: I{{componentName}}Component['styles'] = (props, theme, tokens): I{{componentName}}StylesReturnType => {
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {

--- a/scripts/templates/create-component/slots/EmptyTypes.mustache
+++ b/scripts/templates/create-component/slots/EmptyTypes.mustache
@@ -5,6 +5,12 @@ import { IBaseProps } from '../../Utilities';
 export type I{{componentName}}Component =
   IComponent< I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles, I{{componentName}}ViewProps>;
 
+// These types are redundant with I{{componentName}}Component but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety for tokens and styles functions.
+export type I{{componentName}}TokenReturnType = ReturnType< Extract< I{{componentName}}Component['tokens'], Function>>;
+export type I{{componentName}}StylesReturnType = ReturnType< Extract< I{{componentName}}Component['styles'], Function>>;
+
 // Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
 export interface I{{componentName}} { }
 
@@ -39,15 +45,14 @@ export interface I{{componentName}}Props extends
   warning?: boolean;
 }
 
-export type I{{componentName}}ViewProps = I{{componentName}}Props &
-  {
-    // You can define view only props here.
-    /**
-    * Sample prop internal to component. These types of props aren't exposed
-    *   externally to consumers and their values are typically determined by component state.
-    */
-    status: string;
-  };
+export interface I{{componentName}}ViewProps extends I{{componentName}}Props {
+  // You can define view only props here.
+  /**
+  * Sample prop internal to component. These types of props aren't exposed
+  *   externally to consumers and their values are typically determined by component state.
+  */
+  status: string;
+}
 
 export interface I{{componentName}}Tokens {
   // Define tokens for your component here. Tokens are styling 'knobs' that your component will automatically

--- a/scripts/templates/create-component/slots/EmptyTypesStateless.mustache
+++ b/scripts/templates/create-component/slots/EmptyTypesStateless.mustache
@@ -4,6 +4,12 @@ import { IBaseProps } from '../../Utilities';
 
 export type I{{componentName}}Component = IComponent< I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles>;
 
+// These types are redundant with I{{componentName}}Component but are needed until TS function return widening issue is resolved:
+// https://github.com/Microsoft/TypeScript/issues/241
+// For now, these helper types can be used to provide return type safety for tokens and styles functions.
+export type I{{componentName}}TokenReturnType = ReturnType< Extract< I{{componentName}}Component['tokens'], Function>>;
+export type I{{componentName}}StylesReturnType = ReturnType< Extract< I{{componentName}}Component['styles'], Function>>;
+
 // Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
 export interface I{{componentName}} { }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Due to [TS widening the return type of functional declarations](https://github.com/Microsoft/TypeScript/issues/241), current foundation tokens and styles functions have no type checking on their return type. I've decided to add some return type helpers derived from the existing `IComponent` definitions to existing components and the create-component template.

I also fixed a bug where customizations were incorrectly applied to the example theme and scheme dropdowns.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7711)

