### PR TITLE
Merge styles global fix

### DIFF
--- a/common/changes/@uifabric/merge-styles/merge-styles-global-fix_2019-01-22-17-28.json
+++ b/common/changes/@uifabric/merge-styles/merge-styles-global-fix_2019-01-22-17-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Allow :global to be used in more scenarios than just \":global(selector)\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -182,6 +182,28 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('button{background:red;}');
   });
 
+  it('can register global selectors for a parent', () => {
+    const className = styleToClassName({
+      selectors: {
+        '& :global(button)': { background: 'red' }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.css-0 button{background:red;}');
+  });
+
+  it('can register global selectors hover parent for a selector', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(.ms-button):hover &': { background: 'red' }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.ms-button:hover .css-0{background:red;}');
+  });
+
   it('can expand an array of rules', () => {
     styleToClassName([{ background: 'red' }, { background: 'white' }]);
     expect(_stylesheet.getRules()).toEqual('.css-0{background:white;}');

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -23,8 +23,8 @@ function getDisplayName(rules?: { [key: string]: IRawStyle }): string | undefine
 }
 
 function expandSelector(newSelector: string, currentSelector: string): string {
-  if (newSelector.indexOf(':global(') === 0) {
-    return newSelector.replace(/:global\(|\)$/g, '');
+  if (newSelector.indexOf(':global(') >= 0) {
+    return newSelector.replace(/:global\((.+?)\)/g, '$1');
   } else if (newSelector.indexOf(':') === 0) {
     return currentSelector + newSelector;
   } else if (newSelector.indexOf('&') < 0) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR fixes the scenario below.

> I realise this expands the current functionality, as we would only allow you to start a selector with `:global(`. But perhaps allowing it to be used more freely is how it was intended to work?)

For the following definition
```js
mergeStyleSets({
    root: 
      {
        background: 'red',
        selectors: {
          ':global(body):hover &': {
            background: 'blue',
          },
          '& :global(.ms-button)': {
            background: 'blue',
          }
        }
      }   
  })
```
We currently generate the following css, notice how body has a `)` suffix and for the second selector :global` is not transformed
```css
.root-0 {
  background:red;
}

body):hover .root-0 {
  background:blue;
}

.root-0 :global(.ms-button) {
  background:blue;
}
```

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7745)

