### PR TITLE
Ensure that DetailsHeader disposes DragDropHelper to prevent memory leaks

### DIFF
--- a/common/changes/office-ui-fabric-react/drag-drop-leak_2019-01-21-18-32.json
+++ b/common/changes/office-ui-fabric-react/drag-drop-leak_2019-01-21-18-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dispose DragDropHelper in DetailsHeader to prevent memory leaks",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -157,6 +157,10 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
       this._subscriptionObject.dispose();
       delete this._subscriptionObject;
     }
+
+    if (this._dragDropHelper) {
+      this._dragDropHelper.dispose();
+    }
   }
 
   public render(): JSX.Element {
@@ -179,6 +183,8 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     const isCheckboxHidden = selectAllVisibility === SelectAllVisibility.hidden;
 
     if (!this._dragDropHelper && columnReorderProps) {
+      // TODO Do not assign local fields during render.
+      // This behavior needs to be moved to the appropriate React lifecycle methods.
       this._dragDropHelper = new DragDropHelper({
         selection: {
           getSelection: () => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -162,6 +162,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
 
   public componentWillUnmount(): void {
     if (this._dragDropHelper) {
+      // TODO If the DragDropHelper was passed via props, this will dispose it, which is incorrect behavior.
       this._dragDropHelper.dispose();
     }
   }


### PR DESCRIPTION
Fixes two issues:
1. `DetailsHeaderBase` was creating `DragDropHelper` in the `render()` function, which violates the React lifetime model.
2. `DetailsHeaderBase` was not disposing the `DragDropHelper` instances, leaving document-level event listeners around and leaking captured objects in memory.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7738)

