### PR TITLE
DocumentCard: added native properties to the root element

### DIFF
--- a/common/changes/office-ui-fabric-react/mariust-documentcard_2019-01-18-14-04.json
+++ b/common/changes/office-ui-fabric-react/mariust-documentcard_2019-01-18-14-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Added onMouseLeave, onMouseEnter and ariaLabel properties to the DocumentCard",
+      "comment": "DocumentCard: added native properties to the root element",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/mariust-documentcard_2019-01-18-14-04.json
+++ b/common/changes/office-ui-fabric-react/mariust-documentcard_2019-01-18-14-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added onMouseLeave, onMouseEnter and ariaLabel properties to the DocumentCard",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mariust@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7477,11 +7477,14 @@ interface IDocumentCardPreviewStyles {
 interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
   // @deprecated
   accentColor?: string;
+  ariaLabel?: string;
   children?: React.ReactNode;
   className?: string;
   componentRef?: IRefObject<IDocumentCard>;
   onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
   onClickHref?: string;
+  onMouseEnter?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
+  onMouseLeave?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
   role?: string;
   styles?: IStyleFunctionOrObject<IDocumentCardStyleProps, IDocumentCardStyles>;
   theme?: ITheme;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7474,17 +7474,14 @@ interface IDocumentCardPreviewStyles {
 }
 
 // @public (undocumented)
-interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
+interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTMLAttributes<HTMLElement> {
   // @deprecated
   accentColor?: string;
-  ariaLabel?: string;
   children?: React.ReactNode;
   className?: string;
   componentRef?: IRefObject<IDocumentCard>;
   onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
   onClickHref?: string;
-  onMouseEnter?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
-  onMouseLeave?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
   role?: string;
   styles?: IStyleFunctionOrObject<IDocumentCardStyleProps, IDocumentCardStyles>;
   theme?: ITheme;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7474,7 +7474,7 @@ interface IDocumentCardPreviewStyles {
 }
 
 // @public (undocumented)
-interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTMLAttributes<HTMLElement> {
+interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTMLAttributes<HTMLDivElement> {
   // @deprecated
   accentColor?: string;
   children?: React.ReactNode;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -23,7 +23,7 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
 
   public render(): JSX.Element {
     const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
-    const nativeProps = getNativeProps(this.props, divProperties, ['className', 'onClick', 'type']);
+    const nativeProps = getNativeProps(this.props, divProperties, ['className', 'onClick', 'type', 'role']);
     const actionable = onClick || onClickHref ? true : false;
 
     this._classNames = getClassNames(styles!, {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -23,7 +23,7 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
 
   public render(): JSX.Element {
     const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
-    const nativeProps = getNativeProps(this.props, divProperties, ['onClick']);
+    const nativeProps = getNativeProps(this.props, divProperties, ['onClick', 'type']);
     const actionable = onClick || onClickHref ? true : false;
 
     this._classNames = getClassNames(styles!, {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IProcessedStyleSet } from '../../Styling';
-import { BaseComponent, classNamesFunction, KeyCodes } from '../../Utilities';
+import { BaseComponent, classNamesFunction, KeyCodes, getNativeProps, divProperties } from '../../Utilities';
 import { DocumentCardType, IDocumentCard, IDocumentCardProps, IDocumentCardStyleProps, IDocumentCardStyles } from './DocumentCard.types';
 
 const getClassNames = classNamesFunction<IDocumentCardStyleProps, IDocumentCardStyles>();
@@ -22,19 +22,8 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
   }
 
   public render(): JSX.Element {
-    const {
-      onClick,
-      onClickHref,
-      children,
-      type,
-      accentColor,
-      styles,
-      theme,
-      className,
-      ariaLabel,
-      onMouseEnter,
-      onMouseLeave
-    } = this.props;
+    const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
+    const nativeProps = getNativeProps(this.props, divProperties, ['onClick']);
     const actionable = onClick || onClickHref ? true : false;
 
     this._classNames = getClassNames(styles!, {
@@ -65,10 +54,8 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
         className={this._classNames.root}
         onKeyDown={actionable ? this._onKeyDown : undefined}
         onClick={actionable ? this._onClick : undefined}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
         style={style}
-        aria-label={ariaLabel}
+        {...nativeProps}
       >
         {children}
       </div>

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -22,7 +22,19 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
   }
 
   public render(): JSX.Element {
-    const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
+    const {
+      onClick,
+      onClickHref,
+      children,
+      type,
+      accentColor,
+      styles,
+      theme,
+      className,
+      ariaLabel,
+      onMouseEnter,
+      onMouseLeave
+    } = this.props;
     const actionable = onClick || onClickHref ? true : false;
 
     this._classNames = getClassNames(styles!, {
@@ -53,7 +65,10 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
         className={this._classNames.root}
         onKeyDown={actionable ? this._onKeyDown : undefined}
         onClick={actionable ? this._onClick : undefined}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         style={style}
+        aria-label={ariaLabel}
       >
         {children}
       </div>

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -23,7 +23,7 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
 
   public render(): JSX.Element {
     const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
-    const nativeProps = getNativeProps(this.props, divProperties, ['onClick', 'type']);
+    const nativeProps = getNativeProps(this.props, divProperties, ['className', 'onClick', 'type']);
     const actionable = onClick || onClickHref ? true : false;
 
     this._classNames = getClassNames(styles!, {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -28,6 +28,16 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
   onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
 
   /**
+   * Function to call when the mouse starts hovering over the card.
+   */
+  onMouseEnter?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
+
+  /**
+   * Function to call when the mouse stops hovering over the card.
+   */
+  onMouseLeave?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
+
+  /**
    * A URL to navigate to when the card is clicked. If a function has also been provided,
    * it will be used instead of the URL.
    */
@@ -68,6 +78,11 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
    * Optional override class name
    */
   className?: string;
+
+  /**
+   * Optional aria label override
+   */
+  ariaLabel?: string;
 }
 
 export enum DocumentCardType {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -9,7 +9,7 @@ export interface IDocumentCard {
   focus: () => void;
 }
 
-export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTMLAttributes<HTMLElement> {
+export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTMLAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IDocumentCard interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -9,7 +9,7 @@ export interface IDocumentCard {
   focus: () => void;
 }
 
-export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
+export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTMLAttributes<HTMLElement> {
   /**
    * Optional callback to access the IDocumentCard interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -28,16 +28,6 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
   onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
 
   /**
-   * Function to call when the mouse starts hovering over the card.
-   */
-  onMouseEnter?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
-
-  /**
-   * Function to call when the mouse stops hovering over the card.
-   */
-  onMouseLeave?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
-
-  /**
    * A URL to navigate to when the card is clicked. If a function has also been provided,
    * it will be used instead of the URL.
    */
@@ -78,11 +68,6 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard> {
    * Optional override class name
    */
   className?: string;
-
-  /**
-   * Optional aria label override
-   */
-  ariaLabel?: string;
 }
 
 export enum DocumentCardType {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The DocumentCard was lacking the ability to override the aria label and listening to onMouseLeave and onMouseEnter events. This adds those and other native properties to the root element of the documentcard

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7721)

