### PR TITLE
Fix Callout placed partially off screen by ignoring maxHeight

### DIFF
--- a/common/changes/office-ui-fabric-react/u-jehell-callout-offscreen_2019-01-24-18-41.json
+++ b/common/changes/office-ui-fabric-react/u-jehell-callout-offscreen_2019-01-24-18-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix callouts appearing partially off screen",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jehell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -71,6 +71,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
   private _setHeightOffsetTimer: number;
   private _hasListeners = false;
   private _maxHeight: number | undefined;
+  private _blockResetHeight: boolean;
 
   constructor(props: ICalloutProps) {
     super(props);
@@ -109,7 +110,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
     // do not know if fabric has rendered a new element and disposed the old element.
     const newTarget = this._getTarget(newProps);
     const oldTarget = this._getTarget();
-    if (newTarget !== oldTarget || typeof newTarget === 'string' || newTarget instanceof String) {
+    if ((newTarget !== oldTarget || typeof newTarget === 'string' || newTarget instanceof String) && !this._blockResetHeight) {
       this._maxHeight = undefined;
       this._setTargetWindowAndElement(newTarget!);
     }
@@ -127,6 +128,8 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
         positions: undefined
       });
     }
+
+    this._blockResetHeight = false;
   }
 
   public componentDidMount(): void {
@@ -392,6 +395,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
         this._async.requestAnimationFrame(() => {
           if (this._target) {
             this._maxHeight = getMaxHeight(this._target, this.props.directionalHint!, totalGap, this._getBounds(), this.props.coverTarget);
+            this._blockResetHeight = true;
             this.forceUpdate();
           }
         });


### PR DESCRIPTION
When the height of a Callout is greater than the available window height it can be placed partially off-screen, cutting off a portion of the Callout.  This happens because of a flaw in the Callout maxHeight calculation.  During the render maxHeight is calculated which calls forceUpdate which currently clears out the maxHeight calcuation.  

#### Description of changes

This change prevents the maxHeight from being cleared in componentWillUpdate when forceUpdate is called from the maxHeight calculation.

Note that the logic clearing the maxHeight is currently in componentWillUpdate which is now considered legacy by react and should be refactored soon.  Additionally componentWillUpdate in the CallutContent base is also calling this.setState() which should not happen according to the react API reference and should also be refactored as well

#### Focus areas to test

Callout height, especially with limited window height.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7782)

