### PR TITLE
Add a "menu" role to the unordered list

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-contextual-menu-role_2019-01-23-18-05.json
+++ b/common/changes/office-ui-fabric-react/miwhea-contextual-menu-role_2019-01-23-18-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ContextualMenu: Add menu role for accessibility",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -392,7 +392,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   ): JSX.Element => {
     let indexCorrection = 0;
     return (
-      <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp}>
+      <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp} role="menu">
         {menuListProps.items.map((item, index) => {
           const menuItem = this._renderMenuItem(
             item,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7726
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `role="menu"` to the unordered list so that it is a valid parent of the `role="menuitem"` items.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7767)

