### PR TITLE
Stack: Removing unneeded children logic used to calculate classnames

### DIFF
--- a/common/changes/@uifabric/experiments/stackStyles_2019-01-22-23-54.json
+++ b/common/changes/@uifabric/experiments/stackStyles_2019-01-22-23-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Stack: Removing uneeded children logic used to calculate classnames.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/stackStyles_2019-01-22-23-54.json
+++ b/common/changes/@uifabric/experiments/stackStyles_2019-01-22-23-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/experiments",
-      "comment": "Stack: Removing uneeded children logic used to calculate classnames.",
+      "comment": "Stack: Removing unneeded children logic used to calculate classnames.",
       "type": "patch"
     }
   ],

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -5,7 +5,6 @@ import StackItem from './StackItem/StackItem';
 import { IStackItemProps } from './StackItem/StackItem.types';
 import { IStackComponent, IStackProps, IStackSlots } from './Stack.types';
 import { styles } from './Stack.styles';
-import { mergeStyles } from '../../Styling';
 import { getNativeProps, htmlElementProperties } from '../../Utilities';
 
 const StackItemType = (<StackItem /> as React.ReactElement<IStackItemProps>).type;
@@ -20,28 +19,14 @@ const view: IStackComponent['view'] = props => {
         return null;
       }
 
-      const defaultItemProps: IStackItemProps = {
-        shrink: shrinkItems,
-        className: child.props ? child.props.className : undefined
-      };
-
       if (child.type === StackItemType) {
-        // If child is a StackItem, we need to pass down the className of ITS first child to the StackItem for mergeStylesSet to work
-        // TODO: how will this be affected by mergeStyleSets being removed from createComponent?
-        const children = child.props ? child.props.children : undefined;
-        const stackItemFirstChildren = React.Children.toArray(children) as React.ReactElement<{ className?: string }>[];
-        const stackItemFirstChild = stackItemFirstChildren && stackItemFirstChildren[0];
-
-        // pass down both the className on the StackItem as well as the className on its first child
-        let mergedClassName = defaultItemProps.className;
-        if (stackItemFirstChild && stackItemFirstChild.props && stackItemFirstChild.props.className) {
-          mergedClassName = mergeStyles(mergedClassName, stackItemFirstChild.props.className);
-        }
+        const defaultItemProps: IStackItemProps = {
+          shrink: shrinkItems
+        };
 
         return React.cloneElement(child, {
           ...defaultItemProps,
-          ...child.props,
-          className: mergedClassName
+          ...child.props
         });
       }
 

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
@@ -48,4 +48,25 @@ describe('Stack Item', () => {
 
     expect(createEmptyStackItem).not.toThrow();
   });
+
+  it('includes the classNames on both a StackItem and its child', () => {
+    const stackItemClassName = 'stackItemClass';
+    const childClassName = 'childClass';
+
+    const wrapper = mount(
+      <Stack>
+        <Stack.Item className={stackItemClassName}>
+          <span className={childClassName} />
+        </Stack.Item>
+      </Stack>
+    );
+
+    const stackItem = wrapper.find('span').at(0);
+    const stackItemClass = stackItem.props().className;
+    const child = wrapper.find('span').at(1);
+    const childClass = child.props().className;
+
+    expect(stackItemClass).toContain(stackItemClassName);
+    expect(childClass).toContain(childClassName);
+  });
 });

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
@@ -48,23 +48,4 @@ describe('Stack Item', () => {
 
     expect(createEmptyStackItem).not.toThrow();
   });
-
-  it('includes the classNames on both a StackItem and its child', () => {
-    const stackItemClassName = 'stackItemClass';
-    const childClassName = 'childClass';
-
-    const wrapper = mount(
-      <Stack>
-        <Stack.Item className={stackItemClassName}>
-          <span className={childClassName} />
-        </Stack.Item>
-      </Stack>
-    );
-
-    const child = wrapper.find('span').at(0);
-    const childClass = child.props().className;
-
-    expect(childClass).toContain(stackItemClassName);
-    expect(childClass).toContain(childClassName);
-  });
 });

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.WrapNested.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.WrapNested.Example.tsx
@@ -119,9 +119,9 @@ export class VerticalStackWrapNestedExample extends React.Component<{}, IExample
           The one exception to this case being Microsoft Edge that handles it correctly (though this might go soon with the switch to
           Chromium).
         </span>
+        <span>There are ways in which we could have gone around this issue.</span>
         <span>
-          There are ways in which we could have gone around this issue. However, we have chosen to adhere to the flex-box spec so that we
-          have the correct implementation if support comes down the line.
+          However, we have chosen to adhere to the flex-box spec so that we have the correct implementation if support comes down the line.
         </span>
       </Stack>
     );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR removes some unneeded logic that was required before the `Stack` component started using slots and tokens to properly style `StackItems`. It also updates the test that checked for this behavior to be correct.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7755)

