### PR TITLE
Screener test build improvements

### DIFF
--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -30,7 +30,7 @@
     "postcss-loader": "^2.0.9",
     "raw-loader": "^0.5.1",
     "screener-runner": "^0.10.15",
-    "screener-storybook": "^0.16.0",
+    "screener-storybook": "^0.16.8",
     "storybook-readme": "^3.3.0",
     "style-loader": "^0.21.0"
   },

--- a/apps/vr-tests/prettier.config.js
+++ b/apps/vr-tests/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require('@uifabric/prettier-rules/prettier.config.js'),
+  // The smaller printWidth for the screener tests promotes readability by preventing test cases
+  // from being squished onto one line (and squished up against each other in consecutive lines)
+  printWidth: 100
+};

--- a/apps/vr-tests/src/stories/ActivityItem.stories.tsx
+++ b/apps/vr-tests/src/stories/ActivityItem.stories.tsx
@@ -3,60 +3,64 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { ActivityItem, IActivityItemProps, Icon } from 'office-ui-fabric-react';
+import { ActivityItem, Icon } from 'office-ui-fabric-react';
 
 storiesOf('ActivityItem', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (
-    <ActivityItem
-      activityIcon={<Icon iconName={'Message'} />}
-      activityDescription={<span>description text</span>}
-      comments={<span>comment text</span>}
-      timeStamp={'timeStamp text'}
-    />
-  ), { rtl: true })
-  .addStory('Personas', () => (
-    <ActivityItem
-      activityPersonas={[
-        { imageInitials: 'AB' },
-        { imageInitials: 'CD' },
-        { imageInitials: 'EF' },
-        { imageInitials: 'GH' }
-      ]}
-      activityDescription={<span>description text</span>}
-      comments={<span>comment text</span>}
-      timeStamp={'timeStamp text'}
-    />
-  ), { rtl: true })
+  )
+  .addStory(
+    'Root',
+    () => (
+      <ActivityItem
+        activityIcon={<Icon iconName="Message" />}
+        activityDescription={<span>description text</span>}
+        comments={<span>comment text</span>}
+        timeStamp="timeStamp text"
+      />
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Personas',
+    () => (
+      <ActivityItem
+        activityPersonas={[
+          { imageInitials: 'AB' },
+          { imageInitials: 'CD' },
+          { imageInitials: 'EF' },
+          { imageInitials: 'GH' }
+        ]}
+        activityDescription={<span>description text</span>}
+        comments={<span>comment text</span>}
+        timeStamp="timeStamp text"
+      />
+    ),
+    { rtl: true }
+  )
   .addStory('Compact', () => (
     <ActivityItem
-      activityIcon={<Icon iconName={'Message'} />}
+      activityIcon={<Icon iconName="Message" />}
       isCompact={true}
       activityDescription={<span>description text</span>}
       comments={<span>comment text</span>}
-      timeStamp={'timeStamp text'}
+      timeStamp="timeStamp text"
     />
   ))
   .addStory('CompactPersonas', () => (
     <ActivityItem
-      activityPersonas={[
-        { imageInitials: 'AB' },
-        { imageInitials: 'CD' },
-        { imageInitials: 'EF' }
-      ]}
+      activityPersonas={[{ imageInitials: 'AB' }, { imageInitials: 'CD' }, { imageInitials: 'EF' }]}
       isCompact={true}
       activityDescription={<span>description text</span>}
       comments={<span>comment text</span>}
-      timeStamp={'timeStamp text'}
+      timeStamp="timeStamp text"
     />
   ));

--- a/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
 import { Breadcrumb } from 'office-ui-fabric-react';
@@ -21,23 +21,25 @@ storiesOf('Breadcrumb', module)
         .snapshot('longTitleHover', { cropTo: '.testWrapper' })
         .hover('.ms-Breadcrumb-list li:nth-child(3)')
         .snapshot('shortTitleHover', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
   ))
-  .addStory('Root', () => (
-    <Breadcrumb
-      items={[
-        { text: 'Files', 'key': 'Files', href: '#/examples/breadcrumb' },
-        { text: 'This is link 1', 'key': 'l1', href: '#/examples/breadcrumb' },
-        { text: 'This is link 2', 'key': 'l2', href: '#/examples/breadcrumb' },
-        { text: 'This is link 3 with a long name', 'key': 'l3', href: '#/examples/breadcrumb' },
-        { text: 'This is link 4', 'key': 'l4', href: '#/examples/breadcrumb' },
-        { text: 'This is link 5', 'key': 'l5', href: '#/examples/breadcrumb', isCurrentItem: true },
-      ]}
-      maxDisplayedItems={3}
-      ariaLabel={'Website breadcrumb'}
-    />
-  ), { rtl: true });
+  .addStory(
+    'Root',
+    () => (
+      <Breadcrumb
+        items={[
+          { text: 'Files', key: 'Files', href: '#/examples/breadcrumb' },
+          { text: 'This is link 1', key: 'l1', href: '#/examples/breadcrumb' },
+          { text: 'This is link 2', key: 'l2', href: '#/examples/breadcrumb' },
+          { text: 'This is link 3 with a long name', key: 'l3', href: '#/examples/breadcrumb' },
+          { text: 'This is link 4', key: 'l4', href: '#/examples/breadcrumb' },
+          { text: 'This is link 5', key: 'l5', href: '#/examples/breadcrumb', isCurrentItem: true }
+        ]}
+        maxDisplayedItems={3}
+      />
+    ),
+    { rtl: true }
+  );

--- a/apps/vr-tests/src/stories/Button.stories.tsx
+++ b/apps/vr-tests/src/stories/Button.stories.tsx
@@ -3,7 +3,13 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator, FabricDecoratorTall } from '../utilities';
-import { DefaultButton, ActionButton, CompoundButton, IButtonProps, CommandBarButton } from 'office-ui-fabric-react';
+import {
+  DefaultButton,
+  ActionButton,
+  CompoundButton,
+  IButtonProps,
+  CommandBarButton
+} from 'office-ui-fabric-react';
 
 const baseProps: IButtonProps = {
   iconProps: {
@@ -56,8 +62,12 @@ storiesOf('Button Default', module)
   .addStory('Disabled', () => <DefaultButton {...baseProps} disabled={true} />)
   .addStory('Checked', () => <DefaultButton {...baseProps} checked={true} />)
   .addStory('Primary', () => <DefaultButton {...baseProps} primary={true} />)
-  .addStory('Primary Disabled', () => <DefaultButton {...baseProps} primary={true} disabled={true} />)
-  .addStory('Primary Checked', () => <DefaultButton {...baseProps} primary={true} checked={true} />);
+  .addStory('Primary Disabled', () => (
+    <DefaultButton {...baseProps} primary={true} disabled={true} />
+  ))
+  .addStory('Primary Checked', () => (
+    <DefaultButton {...baseProps} primary={true} checked={true} />
+  ));
 
 storiesOf('Button Action', module)
   .addDecorator(FabricDecorator)
@@ -97,12 +107,17 @@ storiesOf('Button Compound', module)
   .addStory('Disabled', () => <CompoundButton {...baseProps} disabled={true} />)
   .addStory('Checked', () => <CompoundButton {...baseProps} checked={true} />)
   .addStory('Primary', () => <CompoundButton {...baseProps} primary={true} />)
-  .addStory('Primary Disabled', () => <CompoundButton {...baseProps} primary={true} disabled={true} />)
-  .addStory('Primary Checked', () => <CompoundButton {...baseProps} primary={true} checked={true} />);
+  .addStory('Primary Disabled', () => (
+    <CompoundButton {...baseProps} primary={true} disabled={true} />
+  ))
+  .addStory('Primary Checked', () => (
+    <CompoundButton {...baseProps} primary={true} checked={true} />
+  ));
 
 storiesOf('Button Command', module)
-  // tslint:disable-next-line:jsx-ban-props
-  .addDecorator(story => <div style={{ display: 'flex', alignItems: 'stretch', height: '40px' }}>{story()}</div>)
+  .addDecorator(story => (
+    <div style={{ display: 'flex', alignItems: 'stretch', height: '40px' }}>{story()}</div>
+  ))
   .addDecorator(FabricDecoratorTall)
   .addDecorator(story => (
     <Screener
@@ -152,14 +167,20 @@ storiesOf('Button Split', module)
   .addStory('Disabled', () => <DefaultButton {...commandProps} disabled={true} split={true} />)
   .addStory('Checked', () => <DefaultButton {...commandProps} checked={true} split={true} />)
   .addStory('Primary', () => <DefaultButton {...commandProps} primary={true} split={true} />)
-  .addStory('Primary Disabled', () => <DefaultButton {...commandProps} primary={true} disabled={true} split={true} />)
-  .addStory('Primary Checked', () => <DefaultButton {...commandProps} primary={true} checked={true} split={true} />)
+  .addStory('Primary Disabled', () => (
+    <DefaultButton {...commandProps} primary={true} disabled={true} split={true} />
+  ))
+  .addStory('Primary Checked', () => (
+    <DefaultButton {...commandProps} primary={true} checked={true} split={true} />
+  ))
   .addStory('Command Split', () => <CommandBarButton {...commandProps} split={true} />);
 
 storiesOf('Button Special Scenarios', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
-    <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
+    <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
+      {story()}
+    </Screener>
   ))
 
   .addStory('primary with placeholder', () => (
@@ -170,7 +191,6 @@ storiesOf('Button Special Scenarios', module)
     </div>
   ))
   .addStory('no flex shrink', () => (
-    // tslint:disable-next-line:jsx-ban-props
     <div style={{ width: '300px' }}>
       <DefaultButton
         {...baseProps}

--- a/apps/vr-tests/src/stories/Callout.stories.tsx
+++ b/apps/vr-tests/src/stories/Callout.stories.tsx
@@ -1,113 +1,149 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
-import { Callout, Link, DirectionalHint } from 'office-ui-fabric-react';
+import { Callout, DirectionalHint, ICalloutProps } from 'office-ui-fabric-react';
 
-let calloutContent = (
-  <p className='ms-CalloutExample-subText' id={'callout-description-1'}>
-    Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
-</p>);
+const calloutContent = (
+  <p className="ms-CalloutExample-subText" id="callout-description-1">
+    Message body is optional. If help documentation is available, consider adding a link to learn
+    more at the bottom.
+  </p>
+);
 
-let defaultProps = {
+const defaultProps: ICalloutProps = {
   target: '#target',
   calloutWidth: 200
 };
 
-// tslint:disable:jsx-ban-props
 storiesOf('Callout', module)
   .addDecorator(story => (
-    <div style={{ alignItems: 'center', width: '800px', height: '300px', display: 'flex', justifyContent: 'center' }}>
-      <div id='target'>Width of callout is 200 unless otherwise noted</div>
+    <div
+      style={{
+        alignItems: 'center',
+        width: '800px',
+        height: '300px',
+        display: 'flex',
+        justifyContent: 'center'
+      }}
+    >
+      <div id="target">Width of callout is 200 unless otherwise noted</div>
       {story()}
     </div>
   ))
   .addDecorator(FabricDecoratorTall)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default')
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (
+  )
+  .addStory('Root', () =>
+    // prettier-ignore
     <Callout {...defaultProps} >
       {calloutContent}
     </Callout>
-  )).addStory('Bottom auto edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.bottomAutoEdge} >
+  )
+  .addStory('Bottom auto edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.bottomAutoEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Bottom center', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.bottomCenter} >
+  ))
+  .addStory('Bottom center', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.bottomCenter}>
       {calloutContent}
     </Callout>
-  )).addStory('Bottom left edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.bottomLeftEdge} >
+  ))
+  .addStory(
+    'Bottom left edge',
+    () => (
+      <Callout {...defaultProps} directionalHint={DirectionalHint.bottomLeftEdge}>
+        {calloutContent}
+      </Callout>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Bottom right edge',
+    () => (
+      <Callout {...defaultProps} directionalHint={DirectionalHint.bottomRightEdge}>
+        {calloutContent}
+      </Callout>
+    ),
+    { rtl: true }
+  )
+  .addStory('Left bottom edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.leftBottomEdge}>
       {calloutContent}
     </Callout>
-  ), { rtl: true }).addStory('Bottom right edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.bottomRightEdge} >
+  ))
+  .addStory('Left center', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.leftCenter}>
       {calloutContent}
     </Callout>
-  ), { rtl: true }).addStory('Left bottom edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.leftBottomEdge} >
+  ))
+  .addStory('Left top edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.leftTopEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Left center', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.leftCenter} >
+  ))
+  .addStory('Right bottom edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.rightBottomEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Left top edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.leftTopEdge} >
+  ))
+  .addStory('Right center', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.rightCenter}>
       {calloutContent}
     </Callout>
-  )).addStory('Right bottom edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.rightBottomEdge} >
+  ))
+  .addStory('Right top edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.rightTopEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Right center', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.rightCenter} >
+  ))
+  .addStory('Top auto edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.topAutoEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Right top edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.rightTopEdge} >
+  ))
+  .addStory('Top center', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.topCenter}>
       {calloutContent}
     </Callout>
-  )).addStory('Top auto edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.topAutoEdge} >
+  ))
+  .addStory('Top left edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.topLeftEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Top center', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.topCenter} >
+  ))
+  .addStory('Top right edge', () => (
+    <Callout {...defaultProps} directionalHint={DirectionalHint.topRightEdge}>
       {calloutContent}
     </Callout>
-  )).addStory('Top left edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.topLeftEdge} >
+  ))
+  .addStory('Beak 25', () => (
+    <Callout {...defaultProps} beakWidth={25}>
       {calloutContent}
     </Callout>
-  )).addStory('Top right edge', () => (
-    <Callout {...defaultProps} directionalHint={DirectionalHint.topRightEdge} >
-      {calloutContent}
-    </Callout>
-  )).addStory('Beak 25', () => (
-    <Callout {...defaultProps} beakWidth={25} >
-      {calloutContent}
-    </Callout>
-  )).addStory('Gap space 25', () => (
+  ))
+  .addStory('Gap space 25', () => (
     <Callout {...defaultProps} gapSpace={25}>
       {calloutContent}
     </Callout>
-  )).addStory('No beak', () => (
-    <Callout {...defaultProps} isBeakVisible={false} >
+  ))
+  .addStory('No beak', () => (
+    <Callout {...defaultProps} isBeakVisible={false}>
       {calloutContent}
     </Callout>
-  )).addStory('No callout width specified', () => (
-    <Callout {...defaultProps} calloutWidth={undefined} >
+  ))
+  .addStory('No callout width specified', () => (
+    <Callout {...defaultProps} calloutWidth={undefined}>
       {calloutContent}
     </Callout>
   ));

--- a/apps/vr-tests/src/stories/Checkbox.stories.tsx
+++ b/apps/vr-tests/src/stories/Checkbox.stories.tsx
@@ -1,19 +1,28 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Checkbox, Persona, PersonaSize } from 'office-ui-fabric-react';
 
 storiesOf('Checkbox', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
-    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>
-  ))
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Unchecked', () => <Checkbox label="Unchecked checkbox" />, { rtl: true })
   .addStory('Checked', () => <Checkbox label="Checked checkbox" checked />)
   .addStory('Unchecked disabled', () => <Checkbox label="Unchecked disabled checkbox" disabled />)
