### PR TITLE
DetailsList examples: fix issue causing infinite loop in large grouped example

### DIFF
--- a/apps/fabric-website/src/pages/Components/DetailsList/DetailsListLargeGroupedComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/DetailsList/DetailsListLargeGroupedComponentPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DetailsListLargeGroupedPage } from '@uifabric/fabric-website-resources/lib/components/pages/DetailsList/DetailsListLargeGroupedPage';
 
-export class DetailsListGroupedComponentPage extends React.Component<any, any> {
+export class DetailsListLargeGroupedComponentPage extends React.Component<any, any> {
   public render(): JSX.Element {
     return <DetailsListLargeGroupedPage isHeaderVisible={false} />;
   }

--- a/common/changes/@uifabric/fabric-website/detailslist-loop_2019-01-22-23-15.json
+++ b/common/changes/@uifabric/fabric-website/detailslist-loop_2019-01-22-23-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "DetailsList examples: Fix copy paste error causing infinite loop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

The DetailsList large grouped example on the website had an infinite rendering loop due to the component having the wrong name.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7752)

