### PR TITLE
Tooltip: Prevent content scrolling

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-tooltip-prevent-overflow_2019-01-23-21-42.json
+++ b/common/changes/office-ui-fabric-react/miwhea-tooltip-prevent-overflow_2019-01-23-21-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent the Tooltip's content from scrolling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -30,7 +30,8 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
       palette.neutralPrimary,
       {
         wordWrap: 'break-word',
-        overflowWrap: 'break-word'
+        overflowWrap: 'break-word',
+        overflow: 'hidden'
       }
     ],
     subText: [


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7674
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Prevents the Tooltip's content from scrolling. This bug was first reported due to Normalize.css being on the page (likely due to an increase in line height) but other global styles could cause this as well. There should never be a situation where a scrollbar is shown inside the Tooltip.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7774)

