### PR TITLE
Panel: Add aria-hidden to component to prevent narrator from reading content when transitioning to a closed state 

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2019-01-addAriaHiddenPanel_2019-01-23-20-15.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-01-addAriaHiddenPanel_2019-01-23-20-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel:  Add aria-hidden attribute to prevent narrator from reading when transitioning to a closed state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -160,7 +160,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}
         >
-          <div {...nativeProps} ref={this._panel} className={_classNames.root}>
+          <div {...nativeProps} ref={this._panel} className={_classNames.root} aria-hidden={!isOpen && isAnimating}>
             {overlay}
             <FocusTrapZone
               ignoreExternalFocusing={ignoreExternalFocusing}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7758
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add `aria-hidden` attribute to Panel to prevent narrator from reading out content when transitioning states.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7769)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7770)