-  .addStory('Checked disabled', () => <Checkbox label="Checked disabled checkbox" checked disabled />)
+  .addStory('Checked disabled', () => (
+    <Checkbox label="Checked disabled checkbox" checked disabled />
+  ))
   .addStory('End', () => <Checkbox label="Checkbox end" boxSide="end" />, { rtl: true })
   .addStory('Multi-line Checkbox', () => (
     <Checkbox
@@ -26,9 +35,8 @@ storiesOf('Checkbox', module)
   .addStory('Custom render Checkbox', () => (
     <Checkbox
       label="Persona Checkbox"
-      // tslint:disable-next-line:jsx-no-lambda
       onRenderLabel={props => {
-        return <Persona text={props.label} size={PersonaSize.size32} />;
+        return <Persona text={props!.label} size={PersonaSize.size32} />;
       }}
     />
   ));

--- a/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
+++ b/apps/vr-tests/src/stories/ChoiceGroup.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { ChoiceGroup } from 'office-ui-fabric-react';
@@ -13,7 +13,7 @@ const options = [
   },
   {
     key: 'B',
-    text: 'Unselected',
+    text: 'Unselected'
   },
   {
     key: 'C',
@@ -26,7 +26,7 @@ storiesOf('ChoiceGroup', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
-      steps={ new Screener.Steps()
+      steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
         .hover('div.ms-ChoiceField:nth-of-type(1)')
         .snapshot('hover unselected', { cropTo: '.testWrapper' })
@@ -35,52 +35,57 @@ storiesOf('ChoiceGroup', module)
         .click('div.ms-ChoiceField:nth-of-type(1)')
         .hover('div.ms-ChoiceField:nth-of-type(1)')
         .snapshot('hover selected', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
-      { story() }
+      {story()}
     </Screener>
   ))
-  .addStory('Root', () => (
+  .addStory('Root', () =>
+    // prettier-ignore
     <ChoiceGroup
       options={ options }
-      label='Pick one'
+      label="Pick one"
     />
-  ))
-  .addStory('Required', () => (
+  )
+  .addStory('Required', () =>
+    // prettier-ignore
     <ChoiceGroup
       options={ options }
-      label='Pick one'
+      label="Pick one"
       required
     />
-  ))
-  .addStory('With icons', () => (
-    <ChoiceGroup
-      label='Pick one icon'
-      options={ [
-        {
-          key: 'day',
-          iconProps: { iconName: 'CalendarDay' },
-          text: 'Day'
-        },
-        {
-          key: 'week',
-          iconProps: { iconName: 'CalendarWeek' },
-          text: 'Week'
-        },
-        {
-          key: 'month',
-          iconProps: { iconName: 'Calendar' },
-          text: 'Month',
-          disabled: true
-        }
-      ] }
-    />
-  ), { rtl: true })
+  )
+  .addStory(
+    'With icons',
+    () => (
+      <ChoiceGroup
+        label="Pick one icon"
+        options={[
+          {
+            key: 'day',
+            iconProps: { iconName: 'CalendarDay' },
+            text: 'Day'
+          },
+          {
+            key: 'week',
+            iconProps: { iconName: 'CalendarWeek' },
+            text: 'Week'
+          },
+          {
+            key: 'month',
+            iconProps: { iconName: 'Calendar' },
+            text: 'Month',
+            disabled: true
+          }
+        ]}
+      />
+    ),
+    { rtl: true }
+  )
   .addStory('With default size images', () => (
     <ChoiceGroup
-      label='Pick one image'
-      options={ [
+      label="Pick one image"
+      options={[
         {
           key: 'bar',
           imageSrc: TestImages.choiceGroupBarUnselected,
@@ -93,13 +98,13 @@ storiesOf('ChoiceGroup', module)
           selectedImageSrc: TestImages.choiceGroupBarSelected,
           text: 'Pie chart'
         }
-      ] }
+      ]}
     />
   ))
   .addStory('With large size images', () => (
     <ChoiceGroup
-      label='Pick one image'
-      options={ [
+      label="Pick one image"
+      options={[
         {
           key: 'bar2',
           imageSrc: TestImages.choiceGroupBarUnselected,
@@ -114,6 +119,6 @@ storiesOf('ChoiceGroup', module)
           imageSize: { width: 120, height: 120 },
           text: 'Pie chart'
         }
-      ] }
+      ]}
     />
   ));

--- a/apps/vr-tests/src/stories/ColorPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/ColorPicker.stories.tsx
@@ -1,13 +1,22 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { ColorPicker, Fabric } from 'office-ui-fabric-react';
 
 storiesOf('ColorPicker', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory(
     'Root',
     () => (

--- a/apps/vr-tests/src/stories/ComboBox.stories.tsx
+++ b/apps/vr-tests/src/stories/ComboBox.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTallFixedWidth } from '../utilities';
-import { ComboBox, SelectableOptionMenuItemType } from 'office-ui-fabric-react';
+import { ComboBox, SelectableOptionMenuItemType, ISelectableOption } from 'office-ui-fabric-react';
 
 const testOptions = [
   { key: 'Header', text: 'Theme Fonts', itemType: SelectableOptionMenuItemType.Header },
@@ -14,13 +14,16 @@ const testOptions = [
   { key: 'D', text: 'Option d' }
 ];
 
-const fontMapping = {
-  ['Arial Black']: '"Arial Black", "Arial Black_MSFontService", sans-serif',
-  ['Time New Roman']: '"Times New Roman", "Times New Roman_MSFontService", serif'
+const fontMapping: { [key: string]: string } = {
+  'Arial Black': '"Arial Black", "Arial Black_MSFontService", sans-serif',
+  'Time New Roman': '"Times New Roman", "Times New Roman_MSFontService", serif'
 };
 
-const onRenderFontOption = item => {
-  if (item.itemType === SelectableOptionMenuItemType.Header || item.itemType === SelectableOptionMenuItemType.Divider) {
+const onRenderFontOption = (item: ISelectableOption) => {
+  if (
+    item.itemType === SelectableOptionMenuItemType.Header ||
+    item.itemType === SelectableOptionMenuItemType.Divider
+  ) {
     return <span>{item.text}</span>;
   }
 
@@ -51,9 +54,18 @@ storiesOf('ComboBox', module)
       {story()}
     </Screener>
   ))
-  .addStory('Root', () => <ComboBox defaultSelectedKey="A" label="Default with dividers" autoComplete="on" options={testOptions} />, {
-    rtl: true
-  })
+  .addStory(
+    'Root',
+    () => (
+      <ComboBox
+        defaultSelectedKey="A"
+        label="Default with dividers"
+        autoComplete="on"
+        options={testOptions}
+      />
+    ),
+    { rtl: true }
+  )
   .addStory('Styled', () => (
     <ComboBox
       defaultSelectedKey="A"
@@ -63,5 +75,18 @@ storiesOf('ComboBox', module)
       onRenderOption={onRenderFontOption}
     />
   ))
-  .addStory('Disabled', () => <ComboBox defaultSelectedKey="A" label="Disabled" options={testOptions} disabled />)
-  .addStory('Placeholder', () => <ComboBox placeholder="Select an option" label="With a placeholder" options={testOptions} />);
+  .addStory('Disabled', () =>
+    // prettier-ignore
+    <ComboBox
+      defaultSelectedKey="A"
+      label="Disabled"
+      options={testOptions}
+      disabled />
+  )
+  .addStory('Placeholder', () =>
+    // prettier-ignore
+    <ComboBox
+      placeholder="Select an option"
+      label="With a placeholder"
+      options={testOptions} />
+  );

--- a/apps/vr-tests/src/stories/CommandBar.stories.tsx
+++ b/apps/vr-tests/src/stories/CommandBar.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
 import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react';
@@ -9,24 +9,18 @@ const items: ICommandBarItemProps[] = [
   {
     key: 'newItem',
     text: 'New',
-    iconProps: {
-      iconName: 'Add'
-    },
+    iconProps: { iconName: 'Add' },
     subMenuProps: {
       items: [
         {
           key: 'emailMessage',
           text: 'Email message',
-          iconProps: {
-            iconName: 'Mail'
-          }
+          iconProps: { iconName: 'Mail' }
         },
         {
           key: 'calendarEvent',
           text: 'Calendar event',
-          iconProps: {
-            iconName: 'Calendar'
-          }
+          iconProps: { iconName: 'Calendar' }
         }
       ]
     }
@@ -34,30 +28,22 @@ const items: ICommandBarItemProps[] = [
   {
     key: 'upload',
     text: 'Upload',
-    iconProps: {
-      iconName: 'Upload'
-    }
+    iconProps: { iconName: 'Upload' }
   },
   {
     key: 'share',
     text: 'Share',
-    iconProps: {
-      iconName: 'Share'
-    }
+    iconProps: { iconName: 'Share' }
   },
   {
     key: 'download',
     text: 'Download',
-    iconProps: {
-      iconName: 'Download'
-    }
+    iconProps: { iconName: 'Download' }
   },
   {
     key: 'disabled',
     text: 'Disabled...',
-    iconProps: {
-      iconName: 'Cancel'
-    },
+    iconProps: { iconName: 'Cancel' },
     disabled: true
   }
 ];
@@ -66,23 +52,17 @@ const farItems: ICommandBarItemProps[] = [
   {
     key: 'sort',
     text: 'Sort',
-    iconProps: {
-      iconName: 'SortLines'
-    }
+    iconProps: { iconName: 'SortLines' }
   },
   {
     key: 'tile',
     text: 'Grid view',
-    iconProps: {
-      iconName: 'Tiles'
-    }
+    iconProps: { iconName: 'Tiles' }
   },
   {
     key: 'info',
     text: 'Info',
-    iconProps: {
-      iconName: 'Info'
-    }
+    iconProps: { iconName: 'Info' }
   }
 ];
 

--- a/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
+++ b/apps/vr-tests/src/stories/ContextualMenu.stories.tsx
@@ -3,7 +3,12 @@ import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem, DefaultButton } from 'office-ui-fabric-react';
+import {
+  ContextualMenu,
+  ContextualMenuItemType,
+  IContextualMenuItem,
+  DefaultButton
+} from 'office-ui-fabric-react';
 
 const items: IContextualMenuItem[] = [
   {
@@ -41,18 +46,14 @@ const items: IContextualMenuItem[] = [
 const itemsWithIcons: IContextualMenuItem[] = [
   {
     key: 'newItem',
-    iconProps: {
-      iconName: 'Add'
-    },
+    iconProps: { iconName: 'Add' },
     text: 'New'
   },
   {
     key: 'upload',
     iconProps: {
       iconName: 'Upload',
-      style: {
-        color: 'salmon'
-      }
+      style: { color: 'salmon' }
     },
     text: 'Upload',
     title: 'Upload a file'
@@ -63,23 +64,17 @@ const itemsWithIcons: IContextualMenuItem[] = [
   },
   {
     key: 'share',
-    iconProps: {
-      iconName: 'Share'
-    },
+    iconProps: { iconName: 'Share' },
     text: 'Share'
   },
   {
     key: 'print',
-    iconProps: {
-      iconName: 'Print'
-    },
+    iconProps: { iconName: 'Print' },
     text: 'Print'
   },
   {
     key: 'music',
-    iconProps: {
-      iconName: 'MusicInCollectionFill'
-    },
+    iconProps: { iconName: 'MusicInCollectionFill' },
     text: 'Music'
   }
 ];
@@ -87,33 +82,25 @@ const itemsWithIcons: IContextualMenuItem[] = [
 const itemsWithSecondaryText: IContextualMenuItem[] = [
   {
     key: 'Later Today',
-    iconProps: {
-      iconName: 'Clock'
-    },
+    iconProps: { iconName: 'Clock' },
     text: 'Later Today',
     secondaryText: '7:00 PM'
   },
   {
     key: 'Tomorrow',
-    iconProps: {
-      iconName: 'Coffeescript'
-    },
+    iconProps: { iconName: 'Coffeescript' },
     text: 'Tomorrow',
     secondaryText: 'Thu. 8:00 AM'
   },
   {
     key: 'This Weekend',
-    iconProps: {
-      iconName: 'Vacation'
-    },
+    iconProps: { iconName: 'Vacation' },
     text: 'This Weekend',
     secondaryText: 'Sat. 10:00 AM'
   },
   {
     key: 'Next Week',
-    iconProps: {
-      iconName: 'Suitcase'
-    },
+    iconProps: { iconName: 'Suitcase' },
     text: 'Next Week',
     secondaryText: 'Mon. 8:00 AM'
   }
@@ -314,10 +301,14 @@ storiesOf('ContextualMenu', module)
   ))
   .addStory('Root', () => <ContextualMenu items={items} />)
   .addStory('With icons', () => <ContextualMenu items={itemsWithIcons} />)
-  .addStory('With secondaryText', () => <ContextualMenu items={itemsWithSecondaryText} />, { rtl: true })
+  .addStory('With secondaryText', () => <ContextualMenu items={itemsWithSecondaryText} />, {
+    rtl: true
+  })
   .addStory('With submenu', () => <ContextualMenu items={itemsWithSubmenu} />, { rtl: true })
   .addStory('With headers', () => <ContextualMenu items={itemsWithHeaders} />)
-  .addStory('With split button submenu', () => <ContextualMenu items={itemsWithSplitButtonSubmenu} />)
+  .addStory('With split button submenu', () => (
+    <ContextualMenu items={itemsWithSplitButtonSubmenu} />
+  ))
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -335,5 +326,9 @@ storiesOf('ContextualMenu', module)
     </Screener>
   ))
   .addStory('With submenus with hrefs', () => (
-    <DefaultButton id="button" text="Click for ContextualMenu" menuProps={{ items: itemsWithSubmenuHrefs }} />
+    <DefaultButton
+      id="button"
+      text="Click for ContextualMenu"
+      menuProps={{ items: itemsWithSubmenuHrefs }}
+    />
   ));

--- a/apps/vr-tests/src/stories/DatePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/DatePicker.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorFixedWidth } from '../utilities';
 import { Fabric, DatePicker } from 'office-ui-fabric-react';

--- a/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsHeader.stories.tsx
@@ -1,10 +1,16 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { IColumn, DetailsListLayoutMode, ColumnActionsMode, Selection, SelectionMode, IClassNames, classNamesFunction } from 'office-ui-fabric-react';
-import { DetailsHeader } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsHeader'
+import {
+  IColumn,
+  DetailsListLayoutMode,
+  ColumnActionsMode,
+  Selection,
+  SelectionMode
+} from 'office-ui-fabric-react';
+import { DetailsHeader } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsHeader';
 
 const _items: {}[] = [];
 const _selection = new Selection();
@@ -12,7 +18,15 @@ const _selection = new Selection();
 const dndScript = require('!raw-loader!../../dndSim.js') as string;
 
 const columns: IColumn[] = [
-  { key: 'a', name: 'a', fieldName: 'a', minWidth: 100, maxWidth: 200, calculatedWidth: 100, isResizable: true },
+  {
+    key: 'a',
+    name: 'a',
+    fieldName: 'a',
+    minWidth: 100,
+    maxWidth: 200,
+    calculatedWidth: 100,
+    isResizable: true
+  },
   {
     key: 'b',
     name: 'b',
@@ -116,12 +130,12 @@ storiesOf('DetailsHeader', module)
         .executeScript(dndScript)
         // simulate a drag on column 'b' to render the border
         .cssAnimations(false)
-        .executeScript('DndSimulator.simulate(\'[draggable="true"]\', \'[aria-colindex="5"]\', false)')
+        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[aria-colindex="5"]', false)`)
         .snapshot('borderWhileDragging')
         // do a dragover on 'd' to render the drop hint
         .hover('[aria-colindex=5]')
         .cssAnimations(true)
-        .executeScript('DndSimulator.simulate(\'[draggable="true"]\', \'[aria-colindex="5"]\', true)')
+        .executeScript(`DndSimulator.simulate('[draggable="true"]', '[aria-colindex="5"]', true)`)
         .snapshot('dropHint')
         .end()}
     >
@@ -137,4 +151,4 @@ storiesOf('DetailsHeader', module)
       columns={columns}
       columnReorderProps={_columnReorderProps}
     />
-  ))
+  ));

--- a/apps/vr-tests/src/stories/DetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/DetailsList.stories.tsx
@@ -1,13 +1,15 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { DetailsList, DetailsListLayoutMode, IColumn, CheckboxVisibility } from 'office-ui-fabric-react';
+import {
+  DetailsList,
+  DetailsListLayoutMode,
+  IColumn,
+  CheckboxVisibility
+} from 'office-ui-fabric-react';
 
-const url = 'https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/';
-
-// tslint:disable:max-line-length
 const items = [
   {
     name: 'Adaute.pub',
@@ -167,12 +169,16 @@ storiesOf('DetailsList', module)
       isHeaderVisible={true}
     />
   ))
-  .addStory('Checkbox Visible Always', () => (
-    <DetailsList
-      items={items}
-      columns={columns}
-      layoutMode={DetailsListLayoutMode.justified}
-      checkboxVisibility={CheckboxVisibility.always}
-      isHeaderVisible={true}
-    />
-  ), { rtl: true });
+  .addStory(
+    'Checkbox Visible Always',
+    () => (
+      <DetailsList
+        items={items}
+        columns={columns}
+        layoutMode={DetailsListLayoutMode.justified}
+        checkboxVisibility={CheckboxVisibility.always}
+        isHeaderVisible={true}
+      />
+    ),
+    { rtl: true }
+  );

--- a/apps/vr-tests/src/stories/Dialog.stories.tsx
+++ b/apps/vr-tests/src/stories/Dialog.stories.tsx
@@ -1,51 +1,59 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
-import { Dialog, DialogType, DialogFooter, PrimaryButton, DefaultButton } from 'office-ui-fabric-react';
+import {
+  Dialog,
+  DialogType,
+  DialogFooter,
+  PrimaryButton,
+  DefaultButton
+} from 'office-ui-fabric-react';
 
-let footer = (
+const footer = (
   <DialogFooter>
     <PrimaryButton text="Save" />
     <DefaultButton text="Cancel" />
   </DialogFooter>
 );
 
-let text = {
+const text = {
   title: 'All emails together',
-  subText: 'Your Inbox has changed. No longer does it include favorites, it is a singular destination for your emails.'
+  subText:
+    'Your Inbox has changed. No longer does it include favorites, it is a singular destination for your emails.'
 };
 
 storiesOf('Dialog', module)
   .addDecorator(FabricDecoratorTall)
-  .addDecorator(story => (
-    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.ms-Dialog-main' }).end()}>{story()}</Screener>
-  ))
-  .addStory('Root', () => (
-    <Dialog
-      hidden={false}
-      dialogContentProps={{
-        type: DialogType.normal,
-        ...text
-      }}
-      modalProps={{
-        isBlocking: false
-      }}
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.ms-Dialog-main' })
+        .end()}
     >
-      {footer}
-    </Dialog>
-  ), { rtl: true })
+      {story()}
+    </Screener>
+  )
+  .addStory(
+    'Root',
+    () => (
+      <Dialog
+        hidden={false}
+        dialogContentProps={{ type: DialogType.normal, ...text }}
+        modalProps={{ isBlocking: false }}
+      >
+        {footer}
+      </Dialog>
+    ),
+    { rtl: true }
+  )
   .addStory('Wide Dialog', () => (
     <Dialog
       hidden={false}
-      dialogContentProps={{
-        type: DialogType.normal,
-        ...text
-      }}
-      modalProps={{
-        isBlocking: false
-      }}
+      dialogContentProps={{ type: DialogType.normal, ...text }}
+      modalProps={{ isBlocking: false }}
       minWidth="500px"
       maxWidth="600px"
     >
@@ -55,13 +63,8 @@ storiesOf('Dialog', module)
   .addStory('Large header', () => (
     <Dialog
       hidden={false}
-      dialogContentProps={{
-        type: DialogType.largeHeader,
-        ...text
-      }}
-      modalProps={{
-        isBlocking: false
-      }}
+      dialogContentProps={{ type: DialogType.largeHeader, ...text }}
+      modalProps={{ isBlocking: false }}
     >
       {footer}
     </Dialog>
@@ -69,13 +72,8 @@ storiesOf('Dialog', module)
   .addStory('Blocking', () => (
     <Dialog
       hidden={false}
-      dialogContentProps={{
-        type: DialogType.normal,
-        ...text
-      }}
-      modalProps={{
-        isBlocking: true
-      }}
+      dialogContentProps={{ type: DialogType.normal, ...text }}
+      modalProps={{ isBlocking: true }}
     >
       {footer}
     </Dialog>

--- a/apps/vr-tests/src/stories/DocumentCard.stories.tsx
+++ b/apps/vr-tests/src/stories/DocumentCard.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator, FabricDecoratorFullWidth } from '../utilities';
 import {
@@ -11,12 +11,13 @@ import {
   DocumentCardType,
   ImageFit,
   DocumentCardDetails,
-  Fabric
+  Fabric,
+  IDocumentCardPreviewProps
 } from 'office-ui-fabric-react';
 
 import { TestImages } from '../common/TestImages';
 
-let previewProps = {
+const previewProps: IDocumentCardPreviewProps = {
   previewImages: [
     {
       name: 'Revenue stream proposal fiscal year 2016 version02.pptx',
@@ -32,7 +33,7 @@ let previewProps = {
   ]
 };
 
-let previewPropsCompact = {
+const previewPropsCompact: IDocumentCardPreviewProps = {
   getOverflowDocumentCountText: (overflowCount: number) => `+${overflowCount} more`,
   previewImages: [
     {
@@ -74,7 +75,7 @@ let previewPropsCompact = {
   ]
 };
 
-let DocActivity = (
+const docActivity = (
   <Fabric>
     <DocumentCardActivity
       activity="Created a few minutes ago"
@@ -85,7 +86,16 @@ let DocActivity = (
 
 storiesOf('DocumentCard', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Root', () => (
     <Fabric>
       <DocumentCard onClickHref="http://bing.com">
@@ -94,7 +104,7 @@ storiesOf('DocumentCard', module)
           title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"
           shouldTruncate={true}
         />
-        {DocActivity}
+        {docActivity}
       </DocumentCard>
     </Fabric>
   ))
@@ -106,7 +116,7 @@ storiesOf('DocumentCard', module)
           title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"
           shouldTruncate={false}
         />
-        {DocActivity}
+        {docActivity}
       </DocumentCard>
     </Fabric>
   ))
@@ -115,21 +125,30 @@ storiesOf('DocumentCard', module)
       <DocumentCard onClickHref="http://bing.com">
         <DocumentCardPreview {...previewProps} />
         <DocumentCardTitle title="4 files were uploaded" showAsSecondaryTitle={true} />
-        {DocActivity}
+        {docActivity}
       </DocumentCard>
     </Fabric>
   ));
 
 storiesOf('DocumentCard', module)
   .addDecorator(FabricDecoratorFullWidth)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Compact', () => (
     <Fabric>
       <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
         <DocumentCardPreview {...previewPropsCompact} />
         <DocumentCardDetails>
           <DocumentCardTitle title="4 files were uploaded" shouldTruncate={true} />
-          {DocActivity}
+          {docActivity}
         </DocumentCardDetails>
       </DocumentCard>
     </Fabric>

--- a/apps/vr-tests/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests/src/stories/Dropdown.stories.tsx
@@ -1,9 +1,15 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Dropdown, DropdownMenuItemType, IDropdownProps, Icon, IDropdownOption } from 'office-ui-fabric-react';
+import {
+  Dropdown,
+  DropdownMenuItemType,
+  IDropdownProps,
+  Icon,
+  IDropdownOption
+} from 'office-ui-fabric-react';
 
 storiesOf('Dropdown', module)
   .addDecorator(FabricDecorator)
@@ -116,7 +122,12 @@ storiesOf('Dropdown', module)
           return (
             <div className="dropdownExample-option">
               {option.data && option.data.icon && (
-                <Icon style={{ marginRight: '8px' }} iconName={option.data.icon} aria-hidden="true" title={option.data.icon} />
+                <Icon
+                  style={{ marginRight: '8px' }}
+                  iconName={option.data.icon}
+                  aria-hidden="true"
+                  title={option.data.icon}
+                />
               )}
               <span>{option.text}</span>
             </div>
@@ -126,7 +137,12 @@ storiesOf('Dropdown', module)
           return (
             <div className="dropdownExample-option">
               {option.data && option.data.icon && (
-                <Icon style={{ marginRight: '8px' }} iconName={option.data.icon} aria-hidden="true" title={option.data.icon} />
+                <Icon
+                  style={{ marginRight: '8px' }}
+                  iconName={option.data.icon}
+                  aria-hidden="true"
+                  title={option.data.icon}
+                />
               )}
               <span>{option.text}</span>
             </div>

--- a/apps/vr-tests/src/stories/Facepile.stories.tsx
+++ b/apps/vr-tests/src/stories/Facepile.stories.tsx
@@ -1,9 +1,15 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Facepile, PersonaInitialsColor, PersonaSize, OverflowButtonType } from 'office-ui-fabric-react';
+import {
+  Facepile,
+  PersonaInitialsColor,
+  PersonaSize,
+  OverflowButtonType,
+  IFacepileProps
+} from 'office-ui-fabric-react';
 
 import { TestImages } from '../common/TestImages';
 
@@ -41,26 +47,24 @@ const facepilePersonas = [
   }
 ];
 
-let facepileProps = {
+const facepileProps: IFacepileProps = {
   personas: facepilePersonas,
   ariaDescription: 'To move through the items use left and right arrow keys.'
 };
 
 storiesOf('Facepile', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (
-    <Facepile {...facepileProps} />
-  ), { rtl: true })
+  )
+  .addStory('Root', () => <Facepile {...facepileProps} />, { rtl: true })
   .addStory('Extra extra small', () => (
     <Facepile {...facepileProps} personaSize={PersonaSize.size24} />
   ))
@@ -70,17 +74,11 @@ storiesOf('Facepile', module)
       maxDisplayablePersonas={3}
       overflowButtonType={OverflowButtonType.downArrow}
       overflowButtonProps={{
-        ariaLabel: 'More users',
-      }
-      }
+        ariaLabel: 'More users'
+      }}
     />
   ))
-  .addStory('Add face', () => (
-    <Facepile
-      {...facepileProps}
-      showAddButton={true}
-    />
-  ))
+  .addStory('Add face', () => <Facepile {...facepileProps} showAddButton={true} />)
   .addStory('Custom button styles', () => (
     <Facepile
       {...facepileProps}
@@ -89,16 +87,12 @@ storiesOf('Facepile', module)
       maxDisplayablePersonas={3}
       overflowButtonProps={{
         styles: {
-          root: {
-            background: 'yellow'
-          }
+          root: { background: 'yellow' }
         }
       }}
       addButtonProps={{
         styles: {
-          root: {
-            boxShadow: '0px 0px 5px 5px gray'
-          }
+          root: { boxShadow: '0px 0px 5px 5px gray' }
         }
       }}
       styles={{
@@ -113,4 +107,4 @@ storiesOf('Facepile', module)
         }
       }}
     />
-  ))
+  ));

--- a/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
+++ b/apps/vr-tests/src/stories/FocusTrapZone.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Panel, PanelType, Dialog, DialogType } from 'office-ui-fabric-react';
@@ -17,36 +17,40 @@ storiesOf('FocusTrapZones', module)
       {story()}
     </Screener>
   ))
-  .addStory('Dialog nested in Panel', () => (
-    <div>
-      <Panel
-        isOpen={true}
-        type={PanelType.smallFixedFar}
-        headerText="This panel makes use of Layer and FocusTrapZone. Focus should be trapped in the panel."
-        closeButtonAriaLabel="Close"
-        hasCloseButton={true}
-      >
-        <Dialog
-          hidden={false}
-          isBlocking={true}
-          dialogContentProps={{
-            type: DialogType.normal,
-            title:
-              'This dialog uses Modal, which also makes use of Layer and FocusTrapZone. Focus should be trapped in the dialog.',
-            subText: "Focus will move back to the panel if you press 'OK' or 'Cancel'."
-          }}
-          modalProps={{
-            titleAriaId: 'myLabelId',
-            subtitleAriaId: 'mySubTextId',
-            isBlocking: false,
-            containerClassName: 'ms-dialogMainOverride'
-          }}
+  .addStory(
+    'Dialog nested in Panel',
+    () => (
+      <div>
+        <Panel
+          isOpen={true}
+          type={PanelType.smallFixedFar}
+          headerText="This panel makes use of Layer and FocusTrapZone. Focus should be trapped in the panel."
+          closeButtonAriaLabel="Close"
+          hasCloseButton={true}
         >
-          {null}
-        </Dialog>
-      </Panel>
-    </div>
-  ), { rtl: true })
+          <Dialog
+            hidden={false}
+            isBlocking={true}
+            dialogContentProps={{
+              type: DialogType.normal,
+              title:
+                'This dialog uses Modal, which also makes use of Layer and FocusTrapZone. Focus should be trapped in the dialog.',
+              subText: "Focus will move back to the panel if you press 'OK' or 'Cancel'."
+            }}
+            modalProps={{
+              titleAriaId: 'myLabelId',
+              subtitleAriaId: 'mySubTextId',
+              isBlocking: false,
+              containerClassName: 'ms-dialogMainOverride'
+            }}
+          >
+            {null}
+          </Dialog>
+        </Panel>
+      </div>
+    ),
+    { rtl: true }
+  )
   .addStory('Panel on its own', () => (
     <div>
       <Panel

--- a/apps/vr-tests/src/stories/FolderCover.stories.tsx
+++ b/apps/vr-tests/src/stories/FolderCover.stories.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { FolderCover, IFolderCoverProps, getFolderCoverLayout, renderFolderCoverWithLayout, SharedSignal } from '@uifabric/experiments';
+import {
+  FolderCover,
+  IFolderCoverProps,
+  getFolderCoverLayout,
+  renderFolderCoverWithLayout,
+  SharedSignal
+} from '@uifabric/experiments';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { ISize, fitContentToBounds } from 'office-ui-fabric-react';
@@ -9,7 +15,9 @@ interface IFolderCoverWithImageProps extends IFolderCoverProps {
   originalImageSize: ISize;
 }
 
-const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps> = (props: IFolderCoverWithImageProps): JSX.Element => {
+const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps> = (
+  props: IFolderCoverWithImageProps
+): JSX.Element => {
   const { originalImageSize, ...folderCoverProps } = props;
 
   const folderCover = <FolderCover style={{ fontFamily: 'Segoe UI' }} {...folderCoverProps} />;
@@ -23,13 +31,24 @@ const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps>
   });
 
   return renderFolderCoverWithLayout(folderCover, {
-    children: <img src={`//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`} />
+    children: (
+      <img src={`//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`} />
+    )
   });
 };
 
 storiesOf('FolderCover', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Large Default Cover', () => (
     <FolderCoverWithImage
       originalImageSize={{

--- a/apps/vr-tests/src/stories/Fonts.stories.tsx
+++ b/apps/vr-tests/src/stories/Fonts.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { createFontStyles } from 'office-ui-fabric-react/lib/Styling';
@@ -25,19 +25,32 @@ const RepresentativeText = (props: { style: React.CSSProperties }) => (
   </div>
 );
 
+function getStyle(lang: string) {
+  return createFontStyles(lang).medium as React.CSSProperties;
+}
+
 storiesOf('Fonts', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
-  .addStory('Arabic', () => <RepresentativeText style={createFontStyles('ar').medium as React.CSSProperties} />)
-  .addStory('Chinese (Simplified)', () => <RepresentativeText style={createFontStyles('zh-Hans').medium as React.CSSProperties} />)
-  .addStory('Chinese (Traditional)', () => <RepresentativeText style={createFontStyles('zh-Hant').medium as React.CSSProperties} />)
-  .addStory('Cyrillic', () => <RepresentativeText style={createFontStyles('bg').medium as React.CSSProperties} />)
-  .addStory('East European', () => <RepresentativeText style={createFontStyles('cs').medium as React.CSSProperties} />)
-  .addStory('Greek', () => <RepresentativeText style={createFontStyles('el').medium as React.CSSProperties} />)
-  .addStory('Hebrew', () => <RepresentativeText style={createFontStyles('he').medium as React.CSSProperties} />)
-  .addStory('Hindi', () => <RepresentativeText style={createFontStyles('hi').medium as React.CSSProperties} />)
-  .addStory('Japanese', () => <RepresentativeText style={createFontStyles('ja').medium as React.CSSProperties} />)
-  .addStory('Korean', () => <RepresentativeText style={createFontStyles('ko').medium as React.CSSProperties} />)
-  .addStory('Thai', () => <RepresentativeText style={createFontStyles('th').medium as React.CSSProperties} />)
-  .addStory('Vietnamese', () => <RepresentativeText style={createFontStyles('vi').medium as React.CSSProperties} />)
-  .addStory('West European', () => <RepresentativeText style={createFontStyles('en').medium as React.CSSProperties} />);
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
+  .addStory('Arabic', () => <RepresentativeText style={getStyle('ar')} />)
+  .addStory('Chinese (Simplified)', () => <RepresentativeText style={getStyle('zh-Hans')} />)
+  .addStory('Chinese (Traditional)', () => <RepresentativeText style={getStyle('zh-Hant')} />)
+  .addStory('Cyrillic', () => <RepresentativeText style={getStyle('bg')} />)
+  .addStory('East European', () => <RepresentativeText style={getStyle('cs')} />)
+  .addStory('Greek', () => <RepresentativeText style={getStyle('el')} />)
+  .addStory('Hebrew', () => <RepresentativeText style={getStyle('he')} />)
+  .addStory('Hindi', () => <RepresentativeText style={getStyle('hi')} />)
+  .addStory('Japanese', () => <RepresentativeText style={getStyle('ja')} />)
+  .addStory('Korean', () => <RepresentativeText style={getStyle('ko')} />)
+  .addStory('Thai', () => <RepresentativeText style={getStyle('th')} />)
+  .addStory('Vietnamese', () => <RepresentativeText style={getStyle('vi')} />)
+  .addStory('West European', () => <RepresentativeText style={getStyle('en')} />);

--- a/apps/vr-tests/src/stories/GroupedList.stories.tsx
+++ b/apps/vr-tests/src/stories/GroupedList.stories.tsx
@@ -1,19 +1,18 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { GroupedList } from 'office-ui-fabric-react';
 
-const groupCount = 2;
-const groupDepth = 2;
-// tslint:disable-next-line:max-line-length
+// tslint:disable:max-line-length
 const items = [
   {
     thumbnail: '//placehold.it/175x175',
     key: 'item-0 nostrud proident, id non',
     name: 'id velit labore ipsum magna',
-    description: 'dolor nostrud Ut ex dolore mollit veniam, Excepteur aute in magna sint ex sit occaecat non quis cupidatat sit esse',
+    description:
+      'dolor nostrud Ut ex dolore mollit veniam, Excepteur aute in magna sint ex sit occaecat non quis cupidatat sit esse',
     color: 'red',
     shape: 'circle',
     location: 'Los Angeles',
@@ -83,7 +82,7 @@ const groups = [
   }
 ];
 
-let onRenderCell = (nestingDepth: number, item: any, itemIndex: number) => {
+const onRenderCell = (nestingDepth: number, item: any, itemIndex: number) => {
   return <div>{item.name}</div>;
 };
 
@@ -105,8 +104,13 @@ storiesOf('GroupedList', module)
   ))
   .addStory(
     'Root',
-    () => <GroupedList groups={groups} items={items} onRenderCell={onRenderCell} styles={{ root: { color: '#333333' } }} />,
-    {
-      rtl: true
-    }
+    () => (
+      <GroupedList
+        groups={groups}
+        items={items}
+        onRenderCell={onRenderCell}
+        styles={{ root: { color: '#333333' } }}
+      />
+    ),
+    { rtl: true }
   );

--- a/apps/vr-tests/src/stories/HoverCard.stories.tsx
+++ b/apps/vr-tests/src/stories/HoverCard.stories.tsx
@@ -1,11 +1,11 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { HoverCard } from 'office-ui-fabric-react';
 
-let onRenderCompactCard = (item: any) => {
+const onRenderCompactCard = (item: any) => {
   return <div>Content</div>;
 };
 
@@ -16,7 +16,16 @@ const expandingCardProps = {
 
 storiesOf('HoverCard', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory(
     'Root',
     () => (

--- a/apps/vr-tests/src/stories/Icon.stories.tsx
+++ b/apps/vr-tests/src/stories/Icon.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Icon, IconType, getIconClassName, Fabric } from 'office-ui-fabric-react';
@@ -9,14 +9,24 @@ import * as IconNames from '../../../../packages/icons/src/IconNames';
 import { TestImages } from '../common/TestImages';
 
 // Rendering allIcons tests that the icon package can initialize all icons from the cdn
-let allIcons: JSX.Element[] = [];
+const allIcons: JSX.Element[] = [];
+// tslint:disable-next-line
 for (let iconName in (IconNames as any)['IconNames']) {
   allIcons.push(<Icon iconName={iconName} />);
 }
 
 storiesOf('Icon', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Root', () => (
     <Fabric>
       <div>{allIcons}</div>
@@ -26,7 +36,6 @@ storiesOf('Icon', module)
     </Fabric>
   ))
   .addStory('Color', () => (
-    // tslint:disable-next-line:jsx-ban-props
     <Fabric>
       <Icon iconName={'CompassNW'} style={{ color: 'red' }} />
     </Fabric>

--- a/apps/vr-tests/src/stories/Image.stories.tsx
+++ b/apps/vr-tests/src/stories/Image.stories.tsx
@@ -1,42 +1,42 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import { storiesOf } from '@storybook/react';
-import { Image, ImageFit, Label, Layer } from 'office-ui-fabric-react';
+import { Image, ImageFit, Label, Layer, IImageProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { FabricDecorator } from '../utilities';
 
 const img350x150 = 'http://placehold.it/350x150';
 
-let imagePropsFitNone = {
+const imagePropsFitNone: IImageProps = {
   src: 'http://placehold.it/500x250',
   imageFit: ImageFit.none,
   width: 350,
   height: 150
 };
 
-let imagePropsFitCenter = {
+const imagePropsFitCenter: IImageProps = {
   src: 'http://placehold.it/800x300',
   imageFit: ImageFit.center,
   width: 350,
   height: 150
 };
 
-let imagePropsFitContain = {
+const imagePropsFitContain: IImageProps = {
   src: 'http://placehold.it/700x300',
   imageFit: ImageFit.contain
 };
 
-let imagePropsFitCover = {
+const imagePropsFitCover: IImageProps = {
   src: 'http://placehold.it/500x500',
   imageFit: ImageFit.cover
 };
 
-let imagePropsFitCenterCover = {
+const imagePropsFitCenterCover: IImageProps = {
   src: 'http://placehold.it/400x400',
   imageFit: ImageFit.centerCover
 };
 
-let imagePropsMaximizeFrame = {
+const imagePropsMaximizeFrame: IImageProps = {
   src: 'http://placehold.it/500x500',
   imageFit: ImageFit.cover,
   maximizeFrame: true
@@ -46,17 +46,30 @@ let imagePropsMaximizeFrame = {
 
 storiesOf('Image', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('No fit, no w/h', () => (
     <div>
-      <Label>Without a width or height specified, the frame remains at its natural size and the image will not be scaled.</Label>
+      <Label>
+        Without a width or height specified, the frame remains at its natural size and the image
+        will not be scaled.
+      </Label>
       <Image src={img350x150} />
     </div>
   ))
   .addStory('No fit, only width', () => (
     <div>
       <Label>
-        If only a width is provided, the frame will be set to that width. The image will scale proportionally to fill the available width.
+        If only a width is provided, the frame will be set to that width. The image will scale
+        proportionally to fill the available width.
       </Label>
       <Image src={img350x150} width={600} />
     </div>
@@ -64,37 +77,43 @@ storiesOf('Image', module)
   .addStory('No fit, only height', () => (
     <div>
       <Label>
-        If only a height is provided, the frame will be set to that height. The image will scale proportionally to fill the available
-        height.
+        If only a height is provided, the frame will be set to that height. The image will scale
+        proportionally to fill the available height.
       </Label>
       <Image src={img350x150} width={100} />
     </div>
   ))
   .addStory('Fit: none, image larger', () => (
     <div>
-      <Label>The image is larger than the frame, so it is cropped to fit. The image is positioned at the upper left of the frame.</Label>
+      <Label>
+        The image is larger than the frame, so it is cropped to fit. The image is positioned at the
+        upper left of the frame.
+      </Label>
       <Image {...imagePropsFitNone} />
     </div>
   ))
   .addStory('Fit: none, image smaller', () => (
     <div>
       <Label>
-        The image is smaller than the frame, so there is empty space within the frame. The image is positioned at the upper left of the
-        frame.
+        The image is smaller than the frame, so there is empty space within the frame. The image is
+        positioned at the upper left of the frame.
       </Label>
       <Image {...imagePropsFitNone} src="http://placehold.it/100x100" />
     </div>
   ))
   .addStory('Fit: center, image larger', () => (
     <div>
-      <Label>The image is larger than the frame, so all sides are cropped to center the image.</Label>
+      <Label>
+        The image is larger than the frame, so all sides are cropped to center the image.
+      </Label>
       <Image {...imagePropsFitCenter} src="http://placehold.it/800x300" />
     </div>
   ))
   .addStory('Fit: center, image smaller', () => (
     <div>
       <Label>
-        The image is smaller than the frame, so there is empty space within the frame. The image is centered in the available space.
+        The image is smaller than the frame, so there is empty space within the frame. The image is
+        centered in the available space.
       </Label>
       <Image {...imagePropsFitCenter} src="http://placehold.it/100x100" />
     </div>
@@ -102,8 +121,8 @@ storiesOf('Image', module)
   .addStory('Fit: contain, image wider', () => (
     <div>
       <Label>
-        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the width and centered in the
-        available vertical space.
+        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled
+        to fit the width and centered in the available vertical space.
       </Label>
       <Image {...imagePropsFitContain} width={200} height={200} />
     </div>
@@ -111,8 +130,8 @@ storiesOf('Image', module)
   .addStory('Fit: contain, image taller', () => (
     <div>
       <Label>
-        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the height and centered in the
-        available horizontal space.
+        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled
+        to fit the height and centered in the available horizontal space.
       </Label>
       <Image {...imagePropsFitContain} width={300} height={50} />
     </div>
@@ -120,8 +139,8 @@ storiesOf('Image', module)
   .addStory('Fit: cover, image wider', () => (
     <div>
       <Label>
-        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the height and the sides are
-        cropped evenly.
+        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled
+        to fit the height and the sides are cropped evenly.
       </Label>
       <Image {...imagePropsFitCover} width={150} height={250} />
     </div>
@@ -129,15 +148,18 @@ storiesOf('Image', module)
   .addStory('Fit: cover, image taller', () => (
     <div>
       <Label>
-        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the width and the top and bottom
-        are cropped evenly.
+        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled
+        to fit the width and the top and bottom are cropped evenly.
       </Label>
       <Image {...imagePropsFitCover} width={250} height={150} />
     </div>
   ))
   .addStory('Fit: centerCover, image smaller', () => (
     <div>
-      <Label>The image is smaller than the frame, so the image is centered with empty space within the frame.</Label>
+      <Label>
+        The image is smaller than the frame, so the image is centered with empty space within the
+        frame.
+      </Label>
       <Image {...imagePropsFitCenterCover} width={500} height={500} />
     </div>
   ))
@@ -149,13 +171,19 @@ storiesOf('Image', module)
   ))
   .addStory('Fit: centerCover, image wider', () => (
     <div>
-      <Label>The image has a wider aspect ratio (more landscape) than the frame, so the sides are cropped evenly.</Label>
+      <Label>
+        The image has a wider aspect ratio (more landscape) than the frame, so the sides are cropped
+        evenly.
+      </Label>
       <Image {...imagePropsFitCenterCover} width={300} height={500} />
     </div>
   ))
   .addStory('Fit: centerCover, image taller', () => (
     <div>
-      <Label>The image has a taller aspect ratio (more portrait) than the frame, so the top and bottom are cropped evenly.</Label>
+      <Label>
+        The image has a taller aspect ratio (more portrait) than the frame, so the top and bottom
+        are cropped evenly.
+      </Label>
       <Image {...imagePropsFitCenterCover} width={500} height={300} />
     </div>
   ))

--- a/apps/vr-tests/src/stories/Keytip.stories.tsx
+++ b/apps/vr-tests/src/stories/Keytip.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Keytip } from 'office-ui-fabric-react';
@@ -13,16 +13,20 @@ storiesOf('Keytip', module)
     </div>
   ))
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
+  )
+  .addStory('Root', () => <Keytip content={'A'} keySequences={['a']} visible={true} />)
+  .addStory('Disabled', () => (
+    <Keytip content={'A'} keySequences={['a']} visible={true} disabled={true} />
   ))
-  .addStory('Root', () => (<Keytip content={'A'} keySequences={['a']} visible={true} />))
-  .addStory('Disabled', () => (<Keytip content={'A'} keySequences={['a']} visible={true} disabled={true} />))
-  .addStory('Offset', () => (<Keytip content={'A'} keySequences={['a']} visible={true} offset={{ x: 15, y: 15 }} />));
+  .addStory('Offset', () => (
+    <Keytip content={'A'} keySequences={['a']} visible={true} offset={{ x: 15, y: 15 }} />
+  ));

--- a/apps/vr-tests/src/stories/Label.stories.tsx
+++ b/apps/vr-tests/src/stories/Label.stories.tsx
@@ -1,22 +1,22 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Label, ILabelProps } from 'office-ui-fabric-react';
+import { Label } from 'office-ui-fabric-react';
 
 storiesOf('Label', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (<Label>I'm a label</Label>), { rtl: true })
-  .addStory('Disabled', () => (<Label disabled>I'm a disabled label</Label>))
-  .addStory('Required', () => (<Label required>I'm a required label</Label>));
+  )
+  .addStory('Root', () => <Label>I'm a label</Label>, { rtl: true })
+  .addStory('Disabled', () => <Label disabled>I'm a disabled label</Label>)
+  .addStory('Required', () => <Label required>I'm a required label</Label>);

--- a/apps/vr-tests/src/stories/Layer.stories.tsx
+++ b/apps/vr-tests/src/stories/Layer.stories.tsx
@@ -1,22 +1,20 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Layer } from 'office-ui-fabric-react';
 
 storiesOf('Layer', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.ms-Layer' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (
-    <Layer>Layer content</Layer>
-  ), { rtl: true });
+  )
+  .addStory('Root', () => <Layer>Layer content</Layer>, { rtl: true });

--- a/apps/vr-tests/src/stories/Link.stories.tsx
+++ b/apps/vr-tests/src/stories/Link.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Screener, { Steps } from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Link, ILinkProps } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 
 storiesOf('Link', module)
   .addDecorator(FabricDecorator)
@@ -41,7 +41,9 @@ storiesOf('Link', module)
   ))
   .addStory('No Href', () => (
     <div className=".ms-Fabric--isFocusVisible">
-      <Link styles={{ root: { fontSize: '14px' } }}>I'm rendered as a button because I have no href</Link>
+      <Link styles={{ root: { fontSize: '14px' } }}>
+        I'm rendered as a button because I have no href
+      </Link>
     </div>
   ))
   .addStory('No Href Disabled', () => (

--- a/apps/vr-tests/src/stories/List.stories.tsx
+++ b/apps/vr-tests/src/stories/List.stories.tsx
@@ -1,11 +1,11 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { List } from 'office-ui-fabric-react';
 
-// tslint:disable-next-line:max-line-length
+// tslint:disable:max-line-length
 const items = [
   {
     thumbnail: '//placehold.it/233x233',
@@ -47,7 +47,8 @@ const items = [
     thumbnail: '//placehold.it/158x158',
     key: 'item-3 magna Ut nisi dolor',
     name: 'nostrud in reprehenderit eu anim',
-    description: 'nisi eu et in exercitation ut consectetur veniam, ut sunt ut commodo ad laboris sit culpa aliquip',
+    description:
+      'nisi eu et in exercitation ut consectetur veniam, ut sunt ut commodo ad laboris sit culpa aliquip',
     color: 'green',
     shape: 'circle',
     location: 'Seattle',
@@ -128,9 +129,18 @@ const items = [
   }
 ];
 
-const onRenderCell = item => <div>{item.name}</div>;
+const onRenderCell = (item: any) => <div>{item.name}</div>;
 
 storiesOf('List', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Root', () => <List items={items} onRenderCell={onRenderCell} />, { rtl: true });

--- a/apps/vr-tests/src/stories/MessageBar.stories.tsx
+++ b/apps/vr-tests/src/stories/MessageBar.stories.tsx
@@ -1,97 +1,159 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { MessageBarButton, Link, MessageBar, IMessageBarProps, MessageBarType } from 'office-ui-fabric-react';
+import { MessageBarButton, Link, MessageBar, MessageBarType } from 'office-ui-fabric-react';
 
-let noop = (): void => { /**/ };
-// tslint:disable-next-line:max-line-length
-let longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vestibulum tellus at malesuada vestibulum. Pellentesque eget mi sagittis, sagittis nisi a, tristique nisl. Sed sed consequat neque, et dignissim ipsum. Integer in neque vestibulum, aliquet erat nec, vestibulum ex. Nullam et imperdiet lectus. Cras tempus eu tortor a elementum. Proin non justo lacus. Donec tincidunt laoreet malesuada. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean augue nisl, lobortis ut sodales eu, convallis in metus.';
-let link = <Link href='www.bing.com'>Visit our website</Link>;
+const noop = (): void => undefined;
+// tslint:disable:max-line-length
+const longText =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vestibulum tellus at malesuada vestibulum. Pellentesque eget mi sagittis, sagittis nisi a, tristique nisl. Sed sed consequat neque, et dignissim ipsum. Integer in neque vestibulum, aliquet erat nec, vestibulum ex. Nullam et imperdiet lectus. Cras tempus eu tortor a elementum. Proin non justo lacus. Donec tincidunt laoreet malesuada. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean augue nisl, lobortis ut sodales eu, convallis in metus.';
+const link = <Link href="www.bing.com">Visit our website</Link>;
 
 storiesOf('MessageBar', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
-      steps={new Steps()
+      steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (<MessageBar>Info/default message bar. {link}</MessageBar>), { rtl: true })
-  .addStory('Root dismiss', () => (
-    <MessageBar onDismiss={noop}>Info/default message bar. {link}</MessageBar>), { rtl: true })
+  )
+  .addStory('Root', () => <MessageBar>Info/default message bar. {link}</MessageBar>, { rtl: true })
+  .addStory(
+    'Root dismiss',
+    () => <MessageBar onDismiss={noop}>Info/default message bar. {link}</MessageBar>,
+    { rtl: true }
+  )
   .addStory('Root dismiss single line', () => (
-    <MessageBar onDismiss={noop} isMultiline={false}>Info/default message bar. {link}</MessageBar>))
-  .addStory('Root truncated', () => (
-    <MessageBar truncated={true} isMultiline={false}>Blocked lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a lobortis tristique, odio augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum aliquam et nunc semper scelerisque. Curabitur vitae orci nec quam condimentum porttitor et sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat erat euismod et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum mauris. {link}</MessageBar>), { rtl: true })
-  .addStory('Root actions', () => (
-    <MessageBar
-      actions={
-        <div>
-          <MessageBarButton>Yes</MessageBarButton>
-          <MessageBarButton>No</MessageBarButton>
-        </div>
-      }
-    >Info/default message bar. {link}
-    </MessageBar>), { rtl: true })
-  .addStory('Root actions single line', () => (
-    <MessageBar
-      isMultiline={false}
-      actions={
-        <div>
-          <MessageBarButton>Yes</MessageBarButton>
-          <MessageBarButton>No</MessageBarButton>
-        </div>
-      }
-    >Info/default message bar. {link}
-    </MessageBar>), { rtl: true })
-  .addStory('Root dismiss and action', () => (
-    <MessageBar
-      onDismiss={noop}
-      actions={
-        <div>
-          <MessageBarButton>Yes</MessageBarButton>
-          <MessageBarButton>No</MessageBarButton>
-        </div>
-      }
-    >Info/default message bar. {link}
-    </MessageBar>), { rtl: true })
-  .addStory('Root dismiss and action single line', () => (
-    <MessageBar
-      isMultiline={false}
-      onDismiss={noop}
-      actions={
-        <div>
-          <MessageBarButton>Yes</MessageBarButton>
-          <MessageBarButton>No</MessageBarButton>
-        </div>
-      }
-    >Info/default message bar. {link}
-    </MessageBar>), { rtl: true })
-  .addStory('Root multiline', () => (<MessageBar isMultiline>Info/default message bar. {longText}</MessageBar>), { rtl: true })
-  .addStory('Root overflow', () => (<MessageBar isMultiline={false}>Info/default message bar. {longText}  </MessageBar>), { rtl: true })
-  .addStory('Error', () => (
+    <MessageBar onDismiss={noop} isMultiline={false}>
+      Info/default message bar. {link}
+    </MessageBar>
+  ))
+  .addStory(
+    'Root truncated',
+    () => (
+      <MessageBar truncated={true} isMultiline={false}>
+        Blocked lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi luctus, purus a
+        lobortis tristique, odio augue pharetra metus, ac placerat nunc mi nec dui. Vestibulum
+        aliquam et nunc semper scelerisque. Curabitur vitae orci nec quam condimentum porttitor et
+        sed lacus. Vivamus ac efficitur leo. Cras faucibus mauris libero, ac placerat erat euismod
+        et. Donec pulvinar commodo odio sit amet faucibus. In hac habitasse platea dictumst. Duis eu
+        ante commodo, condimentum nibh pellentesque, laoreet enim. Fusce massa lorem, ultrices eu mi
+        a, fermentum suscipit magna. Integer porta purus pulvinar, hendrerit felis eget, condimentum
+        mauris. {link}
+      </MessageBar>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Root actions',
+    () => (
+      <MessageBar
+        actions={
+          <div>
+            <MessageBarButton>Yes</MessageBarButton>
+            <MessageBarButton>No</MessageBarButton>
+          </div>
+        }
+      >
+        Info/default message bar. {link}
+      </MessageBar>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Root actions single line',
+    () => (
+      <MessageBar
+        isMultiline={false}
+        actions={
+          <div>
+            <MessageBarButton>Yes</MessageBarButton>
+            <MessageBarButton>No</MessageBarButton>
+          </div>
+        }
+      >
+        Info/default message bar. {link}
+      </MessageBar>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Root dismiss and action',
+    () => (
+      <MessageBar
+        onDismiss={noop}
+        actions={
+          <div>
+            <MessageBarButton>Yes</MessageBarButton>
+            <MessageBarButton>No</MessageBarButton>
+          </div>
+        }
+      >
+        Info/default message bar. {link}
+      </MessageBar>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Root dismiss and action single line',
+    () => (
+      <MessageBar
+        isMultiline={false}
+        onDismiss={noop}
+        actions={
+          <div>
+            <MessageBarButton>Yes</MessageBarButton>
+            <MessageBarButton>No</MessageBarButton>
+          </div>
+        }
+      >
+        Info/default message bar. {link}
+      </MessageBar>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Root multiline',
+    () => <MessageBar isMultiline>Info/default message bar. {longText}</MessageBar>,
+    { rtl: true }
+  )
+  .addStory(
+    'Root overflow',
+    () => <MessageBar isMultiline={false}>Info/default message bar. {longText} </MessageBar>,
+    { rtl: true }
+  )
+  .addStory('Error', () =>
+    // prettier-ignore
     <MessageBar messageBarType={MessageBarType.error}>
       Error message bar. {link}
-    </MessageBar>))
-  .addStory('Blocked', () => (
+    </MessageBar>
+  )
+  .addStory('Blocked', () =>
+    // prettier-ignore
     <MessageBar messageBarType={MessageBarType.blocked}>
       Blocked message bar. {link}
-    </MessageBar>))
+    </MessageBar>
+  )
   .addStory('Severe Warning', () => (
     <MessageBar messageBarType={MessageBarType.severeWarning}>
       Severe Warning message bar. {link}
-    </MessageBar>))
-  .addStory('Success', () => (
+    </MessageBar>
+  ))
+  .addStory('Success', () =>
+    // prettier-ignore
     <MessageBar messageBarType={MessageBarType.success}>
       Success message bar. {link}
-    </MessageBar>))
-  .addStory('Warning', () => (
+    </MessageBar>
+  )
+  .addStory('Warning', () =>
+    // prettier-ignore
     <MessageBar messageBarType={MessageBarType.warning}>
       Warning message bar. {link}
-    </MessageBar>));
+    </MessageBar>
+  );

--- a/apps/vr-tests/src/stories/Modal.stories.tsx
+++ b/apps/vr-tests/src/stories/Modal.stories.tsx
@@ -1,28 +1,24 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
 
-// tslint:disable:max-line-length
 storiesOf('Modal', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.ms-Modal' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
+  )
   .addStory('Root', () => (
-    <Modal
-      isOpen
-      isBlocking={false}
-    >
+    <Modal isOpen isBlocking={false}>
       Modal content
-    </Modal >
+    </Modal>
   ));

--- a/apps/vr-tests/src/stories/Nav.stories.tsx
+++ b/apps/vr-tests/src/stories/Nav.stories.tsx
@@ -1,12 +1,59 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Nav } from 'office-ui-fabric-react/lib/Nav';
+import { Nav, INavLink } from 'office-ui-fabric-react/lib/Nav';
 import { IconNames } from 'office-ui-fabric-react/lib/Icons';
 
-// tslint:disable:max-line-length
+const links: INavLink[] = [
+  {
+    name: 'Home',
+    url: 'http://example.com',
+    links: [
+      {
+        name: 'Activity',
+        icon: IconNames.Upload,
+        url: 'http://msn.com',
+        key: 'key1'
+      },
+      {
+        name: 'News',
+        url: 'http://msn.com',
+        key: 'key2'
+      }
+    ],
+    isExpanded: true
+  },
+  {
+    name: 'Documents',
+    icon: IconNames.Accept,
+    url: 'http://example.com',
+    key: 'key3'
+  },
+  {
+    name: 'Pages',
+    url: 'http://msn.com',
+    key: 'key4'
+  },
+  {
+    name: 'Notebook',
+    url: 'http://msn.com',
+    key: 'key5'
+  },
+  {
+    name: 'Long Name Test for elipse',
+    url: 'http://msn.com',
+    key: 'key6'
+  },
+  {
+    name: 'Edit',
+    url: 'http://cnn.com',
+    icon: IconNames.Edit,
+    key: 'key8'
+  }
+];
+
 storiesOf('Nav', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
@@ -26,43 +73,9 @@ storiesOf('Nav', module)
   .addStory(
     'Root',
     () => (
-      // tslint:disable-next-line:jsx-ban-props
       <div style={{ width: '208px' }}>
         <Nav
-          groups={[
-            {
-              links: [
-                {
-                  name: 'Home',
-                  url: 'http://example.com',
-                  links: [
-                    {
-                      name: 'Activity',
-                      icon: IconNames.Upload,
-                      url: 'http://msn.com',
-                      key: 'key1'
-                    },
-                    {
-                      name: 'News',
-                      url: 'http://msn.com',
-                      key: 'key2'
-                    }
-                  ],
-                  isExpanded: true
-                },
-                { name: 'Documents', icon: IconNames.Accept, url: 'http://example.com', key: 'key3' },
-                { name: 'Pages', url: 'http://msn.com', key: 'key4' },
-                { name: 'Notebook', url: 'http://msn.com', key: 'key5' },
-                { name: 'Long Name Test for elipse', url: 'http://msn.com', key: 'key6' },
-                {
-                  name: 'Edit',
-                  url: 'http://cnn.com',
-                  icon: IconNames.Edit,
-                  key: 'key8'
-                }
-              ]
-            }
-          ]}
+          groups={[{ links: links }]}
           expandedStateText={'expanded'}
           collapsedStateText={'collapsed'}
           selectedKey={'key3'}

--- a/apps/vr-tests/src/stories/OverflowSet.stories.tsx
+++ b/apps/vr-tests/src/stories/OverflowSet.stories.tsx
@@ -1,12 +1,12 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Fabric, OverflowSet, IconButton } from 'office-ui-fabric-react';
+import { Fabric, OverflowSet, IconButton, IOverflowSetItemProps } from 'office-ui-fabric-react';
 
-const onRenderItem = item => item.name;
-const onRenderOverflowButton = overflowItems => {
+const onRenderItem = (item: IOverflowSetItemProps) => item.name;
+const onRenderOverflowButton = (overflowItems: any[]) => {
   return <IconButton menuProps={{ items: overflowItems! }} />;
 };
 
@@ -30,28 +30,13 @@ storiesOf('OverflowSet', module)
       <Fabric>
         <OverflowSet
           items={[
-            {
-              key: 'item1',
-              name: 'Link 1'
-            },
-            {
-              key: 'item2',
-              name: 'Link 2'
-            },
-            {
-              key: 'item3',
-              name: 'Link 3'
-            }
+            { key: 'item1', name: 'Link 1' },
+            { key: 'item2', name: 'Link 2' },
+            { key: 'item3', name: 'Link 3' }
           ]}
           overflowItems={[
-            {
-              key: 'item4',
-              name: 'Overflow Link 1'
-            },
-            {
-              key: 'item5',
-              name: 'Overflow Link 2'
-            }
+            { key: 'item4', name: 'Overflow Link 1' },
+            { key: 'item5', name: 'Overflow Link 2' }
           ]}
           onRenderOverflowButton={onRenderOverflowButton}
           onRenderItem={onRenderItem}
@@ -63,34 +48,28 @@ storiesOf('OverflowSet', module)
 
 storiesOf('OverflowSet variant', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Vertical Direction', () => (
     <Fabric>
       <OverflowSet
         vertical
         items={[
-          {
-            key: 'item1',
-            name: 'Link 1'
-          },
-          {
-            key: 'item2',
-            name: 'Link 2'
-          },
-          {
-            key: 'item3',
-            name: 'Link 3'
-          }
+          { key: 'item1', name: 'Link 1' },
+          { key: 'item2', name: 'Link 2' },
+          { key: 'item3', name: 'Link 3' }
         ]}
         overflowItems={[
-          {
-            key: 'item4',
-            name: 'Overflow Link 1'
-          },
-          {
-            key: 'item5',
-            name: 'Overflow Link 2'
-          }
+          { key: 'item4', name: 'Overflow Link 1' },
+          { key: 'item5', name: 'Overflow Link 2' }
         ]}
         onRenderOverflowButton={onRenderOverflowButton}
         onRenderItem={onRenderItem}

--- a/apps/vr-tests/src/stories/Overlay.stories.tsx
+++ b/apps/vr-tests/src/stories/Overlay.stories.tsx
@@ -1,25 +1,30 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Overlay } from 'office-ui-fabric-react';
 
 storiesOf('Overlay', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.ms-Overlay' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
-  .addStory('Root', () => (
-    <Overlay>Overlay content</Overlay>
-  ), { rtl: true })
-  .addStory('Dark', () => (
-    <Overlay isDarkThemed>Overlay content</Overlay>
-  ));
+  )
+  .addStory(
+    'Root',
+    // prettier-ignore
+    () => <Overlay>Overlay content</Overlay>,
+    { rtl: true }
+  )
+  .addStory(
+    'Dark',
+    // prettier-ignore
+    () => <Overlay isDarkThemed>Overlay content</Overlay>
+  );

--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Panel, PanelType, SearchBox } from 'office-ui-fabric-react';
@@ -12,19 +12,55 @@ const defaultProps = {
 
 storiesOf('Panel', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default').end()}>{story()}</Screener>)
-  .addStory('Small left w/ close button', () => (
-    <Panel {...defaultProps} hasCloseButton type={PanelType.smallFixedNear} headerText="Small" />
-  ), { rtl: true })
-  .addStory('Small fixed right w/ close button', () => (
-    <Panel {...defaultProps} hasCloseButton type={PanelType.smallFixedFar} headerText="Small fixed" />
-  ), { rtl: true })
-  .addStory('Small fluid right', () => <Panel {...defaultProps} type={PanelType.smallFluid} headerText="Small fluid" />)
-  .addStory('Medium right', () => <Panel {...defaultProps} type={PanelType.medium} headerText="Medium" />, { rtl: true })
-  .addStory('Large right', () => <Panel {...defaultProps} type={PanelType.large} headerText="Large" />)
-  .addStory('Large fixed right', () => <Panel {...defaultProps} type={PanelType.largeFixed} headerText="Large fixed" />)
-  .addStory('Extra large right', () => <Panel {...defaultProps} type={PanelType.extraLarge} headerText="Extra Large" />)
-  .addStory('Custom', () => <Panel {...defaultProps} type={PanelType.custom} headerText="Custom" customWidth="200vw" />);
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
+  .addStory(
+    'Small left w/ close button',
+    () => (
+      <Panel {...defaultProps} hasCloseButton type={PanelType.smallFixedNear} headerText="Small" />
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Small fixed right w/ close button',
+    () => (
+      <Panel
+        {...defaultProps}
+        hasCloseButton
+        type={PanelType.smallFixedFar}
+        headerText="Small fixed"
+      />
+    ),
+    { rtl: true }
+  )
+  .addStory('Small fluid right', () => (
+    <Panel {...defaultProps} type={PanelType.smallFluid} headerText="Small fluid" />
+  ))
+  .addStory(
+    'Medium right',
+    () => <Panel {...defaultProps} type={PanelType.medium} headerText="Medium" />,
+    { rtl: true }
+  )
+  .addStory('Large right', () => (
+    <Panel {...defaultProps} type={PanelType.large} headerText="Large" />
+  ))
+  .addStory('Large fixed right', () => (
+    <Panel {...defaultProps} type={PanelType.largeFixed} headerText="Large fixed" />
+  ))
+  .addStory('Extra large right', () => (
+    <Panel {...defaultProps} type={PanelType.extraLarge} headerText="Extra Large" />
+  ))
+  .addStory('Custom', () => (
+    <Panel {...defaultProps} type={PanelType.custom} headerText="Custom" customWidth="200vw" />
+  ));
 
 storiesOf('Panel', module)
   .addDecorator(FabricDecorator)
@@ -39,11 +75,22 @@ storiesOf('Panel', module)
       {story()}
     </Screener>
   ))
-  .addStory('SearchBox and Right Panel', () => (
-    <div>
-      <SearchBox placeholder="Search" />
-      <Panel {...defaultProps} isOpen={false} type={PanelType.medium} headerClassName="" headerText={'Header'} isHiddenOnDismiss>
-        {null}
-      </Panel>
-    </div>
-  ), { rtl: true });
+  .addStory(
+    'SearchBox and Right Panel',
+    () => (
+      <div>
+        <SearchBox placeholder="Search" />
+        <Panel
+          {...defaultProps}
+          isOpen={false}
+          type={PanelType.medium}
+          headerClassName=""
+          headerText={'Header'}
+          isHiddenOnDismiss
+        >
+          {null}
+        </Panel>
+      </div>
+    ),
+    { rtl: true }
+  );

--- a/apps/vr-tests/src/stories/PeoplePicker.stories.tsx
+++ b/apps/vr-tests/src/stories/PeoplePicker.stories.tsx
@@ -1,9 +1,16 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Fabric, CompactPeoplePicker, ListPeoplePicker, NormalPeoplePicker, IPersonaProps, PersonaPresence } from 'office-ui-fabric-react';
+import {
+  Fabric,
+  CompactPeoplePicker,
+  ListPeoplePicker,
+  NormalPeoplePicker,
+  IPersonaProps,
+  PersonaPresence
+} from 'office-ui-fabric-react';
 
 import { TestImages } from '../common/TestImages';
 

--- a/apps/vr-tests/src/stories/Persona.stories.tsx
+++ b/apps/vr-tests/src/stories/Persona.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { IPersonaProps, Persona, PersonaPresence, PersonaSize } from 'office-ui-fabric-react';
@@ -15,18 +15,18 @@ const examplePersona: IPersonaProps = {
   optionalText: 'Available at 4:00pm'
 };
 
+// prettier-ignore
 storiesOf('Persona', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  ))
+  )
   .addStory('size10 (tiny)', () => (
     <div>
       <Persona
@@ -40,7 +40,8 @@ storiesOf('Persona', module)
         presence={PersonaPresence.offline}
       />
     </div>
-  )).addStory('size24 (extraExtraSmall)', () => (
+  ))
+  .addStory('size24 (extraExtraSmall)', () => (
     <div>
       <Persona
         {...examplePersona}
@@ -53,7 +54,8 @@ storiesOf('Persona', module)
         presence={PersonaPresence.none}
       />
     </div>
-  )).addStory('size28 (extraSmall)', () => (
+  ))
+  .addStory('size28 (extraSmall)', () => (
     <div>
       <Persona
         {...examplePersona}
@@ -66,13 +68,15 @@ storiesOf('Persona', module)
         presence={PersonaPresence.none}
       />
     </div>
-  )).addStory('size32', () => (
+  ))
+  .addStory('size32', () => (
     <Persona
       {...examplePersona}
       size={PersonaSize.size32}
       presence={PersonaPresence.online}
     />
-  )).addStory('size40 (small)', () => (
+  ))
+  .addStory('size40 (small)', () => (
     <div>
       <Persona
         {...examplePersona}
@@ -87,7 +91,8 @@ storiesOf('Persona', module)
         showSecondaryText
       />
     </div>
-  )).addStory('size48 (regular)', () => (
+  ))
+  .addStory('size48 (regular)', () => (
     <div>
       <Persona
         {...examplePersona}
@@ -100,51 +105,54 @@ storiesOf('Persona', module)
         presence={PersonaPresence.away}
       />
     </div>
-  )).addStory('default size, presences', () => (
+  ))
+  .addStory('default size, presences', () => (
     <div>
       <Persona
         {...examplePersona}
-        text='PersonaPresence.away'
+        text="PersonaPresence.away"
         presence={PersonaPresence.away}
       />
       <Persona
         {...examplePersona}
-        text='PersonaPresence.blocked'
+        text="PersonaPresence.blocked"
         presence={PersonaPresence.blocked}
       />
       <Persona
         {...examplePersona}
-        text='PersonaPresence.busy'
+        text="PersonaPresence.busy"
         presence={PersonaPresence.busy}
       />
       <Persona
         {...examplePersona}
-        text='PersonaPresence.dnd'
+        text="PersonaPresence.dnd"
         presence={PersonaPresence.dnd}
       />
       <Persona
         {...examplePersona}
-        text='PersonaPresence.none'
+        text="PersonaPresence.none"
         presence={PersonaPresence.none}
       />
       <Persona
         {...examplePersona}
-        text='PersonaPresence.offline'
+        text="PersonaPresence.offline"
         presence={PersonaPresence.offline}
       />
       <Persona
         {...examplePersona}
-        text='PersonaPresence.online'
+        text="PersonaPresence.online"
         presence={PersonaPresence.online}
       />
     </div>
-  )).addStory('default size, details hidden', () => (
+  ))
+  .addStory('default size, details hidden', () => (
     <Persona
       {...examplePersona}
       presence={PersonaPresence.busy}
       hidePersonaDetails
     />
-  )).addStory('size72 (large)', () => (
+  ))
+  .addStory('size72 (large)', () => (
     <div>
       <Persona
         {...examplePersona}
@@ -157,28 +165,37 @@ storiesOf('Persona', module)
         presence={PersonaPresence.dnd}
       />
     </div>
-  )).addStory('size100 (extraLarge)', () => (
-    <div>
+  ))
+  .addStory(
+    'size100 (extraLarge)',
+    () => (
+      <div>
+        <Persona
+          {...examplePersona}
+          size={PersonaSize.size100}
+          presence={PersonaPresence.blocked}
+        />
+        <Persona
+          {...examplePersona}
+          size={PersonaSize.extraLarge}
+          presence={PersonaPresence.blocked}
+        />
+      </div>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Initials',
+    () => (
       <Persona
         {...examplePersona}
-        size={PersonaSize.size100}
-        presence={PersonaPresence.blocked}
+        imageUrl={undefined}
       />
-      <Persona
-        {...examplePersona}
-        size={PersonaSize.extraLarge}
-        presence={PersonaPresence.blocked}
-      />
-    </div>
-  ), { rtl: true }).addStory('Initials', () => (
-    <Persona
-      {...examplePersona}
-      imageUrl={undefined}
-    />
-  ), { rtl: true }).addStory('Persona with children', () => (
-    <Persona
-      { ...examplePersona }
-    >
+    ),
+    { rtl: true }
+  )
+  .addStory('Persona with children', () => (
+    <Persona { ...examplePersona }>
       <span>Persona Children</span>
     </Persona>
   ));

--- a/apps/vr-tests/src/stories/Pivot.stories.tsx
+++ b/apps/vr-tests/src/stories/Pivot.stories.tsx
@@ -1,62 +1,67 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Pivot, PivotItem, PivotLinkSize, PivotLinkFormat } from 'office-ui-fabric-react';
 
 storiesOf('Pivot', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('Root', () => (
+  )
+  .addStory('Root', () => (
     <Pivot>
-      <PivotItem linkText='My Files'>
-        Content
-      </PivotItem>
-      <PivotItem linkText='Recent' />
-      <PivotItem linkText='Shared with me' />
+      <PivotItem linkText="My Files">Content</PivotItem>
+      <PivotItem linkText="Recent" />
+      <PivotItem linkText="Shared with me" />
     </Pivot>
-  )).addStory('Count and icon', () => (
-    <Pivot>
-      <PivotItem linkText='My Files' itemCount={42} itemIcon='Emoji2'>
-        Content
-      </PivotItem>
-      <PivotItem itemCount={23} itemIcon='Recent' />
-      <PivotItem itemIcon='Globe' />
-      <PivotItem linkText='Shared with me' itemIcon='Ringer' itemCount={1} />
-    </Pivot>
-  ), { rtl: true }).addStory('Large', () => (
+  ))
+  .addStory(
+    'Count and icon',
+    () => (
+      <Pivot>
+        <PivotItem linkText="My Files" itemCount={42} itemIcon="Emoji2">
+          Content
+        </PivotItem>
+        <PivotItem itemCount={23} itemIcon="Recent" />
+        <PivotItem itemIcon="Globe" />
+        <PivotItem linkText="Shared with me" itemIcon="Ringer" itemCount={1} />
+      </Pivot>
+    ),
+    { rtl: true }
+  )
+  .addStory('Large', () => (
     <Pivot linkSize={PivotLinkSize.large}>
-      <PivotItem linkText='My Files'>
-        Content
-          </PivotItem>
-      <PivotItem linkText='Recent' />
-      <PivotItem linkText='Shared with me' />
+      <PivotItem linkText="My Files">Content</PivotItem>
+      <PivotItem linkText="Recent" />
+      <PivotItem linkText="Shared with me" />
     </Pivot>
-  )).addStory('Tabs', () => (
-    <Pivot linkFormat={PivotLinkFormat.tabs}>
-      <PivotItem linkText='Foo'>
-        Content
-          </PivotItem>
-      <PivotItem linkText='Bar' />
-      <PivotItem linkText='Bas' />
-      <PivotItem linkText='Biz' />
-    </Pivot>
-  ), { rtl: true }).addStory('Tabs large', () => (
+  ))
+  .addStory(
+    'Tabs',
+    () => (
+      <Pivot linkFormat={PivotLinkFormat.tabs}>
+        <PivotItem linkText="Foo">Content</PivotItem>
+        <PivotItem linkText="Bar" />
+        <PivotItem linkText="Bas" />
+        <PivotItem linkText="Biz" />
+      </Pivot>
+    ),
+    { rtl: true }
+  )
+  .addStory('Tabs large', () => (
     <Pivot linkFormat={PivotLinkFormat.tabs} linkSize={PivotLinkSize.large}>
-      <PivotItem linkText='Foo'>
-        Content
-          </PivotItem>
-      <PivotItem linkText='Bar' />
-      <PivotItem linkText='Bas' />
-      <PivotItem linkText='Biz' />
+      <PivotItem linkText="Foo">Content</PivotItem>
+      <PivotItem linkText="Bar" />
+      <PivotItem linkText="Bas" />
+      <PivotItem linkText="Biz" />
     </Pivot>
   ));

--- a/apps/vr-tests/src/stories/ProgressIndicator.stories.tsx
+++ b/apps/vr-tests/src/stories/ProgressIndicator.stories.tsx
@@ -1,37 +1,44 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { ProgressIndicator } from 'office-ui-fabric-react';
 
 storiesOf('ProgressIndicator', module)
   .addDecorator(FabricDecorator)
-  .addDecorator(story => (
+  .addDecorator(story =>
+    // prettier-ignore
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('0%', () => (
+  )
+  .addStory('0%', () => (
     <ProgressIndicator
-      label='Example title'
-      description='Example description'
+      label="Example title"
+      description="Example description"
       percentComplete={0}
     />
-  )).addStory('50%', () => (
+  ))
+  .addStory(
+    '50%',
+    () => (
+      <ProgressIndicator
+        label="Example title"
+        description="Example description"
+        percentComplete={0.5}
+      />
+    ),
+    { rtl: true }
+  )
+  .addStory('100%', () => (
     <ProgressIndicator
-      label='Example title'
-      description='Example description'
-      percentComplete={0.5}
-    />
-  ), { rtl: true }).addStory('100%', () => (
-    <ProgressIndicator
-      label='Example title'
-      description='Example description'
+      label="Example title"
+      description="Example description"
       percentComplete={1}
     />
   ));

--- a/apps/vr-tests/src/stories/Rating.stories.tsx
+++ b/apps/vr-tests/src/stories/Rating.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Rating, RatingSize } from 'office-ui-fabric-react';
@@ -13,38 +13,13 @@ storiesOf('Rating', module)
         .snapshot('default', { cropTo: '.testWrapper' })
         .click('button.ms-Rating-button:nth-of-type(2)')
         .snapshot('click', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('Root', () => (
-    <Rating
-      min={1}
-      max={5}
-    />
-  )).addStory('Rated', () => (
-    <Rating
-      min={1}
-      max={5}
-      rating={2}
-    />
-  ), { rtl: true }).addStory('Allow Zero', () => (
-    <Rating
-      allowZeroStars={true}
-      max={5}
-      rating={0}
-    />
-  )).addStory('Large', () => (
-    <Rating
-      min={1}
-      max={5}
-      size={RatingSize.Large}
-    />
-  )).addStory('Disabled', () => (
-    <Rating
-      min={1}
-      max={5}
-      disabled
-    />
-  ));
+  ))
+  .addStory('Root', () => <Rating min={1} max={5} />)
+  .addStory('Rated', () => <Rating min={1} max={5} rating={2} />, { rtl: true })
+  .addStory('Allow Zero', () => <Rating allowZeroStars={true} max={5} rating={0} />)
+  .addStory('Large', () => <Rating min={1} max={5} size={RatingSize.Large} />)
+  .addStory('Disabled', () => <Rating min={1} max={5} disabled />);

--- a/apps/vr-tests/src/stories/ResizeGroup.stories.tsx
+++ b/apps/vr-tests/src/stories/ResizeGroup.stories.tsx
@@ -1,30 +1,29 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { ResizeGroup, OverflowSet, DefaultButton } from 'office-ui-fabric-react';
 
-// tslint:disable-next-line:max-line-length
-let list = {
-  'primary': [
-    { key: 'item0', name: 'Item 0', iconProps: { iconName: 'Add' }, 'checked': false },
-    { key: 'item1', name: 'Item 1', iconProps: { iconName: 'Share' }, 'checked': false },
-    { key: 'item2', name: 'Item 2', iconProps: { iconName: 'Upload' }, 'checked': false },
-    { key: 'item3', name: 'Item 3', iconProps: { iconName: 'Add' }, 'checked': false },
-    { key: 'item4', name: 'Item 4', iconProps: { iconName: 'Share' }, 'checked': false },
-    { key: 'item5', name: 'Item 5', iconProps: { iconName: 'Upload' }, 'checked': false }
+const list = {
+  primary: [
+    { key: 'item0', name: 'Item 0', iconProps: { iconName: 'Add' }, checked: false },
+    { key: 'item1', name: 'Item 1', iconProps: { iconName: 'Share' }, checked: false },
+    { key: 'item2', name: 'Item 2', iconProps: { iconName: 'Upload' }, checked: false },
+    { key: 'item3', name: 'Item 3', iconProps: { iconName: 'Add' }, checked: false },
+    { key: 'item4', name: 'Item 4', iconProps: { iconName: 'Share' }, checked: false },
+    { key: 'item5', name: 'Item 5', iconProps: { iconName: 'Upload' }, checked: false }
   ],
-  'overflow': [
-    { key: 'item6', name: 'Item 6', iconProps: { iconName: 'Add' }, 'checked': false },
-    { key: 'item7', name: 'Item 7', iconProps: { iconName: 'Share' }, 'checked': false },
-    { key: 'item8', name: 'Item 8', iconProps: { iconName: 'Upload' }, 'checked': false },
-    { key: 'item9', name: 'Item 9', iconProps: { iconName: 'Add' }, 'checked': false },
-    { key: 'item10', name: 'Item 10', iconProps: { iconName: 'Share' }, 'checked': false }
+  overflow: [
+    { key: 'item6', name: 'Item 6', iconProps: { iconName: 'Add' }, checked: false },
+    { key: 'item7', name: 'Item 7', iconProps: { iconName: 'Share' }, checked: false },
+    { key: 'item8', name: 'Item 8', iconProps: { iconName: 'Upload' }, checked: false },
+    { key: 'item9', name: 'Item 9', iconProps: { iconName: 'Add' }, checked: false },
+    { key: 'item10', name: 'Item 10', iconProps: { iconName: 'Share' }, checked: false }
   ]
 };
 
-let noop = () => null;
+const noop = () => null;
 
 storiesOf('ResizeGroup', module)
   .addDecorator(FabricDecorator)
@@ -35,41 +34,39 @@ storiesOf('ResizeGroup', module)
         .click('.OverflowButton')
         .hover('.OverflowButton')
         .snapshot('click overflow')
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('Root', () => (
-    <ResizeGroup
-      data={list}
-      onReduceData={noop}
-      // tslint:disable-next-line:jsx-no-lambda
-      onRenderData={(data) => {
-        return (
-          <OverflowSet
-            items={data.primary}
-            overflowItems={data.overflow.length ? data.overflow : null}
-            onRenderItem={(item) => {
-              return (
-                <DefaultButton
-                  text={item.name}
-                  iconProps={item.iconProps}
-                  onClick={item.onClick}
-                  checked={item.checked}
-                />
-              );
-            }}
-            onRenderOverflowButton={(overflowItems) => {
-              return (
-                <DefaultButton
-                  className='OverflowButton'
-                  menuProps={{ items: overflowItems! }}
-                />
-              );
-            }}
-          />
-        );
-      }}
-    />
-  ), { rtl: true });
+  ))
+  .addStory(
+    'Root',
+    () => (
+      <ResizeGroup
+        data={list}
+        onReduceData={noop}
+        onRenderData={data => {
+          return (
+            <OverflowSet
+              items={data.primary}
+              overflowItems={data.overflow.length ? data.overflow : null}
+              onRenderItem={item => {
+                return (
+                  <DefaultButton
+                    text={item.name}
+                    iconProps={item.iconProps}
+                    onClick={item.onClick}
+                    checked={item.checked}
+                  />
+                );
+              }}
+              onRenderOverflowButton={overflowItems => (
+                <DefaultButton className="OverflowButton" menuProps={{ items: overflowItems! }} />
+              )}
+            />
+          );
+        }}
+      />
+    ),
+    { rtl: true }
+  );

--- a/apps/vr-tests/src/stories/ScrollablePane.DetailsList.Story.scss
+++ b/apps/vr-tests/src/stories/ScrollablePane.DetailsList.Story.scss
@@ -1,3 +1,0 @@
-.stickyListTitle{
-  padding-top: 100px;
-}

--- a/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
@@ -1,9 +1,8 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import {
   DetailsList,
   DetailsListLayoutMode,
@@ -16,14 +15,17 @@ import {
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
-import { ScrollablePane, IScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
-import { getTheme } from 'office-ui-fabric-react/lib/Styling';
-import './ScrollablePane.DetailsList.Story.scss';
+import { getTheme, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+
+const stickyListTitleClass = mergeStyles({
+  paddingTop: '100px'
+});
 
 const _columns: IColumn[] = [
   {
@@ -32,8 +34,7 @@ const _columns: IColumn[] = [
     fieldName: 'test1',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true,
-    ariaLabel: 'Operations for name'
+    isResizable: true
   },
   {
     key: 'column2',
@@ -41,8 +42,7 @@ const _columns: IColumn[] = [
     fieldName: 'test2',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true,
-    ariaLabel: 'Operations for value'
+    isResizable: true
   },
   {
     key: 'column3',
@@ -50,8 +50,7 @@ const _columns: IColumn[] = [
     fieldName: 'test3',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true,
-    ariaLabel: 'Operations for value'
+    isResizable: true
   },
   {
     key: 'column4',
@@ -59,8 +58,7 @@ const _columns: IColumn[] = [
     fieldName: 'test4',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true,
-    ariaLabel: 'Operations for value'
+    isResizable: true
   },
   {
     key: 'column5',
@@ -68,8 +66,7 @@ const _columns: IColumn[] = [
     fieldName: 'test5',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true,
-    ariaLabel: 'Operations for value'
+    isResizable: true
   },
   {
     key: 'column6',
@@ -77,8 +74,7 @@ const _columns: IColumn[] = [
     fieldName: 'test6',
     minWidth: 100,
     maxWidth: 200,
-    isResizable: true,
-    ariaLabel: 'Operations for value'
+    isResizable: true
   }
 ];
 
@@ -92,24 +88,18 @@ interface IItem {
   test6: string;
 }
 
-class ScrollablePaneDetailsListStory extends React.Component<
-  {},
-  {
-    items: {}[];
-  }
-  > {
-  private _scrollablePane = React.createRef<IScrollablePane>();
+class ScrollablePaneDetailsListStory extends React.Component<{}, {}> {
   private _selection: Selection;
   private readonly _items: IItem[];
 
   constructor(props: {}) {
     super(props);
 
-    const items: IItem[] = [];
+    this._items = [];
 
     // Populate with items for demos.
     for (let i = 0; i < 200; i++) {
-      items.push({
+      this._items.push({
         key: i,
         test1: i === 0 ? lorem(7) : lorem(2),
         test2: lorem(2),
@@ -120,15 +110,10 @@ class ScrollablePaneDetailsListStory extends React.Component<
       });
     }
 
-    this._items = items;
-
     this._selection = new Selection();
-    this.state = { items: items };
   }
 
   public render(): JSX.Element {
-    const { items } = this.state;
-
     return (
       <div
         style={{
@@ -139,15 +124,21 @@ class ScrollablePaneDetailsListStory extends React.Component<
         }}
       >
         <Fabric>
-          <ScrollablePane componentRef={this._scrollablePane} scrollbarVisibility={ScrollbarVisibility.auto} style={{ maxWidth: '500px', border: '1px solid #edebe9' }}>
+          <ScrollablePane
+            scrollbarVisibility={ScrollbarVisibility.auto}
+            style={{ maxWidth: '500px', border: '1px solid #edebe9' }}
+          >
             {/* providing backgroundColor as no parent element for the test has this property defined */}
-            <Sticky stickyPosition={StickyPositionType.Header} stickyBackgroundColor={getTheme().palette.white}
-              stickyClassName={'stickyListTitle'}>
+            <Sticky
+              stickyPosition={StickyPositionType.Header}
+              stickyBackgroundColor={getTheme().palette.white}
+              stickyClassName={stickyListTitleClass}
+            >
               <h1 style={{ margin: '0px' }}>Item List</h1>
             </Sticky>
             <MarqueeSelection selection={this._selection}>
               <DetailsList
-                items={items}
+                items={this._items}
                 columns={_columns}
                 setKey="set"
                 layoutMode={DetailsListLayoutMode.fixedColumns}
@@ -165,18 +156,23 @@ class ScrollablePaneDetailsListStory extends React.Component<
   }
 }
 
-function onRenderDetailsHeader(props: IDetailsHeaderProps, defaultRender?: IRenderFunction<IDetailsHeaderProps>): JSX.Element {
+function onRenderDetailsHeader(
+  props: IDetailsHeaderProps,
+  defaultRender?: IRenderFunction<IDetailsHeaderProps>
+): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>
       {defaultRender!({
         ...props,
-        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost {...tooltipHostProps} />
+        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => (
+          <TooltipHost {...tooltipHostProps} />
+        )
       })}
     </Sticky>
   );
 }
 
-function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRenderFunction<IDetailsFooterProps>): JSX.Element {
+function onRenderDetailsFooter(props: IDetailsFooterProps): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Footer} isScrollSynced={true}>
       <div style={{ display: 'inline-block' }}>
@@ -201,21 +197,25 @@ function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRend
   );
 }
 
-function hasText(item: IItem, text: string): boolean {
-  return `${item.test1}|${item.test2}|${item.test3}|${item.test4}|${item.test5}|${item.test6}`.indexOf(text) > -1;
-}
-
 storiesOf('ScrollablePane Details List', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 2")
-        .snapshot('scroll down by a small amount so that the first row is still visible', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 99999")
+        .executeScript(
+          "document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 2"
+        )
+        .snapshot('scroll down by a small amount so that the first row is still visible', {
+          cropTo: '.testWrapper'
+        })
+        .executeScript(
+          "document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 99999"
+        )
         .snapshot('scroll down to the bottom', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 0")
+        .executeScript(
+          "document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 0"
+        )
         .snapshot('scroll up to the top', { cropTo: '.testWrapper' })
         .end()}
     >

--- a/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
@@ -97,7 +97,6 @@ class ScrollablePaneDetailsListStory extends React.Component<{}, {}> {
 
     this._items = [];
 
-    // Populate with items for demos.
     for (let i = 0; i < 200; i++) {
       this._items.push({
         key: i,

--- a/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
@@ -1,9 +1,8 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import {
   DetailsList,
   DetailsListLayoutMode,
@@ -12,12 +11,11 @@ import {
   IColumn,
   ConstrainMode,
   IDetailsFooterProps,
-  DetailsRow,
-  IGroup
+  DetailsRow
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
-import { ScrollablePane, IScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
@@ -94,25 +92,18 @@ interface IItem {
   test5: string;
   test6: string;
 }
-let _groups: IGroup[];
-class ScrollablePaneDetailsListStory extends React.Component<
-  {},
-  {
-    items: {}[];
-  }
-  > {
-  private _scrollablePane = React.createRef<IScrollablePane>();
+const _groups = createGroups(100, 0, 0, 1, 0, '', true);
+
+class ScrollablePaneDetailsListStory extends React.Component<{}, {}> {
   private _selection: Selection;
   private readonly _items: IItem[];
 
   constructor(props: {}) {
     super(props);
 
-    const items: IItem[] = [];
-    _groups = createGroups(100, 0, 0, 1, 0, '', true);
-    // Populate with items for demos.
+    this._items = [];
     for (let i = 0; i < 100; i++) {
-      items.push({
+      this._items.push({
         key: i,
         test1: i === 0 ? lorem(7) : lorem(2),
         test2: lorem(2),
@@ -123,16 +114,10 @@ class ScrollablePaneDetailsListStory extends React.Component<
       });
     }
 
-    this._items = items;
-
-    this.state = {
-      items: items
-    };
+    this._selection = new Selection();
   }
 
   public render(): JSX.Element {
-    const { items } = this.state;
-
     return (
       <div
         style={{
@@ -143,14 +128,20 @@ class ScrollablePaneDetailsListStory extends React.Component<
         }}
       >
         <Fabric>
-          <ScrollablePane componentRef={this._scrollablePane} scrollbarVisibility={ScrollbarVisibility.auto} style={{ maxWidth: '800px', border: '1px solid #edebe9' }}>
+          <ScrollablePane
+            scrollbarVisibility={ScrollbarVisibility.auto}
+            style={{ maxWidth: '800px', border: '1px solid #edebe9' }}
+          >
             {/* providing backgroundColor as no parent element for the test has this property defined */}
-            <Sticky stickyPosition={StickyPositionType.Header} stickyBackgroundColor={getTheme().palette.white}>
+            <Sticky
+              stickyPosition={StickyPositionType.Header}
+              stickyBackgroundColor={getTheme().palette.white}
+            >
               <h1 style={{ margin: '0px' }}>Item List</h1>
             </Sticky>
             <MarqueeSelection selection={this._selection}>
               <DetailsList
-                items={items}
+                items={this._items}
                 groups={_groups}
                 columns={_columns}
                 setKey="set"
@@ -169,18 +160,23 @@ class ScrollablePaneDetailsListStory extends React.Component<
   }
 }
 
-function onRenderDetailsHeader(props: IDetailsHeaderProps, defaultRender?: IRenderFunction<IDetailsHeaderProps>): JSX.Element {
+function onRenderDetailsHeader(
+  props: IDetailsHeaderProps,
+  defaultRender?: IRenderFunction<IDetailsHeaderProps>
+): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>
       {defaultRender!({
         ...props,
-        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost {...tooltipHostProps} />
+        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => (
+          <TooltipHost {...tooltipHostProps} />
+        )
       })}
     </Sticky>
   );
 }
 
-function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRenderFunction<IDetailsFooterProps>): JSX.Element {
+function onRenderDetailsFooter(props: IDetailsFooterProps): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Footer} isScrollSynced={true}>
       <div style={{ display: 'inline-block' }}>
@@ -205,35 +201,38 @@ function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRend
   );
 }
 
-function hasText(item: IItem, text: string): boolean {
-  return `${item.test1}|${item.test2}|${item.test3}|${item.test4}|${item.test5}|${item.test6}`.indexOf(text) > -1;
-}
+const getElement = "document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0]";
+const cropTo = { cropTo: '.testWrapper' };
 
 storiesOf('ScrollablePane Grouped Details List', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
-        .snapshot('default: scrollbars should be visible', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 100")
-        .snapshot('Scrollbars visibility when header is sticky', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 99999")
-        .snapshot('Scrollbars visibility after scrolling down to the bottom', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 0")
-        .snapshot('Scrollbars visibility after scrolling up to the top', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollLeft = 100")
-        .snapshot('Scrollbars visibilty after scrolling left', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 100")
-        .snapshot('Scrollbars visibility when header is sticky and scrollLeft is non-zero', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 99999")
-        .snapshot('Scrollbars visibility after scrolling down to the bottom with non-zero scrollLeft', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 0")
-        .snapshot('Scrollbars visibility after scrolling up to the top with non-zero scrollLeft', { cropTo: '.testWrapper' })
+        .snapshot('default: scrollbars should be visible', cropTo)
+        .executeScript(`${getElement}.scrollTop = 100`)
+        .snapshot('Scrollbars visibility when header is sticky', cropTo)
+        .executeScript(`${getElement}.scrollTop = 99999`)
+        .snapshot('Scrollbars visibility after scrolling down to the bottom', cropTo)
+        .executeScript(`${getElement}.scrollTop = 0`)
+        .snapshot('Scrollbars visibility after scrolling up to the top', cropTo)
+        .executeScript(`${getElement}.scrollLeft = 100`)
+        .snapshot('Scrollbars visibilty after scrolling left', cropTo)
+        .executeScript(`${getElement}.scrollTop = 100`)
+        .snapshot('Scrollbars visibility when header is sticky and scrollLeft is non-zero', cropTo)
+        .executeScript(`${getElement}.scrollTop = 99999`)
+        .snapshot(
+          'Scrollbars visibility after scrolling down to the bottom with non-zero scrollLeft',
+          cropTo
+        )
+        .executeScript(`${getElement}.scrollTop = 0`)
+        .snapshot(
+          'Scrollbars visibility after scrolling up to the top with non-zero scrollLeft',
+          cropTo
+        )
         .end()}
     >
       {story()}
     </Screener>
   ))
-  .addStory('ScrollablePane scrollbars visibility', () => (
-    <ScrollablePaneDetailsListStory />
-  ));
+  .addStory('ScrollablePane scrollbars visibility', () => <ScrollablePaneDetailsListStory />);

--- a/apps/vr-tests/src/stories/ScrollablePane.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Fabric, ScrollablePane, StickyPositionType, Sticky } from 'office-ui-fabric-react';
@@ -48,7 +48,9 @@ storiesOf('ScrollablePane', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 9999")
+        .executeScript(
+          "document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 9999"
+        )
         .snapshot('scrolled', { cropTo: '.testWrapper' })
         .end()}
     >
@@ -65,7 +67,10 @@ storiesOf('ScrollablePane', module)
       }}
     >
       <Fabric>
-        <ScrollablePane className="scrollablePaneDefaultExample" style={{ maxWidth: '400px', border: '1px solid #edebe9' }}>
+        <ScrollablePane
+          className="scrollablePaneDefaultExample"
+          style={{ maxWidth: '400px', border: '1px solid #edebe9' }}
+        >
           {contentAreas.map(ele => {
             return ele;
           })}

--- a/apps/vr-tests/src/stories/SearchBox.stories.tsx
+++ b/apps/vr-tests/src/stories/SearchBox.stories.tsx
@@ -1,15 +1,11 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
 import { SearchBox, Fabric } from 'office-ui-fabric-react';
 
-/**
- * FabricDecorator isn't added at the top level so that the full SearchBox can be rendered without a parent div
- */
+// FabricDecorator isn't added at the top level so that the full SearchBox can be rendered without a parent div
 
-// tslint:disable:jsx-ban-props
 storiesOf('SearchBox', module)
   .addDecorator(story => (
     <Screener
@@ -18,19 +14,31 @@ storiesOf('SearchBox', module)
         .click('.ms-SearchBox-field')
         .hover('.ms-SearchBox-field')
         .snapshot('default', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('Root', () => (
-    <Fabric style={{ display: 'flex' }}>
-      <div className='testWrapper' style={{ padding: '10px', overflow: 'hidden', width: '300px' }}>
-        <SearchBox placeholder='Search' />
-      </div>
-    </Fabric>
-  ), { rtl: true }).addStory('Full', () => (
-    <Fabric className='testWrapper'>
-      <SearchBox placeholder='Search' />
-    </Fabric>
-  ), { rtl: true });
+  ))
+  .addStory(
+    'Root',
+    () => (
+      <Fabric style={{ display: 'flex' }}>
+        <div
+          className="testWrapper"
+          style={{ padding: '10px', overflow: 'hidden', width: '300px' }}
+        >
+          <SearchBox placeholder="Search" />
+        </div>
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Full',
+    () => (
+      <Fabric className="testWrapper">
+        <SearchBox placeholder="Search" />
+      </Fabric>
+    ),
+    { rtl: true }
+  );

--- a/apps/vr-tests/src/stories/Shimmer.stories.tsx
+++ b/apps/vr-tests/src/stories/Shimmer.stories.tsx
@@ -1,38 +1,58 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { Shimmer, ShimmerElementType as ElemType, ShimmerElementsGroup } from 'office-ui-fabric-react';
+import {
+  Shimmer,
+  ShimmerElementType as ElemType,
+  ShimmerElementsGroup
+} from 'office-ui-fabric-react';
 
 storiesOf('Shimmer', module)
   .addDecorator(story => (
     // Shimmer without a specified width needs a container with a fixed width or it's collapsing.
-    // tslint:disable-next-line:jsx-ban-props
     <div style={{ width: '500px' }}>{story()}</div>
   ))
   .addDecorator(FabricDecorator)
-  .addDecorator(story => <Screener steps={new Screener.Steps().snapshot('default').end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default')
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
   .addStory('Basic', () => <Shimmer />)
-  .addStory('50% width', () => <Shimmer width={'50%'} />)
-  .addStory('Circle Gap Line', () => (
-    <Shimmer
-      shimmerElements={[{ type: ElemType.circle }, { type: ElemType.gap, width: '2%' }, { type: ElemType.line }]}
-    />
-  ), { rtl: true })
+  .addStory('50% width', () => <Shimmer width="50%" />)
+  .addStory(
+    'Circle Gap Line',
+    () => (
+      <Shimmer
+        shimmerElements={[
+          { type: ElemType.circle },
+          { type: ElemType.gap, width: '2%' },
+          { type: ElemType.line }
+        ]}
+      />
+    ),
+    { rtl: true }
+  )
   .addStory('Custom elements', () => (
     <Shimmer
       customElementsGroup={
-        <div
-          // tslint:disable-next-line:jsx-ban-props
-          style={{ display: 'flex' }}
-        >
+        <div style={{ display: 'flex' }}>
           <ShimmerElementsGroup
-            shimmerElements={[{ type: ElemType.circle, height: 40 }, { type: ElemType.gap, width: 16, height: 40 }]}
+            shimmerElements={[
+              { type: ElemType.circle, height: 40 },
+              { type: ElemType.gap, width: 16, height: 40 }
+            ]}
           />
           <ShimmerElementsGroup
             flexWrap={true}
-            width={'100%'}
+            width="100%"
             shimmerElements={[
               { type: ElemType.line, width: '100%', height: 10, verticalAlign: 'bottom' },
               { type: ElemType.line, width: '90%', height: 8 },

--- a/apps/vr-tests/src/stories/Signals.stories.tsx
+++ b/apps/vr-tests/src/stories/Signals.stories.tsx
@@ -11,7 +11,6 @@ import {
   TrendingSignal,
   SomeoneCheckedOutSignal,
   NewSignal,
-  LiveEditSignal,
   MentionSignal,
   CommentsSignal,
   UnseenReplySignal,

--- a/apps/vr-tests/src/stories/Slider.stories.tsx
+++ b/apps/vr-tests/src/stories/Slider.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
 import { Slider } from 'office-ui-fabric-react';
@@ -14,78 +14,42 @@ storiesOf('Slider', module)
         .snapshot('default', { cropTo: '.testWrapper' })
         .hover('.ms-Slider-line')
         .snapshot('hover', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('Root', () => (
-    <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
-      <Slider
-        label='Basic example:'
-        min={1}
-        max={3}
-        step={1}
-        defaultValue={2}
-        showValue={true}
-      />
-    </div>
-  ), { rtl: true })
+  ))
+  .addStory(
+    'Root',
+    () => (
+      <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
+        <Slider label="Basic example:" min={1} max={3} step={1} defaultValue={2} showValue={true} />
+      </div>
+    ),
+    { rtl: true }
+  )
   .addStory('Disabled', () => (
     <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
-      <Slider
-        label='Basic example:'
-        min={1}
-        max={3}
-        step={1}
-        defaultValue={2}
-        showValue={true}
-        disabled
-      />
+      <Slider label="Basic example:" min={1} max={3} step={1} defaultValue={2} showValue={true} disabled />
     </div>
-  )).addStory('Vertical', () => (
+  ))
+  .addStory('Vertical', () => (
     <div style={{ flexDirection: 'row', height: '200px', display: 'flex' }}>
-      <Slider
-        label='Basic example:'
-        min={1}
-        max={3}
-        step={1}
-        defaultValue={2}
-        showValue={true}
-        vertical={true}
-      />
+      <Slider label="Basic example:" min={1} max={3} step={1} defaultValue={2} showValue={true} vertical={true} />
     </div>
-  )).addStory('EqualMinMax', () => (
+  ))
+  .addStory('EqualMinMax', () => (
     <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
-      <Slider
-        label='Basic example:'
-        min={1}
-        max={1}
-        step={1}
-        defaultValue={1}
-        showValue={true}
-      />
+      <Slider label="Basic example:" min={1} max={1} step={1} defaultValue={1} showValue={true} />
     </div>
-  )).addStory('Max not multiple of step', () => (
+  ))
+  .addStory('Max not multiple of step', () => (
     <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
-      <Slider
-        label='Basic example:'
-        min={18}
-        max={48}
-        step={10}
-        defaultValue={48}
-        showValue={true}
-      />
+      <Slider label="Basic example:" min={18} max={48} step={10} defaultValue={48} showValue={true} />
     </div>
-  )).addStory('Step less than 1', () => (
+  ))
+  .addStory('Step less than 1', () => (
     <div style={{ flexDirection: 'column', width: '300px', display: 'flex' }}>
-      <Slider
-        label='Basic example:'
-        min={1}
-        max={3}
-        step={0.1}
-        defaultValue={1.4}
-        showValue={true}
-      />
+      <Slider label="Basic example:" min={1} max={3} step={0.1} defaultValue={1.4} showValue={true} />
     </div>
   ));

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorFixedWidth } from '../utilities';
 import { Fabric, SpinButton } from 'office-ui-fabric-react';

--- a/apps/vr-tests/src/stories/Spinner.stories.tsx
+++ b/apps/vr-tests/src/stories/Spinner.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';

--- a/apps/vr-tests/src/stories/Stack.stories.tsx
+++ b/apps/vr-tests/src/stories/Stack.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorFullWidth } from '../utilities';
 import { Stack } from '@uifabric/experiments/lib/Stack';
@@ -72,7 +72,17 @@ const defaultProps = {
 
 storiesOf('Stack', module)
   .addDecorator(FabricDecoratorFullWidth)
-  .addDecorator(story => <Screener steps={new Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>{story()}</Screener>)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()
+      }
+    >
+      {story()}
+    </Screener>
+  )
   .addStory(
     'Vertical Stack - Default',
     () => (

--- a/apps/vr-tests/src/stories/Sticky.Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Sticky.Breadcrumb.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import {
@@ -15,7 +15,7 @@ import {
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
-import { ScrollablePane, IScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { lorem } from 'office-ui-fabric-react/lib/utilities/exampleData';
@@ -91,23 +91,16 @@ interface IItem {
   test6: string;
 }
 
-export class ScrollablePaneStickyBreadcrumbExample extends React.Component<
-  {},
-  {
-    items: {}[];
-  }
-  > {
-  private _scrollablePane = React.createRef<IScrollablePane>();
+export class ScrollablePaneStickyBreadcrumbExample extends React.Component<{}, {}> {
   private _selection: Selection;
+  private _items: IItem[];
 
   constructor(props: {}) {
     super(props);
 
-    const items: IItem[] = [];
-
-    // Populate with items for demos.
+    this._items = [];
     for (let i = 0; i < 100; i++) {
-      items.push({
+      this._items.push({
         key: i,
         test1: i === 0 ? lorem(7) : lorem(2),
         test2: lorem(2),
@@ -118,13 +111,10 @@ export class ScrollablePaneStickyBreadcrumbExample extends React.Component<
       });
     }
 
-    this.state = {
-      items: items
-    };
+    this._selection = new Selection();
   }
 
   public render(): JSX.Element {
-    const { items } = this.state;
     const breadcrumbStyle = {
       root: [
         {
@@ -143,7 +133,10 @@ export class ScrollablePaneStickyBreadcrumbExample extends React.Component<
         }}
       >
         <Fabric>
-          <ScrollablePane componentRef={this._scrollablePane} scrollbarVisibility={ScrollbarVisibility.auto} style={{ maxWidth: '900px', border: '1px solid #edebe9' }}>
+          <ScrollablePane
+            scrollbarVisibility={ScrollbarVisibility.auto}
+            style={{ maxWidth: '900px', border: '1px solid #edebe9' }}
+          >
             <Sticky
               stickyPosition={StickyPositionType.Header}
               stickyBackgroundColor={getTheme().palette.white}
@@ -161,7 +154,7 @@ export class ScrollablePaneStickyBreadcrumbExample extends React.Component<
             </Sticky>
             <MarqueeSelection selection={this._selection}>
               <DetailsList
-                items={items}
+                items={this._items}
                 columns={_columns}
                 setKey="set"
                 layoutMode={DetailsListLayoutMode.fixedColumns}
@@ -172,7 +165,6 @@ export class ScrollablePaneStickyBreadcrumbExample extends React.Component<
                 selectionPreservedOnEmptyClick={true}
                 ariaLabelForSelectionColumn="Toggle selection"
                 ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-                // tslint:disable-next-line:jsx-no-lambda
                 onItemInvoked={item => alert(`Item invoked: ${item.name}`)}
               />
             </MarqueeSelection>
@@ -183,20 +175,25 @@ export class ScrollablePaneStickyBreadcrumbExample extends React.Component<
   }
 }
 
-function onRenderDetailsHeader(props: IDetailsHeaderProps, defaultRender?: IRenderFunction<IDetailsHeaderProps>): JSX.Element {
+function onRenderDetailsHeader(
+  props: IDetailsHeaderProps,
+  defaultRender?: IRenderFunction<IDetailsHeaderProps>
+): JSX.Element {
   return (
     <Sticky stickyPosition={StickyPositionType.Header} isScrollSynced={true}>
       {defaultRender!({
         ...props,
-        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => <TooltipHost {...tooltipHostProps} />
+        onRenderColumnHeaderTooltip: (tooltipHostProps: ITooltipHostProps) => (
+          <TooltipHost {...tooltipHostProps} />
+        )
       })}
     </Sticky>
   );
 }
 
-function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRenderFunction<IDetailsFooterProps>): JSX.Element {
+function onRenderDetailsFooter(props: IDetailsFooterProps): JSX.Element {
   return (
-    <Sticky stickyPosition={StickyPositionType.Footer} isScrollSynced={true} >
+    <Sticky stickyPosition={StickyPositionType.Footer} isScrollSynced={true}>
       <div style={{ display: 'inline-block' }}>
         <DetailsRow
           columns={props.columns}
@@ -219,24 +216,30 @@ function onRenderDetailsFooter(props: IDetailsFooterProps, defaultRender?: IRend
   );
 }
 
+const getElement = "document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0]";
+const cropTo = { cropTo: '.testWrapper' };
+
 storiesOf('Sticky breadcrumb and sticky details list header', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
-        .snapshot('default', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 5")
-        .snapshot('scroll down by a small amount so that the first row is still visible and the header becomes sticky', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 99999")
-        .snapshot('scroll down to the bottom', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 0")
-        .snapshot('scroll up to the top', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollLeft = 40")
-        .snapshot('scroll right', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 99999")
-        .snapshot('scroll down when horizontal scroll is non-zero', { cropTo: '.testWrapper' })
-        .executeScript("document.getElementsByClassName('ms-ScrollablePane--contentContainer')[0].scrollTop = 0")
-        .snapshot('scroll back to the top when horizontal scroll is non-zero', { cropTo: '.testWrapper' })
+        .snapshot('default', cropTo)
+        .executeScript(`${getElement}.scrollTop = 5`)
+        .snapshot(
+          'scroll down by a small amount so that the first row is still visible and the header becomes sticky',
+          cropTo
+        )
+        .executeScript(`${getElement}.scrollTop = 99999`)
+        .snapshot('scroll down to the bottom', cropTo)
+        .executeScript(`${getElement}.scrollTop = 0`)
+        .snapshot('scroll up to the top', cropTo)
+        .executeScript(`${getElement}.scrollLeft = 40`)
+        .snapshot('scroll right', cropTo)
+        .executeScript(`${getElement}.scrollTop = 99999`)
+        .snapshot('scroll down when horizontal scroll is non-zero', cropTo)
+        .executeScript(`${getElement}.scrollTop = 0`)
+        .snapshot('scroll back to the top when horizontal scroll is non-zero', cropTo)
         .end()}
     >
       {story()}

--- a/apps/vr-tests/src/stories/SwatchColorPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/SwatchColorPicker.stories.tsx
@@ -1,20 +1,19 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { SwatchColorPicker } from 'office-ui-fabric-react';
+import { SwatchColorPicker, ISwatchColorPickerProps } from 'office-ui-fabric-react';
 
-let props = {
+const props: ISwatchColorPickerProps = {
   columnCount: 4,
   cellShape: 'circle' as any,
-  colorCells:
-    [
-      { id: 'a', label: 'green', color: '#00ff00' },
-      { id: 'b', label: 'orange', color: '#ffa500' },
-      { id: 'c', label: 'blue', color: '#0000ff' },
-      { id: 'd', label: 'red', color: '#ff0000' }
-    ]
+  colorCells: [
+    { id: 'a', label: 'green', color: '#00ff00' },
+    { id: 'b', label: 'orange', color: '#ffa500' },
+    { id: 'c', label: 'blue', color: '#0000ff' },
+    { id: 'd', label: 'red', color: '#ff0000' }
+  ]
 };
 storiesOf('SwatchColorPicker', module)
   .addDecorator(FabricDecorator)
@@ -29,29 +28,12 @@ storiesOf('SwatchColorPicker', module)
         .click('.ms-Button-flexContainer')
         .hover('.ms-Button-flexContainer')
         .snapshot('click', { cropTo: '.testWrapper' })
-        .end()
-      }
+        .end()}
     >
       {story()}
     </Screener>
-  )).addStory('Circle', () => (
-    <SwatchColorPicker
-      {...props}
-    />
-  ), { rtl: true }).addStory('Square', () => (
-    <SwatchColorPicker
-      {...props}
-      cellShape='square'
-    />
-  )).addStory('Disabled', () => (
-    <SwatchColorPicker
-      {...props}
-      disabled
-    />
-  )).addStory('Multiple rows', () => (
-    <SwatchColorPicker
-      {...props}
-      columnCount={4}
-      colorCells={props.colorCells.concat(props.colorCells)}
-    />
-  ));
+  ))
+  .addStory('Circle', () => <SwatchColorPicker {...props} />, { rtl: true })
+  .addStory('Square', () => <SwatchColorPicker {...props} cellShape="square" />)
+  .addStory('Disabled', () => <SwatchColorPicker {...props} disabled />)
+  .addStory('Multiple rows', () => <SwatchColorPicker {...props} columnCount={4} colorCells={props.colorCells.concat(props.colorCells)} />);

--- a/apps/vr-tests/src/stories/TagPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/TagPicker.stories.tsx
@@ -1,11 +1,11 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
-import { TagPicker, Fabric } from 'office-ui-fabric-react';
+import { TagPicker, Fabric, ITag } from 'office-ui-fabric-react';
 
-let testTags = [
+const testTags: ITag[] = [
   'black',
   'blue',
   'brown',
@@ -23,9 +23,9 @@ let testTags = [
   'yellow'
 ].map(item => ({ key: item, name: item }));
 
-let getTextFromItem = item => item.name;
+const getTextFromItem = (item: ITag) => item.name;
 
-let getList = () => testTags;
+const getList = () => testTags;
 
 // Pickers that are 'disabled' are added before the Screener decorator because css classes for suggestion items won't exist
 storiesOf('TagPicker', module)

--- a/apps/vr-tests/src/stories/TeachingBubble.stories.tsx
+++ b/apps/vr-tests/src/stories/TeachingBubble.stories.tsx
@@ -1,54 +1,48 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorTall } from '../utilities';
 import { TeachingBubble } from 'office-ui-fabric-react/lib/TeachingBubble';
-import { IImageProps } from 'office-ui-fabric-react/lib/Image';
-import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 
 // tslint:disable:max-line-length
 storiesOf('TeachingBubble', module)
   .addDecorator(FabricDecoratorTall)
   .addDecorator(story => (
-    <Screener
-      steps={new Screener.Steps()
-        .snapshot('default', { cropTo: '.ms-TeachingBubble' })
-        .end()
-      }
-    >
-      {story()}
-    </Screener>
+    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.ms-TeachingBubble' }).end()}>{story()}</Screener>
   ))
-  .addStory('WideIllustration', () => {
-    let exampleImageProps: IImageProps = { src: 'http://placehold.it/364x140' };
-    let examplePrimaryButton: IButtonProps = {
-      children: 'Got it',
-    };
-    return <TeachingBubble
-      illustrationImage={exampleImageProps}
-      calloutProps={{ directionalHint: DirectionalHint.bottomCenter }}
-      isWide={true}
-      hasSmallHeadline={true}
-      hasCloseIcon={true}
-      primaryButtonProps={examplePrimaryButton}
-      headline='Discover what’s trending around you'
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni harum non?
-      Modal content
-    </TeachingBubble >
-  }, { rtl: true })
+  .addStory(
+    'WideIllustration',
+    () => {
+      return (
+        <TeachingBubble
+          illustrationImage={{ src: 'http://placehold.it/364x140' }}
+          calloutProps={{ directionalHint: DirectionalHint.bottomCenter }}
+          isWide={true}
+          hasSmallHeadline={true}
+          hasCloseIcon={true}
+          primaryButtonProps={{ children: 'Got it' }}
+          headline="Discover what’s trending around you"
+        >
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni harum non? Modal
+          content
+        </TeachingBubble>
+      );
+    },
+    { rtl: true }
+  )
   .addStory('SmallHeadline', () => {
-    let examplePrimaryButton: IButtonProps = {
-      children: 'Got it',
-    };
-    return <TeachingBubble
-      hasSmallHeadline={true}
-      hasCloseIcon={true}
-      primaryButtonProps={examplePrimaryButton}
-      headline='Discover what’s trending around you'
-    >
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni harum non?
-    </TeachingBubble>
+    return (
+      <TeachingBubble
+        hasSmallHeadline={true}
+        hasCloseIcon={true}
+        primaryButtonProps={{
+          children: 'Got it'
+        }}
+        headline="Discover what’s trending around you"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni harum non?
+      </TeachingBubble>
+    );
   });

--- a/apps/vr-tests/src/stories/TextField.stories.tsx
+++ b/apps/vr-tests/src/stories/TextField.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecoratorFixedWidth } from '../utilities';
 import { TextField } from 'office-ui-fabric-react';

--- a/apps/vr-tests/src/stories/Tooltip.stories.tsx
+++ b/apps/vr-tests/src/stories/Tooltip.stories.tsx
@@ -1,6 +1,6 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
-import Screener, { Steps } from 'screener-storybook/src/screener';
+import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
 import { FabricDecorator, FabricDecoratorFixedWidth } from '../utilities';
 import { TooltipHost } from 'office-ui-fabric-react';

--- a/apps/vr-tests/src/utilities/FabricDecorator.tsx
+++ b/apps/vr-tests/src/utilities/FabricDecorator.tsx
@@ -1,10 +1,8 @@
 /*! Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license. */
 import * as React from 'react';
+import { RenderFunction } from '@storybook/react';
 
-// Wrap all stories in a Fabric component for proper styling
-
-// tslint:disable:jsx-ban-props
-export const FabricDecorator = story => (
+export const FabricDecorator = (story: RenderFunction) => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', overflow: 'hidden' }}>
       {story()}
@@ -12,7 +10,7 @@ export const FabricDecorator = story => (
   </div>
 );
 
-export const FabricDecoratorTall = story => (
+export const FabricDecoratorTall = (story: RenderFunction) => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px 10px 120px' }}>
       {story()}
@@ -20,7 +18,7 @@ export const FabricDecoratorTall = story => (
   </div>
 );
 
-export const FabricDecoratorTallFixedWidth = story => (
+export const FabricDecoratorTallFixedWidth = (story: RenderFunction) => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px 10px 120px', width: '300px' }}>
       {story()}
@@ -28,7 +26,7 @@ export const FabricDecoratorTallFixedWidth = story => (
   </div>
 );
 
-export const FabricDecoratorFixedWidth = story => (
+export const FabricDecoratorFixedWidth = (story: RenderFunction) => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '300px' }}>
       {story()}
@@ -36,7 +34,7 @@ export const FabricDecoratorFixedWidth = story => (
   </div>
 );
 
-export const FabricDecoratorFullWidth = story => (
+export const FabricDecoratorFullWidth = (story: RenderFunction) => (
   <div style={{ display: 'flex' }}>
     <div className="testWrapper" style={{ padding: '10px', width: '100%', overflow: 'hidden' }}>
       {story()}

--- a/apps/vr-tests/tsconfig.json
+++ b/apps/vr-tests/tsconfig.json
@@ -8,10 +8,13 @@
     "sourceMap": true,
     "noEmit": true,
     "experimentalDecorators": true,
+    "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "types": ["webpack-env"]
+    "types": ["webpack-env", "screener-storybook"]
   },
   "include": ["src"]
 }

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -141,7 +141,7 @@ dependencies:
   rxjs: 6.3.3
   sass-loader: 6.0.7
   screener-runner: 0.10.22
-  screener-storybook: 0.16.2
+  screener-storybook: 0.16.8
   sinon: 4.5.0
   source-map-loader: 0.2.4
   stickyfilljs: 2.1.0
@@ -8028,7 +8028,7 @@ packages:
       request-promise-native: /request-promise-native/1.0.5/request@2.88.0
       sax: 1.2.4
       symbol-tree: 3.2.2
-      tough-cookie: 2.4.3
+      tough-cookie: 2.5.0
       w3c-hr-time: 1.0.1
       webidl-conversions: 4.0.2
       whatwg-encoding: 1.0.5
@@ -10985,6 +10985,19 @@ packages:
       react: ^16.6.3
     resolution:
       integrity: sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==
+  /react-dom/16.7.0/react@16.7.0:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.6.2
+      react: 16.7.0
+      scheduler: 0.12.0
+    dev: false
+    id: registry.npmjs.org/react-dom/16.7.0
+    peerDependencies:
+      react: ^16.0.0
+    resolution:
+      integrity: sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
   /react-draggable/3.0.5:
     dependencies:
       classnames: 2.2.6
@@ -11312,6 +11325,17 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
+  /react/16.7.0:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.6.2
+      scheduler: 0.12.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
   /read-chunk/2.1.0:
     dependencies:
       pify: 3.0.0
@@ -12062,6 +12086,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
+  /scheduler/0.12.0:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
+    resolution:
+      integrity: sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
   /schema-utils/0.3.0:
     dependencies:
       ajv: 5.5.2
@@ -12128,8 +12159,29 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-CwEClEfZPJTXqx6SLWZql8EV0QV2UnXBe8Yw3QaWFQA8E48ah39avPfmxiutdEg5FihpgHmginU4k7O3cysPSw==
-  /screener-storybook/0.16.2:
+  /screener-runner/0.10.27:
     dependencies:
+      bluebird: 3.4.7
+      colors: 1.1.2
+      commander: 2.9.0
+      compression: 1.7.3
+      connect: 3.6.6
+      http-proxy: 1.16.2
+      joi: 9.2.0
+      lodash: 4.17.11
+      portfinder: 1.0.20
+      request: 2.87.0
+      requestretry: /requestretry/2.0.2/request@2.87.0
+      screener-ngrok: 2.2.27
+    dev: false
+    engines:
+      node: '>= 4'
+    hasBin: true
+    resolution:
+      integrity: sha512-cK7u85iDBP4g19YFyhDuF6+GtiEQDKCFeNXmgXZjGNZoyXeJgeIfjiGmWmk0NrGFIo342hYFH4pTmGoBxihtHA==
+  /screener-storybook/0.16.8:
+    dependencies:
+      '@types/react': 16.3.16
       bluebird: 3.4.7
       colors: 1.1.2
       commander: 2.9.0
@@ -12138,18 +12190,18 @@ packages:
       jsdom: 11.7.0
       lodash: 4.17.11
       prop-types: 15.6.2
-      react: 16.6.3
-      react-dom: /react-dom/16.6.3/react@16.6.3
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
       request: 2.88.0
       requestretry: 1.12.3
-      screener-runner: 0.10.22
+      screener-runner: 0.10.27
       semver: 5.6.0
     dev: false
     engines:
       node: '>= 6'
     hasBin: true
     resolution:
-      integrity: sha512-hEGOWvW02Fn+Vjn8jm/fwTil4LwsswQl9GhMsOzXuYIjk9n37y29FmMydPGp9WEh3L8LhSzh8oYBRWAvdALyug==
+      integrity: sha512-0JBj6acz7T+f887KM8/G1R3UGuFfzMP+b0JCWCW7+ZmixN422PaA/66oHW5uhSRuZOpDRtudk4pKXnmUjIWrtw==
   /scss-tokenizer/0.2.3:
     dependencies:
       js-base64: 2.4.9
@@ -14691,7 +14743,7 @@ packages:
     dev: false
     name: '@rush-temp/azure-themes'
     resolution:
-      integrity: sha512-/OqqKDdNkBw1ucvRdIIh//nJohGfgoGAOaWBr1qGo5sR7xLwyZPDJ8rqTFLazsHNPRaTsea+HD6FJP5IJs0Y5w==
+      integrity: sha512-vT4TSV6sTvg3O2dOeHfmLULydJdjIuD3HyezlTey/cYwGK10YAa7GBJPp5WwY3cU0vvZaHFPuXI+4vh5UBrLfg==
       tarball: 'file:projects/azure-themes.tgz'
     version: 0.0.0
   'file:projects/build.tgz':
@@ -14757,7 +14809,7 @@ packages:
     dev: false
     name: '@rush-temp/build'
     resolution:
-      integrity: sha512-71ImE83Zd9GJSv9ISgpAX0f41Ui1Jtf3rtdzD/KoG5Wr52sCP+ue4v8SJZwloqQfu5BNdcj96n9tsVKcRAOONw==
+      integrity: sha512-dIQNnEOilQrljmrYXuoHRijN9toZ/Z1tnKsBDcO/X+NhFrlsWbPfzHDOSy5H39a7pFK2KD4csDnvr3CIs7mLZg==
       tarball: 'file:projects/build.tgz'
     version: 0.0.0
   'file:projects/charting.tgz':
@@ -14800,7 +14852,7 @@ packages:
     dev: false
     name: '@rush-temp/charting'
     resolution:
-      integrity: sha512-3ONs//2Z6djOL/5ngNoV0YU2gTBmetcgEDC7wiCd9V/tgi9UvCt24kjb2lYfWC4l7ZrU+wpJBhWqP8lmjJyTTQ==
+      integrity: sha512-o7jhnm0b+gZ1vZxY7ReLVytL3Kqtk0kAGW8alZx8b5SVqzHGdpQFPnW98byNbH3jRtkyNr3UcvZs62jPPU/h5Q==
       tarball: 'file:projects/charting.tgz'
     version: 0.0.0
   'file:projects/dashboard.tgz':
@@ -14829,7 +14881,7 @@ packages:
     dev: false
     name: '@rush-temp/dashboard'
     resolution:
-      integrity: sha512-KDo1zLzNcMytvTWE0BfCuOzuLWsf9gA68C+wG87ThVpzaoVz56eapwkqWFQcbUyDLKMyDqHP5wKWeOZqFoFsrQ==
+      integrity: sha512-8+45b0s+YcWGshiA8OFSFXnYTE7Vq3GZmBsxcG/Qkx7PjhtM/jNnd9WPAp6veyftmeCYj1zg/L0sCHryaLlwXw==
       tarball: 'file:projects/dashboard.tgz'
     version: 0.0.0
   'file:projects/date-time.tgz':
@@ -14854,7 +14906,7 @@ packages:
     dev: false
     name: '@rush-temp/date-time'
     resolution:
-      integrity: sha512-0sMDhAD7gNXgDjsM/a/gNgIkQxGTTvDWeKdyX7/YO1SJ6NXl/k+p6Qi1lr0tXypO1Yn+CkBcVS1cB7zFKaaT6w==
+      integrity: sha512-CWtNXULVr65wN3mZ+aRYg6Do2ptFO0O4EcueOAejPw9SnJUBtN7oSE3Ck+vDDOfq1zjFzB9vMGzDcPsicBN6wg==
       tarball: 'file:projects/date-time.tgz'
     version: 0.0.0
   'file:projects/example-app-base.tgz':
@@ -14879,7 +14931,7 @@ packages:
     dev: false
     name: '@rush-temp/example-app-base'
     resolution:
-      integrity: sha512-nEqObuuPgHvsrwvGk7TmLywcbOYR0OtGp5WMeIGEvQ7Jddn1HKo+ldWshIJ4vH2tdymwE+xZWO6Ufh9r7v41WQ==
+      integrity: sha512-6hxUm32TwzItrq/SpLe8IftTKpfcGnlbWcFJRkDXv6GQq0gfWqyxkT8zDAYAnrJDUYs5nCCDlYqcVeCfPLGkSA==
       tarball: 'file:projects/example-app-base.tgz'
     version: 0.0.0
   'file:projects/experiments.tgz':
@@ -14912,7 +14964,7 @@ packages:
     dev: false
     name: '@rush-temp/experiments'
     resolution:
-      integrity: sha512-j0ar0QkqO7XrIiJ/iUlkSB7NhP/EanhRwqssUxaq/gWOZG4gUZvtAqxuWgr1ZcasrH1Hy0nUvjgrTFBawry//w==
+      integrity: sha512-CBwr49Uc5AzzgTCXLzwcJvaXJCNSlDHou/OFYsZ4atfBpUtQDbk0ew3rPFM5zgV7DdhxBxHZx+bWHrFRM3BObw==
       tarball: 'file:projects/experiments.tgz'
     version: 0.0.0
   'file:projects/fabric-website-resources.tgz':
@@ -14948,7 +15000,7 @@ packages:
     dev: false
     name: '@rush-temp/fabric-website-resources'
     resolution:
-      integrity: sha512-gyzbA63FMeCAXp0R/l6eQ/phNv3uUVerOZc8Tq0Rf2lx9aFXkobE74jMVNSXBAR+m/+7cqgDzjgppVv3eTNn5A==
+      integrity: sha512-tTTpeLQkiLVfzfakhpYQiTD6VOGYFTchfQENaTtQkcNnC7hMizzo2IsKrceykqrrGPuOGVcNq0PP0S09lvRMeA==
       tarball: 'file:projects/fabric-website-resources.tgz'
     version: 0.0.0
   'file:projects/fabric-website.tgz':
@@ -14975,7 +15027,7 @@ packages:
     dev: false
     name: '@rush-temp/fabric-website'
     resolution:
-      integrity: sha512-Ko4vpLvcoW/ZVq1HPNB37iudHGDrHGwKAN3Gqbli4hXgkrg4hoAp6slvzzHcypTsv7YxvaKhlDW6yXX2UKjd3w==
+      integrity: sha512-wKK+jlxtI5JKMQmTB3vZmZkUKfxSSHYOWdJYDQctgIq9sIuYzOf5NnpHU9+FEd9OoHofJ7geMwcA+apLB34gQA==
       tarball: 'file:projects/fabric-website.tgz'
     version: 0.0.0
   'file:projects/file-type-icons.tgz':
@@ -14998,7 +15050,7 @@ packages:
     dev: false
     name: '@rush-temp/fluent-theme'
     resolution:
-      integrity: sha512-BX6RIUmCnHOT+6xwTnBlWESCP3Q68Ysjv0CU5J937D1ojMDc6qSeYNMuijCBk7d7W6digJyGb6Qzo/fg/2e8Ug==
+      integrity: sha512-5UDuBCM1Uss4kYWwG9XnXpaNO5WjaR+MwUE4dWiEK4NsOJu3+ZWCKFhx66d+hnL8j5NLLVe4cVLnR+xP6L6VZg==
       tarball: 'file:projects/fluent-theme.tgz'
     version: 0.0.0
   'file:projects/foundation-scenarios.tgz':
@@ -15022,7 +15074,7 @@ packages:
     dev: false
     name: '@rush-temp/foundation-scenarios'
     resolution:
-      integrity: sha512-+CVyJGvjMbPp+iesM0fed3udw0z+LnqyiwZbDKfH2va7X+6Xn6rbotc1I4HJJiQYMIAciefYB8ZQJr9H0nfs0A==
+      integrity: sha512-RWRYbfXlm/VLEoswVhxNwM+mdob4UxE8bxujybNRnEXnhaciCJJ4xh0SRMrvPbUn44c7FyNzVsoinz3RTo2vMw==
       tarball: 'file:projects/foundation-scenarios.tgz'
     version: 0.0.0
   'file:projects/foundation.tgz':
@@ -15068,7 +15120,7 @@ packages:
     dev: false
     name: '@rush-temp/jest-serializer-merge-styles'
     resolution:
-      integrity: sha512-32T0LEPK11cTcnh2vE4cXwWsVoL/SzUeq1fXYpJ3Xi8DZGFTa73w8D6VFogsuzDjeFqxMWCFNI8BlLNkjsBAtg==
+      integrity: sha512-egJhBfF89cvxOkxFa8T1yLUAjIAqILws7vI8UHtW0cMM749ijFpQXubQjuwWlgYAdzx+cFXSf68rIVhWUgXouA==
       tarball: 'file:projects/jest-serializer-merge-styles.tgz'
     version: 0.0.0
   'file:projects/merge-styles.tgz':
@@ -15118,14 +15170,14 @@ packages:
     dev: false
     name: '@rush-temp/office-ui-fabric-react'
     resolution:
-      integrity: sha512-iHEWJpy9CxOFVJ4dbQ0/3dAPzoY3pwezajkV/sF+eQuETHkc54h2INa8F7IrOjVWVIReX7+m59K6fK/O4d8rhg==
+      integrity: sha512-r9yTqJgG0dxV6+Q0kXccNcN2xZW80+pUhjz0A7Qnb99bxYXWBcZjgCYwldTuymHmTAQHyQs7bkppDoJARX0f0g==
       tarball: 'file:projects/office-ui-fabric-react.tgz'
     version: 0.0.0
   'file:projects/pr-deploy-site.tgz':
     dev: false
     name: '@rush-temp/pr-deploy-site'
     resolution:
-      integrity: sha512-LxxVn2/OMKISiUcLvlWAKkHafYh8kOPwx5A3WB1VPFrsRyFpSvmfA97G/KRAbhTRs42a+PtiG1ZhOpD2nrPCfg==
+      integrity: sha512-Pkbbjl6HY83nOkwr5NdyOlTlgrRLrdUK9yS/HxiAoq3VjOgd/OrsijKGUE9mDRi6MUkOFxMRGYV9/86SjNJ28g==
       tarball: 'file:projects/pr-deploy-site.tgz'
     version: 0.0.0
   'file:projects/prettier-rules.tgz':
@@ -15152,7 +15204,7 @@ packages:
     dev: false
     name: '@rush-temp/server-rendered-app'
     resolution:
-      integrity: sha512-O3vD1ZdgHlBZlX7QuVQLmh6wKiS5ffW6P9S6l4Ipq7sncMNKkKEd3W4UAF+z90ZCX3QlRbb0BIGlVi3bf1SrZw==
+      integrity: sha512-jhm8ST4qHyXwvnoo+kCJkEwUSYt+GmBYgr7rEUb1sQQ4HtXnZp8cVfPKVsrITf6GXF93luUL8xO7vpJw+WSJbQ==
       tarball: 'file:projects/server-rendered-app.tgz'
     version: 0.0.0
   'file:projects/set-version.tgz':
@@ -15181,7 +15233,7 @@ packages:
     dev: false
     name: '@rush-temp/ssr-tests'
     resolution:
-      integrity: sha512-vzisikLz8Q4A/qoRxRuZI2vw8lriQvtjK92oO8rxda+1ex14lnFHyNrQbPYTeIJgIODxV6jxkcRKhBXgrvYbdQ==
+      integrity: sha512-U1O4f6DZSMHG8ZI5xHCbMtfna2Slg7rgdYtN1s/1Y0sbsBqR2HtNyLW+JnO9NN8G2DD13OrJge/6yBMvdbo1pA==
       tarball: 'file:projects/ssr-tests.tgz'
     version: 0.0.0
   'file:projects/styling.tgz':
@@ -15198,7 +15250,7 @@ packages:
     dev: false
     name: '@rush-temp/styling'
     resolution:
-      integrity: sha512-8obG2r+9umKeAp+DreK8sztwSMIq7KuA/XtZOdprpRuJqqSslgbdJJXK/R3vGVoMCpivDYEoi0NtHSuKtsHNrg==
+      integrity: sha512-iR9Fdd7ZHG5dIo8jBdZA5PuxD4QQCP9EaZlCsLmJCzlQ2m9BoF2kG72N1ScBHxpT/H2lr5Wlzmi8Rkg1CV7n+g==
       tarball: 'file:projects/styling.tgz'
     version: 0.0.0
   'file:projects/test-bundles.tgz':
@@ -15212,7 +15264,7 @@ packages:
     dev: false
     name: '@rush-temp/test-bundles'
     resolution:
-      integrity: sha512-n5Uhh1+LoOLWlXRQjr6HY2ob47ZtHcjqFGJO0ZhCT3GGDv568TUc2xpzT0CZHC3ymRqd7MNXd809pzBEVJ1ORw==
+      integrity: sha512-2V4rk+u3eo58nFYQfhzmTe0tDckeks6+wEiMVs21mrg8EcF0tD3QstOiR4Of8CZU6ZsHuIK1X/slLqdmNbx6Pg==
       tarball: 'file:projects/test-bundles.tgz'
     version: 0.0.0
   'file:projects/test-utilities.tgz':
@@ -15244,7 +15296,7 @@ packages:
     dev: false
     name: '@rush-temp/theme-samples'
     resolution:
-      integrity: sha512-R1ryRn5tFLrwfUW1iUc26nBqLP/BSRVb4qP0WHNXKC8+HH90gskfnpM/ww2OMhhrCkvXB16N0AGyFcaALgLUSg==
+      integrity: sha512-FvFAxA+vSr8tPrmzk9MmP71okFQm7OvnmXYRe/WhO0eBWhaNjIzE7SP94tYZDG/BHM87V8x//IR/Hl0bOU9+Sw==
       tarball: 'file:projects/theme-samples.tgz'
     version: 0.0.0
   'file:projects/todo-app.tgz':
@@ -15263,7 +15315,7 @@ packages:
     dev: false
     name: '@rush-temp/todo-app'
     resolution:
-      integrity: sha512-mdMKkAYp7N/tb8mfznLUlp747gq3Qp9DPUB2Ls8aRosZ9DYWNagdArS4bZouABEWuAFmdWjQk/TA8UIMFyo8Fg==
+      integrity: sha512-IpKcCBNtk60rr14fJ5kCDbqL6LzMnUuQc3SPJoDd64O95GwV9BmUUb+nS77z1R+LboCZ8OH1re/Go9tRmj1Oig==
       tarball: 'file:projects/todo-app.tgz'
     version: 0.0.0
   'file:projects/tslint-rules.tgz':
@@ -15296,7 +15348,7 @@ packages:
     dev: false
     name: '@rush-temp/utilities'
     resolution:
-      integrity: sha512-qGyIwU64xEqj1G1Rjg64W/PhJlSOydNuL2ymM5VCh2vTDUsGAzdTkiO7nU84N7jxErMnxuGnPZazDBWA7GAmWw==
+      integrity: sha512-z2RWHywC9BLe3SRS2S+ZPBW41JLnn91/ODY/xHYFMSxXKdGuVv+v+0BlbWBQu3HMa3/5U8oq/tvzV76fCx9QkQ==
       tarball: 'file:projects/utilities.tgz'
     version: 0.0.0
   'file:projects/variants.tgz':
@@ -15306,7 +15358,7 @@ packages:
     dev: false
     name: '@rush-temp/variants'
     resolution:
-      integrity: sha512-f4N1KnLY3NWDeXOR+1g7wPvJWe1Af3WcKXPwVqdDvbs2BZcDISJ19q0tX8U8FUeaPlqyj166Fhg437S89JqMnw==
+      integrity: sha512-nH1QCeS3NSvwCz9NQAVn+KK+rvKa2vQebb6qemxVTspG+nmr3ITAOm4BJDonppkNwdQPtcmEG08ha/YHmWDdSA==
       tarball: 'file:projects/variants.tgz'
     version: 0.0.0
   'file:projects/vr-tests.tgz':
@@ -15329,7 +15381,7 @@ packages:
       react: 16.6.3
       react-dom: /react-dom/16.6.3/react@16.6.3
       screener-runner: 0.10.22
-      screener-storybook: 0.16.2
+      screener-storybook: 0.16.8
       storybook-readme: 3.3.0
       style-loader: 0.21.0
       tslib: 1.9.3
@@ -15337,7 +15389,7 @@ packages:
     dev: false
     name: '@rush-temp/vr-tests'
     resolution:
-      integrity: sha512-MVu8+9mpVqZLYMMg1EQNKx9DcZTLaPeiZlGxQOoH8Vwvcr2xEitRUpULvzMIWPZGB72Y+dsHbJ1Sstp/A/sKYQ==
+      integrity: sha512-dQpZ90M+ECQ5fNek4IsRQfFt2ACc+0QEkbZ70KpFMq/VUOSAiktFMrzNTePVNfmUsrEAqzRt1Wc4K5LrYcdL2g==
       tarball: 'file:projects/vr-tests.tgz'
     version: 0.0.0
   'file:projects/webpack-utils.tgz':
@@ -15514,7 +15566,7 @@ specifiers:
   rxjs: ^6.3.3
   sass-loader: ^6.0.6
   screener-runner: ^0.10.15
-  screener-storybook: ^0.16.0
+  screener-storybook: ^0.16.8
   sinon: ^4.1.3
   source-map-loader: ^0.2.1
   stickyfilljs: ^2.1.0


### PR DESCRIPTION
- Pick up the improved `screener-storybook` typings (including from [this PR](https://github.com/screener-io/screener-storybook/pull/86) I submitted), which should make writing screener tests a little easier.

- Use the per-project prettier options capability I added in #7630 to set a shorter max line length for the vr-tests project. Prettier usually tries to stuff as much code as possible on each line, which tends to make test cases rather unreadable with the line length 140 that we have set for the repo in general. Setting the line length to 100 in vr-tests helps mitigate this. (I disagree with both Prettier's insistence on squishing code onto a single line and with our general setting of 140 as line length, but that's another story...)

- Enable stricter build options in vr-tests (no unused stuff, strict null checks) and fix violations
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7757)

