### PR TITLE
DetailsHeader: Refactor componentWillReceiveProps to getDerivedStateFromProps

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-detailsheader-derivedstate_2019-01-18-00-20.json
+++ b/common/changes/office-ui-fabric-react/keco-detailsheader-derivedstate_2019-01-18-00-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsHeader: Refactor deprecated componentWillReceiveProps to getDerivedStateFromProps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -69,15 +69,12 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
   public static getDerivedStateFromProps(newProps: IDetailsHeaderBaseProps, prevState: IDetailsHeaderState): IDetailsHeaderState {
     const columnReorderProps: IColumnReorderHeaderProps | undefined =
       newProps.columnReorderProps || (newProps.columnReorderOptions && getLegacyColumnReorderProps(newProps.columnReorderOptions));
+    const { groupNestingDepth } = newProps;
 
-    const newState: IDetailsHeaderState = { columnReorderProps };
+    const newState: IDetailsHeaderState = { columnReorderProps, groupNestingDepth };
 
     if (newProps.isAllCollapsed !== undefined) {
       newState.isAllCollapsed = newProps.isAllCollapsed;
-    }
-
-    if (newProps.groupNestingDepth !== prevState.groupNestingDepth) {
-      newState.groupNestingDepth = newProps.groupNestingDepth;
     }
 
     return newState;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -48,6 +48,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     selectAllVisibility: SelectAllVisibility.visible,
     collapseAllVisibility: CollapseAllVisibility.visible
   };
+
   private _classNames: IClassNames<IDetailsHeaderStyles>;
   private _rootElement: HTMLElement | undefined;
   private _rootComponent = React.createRef<IFocusZone>();
@@ -64,6 +65,24 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     sourceIndex: number;
     targetIndex: number;
   };
+
+  public static getDerivedStateFromProps(newProps: IDetailsHeaderBaseProps, prevState: IDetailsHeaderState): IDetailsHeaderState {
+    const columnReorderProps: IColumnReorderHeaderProps | undefined =
+      newProps.columnReorderProps || (newProps.columnReorderOptions && getLegacyColumnReorderProps(newProps.columnReorderOptions));
+
+    const newState: IDetailsHeaderState = { columnReorderProps };
+
+    if (newProps.isAllCollapsed !== undefined) {
+      newState.isAllCollapsed = newProps.isAllCollapsed;
+    }
+
+    if (newProps.groupNestingDepth !== prevState.groupNestingDepth) {
+      newState.groupNestingDepth = newProps.groupNestingDepth;
+    }
+
+    return newState;
+  }
+
   constructor(props: IDetailsHeaderBaseProps) {
     super(props);
     const columnReorderProps: IColumnReorderHeaderProps | undefined =
@@ -133,28 +152,6 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
           targetIndex: Number.MIN_SAFE_INTEGER
         };
       }
-    }
-  }
-
-  public componentWillReceiveProps(newProps: IDetailsHeaderBaseProps): void {
-    const columnReorderProps: IColumnReorderHeaderProps | undefined =
-      newProps.columnReorderProps || (newProps.columnReorderOptions && getLegacyColumnReorderProps(newProps.columnReorderOptions));
-
-    const { groupNestingDepth } = this.state;
-
-    if (newProps.groupNestingDepth !== groupNestingDepth) {
-      this.setState({
-        columnReorderProps,
-        groupNestingDepth: newProps.groupNestingDepth
-      });
-    } else {
-      this.setState({ columnReorderProps });
-    }
-
-    if (newProps.isAllCollapsed !== undefined) {
-      this.setState({
-        isAllCollapsed: newProps.isAllCollapsed
-      });
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

While investigating #7704, I realized this deprecated lifecycle method would be relatively straightforward to refactor to avoid a separate `React.StrictMode` "error".

```shell
componentWillReceiveProps: Please update the following components to use static getDerivedStateFromProps instead: **DetailsHeaderBase**, DetailsListBase, List
```

Reference: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#new-lifecycle-getderivedstatefromprops

#### Focus areas to test

Behaviors to test:

- `DetailsList` column re-ordering
- `DetailsHeader` column drag & drop
- Grouped `DetailsList` & group collapse

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7715)

