### PR TITLE
Use <button> element for Tile when there is no href

### DIFF
--- a/common/changes/@uifabric/experiments/tile-click_2019-01-21-15-42.json
+++ b/common/changes/@uifabric/experiments/tile-click_2019-01-21-15-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Use button element for Tile when there is no href",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -87,13 +87,18 @@
 }
 
 .link {
+  border: none;
+  background: transparent;
+
   @include focus-clear();
 
   position: absolute;
+  padding: 0;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
+  width: 100%;
   text-decoration: none;
   color: inherit;
   overflow: hidden;

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -158,6 +158,55 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     const isSelectable = !!selection && selectionIndex > -1;
     const isInvokable = (!!href || !!onClick || !!invokeSelection) && !isModal;
 
+    const content = (
+      <>
+        {ariaLabel ? (
+          <span key="label" id={this._labelId} className={css('ms-Tile-label', TileStylesModule.label)}>
+            {ariaLabel}
+          </span>
+        ) : null}
+        {background
+          ? this._onRenderBackground({
+              background: background,
+              hideBackground
+            })
+          : null}
+        {foreground
+          ? this._onRenderForeground({
+              foreground: foreground,
+              hideForeground
+            })
+          : null}
+        {itemName || itemActivity
+          ? this._onRenderNameplate({
+              name: itemName,
+              activity: itemActivity
+            })
+          : null}
+      </>
+    );
+
+    const link = href ? (
+      <a
+        href={href}
+        onClick={onClick}
+        ref={this.props.linkRef}
+        data-selection-invoke={isInvokable && selectionIndex > -1 ? true : undefined}
+        className={css('ms-Tile-link', TileStyles.link)}
+      >
+        {content}
+      </a>
+    ) : (
+      <button
+        onClick={onClick}
+        ref={this.props.linkRef}
+        data-selection-invoke={isInvokable && selectionIndex > -1 ? true : undefined}
+        className={css('ms-Tile-link', TileStyles.link)}
+      >
+        {content}
+      </button>
+    );
+
     return (
       <div
         aria-selected={isSelected}
@@ -184,39 +233,9 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         data-disable-click-on-enter={true}
         data-selection-index={selectionIndex > -1 ? selectionIndex : undefined}
       >
-        <a
-          href={href}
-          onClick={onClick}
-          ref={this.props.linkRef}
-          data-selection-invoke={isInvokable && selectionIndex > -1 ? true : undefined}
-          className={css('ms-Tile-link', TileStyles.link)}
-        >
-          {ariaLabel ? (
-            <span id={this._labelId} className={css('ms-Tile-label', TileStylesModule.label)}>
-              {ariaLabel}
-            </span>
-          ) : null}
-          {background
-            ? this._onRenderBackground({
-                background: background,
-                hideBackground
-              })
-            : null}
-          {foreground
-            ? this._onRenderForeground({
-                foreground: foreground,
-                hideForeground
-              })
-            : null}
-          {itemName || itemActivity
-            ? this._onRenderNameplate({
-                name: itemName,
-                activity: itemActivity
-              })
-            : null}
-        </a>
+        {link}
         {descriptionAriaLabel ? (
-          <span id={this._descriptionId} className={css('ms-Tile-description', TileStylesModule.description)}>
+          <span key="description" id={this._descriptionId} className={css('ms-Tile-description', TileStylesModule.description)}>
             {descriptionAriaLabel}
           </span>
         ) : null}
@@ -238,6 +257,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
   }): JSX.Element {
     return (
       <span
+        key="background"
         className={css('ms-Tile-background', TileStyles.background, {
           [`ms-Tile-background--hide ${TileStyles.backgroundHide}`]: hideBackground
         })}
@@ -255,7 +275,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     hideForeground: boolean;
   }): JSX.Element {
     return (
-      <span role="presentation" className={css('ms-Tile-aboveNameplate', TileStyles.aboveNameplate)}>
+      <span key="foreground" role="presentation" className={css('ms-Tile-aboveNameplate', TileStyles.aboveNameplate)}>
         <span role="presentation" className={css('ms-Tile-content', TileStyles.content)}>
           <span
             role="presentation"
@@ -278,7 +298,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     activity: React.ReactNode | React.ReactNode[];
   }): JSX.Element {
     return (
-      <span className={css('ms-Tile-nameplate', TileStyles.nameplate)}>
+      <span key="nameplate" className={css('ms-Tile-nameplate', TileStyles.nameplate)}>
         {name ? (
           <span id={this._nameId} className={css('ms-Tile-name', TileStyles.name)}>
             {name}
@@ -298,6 +318,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
 
     return (
       <span
+        key="check"
         role="checkbox"
         aria-label={toggleSelectionAriaLabel}
         className={css('ms-Tile-check', TileStyles.check, CheckStyles.checkHost, {

--- a/packages/experiments/src/components/Tile/Tile.types.ts
+++ b/packages/experiments/src/components/Tile/Tile.types.ts
@@ -130,5 +130,5 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    * @type {() => void}
    * @memberof ITileProps
    */
-  linkRef?: (element: HTMLAnchorElement) => void;
+  linkRef?: (element: HTMLAnchorElement | HTMLButtonElement | null) => void;
 }


### PR DESCRIPTION
This change fixes an issue with the `<Tile>` component, where the use of an `href="#"` attribute could cause problems in some host applications. Use of `href="#"` should be avoided in shared components, but since that is the only way to make an `<a>` element focusable, `<Tile>` should really use a `<button>` element when there is no need for hash-navigation.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7736)

