### PR TITLE
ContextualMenu: Fix split button layout issues in IE11

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-contextual-menu-ie11_2019-01-18-20-07.json
+++ b/common/changes/office-ui-fabric-react/miwhea-contextual-menu-ie11_2019-01-18-20-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Fixes a layout bug with split menu items in IE11",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -148,7 +148,8 @@ export const getItemClassNames = memoizeFunction(
         styles.root,
         {
           flexBasis: '0',
-          padding: '0 8px'
+          padding: '0 8px',
+          minWidth: 28
         },
         expanded && ['is-expanded', styles.rootExpanded],
         disabled && ['is-disabled', styles.rootDisabled],
@@ -187,6 +188,9 @@ export const getItemClassNames = memoizeFunction(
       secondaryText: [classNames.secondaryText, styles.secondaryText],
       splitContainer: [
         styles.splitButtonFlexContainer,
+        {
+          alignItems: 'flex-start'
+        },
         !disabled &&
           !checked && [
             {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7699 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes a layout issue in IE11 where the ContextualMenu's split button was being sized incorrectly and the alignment of the divider was off.

#### Before
![image](https://user-images.githubusercontent.com/1382445/51410565-e31d6e80-1b19-11e9-8363-0325fa9cb3b3.png)

#### After
![image](https://user-images.githubusercontent.com/1382445/51410573-ea447c80-1b19-11e9-8726-16a7a18d3654.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7724)

