### PR TITLE
Fix ColorPicker when alpha slider is hidden

### DIFF
--- a/common/changes/office-ui-fabric-react/color-picker-2_2019-01-24-04-04.json
+++ b/common/changes/office-ui-fabric-react/color-picker-2_2019-01-24-04-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix ColorPicker when alpha slider is hidden",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -608,8 +608,10 @@ enum CollapseAllVisibility {
 }
 
 // @public (undocumented)
-class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPickerState> {
+class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPickerState>, implements IColorPicker {
   constructor(props: IColorPickerProps);
+  // (undocumented)
+  readonly color: IColor;
   // (undocumented)
   componentWillReceiveProps(newProps: IColorPickerProps): void;
   // (undocumented)
@@ -2665,6 +2667,7 @@ interface IColorCellProps {
 
 // @public (undocumented)
 interface IColorPicker {
+  color: IColor;
 }
 
 // @public (undocumented)
@@ -2730,8 +2733,6 @@ interface IColorPickerProps extends IBaseProps<IColorPicker> {
 interface IColorPickerState {
   // (undocumented)
   color: IColor;
-  // (undocumented)
-  isOpen: boolean;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/common/testUtilities.ts
+++ b/packages/office-ui-fabric-react/src/common/testUtilities.ts
@@ -40,3 +40,8 @@ export function renderIntoDocument(element: React.ReactElement<any>): HTMLElemen
   const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
   return renderedDOM as HTMLElement;
 }
+
+export function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
+  const target: EventTarget = { value: targetValue } as HTMLInputElement;
+  return { target };
+}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -1,7 +1,5 @@
-/* tslint:disable:no-unused-variable */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-/* tslint:enable:no-unused-variable */
 
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
@@ -12,7 +10,7 @@ import { ActionButton } from './ActionButton/ActionButton';
 import { CommandBarButton } from './CommandBarButton/CommandBarButton';
 import { CompoundButton } from './CompoundButton/CompoundButton';
 import { KeyCodes } from '../../Utilities';
-// import { IconButton } from "src";
+import { renderIntoDocument } from '../../common/testUtilities';
 
 const alertClicked = (): void => {
   /*noop*/
@@ -79,12 +77,6 @@ describe('Button', () => {
   });
 
   describe('DefaultButton', () => {
-    function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
-      const component = ReactTestUtils.renderIntoDocument(element);
-      const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
-      return renderedDOM as HTMLElement;
-    }
-
     it('can render without an onClick.', () => {
       const button = ReactTestUtils.renderIntoDocument<any>(<DefaultButton>Hello</DefaultButton>);
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -1,88 +1,79 @@
-/* tslint:disable:no-unused-variable */
 import * as React from 'react';
-/* tslint:enable:no-unused-variable */
 import * as renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
+import * as ReactTestUtils from 'react-dom/test-utils';
 
 import { ColorPicker } from './ColorPicker';
 import { ColorPickerBase, IColorPickerState } from './ColorPicker.base';
 import { IColorPicker, IColorPickerProps } from './ColorPicker.types';
 import { IColor, getColorFromString } from '../../utilities/color/colors';
+import { mockEvent } from '../../common/testUtilities';
 
 describe('ColorPicker', () => {
-  it('renders ColorPicker correctly', () => {
-    const component = renderer.create(<ColorPicker color="#FFFFFF" />);
+  let wrapper: ReactWrapper<IColorPickerProps, IColorPickerState, ColorPickerBase> | undefined;
+  const colorPickerRef = React.createRef<IColorPicker>();
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  it('renders correctly', () => {
+    const component = renderer.create(<ColorPicker color="#abcdef" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('Props are correctly parsed', () => {
-    let colorPickerComponent: any;
-    const setRef = (ref: IColorPicker): void => {
-      colorPickerComponent = ref;
-    };
+  it('correctly parses props', () => {
+    wrapper = mount(<ColorPicker color="#abcdef" componentRef={colorPickerRef} />);
 
-    mount(<ColorPicker color="#FFFFFF" componentRef={setRef} />);
-
-    expect(colorPickerComponent.state.color.hex).toEqual('ffffff');
+    expect(colorPickerRef.current!.color.hex).toEqual('abcdef');
   });
 
-  it('Reacts to props change', () => {
-    let colorPickerComponent: any;
-    const setRef = (ref: IColorPicker): void => {
-      colorPickerComponent = ref;
-    };
+  it('reacts to props change', () => {
+    wrapper = mount(<ColorPicker color="#abcdef" componentRef={colorPickerRef} />);
 
-    mount(<ColorPicker color="#FFFFFF" componentRef={setRef} />);
-
-    const component = colorPickerComponent;
-    colorPickerComponent.componentWillReceiveProps({ color: '#AEAEAE' });
-    expect(component.state.color.hex).toEqual('aeaeae');
+    wrapper.setProps({ color: '#AEAEAE' });
+    expect(colorPickerRef.current!.color.hex).toEqual('aeaeae');
   });
 
-  it('onColorChange is called', () => {
-    let color = '#FFFFFF';
-    let newColorObject;
+  it('calls onColorChange', () => {
+    let color = '#FFFFFFs';
+    let newColorObject: IColor | undefined;
     const onColorChanged = (str: string, colorObject: IColor): void => {
       color = str;
       newColorObject = colorObject;
     };
 
-    let colorPickerComponent: any;
-    const setRef = (ref: IColorPicker): void => {
-      colorPickerComponent = ref;
-    };
-
-    mount(<ColorPicker color={color} componentRef={setRef} onColorChanged={onColorChanged} />);
+    wrapper = mount(<ColorPicker color={color} componentRef={colorPickerRef} onColorChanged={onColorChanged} />);
 
     const newColor = '#AEAEAE';
-    const component = colorPickerComponent;
-    colorPickerComponent.componentWillReceiveProps({ color: newColor });
+    wrapper.setProps({ color: newColor });
 
-    expect(component.state.color.hex).toEqual('aeaeae');
+    expect(colorPickerRef.current!.color.hex).toEqual('aeaeae');
     expect(color).toEqual(newColor);
     expect(newColorObject).toEqual(getColorFromString(newColor));
   });
 
-  it('Hides alpha control slider', () => {
-    const wrapper = mount(<ColorPicker color="#FFFFFF" alphaSliderHidden={true} />);
+  it('hides alpha control slider', () => {
+    wrapper = mount(<ColorPicker color="#FFFFFF" alphaSliderHidden={true} />);
 
     const alphaSlider = wrapper.find('.is-alpha');
-    const tableHeaders = wrapper.find('.ms-ColorPicker-table > thead > tr > td');
-    const tableInputs = wrapper.find('.ms-ColorPicker-table > tbody> tr > td');
+    const tableHeaders = wrapper.find('thead td');
+    const inputs = wrapper.find('.ms-TextField');
 
     // There should only be table headers and inputs for hex, red, green, and blue (no alpha)
-    const expectedTableComponents = 4;
-
     expect(alphaSlider.exists()).toBe(false);
-    expect(tableHeaders).toHaveLength(expectedTableComponents);
-    expect(tableInputs).toHaveLength(expectedTableComponents);
+    expect(tableHeaders).toHaveLength(4);
+    expect(inputs).toHaveLength(4);
   });
 
-  it('Renders default RGBA/Hex strings', () => {
-    const wrapper = mount(<ColorPicker color="#FFFFFF" />);
+  it('renders default RGBA/Hex strings', () => {
+    wrapper = mount(<ColorPicker color="#FFFFFF" />);
 
-    const tableHeaders = wrapper.find('.ms-ColorPicker-table > thead > tr > td');
+    const tableHeaders = wrapper.find('thead td');
     const textHeaders = [
       ColorPickerBase.defaultProps.hexLabel,
       ColorPickerBase.defaultProps.redLabel,
@@ -96,10 +87,10 @@ describe('ColorPicker', () => {
     });
   });
 
-  it('Renders custom RGBA/Hex strings', () => {
+  it('renders custom RGBA/Hex strings', () => {
     const textHeaders = ['Custom Hex', 'Custom Red', 'Custom Green', 'Custom Blue', 'Custom Alpha'];
 
-    const wrapper = mount(
+    wrapper = mount(
       <ColorPicker
         color="#FFFFFF"
         hexLabel={textHeaders[0]}
@@ -110,46 +101,84 @@ describe('ColorPicker', () => {
       />
     );
 
-    const tableHeaders = wrapper.find('.ms-ColorPicker-table > thead > tr > td');
+    const tableHeaders = wrapper.find('thead td');
     tableHeaders.forEach((node, index) => {
       expect(node.text()).toEqual(textHeaders[index]);
     });
   });
 
-  it('Keeps color value when tabbing between Hex and RGBA text inputs', () => {
-    const colorStringValue = 'ffffff';
-    let colorChangeCalled = false;
-    const onColorChanged = (newColor: string): void => {
-      colorChangeCalled = newColor !== colorStringValue;
-    };
-
-    let colorPickerComponent: any;
-    const setRef = (ref: IColorPicker): void => {
-      colorPickerComponent = ref;
-    };
-
+  it('keeps color value when tabbing between Hex and RGBA text inputs', () => {
+    const colorStringValue = 'abcdef';
+    const colorChangeSpy = jest.fn();
     const inputClassName = 'input-tab-test';
-    const wrapper = mount<IColorPickerProps, IColorPickerState>(
+    wrapper = mount(
       <ColorPicker
         color={`#${colorStringValue}`}
-        onColorChanged={onColorChanged}
-        componentRef={setRef}
+        onColorChanged={colorChangeSpy}
+        componentRef={colorPickerRef}
         styles={{ input: inputClassName }}
       />
     );
 
-    expect(colorPickerComponent.state.color.hex).toEqual(colorStringValue);
-    expect(colorChangeCalled).toBeFalsy();
+    expect(colorPickerRef.current!.color.hex).toEqual(colorStringValue);
+    expect(colorChangeSpy).toHaveBeenCalledTimes(0);
 
     // Tab between text inputs checking state after each time.
     const allInputs = wrapper.find(`.${inputClassName} input`);
     expect(allInputs.length).toBe(5);
 
     allInputs.forEach(input => {
+      input.simulate('focus');
       input.simulate('blur');
 
-      expect(colorPickerComponent.state.color.hex).toEqual(colorStringValue);
-      expect(colorChangeCalled).toBeFalsy();
+      expect(colorPickerRef.current!.color.hex).toEqual(colorStringValue);
+      expect(colorChangeSpy).toHaveBeenCalledTimes(0);
     });
+  });
+
+  it('allows updating text fields', () => {
+    let updatedColor: string | undefined;
+    const onChange = jest.fn((color: string) => (updatedColor = color));
+
+    wrapper = mount(<ColorPicker onColorChanged={onChange} color="#000000" />);
+
+    const inputs = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input');
+    const redInput = inputs[1];
+    ReactTestUtils.Simulate.input(redInput, mockEvent('255'));
+    ReactTestUtils.Simulate.blur(redInput);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(updatedColor).toBe('#ff0000');
+
+    const hexInput = inputs[0];
+    ReactTestUtils.Simulate.input(hexInput, mockEvent('00ff00'));
+    ReactTestUtils.Simulate.blur(hexInput);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(updatedColor).toBe('#00ff00');
+
+    const alphaInput = inputs[4];
+    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50'));
+    ReactTestUtils.Simulate.blur(alphaInput);
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(updatedColor).toBe('rgba(0, 255, 0, 0.5)');
+  });
+
+  it('allows updating text fields when alpha slider is hidden', () => {
+    let updatedColor: string | undefined;
+    const onChange = jest.fn((color: string) => (updatedColor = color));
+
+    wrapper = mount(<ColorPicker onColorChanged={onChange} color="#000000" alphaSliderHidden />);
+
+    const inputs = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input');
+    const redInput = inputs[1];
+    ReactTestUtils.Simulate.input(redInput, mockEvent('255'));
+    ReactTestUtils.Simulate.blur(redInput);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(updatedColor).toBe('#ff0000');
+
+    const hexInput = inputs[0];
+    ReactTestUtils.Simulate.input(hexInput, mockEvent('00ff00'));
+    ReactTestUtils.Simulate.blur(hexInput);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(updatedColor).toBe('#00ff00');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -40,7 +40,7 @@ describe('ColorPicker', () => {
   });
 
   it('calls onColorChange', () => {
-    let color = '#FFFFFFs';
+    let color = '#FFFFFF';
     let newColorObject: IColor | undefined;
     const onColorChanged = (str: string, colorObject: IColor): void => {
       color = str;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.types.ts
@@ -2,7 +2,10 @@ import { ITheme, IStyle } from '../../Styling';
 import { IBaseProps, IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { IColor } from '../../utilities/color/colors';
 
-export interface IColorPicker {}
+export interface IColorPicker {
+  /** The currently selected color. */
+  color: IColor;
+}
 
 export interface IColorPickerProps extends IBaseProps<IColorPicker> {
   /**
@@ -16,35 +19,35 @@ export interface IColorPickerProps extends IBaseProps<IColorPicker> {
   color: string;
 
   /**
-   * Callback issued when the user changes the color.
+   * Callback for when the user changes the color.
    */
   onColorChanged?: (color: string, colorObject: IColor) => void;
 
   /**
-   * The setting of whether to hide the alpha control slider.
+   * Whether to hide the alpha control slider.
    */
   alphaSliderHidden?: boolean;
 
   /**
-   * Label for the hex textfield.
+   * Label for the hex text field.
    * @defaultvalue Hex
    */
   hexLabel?: string;
 
   /**
-   * Label for the red textfield.
+   * Label for the red text field.
    * @defaultvalue Red
    */
   redLabel?: string;
 
   /**
-   * Label for the green textfield.
+   * Label for the green text field.
    * @defaultvalue Green
    */
   greenLabel?: string;
 
   /**
-   * Label for the blue textfield.
+   * Label for the blue text field.
    * @defaultvalue Blue
    */
   blueLabel?: string;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ColorPicker renders ColorPicker correctly 1`] = `
+exports[`ColorPicker renders correctly 1`] = `
 <div
   className=
       ms-ColorPicker
@@ -37,7 +37,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
       onMouseDown={[Function]}
       style={
         Object {
-          "backgroundColor": "#ff0000",
+          "backgroundColor": "#0080ff",
           "minHeight": 220,
           "minWidth": 220,
         }
@@ -82,9 +82,9 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
             }
         style={
           Object {
-            "backgroundColor": "#FFFFFF",
-            "left": "0%",
-            "top": "0%",
+            "backgroundColor": "#abcdef",
+            "left": "28%",
+            "top": "6%",
           }
         }
       />
@@ -136,7 +136,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
             }
         style={
           Object {
-            "left": "0%",
+            "left": "58.4958217270195%",
           }
         }
       />
@@ -172,7 +172,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
             }
         style={
           Object {
-            "background": "linear-gradient(to right, transparent 0, #ffffff 100%)",
+            "background": "linear-gradient(to right, transparent 0, #abcdef 100%)",
           }
         }
       />
@@ -360,7 +360,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onInput={[Function]}
                     spellCheck={false}
                     type="text"
-                    value="ffffff"
+                    value="abcdef"
                   />
                 </div>
               </div>
@@ -487,7 +487,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onInput={[Function]}
                     spellCheck={false}
                     type="text"
-                    value="255"
+                    value="171"
                   />
                 </div>
               </div>
@@ -614,7 +614,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onInput={[Function]}
                     spellCheck={false}
                     type="text"
-                    value="255"
+                    value="205"
                   />
                 </div>
               </div>
@@ -741,7 +741,7 @@ exports[`ColorPicker renders ColorPicker correctly 1`] = `
                     onInput={[Function]}
                     spellCheck={false}
                     type="text"
-                    value="255"
+                    value="239"
                   />
                 </div>
               </div>

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
@@ -1,33 +1,42 @@
+// @codepen
+
 import * as React from 'react';
-import { ColorPicker } from 'office-ui-fabric-react/lib/ColorPicker';
+import { ColorPicker, Toggle } from 'office-ui-fabric-react/lib/index';
 
 export interface IBasicColorPickerExampleState {
   color: string;
+  alphaSliderHidden: boolean;
 }
 
-export class ColorPickerBasicExample extends React.Component<any, IBasicColorPickerExampleState> {
-  constructor(props: any) {
+export class ColorPickerBasicExample extends React.Component<{}, IBasicColorPickerExampleState> {
+  constructor(props: {}) {
     super(props);
 
     this.state = {
-      color: '#ffffff'
+      color: '#ffffff',
+      alphaSliderHidden: false
     };
-
-    this._updateColor = this._updateColor.bind(this);
   }
 
   public render(): JSX.Element {
+    const { color, alphaSliderHidden } = this.state;
     return (
       <div style={{ display: 'flex' }}>
-        <ColorPicker color={this.state.color} onColorChanged={this._updateColor} />
-        <div style={{ backgroundColor: this.state.color, width: 100, height: 100, margin: 16, border: '1px solid #c8c6c4' }} />
+        <ColorPicker color={color} onColorChanged={this._updateColor} alphaSliderHidden={alphaSliderHidden} />
+
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div style={{ backgroundColor: color, width: 100, height: 100, margin: 16, border: '1px solid #c8c6c4' }} />
+          <Toggle label="Hide alpha slider" onChange={this._onHideAlphaClick} checked={alphaSliderHidden} />
+        </div>
       </div>
     );
   }
 
   private _updateColor = (color: string): void => {
-    this.setState({
-      color: color
-    });
+    this.setState({ color: color });
+  };
+
+  private _onHideAlphaClick = (ev: React.MouseEvent<HTMLElement>, checked?: boolean) => {
+    this.setState({ alphaSliderHidden: !!checked });
   };
 }

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -1,24 +1,12 @@
 import { Promise } from 'es6-promise';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { SpinButton } from './SpinButton';
 import { KeyCodes } from '../../Utilities';
+import { mockEvent, renderIntoDocument } from '../../common/testUtilities';
 
 describe('SpinButton', () => {
-  function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
-    const component = ReactTestUtils.renderIntoDocument(element);
-    const renderedDOM: Element = ReactDOM.findDOMNode(component as React.ReactInstance) as Element;
-    return renderedDOM as HTMLElement;
-  }
-
-  function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
-    const target: EventTarget = { value: targetValue } as HTMLInputElement;
-    const event: ReactTestUtils.SyntheticEventData = { target };
-    return event;
-  }
-
   it('renders SpinButton correctly', () => {
     const component = renderer.create(<SpinButton label="label" />);
     const tree = component.toJSON();

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.test.tsx
@@ -1,19 +1,12 @@
 import * as React from 'react';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { KeyCodes } from '../../../Utilities';
+import { mockEvent } from '../../../common/testUtilities';
 
 import { MaskedTextField } from './MaskedTextField';
 
 describe('MaskedTextField', () => {
-  function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
-    const target: EventTarget = { value: targetValue } as HTMLInputElement;
-    const event: ReactTestUtils.SyntheticEventData = { target };
-
-    return event;
-  }
-
   it('renders TextField correctly', () => {
     const component = renderer.create(<MaskedTextField label="With input mask" mask="m\ask: (999) 999 - 9999" />);
     const tree = component.toJSON();

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.deprecated.test.tsx
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 
 import { resetIds } from '../../Utilities';
 import { TextField } from './TextField';
+import { mockEvent } from '../../common/testUtilities';
 
 describe('TextField deprecated', () => {
   beforeAll(() => {
@@ -22,13 +23,6 @@ describe('TextField deprecated', () => {
   beforeEach(() => {
     resetIds();
   });
-
-  function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
-    const target: EventTarget = { value: targetValue } as HTMLInputElement;
-    const event: ReactTestUtils.SyntheticEventData = { target };
-
-    return event;
-  }
 
   it('renders with deprecated props affecting styling', () => {
     const component = renderer.create(<TextField addonString={'test addonString'} iconClass={'test-iconClass'} />);

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -1,6 +1,5 @@
 import { Promise } from 'es6-promise';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
@@ -10,6 +9,7 @@ import { resetIds } from '../../Utilities';
 import { TextField } from './TextField';
 import { TextFieldBase } from './TextField.base';
 import { ITextFieldStyles, ITextField } from './TextField.types';
+import { mockEvent, renderIntoDocument } from '../../common/testUtilities';
 
 describe('TextField', () => {
   const textFieldRef = React.createRef<TextFieldBase>();
@@ -22,12 +22,6 @@ describe('TextField', () => {
     jest.useRealTimers();
   });
 
-  function renderIntoDocument(element: React.ReactElement<any>): HTMLElement {
-    const component = ReactTestUtils.renderIntoDocument(element);
-    const renderedDOM = ReactDOM.findDOMNode(component as React.ReactInstance);
-    return renderedDOM as HTMLElement;
-  }
-
   /**
    * Mounts the element attached to a child of document.body. This is primarily for tests involving
    * event handlers (which don't work right unless the element is attached).
@@ -36,13 +30,6 @@ describe('TextField', () => {
     const parent = document.createElement('div');
     document.body.appendChild(parent);
     return mount(element, { attachTo: parent });
-  }
-
-  function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
-    const target: EventTarget = { value: targetValue } as HTMLInputElement;
-    const event: ReactTestUtils.SyntheticEventData = { target };
-
-    return event;
   }
 
   function delay(millisecond: number): Promise<void> {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -889,13 +889,146 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
   <div
     style={
       Object {
-        "backgroundColor": "#ffffff",
-        "border": "1px solid #c8c6c4",
-        "height": 100,
-        "margin": 16,
-        "width": 100,
+        "display": "flex",
+        "flexDirection": "column",
       }
     }
-  />
+  >
+    <div
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+          "border": "1px solid #c8c6c4",
+          "height": 100,
+          "margin": 16,
+          "width": 100,
+        }
+      }
+    />
+    <div
+      className=
+          ms-Toggle
+          is-enabled
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 8px;
+          }
+    >
+      <label
+        className=
+            ms-Label
+            ms-Toggle-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        htmlFor="Toggle10"
+      >
+        Hide alpha slider
+      </label>
+      <div
+        className=
+            ms-Toggle-innerContainer
+            {
+              display: inline-flex;
+              position: relative;
+            }
+      >
+        <button
+          aria-checked={false}
+          checked={false}
+          className=
+              ms-Toggle-background
+              {
+                align-items: center;
+                background: #ffffff;
+                border-color: #666666;
+                border-radius: 1em;
+                border-style: solid;
+                border-width: 1px;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: flex;
+                font-size: 20px;
+                height: 1em;
+                outline: transparent;
+                padding-bottom: 0;
+                padding-left: .2em;
+                padding-right: .2em;
+                padding-top: 0;
+                position: relative;
+                transition: all 0.1s ease;
+                width: 2.2em;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: -2px;
+                content: "";
+                left: -2px;
+                outline: 1px solid #666666;
+                position: absolute;
+                right: -2px;
+                top: -2px;
+                z-index: 1;
+              }
+              &:hover {
+                border-color: #333333;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+                border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
+          data-is-focusable={true}
+          id="Toggle10"
+          onChange={[Function]}
+          onClick={[Function]}
+          role="switch"
+          type="button"
+        >
+          <div
+            className=
+                ms-Toggle-thumb
+                {
+                  background-color: #333333;
+                  border-color: transparent;
+                  border-radius: .5em;
+                  border-style: solid;
+                  border-width: .28em;
+                  box-sizing: border-box;
+                  height: .5em;
+                  transition: all 0.1s ease;
+                  width: .5em;
+                }
+          />
+        </button>
+      </div>
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7426
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When the ColorPicker's alpha slider was hidden, for some reason it wouldn't respect updates to the text fields. It seems this had something to do with the odd way that the ColorPicker was using text fields, because when the text field usage was switched to a more idiomatic controlled pattern, the problem went away.

While working on a test for this scenario, I noticed that several components had duplicate definitions of the `mockEvent` and `renderIntoDocument` functions, so I removed those in favor of the definitions from `src/common/testUtilities` (that's the reason for changes to tests for Button and other random components).
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7785)

