### PR TITLE
Fluent-theme: split TeachingBubble fluent styles to fix bug in Coachmark

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-Coachmark_2019-01-24-03-00.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-Coachmark_2019-01-24-03-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "TeachingBubble: split the styles in two different regions to take into account when the TeachingBubbleContent is used as a standalone component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -25,7 +25,7 @@ import { PrimaryButtonStyles } from './styles/PrimaryButton.styles';
 import { RatingStyles } from './styles/Rating.styles';
 import { SliderStyles } from './styles/Slider.styles';
 import { SpinButtonStyles } from './styles/SpinButton.styles';
-import { TeachingBubbleStyles } from './styles/TeachingBubble.styles';
+import { TeachingBubbleStyles, TeachingBubbleContentStyles } from './styles/TeachingBubble.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
 import { ColorPickerGridCellStyles } from './styles/ColorPickerGridCell.styles';
@@ -137,6 +137,9 @@ export const FluentStyles: any = {
   },
   TeachingBubble: {
     styles: TeachingBubbleStyles
+  },
+  TeachingBubbleContent: {
+    styles: TeachingBubbleContentStyles
   },
   TextField: {
     styles: TextFieldStyles

--- a/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
@@ -4,6 +4,18 @@ import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react/lib/TeachingBubble';
 
 export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
+  return {
+    subComponentStyles: {
+      callout: {
+        root: {
+          boxShadow: Depths.depth16
+        }
+      }
+    }
+  };
+};
+
+export const TeachingBubbleContentStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
   const { hasCondensedHeadline, hasSmallHeadline, theme } = props;
   const { palette } = theme;
 
@@ -29,13 +41,6 @@ export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<
       selectors: {
         '&:hover': {
           color: palette.black
-        }
-      }
-    },
-    subComponentStyles: {
-      callout: {
-        root: {
-          boxShadow: Depths.depth16
         }
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Because `Coachmark` is using `TeachingBubbleContent` as its child due to the fact that it gets rendered in `PositioningContainer` instead of `Callout` we had a very weird bug on the page when using fluent theme:
# Before
![2019-01-23 18 46 43](https://user-images.githubusercontent.com/29514833/51651765-08f3aa80-1f42-11e9-8b31-5e406b19441f.gif)
# After
![2019-01-23 18 56 55](https://user-images.githubusercontent.com/29514833/51651769-0ee98b80-1f42-11e9-82d2-4fd52e2ba952.gif)
 
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7784)

