### PR TITLE
Added a simpler DocumentCardImage component

### DIFF
--- a/common/changes/office-ui-fabric-react/mariust-documentcardimage_2019-01-22-10-53.json
+++ b/common/changes/office-ui-fabric-react/mariust-documentcardimage_2019-01-22-10-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added a simpler DocumentCardImage component for use in the DocumentCard component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mariust@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7361,6 +7361,45 @@ interface IDocumentCardDetailsStyles {
 }
 
 // @public (undocumented)
+interface IDocumentCardImage {
+}
+
+// @public (undocumented)
+interface IDocumentCardImageProps extends IBaseProps<{}> {
+  className?: string;
+  componentRef?: IRefObject<IDocumentCardImage>;
+  height?: number;
+  iconProps?: IIconProps;
+  imageFit?: ImageFit;
+  imageSrc?: string;
+  styles?: IStyleFunctionOrObject<IDocumentCardImageStyleProps, IDocumentCardImageStyles>;
+  theme?: ITheme;
+  width?: number;
+}
+
+// @public (undocumented)
+interface IDocumentCardImageStyleProps {
+  centeredIconSize: string | number;
+  className?: string;
+  cornerIconSize: string | number;
+  height?: number;
+  theme: ITheme;
+  width?: number;
+}
+
+// @public (undocumented)
+interface IDocumentCardImageStyles {
+  // (undocumented)
+  centeredIcon: IStyle;
+  // (undocumented)
+  centeredIconWrapper: IStyle;
+  // (undocumented)
+  cornerIcon: IStyle;
+  // (undocumented)
+  root: IStyle;
+}
+
+// @public (undocumented)
 interface IDocumentCardLocation {
 }
 
