### PR TITLE
Pass tabIndex from ComboBox to Autofill component

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2019-01-autofillGetNativeInputProps_2019-01-23-19-52.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-01-autofillGetNativeInputProps_2019-01-23-19-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Combobox: Add getNativeProps to component to fix tabIndex not being inherited",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/edwl-2019-01-autofillGetNativeInputProps_2019-01-23-19-52.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-01-autofillGetNativeInputProps_2019-01-23-19-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Combobox: Add getNativeProps to component to fix tabIndex not being inherited",
+      "comment": "Combobox: Pass taxIndex to Autofill component",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -5,7 +5,6 @@ import {
   css,
   customizable,
   divProperties,
-  inputProperties,
   findElementRecursive,
   findIndex,
   focusAsync,
@@ -325,13 +324,13 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       theme,
       title,
       keytipProps,
-      placeholder
+      placeholder,
+      tabIndex
     } = this.props;
     const { isOpen, focused, suggestedDisplayValue } = this.state;
     this._currentVisibleValue = this._getVisibleValue();
 
     const divProps = getNativeProps(this.props, divProperties, ['onChange', 'value']);
-    const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
     const hasErrorMessage = errorMessage && errorMessage.length > 0 ? true : false;
 
@@ -364,7 +363,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
               className={this._classNames.root}
             >
               <Autofill
-                {...inputProps}
                 data-ktp-execute-target={keytipAttributes['data-ktp-execute-target']}
                 data-is-interactable={!disabled}
                 componentRef={this._autofill}
@@ -396,6 +394,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 title={title}
                 preventValueSelection={!focused}
                 placeholder={placeholder}
+                tabIndex={tabIndex}
               />
               <IconButton
                 className={'ms-ComboBox-CaretDown-button'}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -331,11 +331,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._currentVisibleValue = this._getVisibleValue();
 
     const divProps = getNativeProps(this.props, divProperties, ['onChange', 'value']);
-    const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, [
-      'defaultValue',
-      'onChange',
-      'onChanged'
-    ]);
+    const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
 
     const hasErrorMessage = errorMessage && errorMessage.length > 0 ? true : false;
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -5,6 +5,7 @@ import {
   css,
   customizable,
   divProperties,
+  inputProperties,
   findElementRecursive,
   findIndex,
   focusAsync,
@@ -330,6 +331,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._currentVisibleValue = this._getVisibleValue();
 
     const divProps = getNativeProps(this.props, divProperties, ['onChange', 'value']);
+    const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, [
+      'defaultValue',
+      'onChange',
+      'onChanged'
+    ]);
 
     const hasErrorMessage = errorMessage && errorMessage.length > 0 ? true : false;
 
@@ -362,6 +368,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
               className={this._classNames.root}
             >
               <Autofill
+                {...inputProps}
                 data-ktp-execute-target={keytipAttributes['data-ktp-execute-target']}
                 data-is-interactable={!disabled}
                 componentRef={this._autofill}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7729
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `getNativeProps` to `ComboBox` component to fix tabIndex not being inherited

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7768)

