### PR TITLE
Updating merge-styles documentation regarding "$"

### DIFF
--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -296,12 +296,16 @@ mergeStyleSets({
     { background: 'lightgreen' }
   ],
 
-  thumb: {
-    selectors: {
-      `.${classNames.root}:hover &`: {
-        background: 'green'
+  child: [
+    classNames.child,
+    {
+      selectors: {
+        `.${classNames.root}:hover &`: {
+          background: 'green'
+        }
       }
     }
+  ]
 });
 ```
 

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -292,7 +292,7 @@ const classNames = {
 
 mergeStyleSets({
   root: [
-    'Foo-root',
+    classNames.root,
     { background: 'lightgreen' }
   ],
 

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -281,20 +281,33 @@ Produces:
 }
 ```
 
-In some cases, you may need to alter a child area by interacting with the parent. For example, when the parent is hovered, change the child background. You can reference the areas defined in the style set using $ tokens:
+In some cases, you may need to alter a child area by interacting with the parent. For example, when the parent is hovered, change the child background. We recommend using global, non-changing static classnames
+to target the parent elements:
 
 ```tsx
+const classNames = {
+  root: 'Foo-root',
+  child: 'Foo-child'
+};
+
 mergeStyleSets({
-  root: {
+  root: [
+    'Foo-root',
+    { background: 'lightgreen' }
+  ],
+
+  thumb: {
     selectors: {
-      ':hover $thumb': { background: 'lightgreen' }
+      `.${classNames.root}:hover &`: {
+        background: 'green'
+      }
     }
-   }
-  thumb: { background: 'green' }
 });
 ```
 
-The `$thumb` reference in the selector on root will be replaced with the class name generated for thumb.
+The important part here is that the selector does not have any mutable information. In the example above,
+if `classNames.root` were dynamic, it would require the rule to be re-registered when it mutates, which
+would be a performance hit.
 
 ## Custom class names
 


### PR DESCRIPTION
Removing comments about "$" usage for cross referencing parts as its a bad idea.

Replaced with a better idea.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7788)

