### PR TITLE
Add the lang tag to the Header item of a Menu Section

### DIFF
--- a/common/changes/office-ui-fabric-react/headerLangTag_2019-01-18-02-02.json
+++ b/common/changes/office-ui-fabric-react/headerLangTag_2019-01-18-02-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add lang tag to the section header by getting the native props",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "makopch@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -604,7 +604,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     const { itemProps } = item;
     const divHtmlProperties = itemProps && getNativeProps(itemProps, divProperties);
     return (
-      <div className={this._classNames.header} style={item.style} {...divHtmlProperties}>
+      <div className={this._classNames.header} {...divHtmlProperties} style={item.style}>
         <ChildrenRenderer
           item={item}
           classNames={classNames}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -602,9 +602,9 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   ): React.ReactNode {
     const { contextualMenuItemAs: ChildrenRenderer = ContextualMenuItem } = this.props;
     const { itemProps } = item;
-
+    const divHtmlProperties = itemProps && getNativeProps(itemProps, divProperties);
     return (
-      <div className={this._classNames.header} style={item.style} {...getNativeProps(item, divProperties)}>
+      <div className={this._classNames.header} style={item.style} {...divHtmlProperties}>
         <ChildrenRenderer
           item={item}
           classNames={classNames}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -10,6 +10,7 @@ import {
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
 import { IMenuItemClassNames, IContextualMenuClassNames } from './ContextualMenu.classNames';
+import { divProperties, getNativeProps } from '../../Utilities';
 
 import {
   assign,
@@ -603,7 +604,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     const { itemProps } = item;
 
     return (
-      <div className={this._classNames.header} style={item.style}>
+      <div className={this._classNames.header} style={item.style} {...getNativeProps(item, divProperties)}>
         <ChildrenRenderer
           item={item}
           classNames={classNames}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
@@ -15,6 +15,7 @@ import { ContextualMenuCustomizationWithNoWrapExample } from './examples/Context
 import { ContextualMenuWithScrollBarExample } from './examples/ContextualMenu.ScrollBar.Example';
 import { ContextualMenuWithCustomMenuItemExample } from './examples/ContextualMenu.CustomMenuItem.Example';
 import { ContextualMenuWithCustomMenuListExample } from './examples/ContextualMenu.CustomMenuList.Example';
+import { ContextualMenuHeaderExample } from './examples/ContextualMenu.Header.Example';
 
 const ContextualMenuBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx') as string;
 const ContextualMenuBasicExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/ContextualMenu/ContextualMenu.Basic.Example.Codepen.txt') as string;
@@ -29,6 +30,7 @@ const ContextualMenuCustomizationWithNoWrapExampleCode = require('!raw-loader!of
 const ContextualMenuWithScrollBarExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx') as string;
 const ContextualMenuWithCustomMenuItemExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx') as string;
 const ContextualMenuCustomMenuListExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx') as string;
+const ContextualMenuHeaderExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx') as string;
 
 export const ContextualMenuPageProps: IDocPageProps = {
   title: 'ContextualMenu',
@@ -97,6 +99,11 @@ export const ContextualMenuPageProps: IDocPageProps = {
       title: 'ContextualMenu with custom rendered menu list that renders a search box to filter menu items',
       code: ContextualMenuCustomMenuListExampleCode,
       view: <ContextualMenuWithCustomMenuListExample />
+    },
+    {
+      title: 'ContextualMenu with header',
+      code: ContextualMenuHeaderExampleCode,
+      view: <ContextualMenuHeaderExample />
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
 import './ContextualMenuExample.scss';
 
 export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
@@ -13,8 +14,11 @@ export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
           items: [
             {
               key: 'Actions',
-              itemType: 2,
-              text: 'Actions'
+              itemType: ContextualMenuItemType.Header,
+              text: 'Actions',
+              itemProps: {
+                lang: 'en-us'
+              }
             },
             {
               key: 'upload',
@@ -62,7 +66,7 @@ export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
             },
             {
               key: 'navigation',
-              itemType: 2,
+              itemType: ContextualMenuItemType.Header,
               text: 'Navigation'
             },
             {


### PR DESCRIPTION
#### Description of changes

This change allows div properties to be set on the the div element that gets added as part of the header item of a menu section.  For purposes of accessibility and having the contents read in the proper language we wanted this attribute to be able to be added.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7717)

