### PR TITLE
Add type attribute to Link when it is rendered as a button

### DIFF
--- a/common/changes/office-ui-fabric-react/add-type-to-button-link_2019-01-24-15-18.json
+++ b/common/changes/office-ui-fabric-react/add-type-to-button-link_2019-01-24-15-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Specify prop \"type\" to be \"button\" for links which are of type button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dahanlon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
@@ -29,7 +29,7 @@ export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
         {(keytipAttributes: any): JSX.Element => (
           <RootType
             {...keytipAttributes}
-            {...this._removeInvalidPropsForRootType(RootType, this.props)}
+            {...this._adjustPropsForRootType(RootType, this.props)}
             className={classNames.root}
             onClick={this._onClick}
             ref={this._link}
@@ -60,7 +60,7 @@ export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
     }
   };
 
-  private _removeInvalidPropsForRootType(
+  private _adjustPropsForRootType(
     RootType: string | React.ComponentClass | React.StatelessComponent,
     props: ILinkProps & { getStyles?: any }
   ): Partial<ILinkProps> {
@@ -80,7 +80,16 @@ export class LinkBase extends BaseComponent<ILinkProps, any> implements ILink {
         };
       }
 
-      // Remove the target and href props for non anchor elements
+      // Add the type='button' prop for button elements
+      if (RootType === 'button') {
+        return {
+          type: 'button',
+          disabled,
+          ...restProps
+        };
+      }
+
+      // Remove the target and href props for all other non anchor elements
       return { ...restProps, disabled };
     }
 

--- a/packages/office-ui-fabric-react/src/components/Link/Link.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.test.tsx
@@ -27,6 +27,18 @@ describe('Link', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('Set type=button property when link is a button', () => {
+    const component = mount(
+      <Link>
+        I'm link as a button
+      </Link>
+    );
+
+    expect(Object.keys(component.find('button').props())).toContain('type');
+    expect(component.find('button').props().type).toBe('button');
+  });
+
   it('renders disabled Link with no href as a button correctly', () => {
     const component = renderer.create(<Link disabled={true}>I'm a link as a button</Link>);
     const tree = component.toJSON();

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`Link renders Link with no href as a button 1`] = `
         color: #0078d4;
       }
   onClick={[Function]}
+  type="button"
 >
   I'm a link as a button
 </button>
@@ -264,6 +265,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       }
   disabled={true}
   onClick={[Function]}
+  type="button"
 >
   I'm a link as a button
 </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -116,6 +116,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Philippe Lampros
         </button>
@@ -185,6 +186,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           @Anđela Debeljak
         </button>
@@ -322,6 +324,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Lisha Refai
         </button>
@@ -468,6 +471,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Julian Arvidsson
         </button>
@@ -526,6 +530,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           PresentationTitle.pptx
         </button>
@@ -584,6 +589,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Destination Folder
         </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -191,6 +191,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Jack Howden
         </button>
@@ -480,6 +481,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Javiera Márquez
         </button>
@@ -538,6 +540,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Amelia Povalіy
         </button>
@@ -596,6 +599,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           SpreadsheetTitle.xlsx
         </button>
@@ -938,6 +942,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Robert Larsson
         </button>
@@ -996,6 +1001,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           2 others
         </button>
@@ -1394,6 +1400,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           Jin Cheng
         </button>
@@ -1452,6 +1459,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #0078d4;
               }
           onClick={[Function]}
+          type="button"
         >
           5 others
         </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -204,6 +204,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -365,6 +366,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -526,6 +528,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -687,6 +690,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -848,6 +852,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1010,6 +1015,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1239,6 +1245,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1392,6 +1399,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1545,6 +1553,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1698,6 +1707,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1851,6 +1861,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -2005,6 +2016,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -361,6 +361,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -522,6 +523,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -684,6 +686,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         max-width: 116px;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -305,6 +305,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               color: #0078d4;
             }
         onClick={[Function]}
+        type="button"
       >
         Hyperlink inside FocusTrapZone
       </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -305,6 +305,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               color: #0078d4;
             }
         onClick={[Function]}
+        type="button"
       >
         Hyperlink inside FocusTrapZone
       </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -303,6 +303,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               color: #0078d4;
             }
         onClick={[Function]}
+        type="button"
       >
         Hyperlink inside FocusTrapZone
       </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -92,6 +92,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           color: #0078d4;
         }
     onClick={[Function]}
+    type="button"
   >
     the link is rendered as a button
   </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -76,6 +76,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             color: #0078d4;
           }
       onClick={[Function]}
+      type="button"
     >
       Link 1
     </button>
@@ -140,6 +141,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             color: #0078d4;
           }
       onClick={[Function]}
+      type="button"
     >
       Link 2
     </button>
@@ -204,6 +206,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             color: #0078d4;
           }
       onClick={[Function]}
+      type="button"
     >
       Link 3
     </button>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When a Link component is rendered as a `button` (i.e. when the type or href is not specified), it does not set the `type` attribute to be 'button'. This leads to some unexpected behaviour as the expected behaviour is for `button` to have it's type specified

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7787)

