### PR TITLE
Add documentation and tests for color utilities

### DIFF
--- a/common/changes/office-ui-fabric-react/color-tests_2019-01-24-01-36.json
+++ b/common/changes/office-ui-fabric-react/color-tests_2019-01-24-01-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add documentation and tests for color utilities",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -578,6 +578,9 @@ class ChoiceGroupBase extends BaseComponent<IChoiceGroupProps, IChoiceGroupState
 }
 
 // @public
+export function clamp(value: number, max: number, min?: number): number;
+
+// @public
 export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet<TStyleSet>>(): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet>;
 
 // @public (undocumented)
@@ -754,6 +757,12 @@ enum ContextualMenuItemType {
 }
 
 // @public
+export function correctHSV(color: IHSV): IHSV;
+
+// @public
+export function correctRGB(color: IRGB): IRGB;
+
+// @public
 export function createArray<T>(size: number, getItem: (index: number) => T): T[];
 
 // @public (undocumented)
@@ -776,7 +785,7 @@ export function createTheme(theme: IPartialTheme, depComments?: boolean): ITheme
 // @public
 export function css(...args: ICssInput[]): string;
 
-// @public (undocumented)
+// @public
 export function cssColor(color: string): IRGB | undefined;
 
 // @public (undocumented)
@@ -1323,15 +1332,13 @@ export function getBackgroundShade(color: IColor, shade: Shade, isInverted?: boo
 // @public
 export function getChildren(parent: HTMLElement, allowVirtualChildren?: boolean): HTMLElement[];
 
-// @public (undocumented)
-export function getColorFromRGBA(rgba: {
-    r: number;
-    g: number;
-    b: number;
-    a: number;
-}): IColor;
+// @public
+export function getColorFromHSV(hsv: IHSV, a?: number): IColor;
 
-// @public (undocumented)
+// @public
+export function getColorFromRGBA(rgba: IRGB): IColor;
+
+// @public
 export function getColorFromString(inputColor: string): IColor | undefined;
 
 // @public (undocumented)
@@ -1355,7 +1362,7 @@ export function getFirstTabbable(rootElement: HTMLElement, currentElement: HTMLE
 // @public
 export function getFocusStyle(theme: ITheme, inset?: number, position?: 'relative' | 'absolute', highContrastStyle?: IRawStyle | undefined, borderColor?: string, outlineColor?: string, isFocusedOnly?: boolean): IRawStyle;
 
-// @public (undocumented)
+// @public
 export function getFullColorString(color: IColor): string;
 
 // @public
@@ -1525,23 +1532,19 @@ enum HoverCardType {
   plain = "PlainCard"
 }
 
-// @public (undocumented)
+// @public
 export function hsl2hsv(h: number, s: number, l: number): IHSV;
 
-// @public (undocumented)
+// @public
 export function hsl2rgb(h: number, s: number, l: number): IRGB;
 
-// @public (undocumented)
+// @public
 export function hsv2hex(h: number, s: number, v: number): string;
 
-// @public (undocumented)
-export function hsv2hsl(h: number, s: number, v: number): {
-    h: number;
-    s: number;
-    l: number;
-};
+// @public
+export function hsv2hsl(h: number, s: number, v: number): IHSL;
 
-// @public (undocumented)
+// @public
 export function hsv2rgb(h: number, s: number, v: number): IRGB;
 
 // @public (undocumented)
@@ -2649,9 +2652,7 @@ interface ICoachmarkStyles {
 
 // @public (undocumented)
 interface IColor extends IRGB, IHSV {
-  // (undocumented)
   hex: string;
-  // (undocumented)
   str: string;
 }
 
@@ -8207,21 +8208,15 @@ interface IHoverCardStyles {
 
 // @public (undocumented)
 interface IHSL {
-  // (undocumented)
   h: number;
-  // (undocumented)
   l: number;
-  // (undocumented)
   s: number;
 }
 
 // @public (undocumented)
 interface IHSV {
-  // (undocumented)
   h: number;
-  // (undocumented)
   s: number;
-  // (undocumented)
   v: number;
 }
 
@@ -9751,15 +9746,11 @@ interface IResizeGroupStyles {
   root: IStyle;
 }
 
-// @public (undocumented)
+// @public
 interface IRGB {
-  // (undocumented)
   a?: number;
-  // (undocumented)
   b: number;
-  // (undocumented)
   g: number;
-  // (undocumented)
   r: number;
 }
 
@@ -11835,10 +11826,10 @@ class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGroupState
   render(): JSX.Element;
 }
 
-// @public (undocumented)
+// @public
 export function rgb2hex(r: number, g: number, b: number): string;
 
-// @public (undocumented)
+// @public
 export function rgb2hsv(r: number, g: number, b: number): IHSV;
 
 // @public (undocumented)
@@ -12638,13 +12629,16 @@ export function unhoistMethods(source: any, methodNames: string[]): void;
 // @public
 export function unregisterIcons(iconNames: string[]): void;
 
-// @public (undocumented)
+// @public
 export function updateA(color: IColor, a: number): IColor;
 
-// @public (undocumented)
+// @public
 export function updateH(color: IColor, h: number): IColor;
 
-// @public (undocumented)
+// @public
+export function updateRGB(color: IColor, component: keyof IRGB, value: number): IColor;
+
+// @public
 export function updateSV(color: IColor, s: number, v: number): IColor;
 
 // @public
@@ -12730,7 +12724,9 @@ module ZIndexes {
 // WARNING: Unsupported export: MAX_COLOR_SATURATION
 // WARNING: Unsupported export: MAX_COLOR_HUE
 // WARNING: Unsupported export: MAX_COLOR_VALUE
+// WARNING: Unsupported export: MAX_COLOR_RGB
 // WARNING: Unsupported export: MAX_COLOR_RGBA
+// WARNING: Unsupported export: MAX_COLOR_ALPHA
 // WARNING: Unsupported export: ColorPicker
 // WARNING: Unsupported export: CommandBar
 // WARNING: Unsupported export: ContextualMenu

--- a/packages/office-ui-fabric-react/src/utilities/color/colors.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/colors.test.ts
@@ -1,0 +1,309 @@
+import {
+  cssColor,
+  rgb2hex,
+  hsv2hex,
+  rgb2hsv,
+  hsl2hsv,
+  hsv2hsl,
+  hsl2rgb,
+  hsv2rgb,
+  getColorFromString,
+  getColorFromRGBA,
+  getColorFromHSV,
+  getFullColorString,
+  updateSV,
+  updateH,
+  updateRGB,
+  updateA,
+  correctRGB,
+  correctHSV,
+  clamp,
+  IColor
+} from './colors';
+
+describe('color utilities', () => {
+  const testColor: IColor = {
+    r: 0,
+    g: 21,
+    b: 255,
+    h: 235,
+    s: 100,
+    v: 100,
+    a: 100,
+    hex: '0015ff',
+    str: '#0015ff'
+  };
+  const testColorAlpha: IColor = { ...testColor, a: 50, str: 'rgba(0, 21, 255, 0.5)' };
+  const testColorNoAlpha: IColor = { ...testColor, a: undefined };
+
+  describe('rgb2hex', () => {
+    it('works', () => {
+      expect(rgb2hex(0, 0, 0)).toEqual('000000');
+      expect(rgb2hex(255, 255, 255)).toEqual('ffffff');
+      expect(rgb2hex(171, 205, 239)).toEqual('abcdef');
+      expect(rgb2hex(1, 0, 0)).toEqual('010000');
+      expect(rgb2hex(14, 0, 0)).toEqual('0e0000');
+    });
+  });
+
+  describe('rgb2hsv', () => {
+    it('works', () => {
+      expect(rgb2hsv(0, 0, 0)).toEqual({ h: 0, s: 0, v: 0 });
+      expect(rgb2hsv(255, 255, 255)).toEqual({ h: 0, s: 0, v: 100 });
+      expect(rgb2hsv(255, 0, 0)).toEqual({ h: 0, s: 100, v: 100 });
+      expect(rgb2hsv(0, 255, 0)).toEqual({ h: 120, s: 100, v: 100 });
+      expect(rgb2hsv(0, 0, 255)).toEqual({ h: 240, s: 100, v: 100 });
+      expect(rgb2hsv(235, 33, 10)).toEqual({ h: 6, s: 96, v: 92 });
+    });
+  });
+
+  describe('hsv2hex', () => {
+    it('works', () => {
+      expect(hsv2hex(0, 0, 0)).toEqual('000000');
+      expect(hsv2hex(0, 100, 100)).toEqual('ff0000');
+      expect(hsv2hex(359, 100, 100)).toEqual('ff0004');
+      expect(hsv2hex(0, 50, 100)).toEqual('ff8080');
+      expect(hsv2hex(0, 100, 50)).toEqual('800000');
+      expect(hsv2hex(0, 50, 50)).toEqual('804040');
+      expect(hsv2hex(221, 61, 50)).toEqual('324a80');
+      expect(hsv2hex(221, 0, 100)).toEqual('ffffff');
+      expect(hsv2hex(253, 100, 0)).toEqual('000000');
+    });
+  });
+
+  describe('hsl2hsv', () => {
+    it('works', () => {
+      expect(hsl2hsv(0, 0, 0)).toEqual({ h: 0, s: 0, v: 0 });
+      expect(hsl2hsv(359, 100, 100)).toEqual({ h: 359, s: 0, v: 100 });
+      expect(hsl2hsv(50, 100, 25)).toEqual({ h: 50, s: 100, v: 50 });
+      expect(hsl2hsv(50, 100, 75)).toEqual({ h: 50, s: 50, v: 100 });
+      const result = hsl2hsv(205, 55, 32);
+      result.s = Math.round(result.s);
+      result.v = Math.round(result.v);
+      expect(result).toEqual({ h: 205, s: 71, v: 50 });
+    });
+  });
+
+  describe('hsv2hsl', () => {
+    it('works', () => {
+      expect(hsv2hsl(0, 0, 0)).toEqual({ h: 0, s: 0, l: 0 });
+      expect(hsv2hsl(359, 100, 100)).toEqual({ h: 359, s: 100, l: 50 });
+      expect(hsv2hsl(0, 100, 50)).toEqual({ h: 0, s: 100, l: 25 });
+      expect(hsv2hsl(0, 50, 100)).toEqual({ h: 0, s: 100, l: 75 });
+      const result = hsv2hsl(205, 71, 50);
+      result.s = Math.round(result.s);
+      result.l = Math.round(result.l);
+      expect(result).toEqual({ h: 205, s: 55, l: 32 });
+    });
+  });
+
+  describe('hsv2rgb', () => {
+    it('works', () => {
+      expect(hsv2rgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+      expect(hsv2rgb(50, 100, 0)).toEqual({ r: 0, g: 0, b: 0 });
+      expect(hsv2rgb(50, 0, 100)).toEqual({ r: 255, g: 255, b: 255 });
+      expect(hsv2rgb(50, 100, 100)).toEqual({ r: 255, g: 213, b: 0 });
+      expect(hsv2rgb(50, 50, 100)).toEqual({ r: 255, g: 234, b: 128 });
+      expect(hsv2rgb(50, 100, 50)).toEqual({ r: 128, g: 106, b: 0 });
+      expect(hsv2rgb(262, 77, 63)).toEqual({ r: 82, g: 37, b: 161 });
+    });
+  });
+
+  describe('hsl2rgb', () => {
+    it('works', () => {
+      expect(hsl2rgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+      expect(hsl2rgb(50, 100, 0)).toEqual({ r: 0, g: 0, b: 0 });
+      expect(hsl2rgb(50, 0, 100)).toEqual({ r: 255, g: 255, b: 255 });
+      expect(hsl2rgb(50, 100, 100)).toEqual({ r: 255, g: 255, b: 255 });
+      expect(hsl2rgb(50, 100, 50)).toEqual({ r: 255, g: 213, b: 0 });
+      expect(hsl2rgb(262, 77, 63)).toEqual({ r: 141, g: 88, b: 233 });
+    });
+  });
+
+  describe('getColorFromRGBA', () => {
+    it('works without alpha', () => {
+      const result = getColorFromRGBA({ r: 0, g: 0, b: 0 });
+      expect(result.a).toEqual(100);
+      expect(result.hex).toEqual('000000');
+      expect(result.str).toEqual('#000000');
+    });
+
+    it('works with alpha', () => {
+      const result = getColorFromRGBA({ r: 0, g: 0, b: 0, a: 50 });
+      expect(result.a).toEqual(50);
+      expect(result.hex).toEqual('000000');
+      expect(result.str).toEqual('rgba(0, 0, 0, 0.5)');
+    });
+
+    it('works all-up', () => {
+      expect(getColorFromRGBA({ r: testColor.r, g: testColor.g, b: testColor.b })).toEqual(testColor);
+    });
+  });
+
+  describe('cssColor', () => {
+    it('handles named colors', () => {
+      expect(cssColor('crimson')).toEqual({ r: 220, g: 20, b: 60, a: 100 });
+    });
+
+    it('handles invalid hex input', () => {
+      expect(cssColor(undefined as any)).toBeUndefined();
+      expect(cssColor(null as any)).toBeUndefined();
+      expect(cssColor('')).toBeUndefined();
+      expect(cssColor('000')).toBeUndefined(); // missing #
+      expect(cssColor('#0000')).toBeUndefined(); // wrong length
+      expect(cssColor('#00000')).toBeUndefined(); // wrong length
+      expect(cssColor('000000')).toBeUndefined(); // missing #
+      expect(cssColor('#qwerty')).toBeUndefined(); // invalid chars
+      expect(cssColor('')).toBeUndefined();
+    });
+
+    it('handles valid hex input', () => {
+      expect(cssColor('#000')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('#000000')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('#abc')).toEqual({ r: 170, g: 187, b: 204, a: 100 });
+      expect(cssColor('#ABC')).toEqual({ r: 170, g: 187, b: 204, a: 100 });
+      expect(cssColor('#123456')).toEqual({ r: 18, g: 52, b: 86, a: 100 });
+    });
+
+    it('handles invalid rgba input', () => {
+      expect(cssColor('rgb(0)')).toBeUndefined(); // not enough numbers
+      expect(cssColor('rgb(0, 0, 0, 0)')).toBeUndefined(); // too many numbers for rgb non-a
+      expect(cssColor('rgb(foo)')).toBeUndefined();
+      expect(cssColor('rgba(0, 0, 0)')).toBeUndefined(); // not enough numbers for rgba
+      expect(cssColor('rgb(0, 0, 0, 0, 0)')).toBeUndefined(); // too many numbers
+    });
+
+    it('handles valid rgba input', () => {
+      expect(cssColor('rgb(0, 0, 0)')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('rgb(0,0,0)')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('rgb(18, 52, 86)')).toEqual({ r: 18, g: 52, b: 86, a: 100 });
+      expect(cssColor('rgba(0, 0, 0, 1.0)')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('rgba(0, 0, 0, 0.5)')).toEqual({ r: 0, g: 0, b: 0, a: 50 });
+    });
+
+    it('handles invalid hsla input', () => {
+      expect(cssColor('hsl(0)')).toBeUndefined(); // not enough numbers
+      expect(cssColor('hsl(0, 0, 0, 0)')).toBeUndefined(); // too many numbers for hsl non-a
+      expect(cssColor('hsl(foo)')).toBeUndefined();
+      expect(cssColor('hsla(0, 0, 0)')).toBeUndefined(); // not enough numbers for hsla
+      expect(cssColor('hsl(0, 0, 0, 0, 0)')).toBeUndefined(); // too many numbers
+    });
+
+    it('handles valid hsla input', () => {
+      expect(cssColor('hsl(0, 0, 0)')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('hsl(0,0,0)')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('hsl(18, 52, 50)')).toEqual({ r: 194, g: 101, b: 61, a: 100 });
+      expect(cssColor('hsla(0, 0, 0, 1.0)')).toEqual({ r: 0, g: 0, b: 0, a: 100 });
+      expect(cssColor('hsla(0, 0, 0, 0.5)')).toEqual({ r: 0, g: 0, b: 0, a: 50 });
+    });
+  });
+
+  describe('getColorFromString', () => {
+    // not testing this in detail since it's mostly just a composition of other things already tested
+    it('works', () => {
+      expect(getColorFromString('000')).toBeUndefined();
+      expect(getColorFromString('#000')).toBeTruthy();
+      expect(getColorFromString(testColor.str)).toEqual(testColor);
+
+      expect(getColorFromString(testColorAlpha.str)).toEqual(testColorAlpha);
+    });
+
+    it('preserves exact string passed in', () => {
+      // usually we generate lowercase full-length hex values
+      expect(getColorFromString('#EEE')!.str).toEqual('#EEE');
+      // our generated RGB values don't have weird spacing
+      // (and we generate hex values not rgb() for colors without alpha)
+      expect(getColorFromString('rgb(0 ,0,          0)')!.str).toEqual('rgb(0 ,0,          0)');
+    });
+  });
+
+  describe('getColorFromHSV', () => {
+    it('works without alpha', () => {
+      expect(getColorFromHSV({ h: testColor.h, s: testColor.s, v: testColor.v })).toEqual(testColor);
+    });
+
+    it('works with alpha', () => {
+      const result = getColorFromHSV({ h: testColor.h, s: testColor.s, v: testColor.v }, testColorAlpha.a);
+      expect(result).toEqual(testColorAlpha);
+    });
+  });
+
+  describe('getFullColorString', () => {
+    it('works', () => {
+      // despite the name, this function returns an HTML color string based on *only* the hue
+      expect(getFullColorString({ h: 0, s: 50, v: 50 } as IColor)).toEqual('#ff0000');
+      expect(getFullColorString({ h: testColor.h, s: 50, v: 50, a: 50 } as IColor)).toEqual(testColor.str);
+    });
+  });
+
+  describe('updateSV', () => {
+    it('works', () => {
+      expect(updateSV({ h: testColor.h, s: 50, v: 50 } as IColor, 100, 100)).toEqual(testColorNoAlpha);
+
+      expect(updateSV({ h: testColor.h, s: 50, v: 50, a: 50 } as IColor, 100, 100)).toEqual(testColorAlpha);
+    });
+  });
+
+  describe('updateH', () => {
+    it('works', () => {
+      expect(updateH({ h: 15, s: testColor.s, v: testColor.v } as IColor, testColor.h)).toEqual(testColorNoAlpha);
+
+      expect(updateH({ h: 15, s: testColor.s, v: testColor.v, a: testColorAlpha.a } as IColor, testColor.h)).toEqual(testColorAlpha);
+    });
+  });
+
+  describe('updateRGB', () => {
+    it('works', () => {
+      // this uses getColorFromRGBA() internally, so not much to test
+      const expected: IColor = {
+        r: 0,
+        g: 21,
+        b: 255,
+        h: 235,
+        s: 100,
+        v: 100,
+        a: 100,
+        hex: '0015ff',
+        str: '#0015ff'
+      };
+      expect(updateRGB({ r: 255, g: 21, b: 255 } as IColor, 'r', 0)).toEqual(expected);
+      expect(updateRGB({ r: 0, g: 255, b: 255 } as IColor, 'g', 21)).toEqual(expected);
+      expect(updateRGB({ r: 0, g: 21, b: 0 } as IColor, 'b', 255)).toEqual(expected);
+
+      expected.a = 50;
+      expected.str = 'rgba(0, 21, 255, 0.5)';
+      expect(updateRGB({ r: 0, g: 21, b: 255 } as IColor, 'a', 50)).toEqual(expected);
+      expect(updateRGB({ r: 0, g: 21, b: 255, a: 25 } as IColor, 'a', 50)).toEqual(expected);
+    });
+  });
+
+  describe('updateA', () => {
+    it('works', () => {
+      expect(updateA(testColor, testColorAlpha.a!)).toEqual(testColorAlpha);
+    });
+  });
+
+  describe('clamp', () => {
+    it('works', () => {
+      expect(clamp(-1, 10)).toEqual(0);
+      expect(clamp(0, 10)).toEqual(0);
+      expect(clamp(-1, 10, 2)).toEqual(2);
+      expect(clamp(-1, 10, -1)).toEqual(-1);
+      expect(clamp(5, 10)).toEqual(5);
+      expect(clamp(11, 10)).toEqual(10);
+    });
+  });
+
+  describe('correctRGB', () => {
+    it('works', () => {
+      expect(correctRGB({ r: -4, g: 300, b: 150 })).toEqual({ r: 0, g: 255, b: 150 });
+      expect(correctRGB({ r: -4, g: 300, b: 150, a: 200 })).toEqual({ r: 0, g: 255, b: 150, a: 100 });
+    });
+  });
+
+  describe('correctHSV', () => {
+    it('works', () => {
+      expect(correctHSV({ h: 400, s: -1, v: 30 })).toEqual({ h: 359, s: 0, v: 30 });
+    });
+  });
+});

--- a/packages/office-ui-fabric-react/src/utilities/color/colors.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/colors.ts
@@ -1,49 +1,76 @@
-import { assign } from '../../Utilities';
 import { COLOR_VALUES } from './colorValues';
 
 export const MAX_COLOR_SATURATION = 100;
 export const MAX_COLOR_HUE = 359;
 export const MAX_COLOR_VALUE = 100;
-export const MAX_COLOR_RGBA = 255;
+export const MAX_COLOR_RGB = 255;
+/** @deprecated Use MAX_COLOR_RGB (255) or MAX_COLOR_ALPHA (100) */
+export const MAX_COLOR_RGBA = MAX_COLOR_RGB;
+export const MAX_COLOR_ALPHA = 100;
 
+/** RGB color with optional alpha value. */
 export interface IRGB {
+  /** Red, range 0-255. */
   r: number;
+  /** Green, range 0-255. */
   g: number;
+  /** Blue, range 0-255. */
   b: number;
+  /** Alpha, range 0 (transparent)-100. Usually assumed to be 100 if not specified. */
   a?: number;
 }
 
 export interface IHSV {
+  /** Hue, range 0-359. */
   h: number;
+  /** Saturation, range 0-100. */
   s: number;
+  /** Value, range 0-100. */
   v: number;
 }
 
 export interface IHSL {
+  /** Hue, range 0-359. */
   h: number;
+  /** Saturation, range 0-100. */
   s: number;
+  /** Lightness, range 0-100. */
   l: number;
 }
 
 export interface IColor extends IRGB, IHSV {
+  /** Hex string for the color (excluding alpha component), *not* prefixed with #. */
   hex: string;
+
+  /** CSS color string. If a hex value, it must be prefixed with #. */
   str: string;
 }
 
+/**
+ * Converts a valid CSS color string to an RGB color.
+ * Note that hex colors *must* be prefixed with # to be considered valid.
+ * Alpha in returned color defaults to 100.
+ */
 export function cssColor(color: string): IRGB | undefined {
-  return _named(color) || _hex3(color) || _hex6(color) || _rgb(color) || _rgba(color) || _hsl(color) || (_hsla(color) as IRGB);
+  if (!color) {
+    return undefined;
+  }
+  return _named(color) || _hex3(color) || _hex6(color) || _rgba(color) || _hsla(color);
 }
 
+/** Converts RGB components to a hex color string (without # prefix). */
 export function rgb2hex(r: number, g: number, b: number): string {
-  return [_numberToPaddedHex(r), _numberToPaddedHex(g), _numberToPaddedHex(b)].join('');
+  return [_rgbToPaddedHex(r), _rgbToPaddedHex(g), _rgbToPaddedHex(b)].join('');
 }
 
+/** Converts HSV components to a hex color string (without # prefix). */
 export function hsv2hex(h: number, s: number, v: number): string {
   const { r, g, b } = hsv2rgb(h, s, v);
 
   return rgb2hex(r, g, b);
 }
 
+/** Converts RGB components to an HSV color. */
 export function rgb2hsv(r: number, g: number, b: number): IHSV {
   let h = NaN;
   let s;
@@ -73,22 +100,25 @@ export function rgb2hsv(r: number, g: number, b: number): IHSV {
   s = Math.round((max === 0 ? 0 : delta / max) * 100);
 
   // value
-  v = Math.round((max / 255) * 100);
+  v = Math.round((max / MAX_COLOR_RGB) * 100);
 
   return { h, s, v };
 }
 
+/** Converts HSL components to an HSV color. */
 export function hsl2hsv(h: number, s: number, l: number): IHSV {
   s *= (l < 50 ? l : 100 - l) / 100;
+  const v = l + s;
 
   return {
     h: h,
-    s: ((2 * s) / (l + s)) * 100,
-    v: l + s
+    s: v === 0 ? 0 : ((2 * s) / v) * 100,
+    v: v
   };
 }
 
-export function hsv2hsl(h: number, s: number, v: number): { h: number; s: number; l: number } {
+/** Converts HSV components to an HSL color. */
+export function hsv2hsl(h: number, s: number, v: number): IHSL {
   s /= MAX_COLOR_SATURATION;
   v /= MAX_COLOR_VALUE;
 
@@ -101,12 +131,14 @@ export function hsv2hsl(h: number, s: number, v: number): { h: number; s: number
   return { h: h, s: sl * 100, l: l * 100 };
 }
 
+/** Converts HSL components to an RGB color. Does not set the alpha value. */
 export function hsl2rgb(h: number, s: number, l: number): IRGB {
   const hsv = hsl2hsv(h, s, l);
 
   return hsv2rgb(hsv.h, hsv.s, hsv.v);
 }
 
+/** Converts HSV components to an RGB color. Does not set the alpha value. */
 export function hsv2rgb(h: number, s: number, v: number): IRGB {
   s = s / 100;
   v = v / 100;
@@ -145,12 +177,20 @@ export function hsv2rgb(h: number, s: number, v: number): IRGB {
   }
 
   return {
-    r: Math.round(MAX_COLOR_RGBA * (rgb[0] + m)),
-    g: Math.round(MAX_COLOR_RGBA * (rgb[1] + m)),
-    b: Math.round(MAX_COLOR_RGBA * (rgb[2] + m))
+    r: Math.round(MAX_COLOR_RGB * (rgb[0] + m)),
+    g: Math.round(MAX_COLOR_RGB * (rgb[1] + m)),
+    b: Math.round(MAX_COLOR_RGB * (rgb[2] + m))
   };
 }
 
+/**
+ * Converts a CSS color string to a color object.
+ * Note that hex colors *must* be prefixed with # to be considered valid.
+ *
+ * `inputColor` will be used unmodified as the `str` property of the returned object.
+ * Alpha defaults to 100 if not specified in `inputColor`.
+ * Returns undefined if the color string is invalid/not recognized.
+ */
 export function getColorFromString(inputColor: string): IColor | undefined {
   const color = cssColor(inputColor);
 
@@ -158,44 +198,54 @@ export function getColorFromString(inputColor: string): IColor | undefined {
     return;
   }
 
-  const { a, b, g, r } = color;
-  const { h, s, v } = rgb2hsv(r, g, b);
-
   return {
-    a: a,
-    b: b,
-    g: g,
-    h: h,
-    hex: rgb2hex(r, g, b),
-    r: r,
-    s: s,
-    str: inputColor,
-    v: v
+    ...getColorFromRGBA(color!),
+    str: inputColor
   };
 }
 
-export function getColorFromRGBA(rgba: { r: number; g: number; b: number; a: number }): IColor {
-  const { a, b, g, r } = rgba;
+/** Converts an RGBA color to a color object (alpha defaults to 100). */
+export function getColorFromRGBA(rgba: IRGB): IColor {
+  const { a = MAX_COLOR_ALPHA, b, g, r } = rgba;
   const { h, s, v } = rgb2hsv(r, g, b);
-
   const hex = rgb2hex(r, g, b);
-  return {
-    a: a,
-    b: b,
-    g: g,
-    h: h,
-    hex: hex,
-    r: r,
-    s: s,
-    str: a === 100 ? `#${hex}` : `rgba(${r}, ${g}, ${b}, ${a / 100})`,
-    v: v
-  };
+  const str = _rgbaOrHexString(r, g, b, a, hex);
+
+  return { a, b, g, h, hex, r, s, str, v };
 }
 
+/**
+ * Converts an HSV color (and optional alpha value) to a color object.
+ * If `a` is not given, a default of 100 is used.
+ * Hex in the returned value will *not* be prefixed with #.
+ * If `a` is unspecified or 100, the result's `str` property will contain a hex value
+ * (*not* prefixed with #)
+ */
+export function getColorFromHSV(hsv: IHSV, a?: number): IColor {
+  const { h, s, v } = hsv;
+  a = typeof a === 'number' ? a : MAX_COLOR_ALPHA;
+
+  const { r, g, b } = hsv2rgb(h, s, v);
+  const hex = hsv2hex(h, s, v);
+  const str = _rgbaOrHexString(r, g, b, a, hex);
+
+  return { a, b, g, h, hex, r, s, str, v };
+}
+
+/**
+ * Converts a color hue to an HTML color string (with # prefix).
+ * This implementation ignores all components of `color` except hue.
+ */
 export function getFullColorString(color: IColor): string {
   return `#${hsv2hex(color.h, MAX_COLOR_SATURATION, MAX_COLOR_VALUE)}`;
 }
 
+/**
+ * Gets a color with the same hue as `color` and other components updated to match the given
+ * saturation and value.
+ *
+ * Does not modify the original `color` and does not supply a default alpha value.
+ */
 export function updateSV(color: IColor, s: number, v: number): IColor {
   const { r, g, b } = hsv2rgb(color.h, s, v);
   const hex = rgb2hex(r, g, b);
@@ -208,11 +258,17 @@ export function updateSV(color: IColor, s: number, v: number): IColor {
     hex: hex,
     r: r,
     s: s,
-    str: color.a === 100 ? `#${hex}` : `rgba(${r}, ${g}, ${b}, ${(color.a as number) / 100})`,
+    str: _rgbaOrHexString(r, g, b, color.a, hex),
     v: v
   };
 }
 
+/**
+ * Gets a color with the same saturation and value as `color` and the other components updated
+ * to match the given hue.
+ *
+ * Does not modify the original `color` and does not supply a default alpha value.
+ */
 export function updateH(color: IColor, h: number): IColor {
   const { r, g, b } = hsv2rgb(h, color.s, color.v);
   const hex = rgb2hex(r, g, b);
@@ -225,24 +281,73 @@ export function updateH(color: IColor, h: number): IColor {
     hex: hex,
     r: r,
     s: color.s,
-    str: color.a === 100 ? `#${hex}` : `rgba(${r}, ${g}, ${b}, ${(color.a as number) / 100})`,
+    str: _rgbaOrHexString(r, g, b, color.a, hex),
     v: color.v
   };
 }
 
-export function updateA(color: IColor, a: number): IColor {
-  return assign({}, color, {
-    a: a,
-    str: a === 100 ? `#${color.hex}` : `rgba(${color.r}, ${color.g}, ${color.b}, ${a / 100})`
+/**
+ * Gets a color with a single RGBA component updated to a new value.
+ * Does not modify the original `color`. Alpha defaults to 100 if not set.
+ */
+export function updateRGB(color: IColor, component: keyof IRGB, value: number): IColor {
+  return getColorFromRGBA({
+    r: color.r,
+    g: color.g,
+    b: color.b,
+    a: color.a,
+    [component]: value
   });
 }
 
-function _numberToPaddedHex(num: number): string {
+/**
+ * Gets a color with the given alpha value and the same other components as `color`.
+ * Does not modify the original color.
+ */
+export function updateA(color: IColor, a: number): IColor {
+  return {
+    ...color,
+    a: a,
+    str: _rgbaOrHexString(color.r, color.g, color.b, a, color.hex)
+  };
+}
+
+/** Corrects an RGB color to fall within the valid range.  */
+export function correctRGB(color: IRGB): IRGB {
+  return {
+    r: clamp(color.r, MAX_COLOR_RGB),
+    g: clamp(color.g, MAX_COLOR_RGB),
+    b: clamp(color.b, MAX_COLOR_RGB),
+    a: typeof color.a === 'number' ? clamp(color.a, MAX_COLOR_ALPHA) : color.a
+  };
+}
+
+/** Corrects an HSV color to fall within the valid range. */
+export function correctHSV(color: IHSV): IHSV {
+  return {
+    h: clamp(color.h, MAX_COLOR_HUE),
+    s: clamp(color.s, MAX_COLOR_SATURATION),
+    v: clamp(color.v, MAX_COLOR_VALUE)
+  };
+}
+
+/** Clamp a value to ensure it falls within a given range. */
+export function clamp(value: number, max: number, min = 0): number {
+  return value < min ? min : value > max ? max : value;
+}
+
+/** Converts an RGB component to a 0-padded hex component of length 2. */
+function _rgbToPaddedHex(num: number): string {
+  num = clamp(num, MAX_COLOR_RGB);
   const hex = num.toString(16);
 
   return hex.length === 1 ? '0' + hex : hex;
 }
 
+/**
+ * If `str` is a valid HTML color name, returns an RGB color (with alpha 100).
+ * Otherwise returns undefined.
+ */
 function _named(str: string): IRGB | undefined {
   const c = (COLOR_VALUES as any)[str.toLowerCase()];
 
@@ -251,92 +356,87 @@ function _named(str: string): IRGB | undefined {
       r: c[0],
       g: c[1],
       b: c[2],
-      a: 100
+      a: MAX_COLOR_ALPHA
     };
   }
 }
 
-function _rgb(str: string): IRGB | undefined {
-  if (0 === str.indexOf('rgb(')) {
-    str = str.match(/rgb\(([^)]+)\)/)![1];
-
-    const parts = str.split(/ *, */).map(Number);
-
-    return {
-      r: parts[0],
-      g: parts[1],
-      b: parts[2],
-      a: 100
-    };
-  }
-}
-
+/**
+ * If `str` is in valid `rgb()` or `rgba()` format, returns an RGB color (alpha defaults to 100).
+ * Otherwise returns undefined.
+ */
 function _rgba(str: string): IRGB | undefined {
-  if (str.indexOf('rgba(') === 0) {
-    str = str.match(/rgba\(([^)]+)\)/)![1];
+  const match = str.match(/^rgb(a?)\(([\d., ]+)\)$/);
+  if (match) {
+    const hasAlpha = !!match[1];
+    const expectedPartCount = hasAlpha ? 4 : 3;
+    const parts = match[2].split(/ *, */).map(Number);
 
-    const parts = str.split(/ *, */).map(Number);
-
-    return {
-      r: parts[0],
-      g: parts[1],
-      b: parts[2],
-      a: parts[3] * 100
-    };
+    if (parts.length === expectedPartCount) {
+      return {
+        r: parts[0],
+        g: parts[1],
+        b: parts[2],
+        a: hasAlpha ? parts[3] * 100 : MAX_COLOR_ALPHA
+      };
+    }
   }
 }
 
+/**
+ * If `str` is in valid 6-digit hex format *with* # prefix, returns an RGB color (with alpha 100).
+ * Otherwise returns undefined.
+ */
 function _hex6(str: string): IRGB | undefined {
-  if ('#' === str[0] && 7 === str.length) {
+  if ('#' === str[0] && 7 === str.length && /^#[\da-fA-F]{6}$/.test(str)) {
     return {
       r: parseInt(str.slice(1, 3), 16),
       g: parseInt(str.slice(3, 5), 16),
       b: parseInt(str.slice(5, 7), 16),
-      a: 100
+      a: MAX_COLOR_ALPHA
     };
   }
 }
 
+/**
+ * If `str` is in valid 3-digit hex format *with* # prefix, returns an RGB color (with alpha 100).
+ * Otherwise returns undefined.
+ */
 function _hex3(str: string): IRGB | undefined {
-  if ('#' === str[0] && 4 === str.length) {
+  if ('#' === str[0] && 4 === str.length && /^#[\da-fA-F]{3}$/.test(str)) {
     return {
       r: parseInt(str[1] + str[1], 16),
       g: parseInt(str[2] + str[2], 16),
       b: parseInt(str[3] + str[3], 16),
-      a: 100
+      a: MAX_COLOR_ALPHA
     };
   }
 }
 
-function _hsl(str: string): IRGB | undefined {
-  if (str.indexOf('hsl(') === 0) {
-    str = str.match(/hsl\(([^)]+)\)/)![1];
-    const parts = str.split(/ *, */);
+/**
+ * If `str` is in `hsl()` or `hsla()` format, returns an RGB color (alpha defaults to 100).
+ * Otherwise returns undefined.
+ */
+function _hsla(str: string): IRGB | undefined {
+  const match = str.match(/^hsl(a?)\(([\d., ]+)\)$/);
+  if (match) {
+    const hasAlpha = !!match[1];
+    const expectedPartCount = hasAlpha ? 4 : 3;
+    const parts = match[2].split(/ *, */).map(Number);
 
-    const h = parseInt(parts[0], 10);
-    const s = parseInt(parts[1], 10);
-    const l = parseInt(parts[2], 10);
-
-    const rgba = hsl2rgb(h, s, l);
-    rgba.a = 100;
-
-    return rgba;
+    if (parts.length === expectedPartCount) {
+      const rgba = hsl2rgb(parts[0], parts[1], parts[2]);
+      rgba.a = hasAlpha ? parts[3] * 100 : MAX_COLOR_ALPHA;
+      return rgba;
+    }
   }
 }
 
-function _hsla(str: string): IRGB | undefined {
-  if (str.indexOf('hsla(') === 0) {
-    str = str.match(/hsla\(([^)]+)\)/)![1];
-
-    const parts = str.split(/ *, */);
-    const h = parseInt(parts[0], 10);
-    const s = parseInt(parts[1], 10);
-    const l = parseInt(parts[2], 10);
-    const a = parseInt(parts[3], 10) * 100;
-    const rgba = hsl2rgb(h, s, l);
-
-    rgba.a = a;
-
-    return rgba;
-  }
+/**
+ * Get a CSS color string from some color components.
+ * If `a` is specified and not 100, returns an `rgba()` string.
+ * Otherwise returns `hex` prefixed with #.
+ */
+function _rgbaOrHexString(r: number, g: number, b: number, a: number | undefined, hex: string): string {
+  return a === MAX_COLOR_ALPHA || typeof a !== 'number' ? `#${hex}` : `rgba(${r}, ${g}, ${b}, ${a / MAX_COLOR_ALPHA})`;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

The color utility functions had no documentation, which made things more difficult when working on the color picker. They also had no tests. This PR adds both and fixes a few bugs.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7783)