@@ -12721,6 +12760,7 @@ module ZIndexes {
 // WARNING: Unsupported export: DocumentCardDetails
 // WARNING: Unsupported export: DocumentCardLocation
 // WARNING: Unsupported export: DocumentCardPreview
+// WARNING: Unsupported export: DocumentCardImage
 // WARNING: Unsupported export: DocumentCardTitle
 // WARNING: Unsupported export: DocumentCardLogo
 // WARNING: Unsupported export: DocumentCardStatus

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7378,13 +7378,7 @@ interface IDocumentCardImageProps extends IBaseProps<{}> {
 }
 
 // @public (undocumented)
-interface IDocumentCardImageStyleProps {
-  centeredIconSize: string | number;
-  className?: string;
-  cornerIconSize: string | number;
-  height?: number;
-  theme: ITheme;
-  width?: number;
+interface IDocumentCardImageStyleProps extends IDocumentCardImageProps {
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.base.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Icon } from '../../Icon';
+import { Image } from '../../Image';
+import { IProcessedStyleSet } from '../../Styling';
+import { BaseComponent, classNamesFunction, css } from '../../Utilities';
+import { IDocumentCardImageProps, IDocumentCardImageStyleProps, IDocumentCardImageStyles } from './DocumentCardImage.types';
+
+export interface IDocumentCardImageState {
+  readonly imageHasLoaded: boolean;
+}
+
+const getClassNames = classNamesFunction<IDocumentCardImageStyleProps, IDocumentCardImageStyles>();
+
+const defaultCenteredIconSize = '42px';
+const cornerIconSize = '32px';
+
+export class DocumentCardImageBase extends BaseComponent<IDocumentCardImageProps, IDocumentCardImageState> {
+  private _classNames: IProcessedStyleSet<IDocumentCardImageStyles>;
+  private _centeredIconSize: string | number;
+
+  constructor(props: IDocumentCardImageProps) {
+    super(props);
+    this.state = { imageHasLoaded: false };
+  }
+
+  public render(): JSX.Element {
+    const { styles, theme, className, width, height, imageFit, imageSrc, iconProps } = this.props;
+
+    this._centeredIconSize = (iconProps && iconProps.style && iconProps.style.fontSize) || defaultCenteredIconSize;
+    this._classNames = getClassNames(styles!, {
+      theme: theme!,
+      className,
+      height,
+      width,
+      cornerIconSize,
+      centeredIconSize: this._centeredIconSize
+    });
+
+    return (
+      <div className={this._classNames.root}>
+        {imageSrc && (
+          <Image width={width} height={height} imageFit={imageFit} src={imageSrc} role="presentation" alt="" onLoad={this._onImageLoad} />
+        )}
+        {this.state.imageHasLoaded ? this._renderCornerIcon() : this._renderCenterIcon()}
+      </div>
+    );
+  }
+
+  private _onImageLoad = () => {
+    this.setState({ imageHasLoaded: true });
+  };
+
+  private _renderCenterIcon(): JSX.Element {
+    const { iconProps } = this.props;
+
+    return (
+      <div className={css(this._classNames.centeredIconWrapper)}>
+        <Icon style={{ fontSize: this._centeredIconSize }} className={css(this._classNames.centeredIcon)} {...iconProps} />
+      </div>
+    );
+  }
+
+  private _renderCornerIcon(): JSX.Element {
+    const { iconProps } = this.props;
+    return <Icon style={{ fontSize: cornerIconSize }} className={css(this._classNames.cornerIcon)} {...iconProps} />;
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Icon } from '../../Icon';
 import { Image } from '../../Image';
 import { IProcessedStyleSet } from '../../Styling';
-import { BaseComponent, classNamesFunction, css } from '../../Utilities';
+import { BaseComponent, classNamesFunction } from '../../Utilities';
 import { IDocumentCardImageProps, IDocumentCardImageStyleProps, IDocumentCardImageStyles } from './DocumentCardImage.types';
 
 export interface IDocumentCardImageState {
@@ -11,12 +11,8 @@ export interface IDocumentCardImageState {
 
 const getClassNames = classNamesFunction<IDocumentCardImageStyleProps, IDocumentCardImageStyles>();
 
-const defaultCenteredIconSize = '42px';
-const cornerIconSize = '32px';
-
 export class DocumentCardImageBase extends BaseComponent<IDocumentCardImageProps, IDocumentCardImageState> {
   private _classNames: IProcessedStyleSet<IDocumentCardImageStyles>;
-  private _centeredIconSize: string | number;
 
   constructor(props: IDocumentCardImageProps) {
     super(props);
@@ -24,17 +20,9 @@ export class DocumentCardImageBase extends BaseComponent<IDocumentCardImageProps
   }
 
   public render(): JSX.Element {
-    const { styles, theme, className, width, height, imageFit, imageSrc, iconProps } = this.props;
+    const { styles, width, height, imageFit, imageSrc } = this.props;
 
-    this._centeredIconSize = (iconProps && iconProps.style && iconProps.style.fontSize) || defaultCenteredIconSize;
-    this._classNames = getClassNames(styles!, {
-      theme: theme!,
-      className,
-      height,
-      width,
-      cornerIconSize,
-      centeredIconSize: this._centeredIconSize
-    });
+    this._classNames = getClassNames(styles!, this.props);
 
     return (
       <div className={this._classNames.root}>
@@ -52,16 +40,15 @@ export class DocumentCardImageBase extends BaseComponent<IDocumentCardImageProps
 
   private _renderCenterIcon(): JSX.Element {
     const { iconProps } = this.props;
-
     return (
-      <div className={css(this._classNames.centeredIconWrapper)}>
-        <Icon style={{ fontSize: this._centeredIconSize }} className={css(this._classNames.centeredIcon)} {...iconProps} />
+      <div className={this._classNames.centeredIconWrapper}>
+        <Icon className={this._classNames.centeredIcon} {...iconProps} />
       </div>
     );
   }
 
   private _renderCornerIcon(): JSX.Element {
     const { iconProps } = this.props;
-    return <Icon style={{ fontSize: cornerIconSize }} className={css(this._classNames.cornerIcon)} {...iconProps} />;
+    return <Icon className={this._classNames.cornerIcon} {...iconProps} />;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.styles.ts
@@ -1,23 +1,14 @@
-import { getGlobalClassNames } from '../../Styling';
 import { IDocumentCardImageStyleProps, IDocumentCardImageStyles } from './DocumentCardImage.types';
 
-export const GlobalClassNames = {
-  root: 'ms-DocumentCardImage',
-  icon: 'ms-DocumentCardImage-icon',
-  centeredIcon: 'ms-DocumentCardImage-centeredIcon',
-  centeredIconContainer: 'ms-DocumentCardImage-centeredIconContainer',
-  cornerIcon: 'ms-DocumentCardImage-cornerIcon'
-};
+const centeredIconSize = '42px';
+const cornerIconSize = '32px';
 
 export const getStyles = (props: IDocumentCardImageStyleProps): IDocumentCardImageStyles => {
-  const { theme, className, height, width, cornerIconSize, centeredIconSize } = props;
-  const { palette } = theme;
-
-  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const { theme, className, height, width } = props;
+  const { palette } = theme!;
 
   return {
     root: [
-      classNames.root,
       {
         borderBottom: `1px solid ${palette.neutralLight}`,
         position: 'relative',
@@ -29,14 +20,13 @@ export const getStyles = (props: IDocumentCardImageStyleProps): IDocumentCardIma
       className
     ],
     centeredIcon: [
-      classNames.centeredIcon,
       {
         height: centeredIconSize,
-        width: centeredIconSize
+        width: centeredIconSize,
+        fontSize: centeredIconSize
       }
     ],
     centeredIconWrapper: [
-      classNames.centeredIconContainer,
       {
         display: 'flex',
         alignItems: 'center',
@@ -49,12 +39,12 @@ export const getStyles = (props: IDocumentCardImageStyleProps): IDocumentCardIma
       }
     ],
     cornerIcon: [
-      classNames.cornerIcon,
       {
         left: '10px',
         bottom: '10px',
         height: cornerIconSize,
         width: cornerIconSize,
+        fontSize: cornerIconSize,
         position: 'absolute',
         overflow: 'visible'
       }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.styles.ts
@@ -1,0 +1,63 @@
+import { getGlobalClassNames } from '../../Styling';
+import { IDocumentCardImageStyleProps, IDocumentCardImageStyles } from './DocumentCardImage.types';
+
+export const GlobalClassNames = {
+  root: 'ms-DocumentCardImage',
+  icon: 'ms-DocumentCardImage-icon',
+  centeredIcon: 'ms-DocumentCardImage-centeredIcon',
+  centeredIconContainer: 'ms-DocumentCardImage-centeredIconContainer',
+  cornerIcon: 'ms-DocumentCardImage-cornerIcon'
+};
+
+export const getStyles = (props: IDocumentCardImageStyleProps): IDocumentCardImageStyles => {
+  const { theme, className, height, width, cornerIconSize, centeredIconSize } = props;
+  const { palette } = theme;
+
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  return {
+    root: [
+      classNames.root,
+      {
+        borderBottom: `1px solid ${palette.neutralLight}`,
+        position: 'relative',
+        backgroundColor: palette.neutralLighterAlt,
+        overflow: `hidden`,
+        height: height && `${height}px`,
+        width: width && `${width}px`
+      },
+      className
+    ],
+    centeredIcon: [
+      classNames.centeredIcon,
+      {
+        height: centeredIconSize,
+        width: centeredIconSize
+      }
+    ],
+    centeredIconWrapper: [
+      classNames.centeredIconContainer,
+      {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        width: '100%',
+        position: 'absolute',
+        top: 0,
+        left: 0
+      }
+    ],
+    cornerIcon: [
+      classNames.cornerIcon,
+      {
+        left: '10px',
+        bottom: '10px',
+        height: cornerIconSize,
+        width: cornerIconSize,
+        position: 'absolute',
+        overflow: 'visible'
+      }
+    ]
+  };
+};

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+import { ImageFit } from '../Image';
+import { DocumentCardImage } from './DocumentCardImage';
+import { TestImages } from 'office-ui-fabric-react/lib/common/TestImages';
+
+describe('DocumentCard', () => {
+  it('renders DocumentCardImage correctly without an image provided', () => {
+    const component = renderer.create(
+      <DocumentCardImage
+        height={150}
+        iconProps={{
+          iconName: 'OneNoteLogo',
+          styles: { root: { color: '#813a7c', fontSize: '120px', width: '120px', height: '120px' } }
+        }}
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders DocumentCardImage correctly with an invalid image', () => {
+    const component = renderer.create(
+      <DocumentCardImage
+        height={150}
+        imageSrc={'someinvalidurl'}
+        iconProps={{
+          iconName: 'OneNoteLogo',
+          styles: { root: { color: '#813a7c', fontSize: '120px', width: '120px', height: '120px' } }
+        }}
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders DocumentCardImage correctly with a valid image', () => {
+    const component = renderer.create(
+      <DocumentCardImage
+        height={100}
+        imageFit={ImageFit.cover}
+        iconProps={{ iconName: 'OneNoteLogo', styles: { root: { color: '#813a7c' } } }}
+        imageSrc={TestImages.documentPreviewTwo}
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders DocumentCardImage correctly without an image or icon', () => {
+    const component = renderer.create(<DocumentCardImage height={100} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
-import { ImageFit } from '../Image';
+import { ImageFit } from '../Image/Image.types';
 import { DocumentCardImage } from './DocumentCardImage';
 import { TestImages } from 'office-ui-fabric-react/lib/common/TestImages';
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.ts
@@ -1,0 +1,11 @@
+import { styled } from '../../Utilities';
+import { DocumentCardImageBase } from './DocumentCardImage.base';
+import { getStyles } from './DocumentCardImage.styles';
+import { IDocumentCardImageProps, IDocumentCardImageStyleProps, IDocumentCardImageStyles } from './DocumentCardImage.types';
+
+export const DocumentCardImage = styled<IDocumentCardImageProps, IDocumentCardImageStyleProps, IDocumentCardImageStyles>(
+  DocumentCardImageBase,
+  getStyles,
+  undefined,
+  { scope: 'DocumentCardImage' }
+);

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.types.ts
@@ -1,0 +1,93 @@
+import { IIconProps } from '../../Icon';
+import { ImageFit } from '../../Image';
+import { IStyle, ITheme } from '../../Styling';
+import { IBaseProps, IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+
+export interface IDocumentCardImage {}
+
+export interface IDocumentCardImageProps extends IBaseProps<{}> {
+  /**
+   * Gets the component ref.
+   */
+  componentRef?: IRefObject<IDocumentCardImage>;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules
+   */
+  styles?: IStyleFunctionOrObject<IDocumentCardImageStyleProps, IDocumentCardImageStyles>;
+
+  /**
+   * Theme provided by HOC.
+   */
+  theme?: ITheme;
+
+  /**
+   * Optional override class name
+   */
+  className?: string;
+
+  /**
+   * Path to the preview image.
+   */
+  imageSrc?: string;
+
+  /**
+   * The props for the icon associated with this document type.
+   */
+  iconProps?: IIconProps;
+
+  /**
+   * If provided, forces the preview image to be this width.
+   */
+  width?: number;
+
+  /**
+   * If provided, forces the preview image to be this height.
+   */
+  height?: number;
+
+  /**
+   * Used to determine how to size the image to fit the dimensions of the component.
+   * If both dimensions are provided, then the image is fit using ImageFit.scale, otherwise ImageFit.none is used.
+   */
+  imageFit?: ImageFit;
+}
+
+export interface IDocumentCardImageStyleProps {
+  /**
+   * Accept theme prop.
+   */
+  theme: ITheme;
+
+  /**
+   * The size of the corner icon if rendered
+   */
+  cornerIconSize: string | number;
+
+  /**
+   * The size of the centered icon if rendered
+   */
+  centeredIconSize: string | number;
+
+  /**
+   * Optional override class name
+   */
+  className?: string;
+
+  /**
+   * Optional height override
+   */
+  height?: number;
+
+  /**
+   * Optional width override
+   */
+  width?: number;
+}
+
+export interface IDocumentCardImageStyles {
+  root: IStyle;
+  cornerIcon: IStyle;
+  centeredIcon: IStyle;
+  centeredIconWrapper: IStyle;
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.types.ts
@@ -53,37 +53,7 @@ export interface IDocumentCardImageProps extends IBaseProps<{}> {
   imageFit?: ImageFit;
 }
 
-export interface IDocumentCardImageStyleProps {
-  /**
-   * Accept theme prop.
-   */
-  theme: ITheme;
-
-  /**
-   * The size of the corner icon if rendered
-   */
-  cornerIconSize: string | number;
-
-  /**
-   * The size of the centered icon if rendered
-   */
-  centeredIconSize: string | number;
-
-  /**
-   * Optional override class name
-   */
-  className?: string;
-
-  /**
-   * Optional height override
-   */
-  height?: number;
-
-  /**
-   * Optional width override
-   */
-  width?: number;
-}
+export interface IDocumentCardImageStyleProps extends IDocumentCardImageProps {}
 
 export interface IDocumentCardImageStyles {
   root: IStyle;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCardImage.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCardImage.test.tsx.snap
@@ -1,0 +1,275 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocumentCard renders DocumentCardImage correctly with a valid image 1`] = `
+<div
+  className=
+
+      {
+        background-color: #f8f8f8;
+        border-bottom: 1px solid #eaeaea;
+        height: 100px;
+        overflow: hidden;
+        position: relative;
+      }
+>
+  <div
+    className=
+        ms-Image
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          overflow: hidden;
+          position: relative;
+        }
+    style={
+      Object {
+        "height": 100,
+        "width": undefined,
+      }
+    }
+  >
+    <img
+      alt=""
+      className=
+          ms-Image-image
+          ms-Image-image--cover
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: auto;
+            left: 50% /* @noflip */;
+            opacity: 0;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%,-50%);
+            width: 100%;
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      role="presentation"
+      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview2.png"
+    />
+  </div>
+  <div
+    className=
+
+        {
+          align-items: center;
+          display: flex;
+          height: 100%;
+          justify-content: center;
+          left: 0px;
+          position: absolute;
+          top: 0px;
+          width: 100%;
+        }
+  >
+    <i
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #813a7c;
+            display: inline-block;
+            font-family: "FabricMDL2Icons-9";
+            font-size: 42px;
+            font-style: normal;
+            font-weight: normal;
+            height: 42px;
+            speak: none;
+            width: 42px;
+          }
+      data-icon-name="OneNoteLogo"
+      role="presentation"
+    >
+      
+    </i>
+  </div>
+</div>
+`;
+
+exports[`DocumentCard renders DocumentCardImage correctly with an invalid image 1`] = `
+<div
+  className=
+
+      {
+        background-color: #f8f8f8;
+        border-bottom: 1px solid #eaeaea;
+        height: 150px;
+        overflow: hidden;
+        position: relative;
+      }
+>
+  <div
+    className=
+        ms-Image
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          overflow: hidden;
+        }
+    style={
+      Object {
+        "height": 150,
+        "width": undefined,
+      }
+    }
+  >
+    <img
+      alt=""
+      className=
+          ms-Image-image
+          ms-Image-image--portrait
+          is-notLoaded
+          is-fadeIn
+          {
+            display: block;
+            height: 100%;
+            opacity: 0;
+            width: auto;
+          }
+      onError={[Function]}
+      onLoad={[Function]}
+      role="presentation"
+      src="someinvalidurl"
+    />
+  </div>
+  <div
+    className=
+
+        {
+          align-items: center;
+          display: flex;
+          height: 100%;
+          justify-content: center;
+          left: 0px;
+          position: absolute;
+          top: 0px;
+          width: 100%;
+        }
+  >
+    <i
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #813a7c;
+            display: inline-block;
+            font-family: "FabricMDL2Icons-9";
+            font-size: 120px;
+            font-style: normal;
+            font-weight: normal;
+            height: 120px;
+            speak: none;
+            width: 120px;
+          }
+      data-icon-name="OneNoteLogo"
+      role="presentation"
+    >
+      
+    </i>
+  </div>
+</div>
+`;
+
+exports[`DocumentCard renders DocumentCardImage correctly without an image or icon 1`] = `
+<div
+  className=
+
+      {
+        background-color: #f8f8f8;
+        border-bottom: 1px solid #eaeaea;
+        height: 100px;
+        overflow: hidden;
+        position: relative;
+      }
+>
+  <div
+    className=
+
+        {
+          align-items: center;
+          display: flex;
+          height: 100%;
+          justify-content: center;
+          left: 0px;
+          position: absolute;
+          top: 0px;
+          width: 100%;
+        }
+  >
+    <i
+      className=
+
+          {
+            display: inline-block;
+            font-size: 42px;
+            height: 42px;
+            width: 42px;
+          }
+      role="presentation"
+    />
+  </div>
+</div>
+`;
+
+exports[`DocumentCard renders DocumentCardImage correctly without an image provided 1`] = `
+<div
+  className=
+
+      {
+        background-color: #f8f8f8;
+        border-bottom: 1px solid #eaeaea;
+        height: 150px;
+        overflow: hidden;
+        position: relative;
+      }
+>
+  <div
+    className=
+
+        {
+          align-items: center;
+          display: flex;
+          height: 100%;
+          justify-content: center;
+          left: 0px;
+          position: absolute;
+          top: 0px;
+          width: 100%;
+        }
+  >
+    <i
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #813a7c;
+            display: inline-block;
+            font-family: "FabricMDL2Icons-9";
+            font-size: 120px;
+            font-style: normal;
+            font-weight: normal;
+            height: 120px;
+            speak: none;
+            width: 120px;
+          }
+      data-icon-name="OneNoteLogo"
+      role="presentation"
+    >
+      
+    </i>
+  </div>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -249,6 +249,24 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
             ]}
           />
         </DocumentCard>
+        <p />
+        <DocumentCard onClickHref="http://bing.com">
+          <DocumentCardImage
+            height={150}
+            imageFit={ImageFit.cover}
+            iconProps={{
+              iconName: 'OneNoteLogo',
+              styles: { root: { color: '#813a7c', fontSize: '120px', width: '120px', height: '120px' } }
+            }}
+          />
+          <DocumentCardDetails>
+            <DocumentCardTitle title="How to make good design without an image" shouldTruncate={true} />
+          </DocumentCardDetails>
+          <DocumentCardActivity
+            activity="Modified January 1, 2019"
+            people={[{ name: 'Roko Kolar', profileImageSrc: '', initials: 'JH' }]}
+          />
+        </DocumentCard>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -4,6 +4,7 @@ import {
   DocumentCardActions,
   DocumentCardActivity,
   DocumentCardDetails,
+  DocumentCardImage,
   DocumentCardLocation,
   DocumentCardPreview,
   DocumentCardTitle,
@@ -228,6 +229,25 @@ export class DocumentCardCompleteExample extends React.Component<any, any> {
               people={[{ name: 'Kat Larrson', profileImageSrc: TestImages.personaFemale }]}
             />
           </DocumentCardDetails>
+        </DocumentCard>
+        <p />
+        <DocumentCard onClickHref="http://bing.com">
+          <DocumentCardImage
+            height={100}
+            imageFit={ImageFit.cover}
+            iconProps={{ iconName: 'OneNoteLogo', styles: { root: { color: '#813a7c' } } }}
+            imageSrc={TestImages.documentPreviewTwo}
+          />
+          <DocumentCardDetails>
+            <DocumentCardTitle title="How to make good design" shouldTruncate={true} />
+          </DocumentCardDetails>
+          <DocumentCardActivity
+            activity="Modified March 13, 2018"
+            people={[
+              { name: 'Annie Lindqvist', profileImageSrc: TestImages.personaFemale },
+              { name: 'Roko Kolar', profileImageSrc: '', initials: 'JH' }
+            ]}
+          />
         </DocumentCard>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/index.ts
@@ -10,6 +10,8 @@ export * from './DocumentCardLocation';
 export * from './DocumentCardLocation.types';
 export * from './DocumentCardPreview';
 export * from './DocumentCardPreview.types';
+export * from './DocumentCardImage';
+export * from './DocumentCardImage.types';
 export * from './DocumentCardTitle';
 export * from './DocumentCardTitle.types';
 export * from './DocumentCardLogo';

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -2558,5 +2558,424 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       </div>
     </div>
   </div>
+  <p />
+  <div
+    className=
+        ms-DocumentCard
+        ms-DocumentCard--actionable
+        {
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border: 1px solid #eaeaea;
+          box-sizing: border-box;
+          max-width: 320px;
+          min-width: 206px;
+          position: relative;
+          user-select: none;
+        }
+        & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
+          padding-top: 4px;
+        }
+        &:hover {
+          border-color: #c8c8c8;
+          cursor: pointer;
+        }
+        &:hover:after {
+          border: 1px solid #c8c8c8;
+          bottom: 0px;
+          content: " ";
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="link"
+    tabIndex={0}
+  >
+    <div
+      className=
+          ms-DocumentCardImage
+          {
+            background-color: #f8f8f8;
+            border-bottom: 1px solid #eaeaea;
+            height: 100px;
+            overflow: hidden;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-Image
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              overflow: hidden;
+              position: relative;
+            }
+        style={
+          Object {
+            "height": 100,
+            "width": undefined,
+          }
+        }
+      >
+        <img
+          alt=""
+          className=
+              ms-Image-image
+              ms-Image-image--cover
+              ms-Image-image--portrait
+              is-notLoaded
+              is-fadeIn
+              {
+                display: block;
+                height: auto;
+                left: 50% /* @noflip */;
+                opacity: 0;
+                position: absolute;
+                top: 50%;
+                transform: translate(-50%,-50%);
+                width: 100%;
+              }
+          onError={[Function]}
+          onLoad={[Function]}
+          role="presentation"
+          src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/document-preview2.png"
+        />
+      </div>
+      <div
+        className=
+            ms-DocumentCardImage-centeredIconContainer
+            {
+              align-items: center;
+              display: flex;
+              height: 100%;
+              justify-content: center;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+      >
+        <i
+          className=
+              ms-DocumentCardImage-centeredIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #813a7c;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-9";
+                font-style: normal;
+                font-weight: normal;
+                height: 42px;
+                speak: none;
+                width: 42px;
+              }
+          data-icon-name="OneNoteLogo"
+          role="presentation"
+          style={
+            Object {
+              "fontSize": "42px",
+            }
+          }
+        >
+          
+        </i>
+      </div>
+    </div>
+    <div
+      className=
+          ms-DocumentCardDetails
+          {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            justify-content: space-between;
+            overflow: hidden;
+          }
+    >
+      <div
+        className=
+            ms-DocumentCardTitle
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 17px;
+              font-weight: 300;
+              height: 38px;
+              line-height: 21px;
+              overflow: hidden;
+              padding-bottom: 8px;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 8px;
+              word-wrap: break-word;
+            }
+        title="How to make good design"
+      >
+        How to make good design
+      </div>
+    </div>
+    <div
+      className=
+          ms-DocumentCardActivity
+          ms-DocumentCardActivity--multiplePeople
+          {
+            padding-bottom: 8px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 8px;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-DocumentCardActivity-avatars
+            {
+              height: 32px;
+              margin-left: -2px;
+            }
+      >
+        <div
+          className=
+              ms-DocumentCardActivity-avatar
+              {
+                display: inline-block;
+                height: 32px;
+                position: relative;
+                text-align: center;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:after {
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -1px;
+                content: " ";
+                left: -1px;
+                position: absolute;
+                right: -1px;
+                top: -1px;
+              }
+              &:nth-of-type(2) {
+                margin-left: -16px;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+            size={11}
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
+            >
+              <div
+                aria-hidden="true"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
+              >
+                <span>
+                  JH
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className=
+              ms-DocumentCardActivity-avatar
+              {
+                display: inline-block;
+                height: 32px;
+                position: relative;
+                text-align: center;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:after {
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -1px;
+                content: " ";
+                left: -1px;
+                position: absolute;
+                right: -1px;
+                top: -1px;
+              }
+              &:nth-of-type(2) {
+                margin-left: -16px;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+            size={11}
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
+            >
+              <div
+                className=
+                    ms-Image
+                    ms-Persona-image
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-radius: 50%;
+                      border: 0px;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      left: 0px;
+                      margin-right: 10px;
+                      overflow: hidden;
+                      perspective: 1px;
+                      position: absolute;
+                      top: 0px;
+                      width: 32px;
+                    }
+                style={
+                  Object {
+                    "height": 32,
+                    "width": 32,
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className=
+                      ms-Image-image
+                      ms-Image-image--cover
+                      ms-Image-image--portrait
+                      is-notLoaded
+                      is-fadeIn
+                      {
+                        display: block;
+                        height: auto;
+                        left: 50% /* @noflip */;
+                        opacity: 0;
+                        position: absolute;
+                        top: 50%;
+                        transform: translate(-50%,-50%);
+                        width: 100%;
+                      }
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className=
+            ms-DocumentCardActivity-details
+            {
+              height: 32px;
+              left: 72px;
+              position: absolute;
+              top: 8px;
+              width: calc(100% - 72px);
+            }
+      >
+        <span
+          className=
+              ms-DocumentCardActivity-name
+              {
+                color: #333333;
+                display: block;
+                font-size: 12px;
+                font-weight: 600;
+                height: 15px;
+                line-height: 15px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+        >
+          Annie Lindqvist +1
+        </span>
+        <span
+          className=
+              ms-DocumentCardActivity-activity
+              {
+                color: #666666;
+                display: block;
+                font-size: 12px;
+                height: 15px;
+                line-height: 15px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+        >
+          Modified March 13, 2018
+        </span>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -2598,7 +2598,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
   >
     <div
       className=
-          ms-DocumentCardImage
+
           {
             background-color: #f8f8f8;
             border-bottom: 1px solid #eaeaea;
@@ -2652,7 +2652,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       </div>
       <div
         className=
-            ms-DocumentCardImage-centeredIconContainer
+
             {
               align-items: center;
               display: flex;
@@ -2666,13 +2666,14 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       >
         <i
           className=
-              ms-DocumentCardImage-centeredIcon
+
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 color: #813a7c;
                 display: inline-block;
                 font-family: "FabricMDL2Icons-9";
+                font-size: 42px;
                 font-style: normal;
                 font-weight: normal;
                 height: 42px;
@@ -2681,11 +2682,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               }
           data-icon-name="OneNoteLogo"
           role="presentation"
-          style={
-            Object {
-              "fontSize": "42px",
-            }
-          }
         >
           
         </i>
@@ -2973,6 +2969,270 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               }
         >
           Modified March 13, 2018
+        </span>
+      </div>
+    </div>
+  </div>
+  <p />
+  <div
+    className=
+        ms-DocumentCard
+        ms-DocumentCard--actionable
+        {
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border: 1px solid #eaeaea;
+          box-sizing: border-box;
+          max-width: 320px;
+          min-width: 206px;
+          position: relative;
+          user-select: none;
+        }
+        & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
+          padding-top: 4px;
+        }
+        &:hover {
+          border-color: #c8c8c8;
+          cursor: pointer;
+        }
+        &:hover:after {
+          border: 1px solid #c8c8c8;
+          bottom: 0px;
+          content: " ";
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="link"
+    tabIndex={0}
+  >
+    <div
+      className=
+
+          {
+            background-color: #f8f8f8;
+            border-bottom: 1px solid #eaeaea;
+            height: 150px;
+            overflow: hidden;
+            position: relative;
+          }
+    >
+      <div
+        className=
+
+            {
+              align-items: center;
+              display: flex;
+              height: 100%;
+              justify-content: center;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              width: 100%;
+            }
+      >
+        <i
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #813a7c;
+                display: inline-block;
+                font-family: "FabricMDL2Icons-9";
+                font-size: 120px;
+                font-style: normal;
+                font-weight: normal;
+                height: 120px;
+                speak: none;
+                width: 120px;
+              }
+          data-icon-name="OneNoteLogo"
+          role="presentation"
+        >
+          
+        </i>
+      </div>
+    </div>
+    <div
+      className=
+          ms-DocumentCardDetails
+          {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            justify-content: space-between;
+            overflow: hidden;
+          }
+    >
+      <div
+        className=
+            ms-DocumentCardTitle
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 17px;
+              font-weight: 300;
+              height: 38px;
+              line-height: 21px;
+              overflow: hidden;
+              padding-bottom: 8px;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 8px;
+              word-wrap: break-word;
+            }
+        title="How to make good design without an image"
+      >
+        How to make good design without an image
+      </div>
+    </div>
+    <div
+      className=
+          ms-DocumentCardActivity
+          {
+            padding-bottom: 8px;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 8px;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-DocumentCardActivity-avatars
+            {
+              height: 32px;
+              margin-left: -2px;
+            }
+      >
+        <div
+          className=
+              ms-DocumentCardActivity-avatar
+              {
+                display: inline-block;
+                height: 32px;
+                position: relative;
+                text-align: center;
+                vertical-align: top;
+                width: 32px;
+              }
+              &:after {
+                border-radius: 50%;
+                border: 2px solid #ffffff;
+                bottom: -1px;
+                content: " ";
+                left: -1px;
+                position: absolute;
+                right: -1px;
+                top: -1px;
+              }
+        >
+          <div
+            className=
+                ms-Persona-coin
+                ms-Persona--size32
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            role="presentation"
+            size={11}
+          >
+            <div
+              className=
+                  ms-Persona-imageArea
+                  {
+                    flex: 0 0 auto;
+                    height: 32px;
+                    position: relative;
+                    text-align: center;
+                    width: 32px;
+                  }
+            >
+              <div
+                aria-hidden="true"
+                className=
+                    ms-Persona-initials
+                    {
+                      background-color: #00ABA9;
+                      border-radius: 50%;
+                      color: #ffffff;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      line-height: 32px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background-color: Window !important;
+                      border: 1px solid WindowText;
+                      box-sizing: border-box;
+                      color: WindowText;
+                    }
+              >
+                <span>
+                  JH
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className=
+            ms-DocumentCardActivity-details
+            {
+              height: 32px;
+              left: 56px;
+              position: absolute;
+              top: 8px;
+              width: calc(100% - 72px);
+            }
+      >
+        <span
+          className=
+              ms-DocumentCardActivity-name
+              {
+                color: #333333;
+                display: block;
+                font-size: 12px;
+                font-weight: 600;
+                height: 15px;
+                line-height: 15px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+        >
+          Roko Kolar
+        </span>
+        <span
+          className=
+              ms-DocumentCardActivity-activity
+              {
+                color: #666666;
+                display: block;
+                font-size: 12px;
+                height: 15px;
+                line-height: 15px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+        >
+          Modified January 1, 2019
         </span>
       </div>
     </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The current DocumentCardPreview component has a fairly complex interface, and the behavior can be unexpected based on the props passed. For instance, centered icons are passed in as iconprops, while corner icons are passed in as image urls. Furthermore, if a centered icon is passed in, no image is rendered at all (even if it is valid), so the file type icon can not be used as a fallback when the image for some reason fails (without writing a custom wrapper on the consumer side). Also, the support for multiple previews does not seem to work properly, which then complicates the usage and property interface unnecessarily.

Instead of adding even more props, fixing the issues, and overall adding more code and functionality to the component while attempting to maintain backwards compatibility, this PR introduces a new, cleaner and simpler preview component. The name is not written in stone and can ofc. be changed

I thought about putting this in fabric-experiments, but seems overkill for such a simple component?

#### Some screenshots
##### Image successfully loaded
![image](https://user-images.githubusercontent.com/11868950/51534029-dd3eca80-1e44-11e9-944d-b26306edea7d.png)

##### Image failed to load or was not provided
![image](https://user-images.githubusercontent.com/11868950/51534122-2d1d9180-1e45-11e9-8cf1-6de101965db4.png)


#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7741)

