### PR TITLE
Experiments: Toggle and CollapsibleSection Fixes

### DIFF
--- a/common/changes/@uifabric/experiments/jg-minor-fixes_2019-01-24-21-57.json
+++ b/common/changes/@uifabric/experiments/jg-minor-fixes_2019-01-24-21-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Minor fixes to Toggle and CollapsibleSection.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -26,20 +26,13 @@ export interface ICollapsibleSectionTitleSlots {
 
 export interface ICollapsibleSectionTitleProps
   extends ICollapsibleSectionTitleSlots,
-    IStyleableComponentProps<ICollapsibleSectionTitleProps, ICollapsibleSectionTitleTokens, ICollapsibleSectionTitleStyles> {
+    IStyleableComponentProps<ICollapsibleSectionTitleProps, ICollapsibleSectionTitleTokens, ICollapsibleSectionTitleStyles>,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {
   focusElementRef?: IRefObject<HTMLButtonElement>;
   /**
    * Collapsed state of body associated with this component.
    */
   collapsed?: boolean;
-  /**
-   * Toggle input callback triggered by mouse and keyboard input.
-   */
-  onClick?: (ev: React.MouseEvent<Element>) => void;
-  /**
-   * Key down callback for input on title.
-   */
-  onKeyDown?: (ev: React.KeyboardEvent<Element>) => void;
   /**
    * Disable chevron appearance.
    */

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
@@ -1,6 +1,7 @@
 /** @jsx withSlots */
 import { Text } from '../../Text';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { getNativeProps, buttonProperties } from 'office-ui-fabric-react/lib/Utilities';
 import { withSlots, getSlots } from '../../Foundation';
 import {
   ICollapsibleSectionTitleComponent,
@@ -15,8 +16,10 @@ export const CollapsibleSectionTitleView: ICollapsibleSectionTitleComponent['vie
     text: Text
   });
 
+  const buttonProps = getNativeProps(props, buttonProperties);
+
   return (
-    <Slots.root ref={props.focusElementRef} onClick={props.onClick} onKeyDown={props.onKeyDown}>
+    <Slots.root {...buttonProps} ref={props.focusElementRef}>
       {!props.chevronDisabled && <Slots.chevron iconName="ChevronDown" />}
       <Slots.text />
     </Slots.root>

--- a/packages/experiments/src/components/Toggle/Toggle.state.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.state.ts
@@ -2,18 +2,23 @@ import * as React from 'react';
 import { IToggle, IToggleProps, IToggleViewProps } from './Toggle.types';
 import { BaseState } from '../../utilities/BaseState';
 
-export type IToggleState = Pick<IToggleViewProps, 'checked' | 'onChange' | 'onClick' | 'toggleButtonRef'>;
+export type IToggleState = Pick<IToggleViewProps, 'checked' | 'onChange' | 'onClick' | 'text' | 'toggleButtonRef'>;
 
 export class ToggleState extends BaseState<IToggleProps, IToggleViewProps, IToggleState> implements IToggle {
   private _toggleButtonRef = React.createRef<HTMLButtonElement>();
 
   constructor(props: ToggleState['props']) {
     super(props, {
-      controlledProps: ['checked']
+      controlledProps: ['checked', 'text'],
+      transformViewProps: (newProps: IToggleViewProps) => {
+        newProps.text = newProps.checked ? props.onText : props.offText;
+        return newProps;
+      }
     });
 
     this.state = {
       checked: !!props.defaultChecked,
+      text: !!props.defaultChecked ? props.onText : props.offText,
       onChange: this._noop,
       onClick: this._onClick,
       toggleButtonRef: this._toggleButtonRef

--- a/packages/experiments/src/components/Toggle/Toggle.styles.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.styles.ts
@@ -200,7 +200,6 @@ export const ToggleStyles: IToggleComponent['styles'] = (props, theme, tokens): 
         }
       }
     ],
-    offText: textStyles,
-    onText: textStyles
+    text: textStyles
   };
 };

--- a/packages/experiments/src/components/Toggle/Toggle.types.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.types.ts
@@ -15,39 +15,34 @@ export type IToggleStylesReturnType = ReturnType<Extract<IToggleComponent['style
 
 export interface IToggleSlots {
   /**
-   * Root element.
+   * Defines root slot.
    */
   root?: IHTMLDivSlot;
 
   /**
-   * A label for the toggle.
+   * Defines label slot displayed above pill.
    */
   label?: ILabelSlot;
 
   /**
-   * Container for the toggle pill and the text next to it.
+   * Defines container slot for the toggle pill and the text next to it.
    */
   container?: IHTMLDivSlot;
 
   /**
-   * Pill, rendered as a button.
+   * Defines pill slot, rendered as a button by default.
    */
   pill?: IHTMLButtonSlot;
 
   /**
-   * Thumb inside of the pill.
+   * Defines thumb slot inside of the pill.
    */
   thumb?: IHTMLDivSlot;
 
   /**
-   * Text to display when toggle is ON.
+   * Defines text slot displayed alongside pill. Overrides onText and offText.
    */
-  onText?: ILabelSlot;
-
-  /**
-   * Text to display when toggle is OFF.
-   */
-  offText?: ILabelSlot;
+  text?: ILabelSlot;
 }
 
 export interface IToggle {
@@ -95,6 +90,16 @@ export interface IToggleProps
    * Optional keytip for this toggle
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * Text to display when toggle is ON.
+   */
+  onText?: string;
+
+  /**
+   * Text to display when toggle is OFF.
+   */
+  offText?: string;
 }
 
 export interface IToggleViewProps extends IToggleProps {

--- a/packages/experiments/src/components/Toggle/Toggle.view.tsx
+++ b/packages/experiments/src/components/Toggle/Toggle.view.tsx
@@ -16,8 +16,7 @@ export const ToggleView: IToggleComponent['view'] = props => {
     container: 'div',
     pill: 'button',
     thumb: 'div',
-    offText: Label,
-    onText: Label
+    text: Label
   });
 
   return (
@@ -45,8 +44,7 @@ export const ToggleView: IToggleComponent['view'] = props => {
             </Slots.pill>
           )}
         </KeytipData>
-        {checked && <Slots.onText />}
-        {!checked && <Slots.offText />}
+        <Slots.text />
       </Slots.container>
     </Slots.root>
   );

--- a/packages/experiments/src/components/Toggle/examples/Toggle.Example.tsx
+++ b/packages/experiments/src/components/Toggle/examples/Toggle.Example.tsx
@@ -1,10 +1,20 @@
 import * as React from 'react';
-import { Toggle } from '../index';
+import { Toggle } from '@uifabric/experiments';
 import { Label, Spinner } from 'office-ui-fabric-react';
 
+export interface IToggleExampleState {
+  checked: boolean;
+}
+
 // tslint:disable:jsx-no-lambda
-export class ToggleExample extends React.Component<{}, {}> {
+export class ToggleExample extends React.Component<{}, IToggleExampleState> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { checked: true };
+  }
+
   public render(): JSX.Element {
+    const { checked } = this.state;
     return (
       <div>
         <Toggle defaultChecked={true} onText="No Label" offText="No Label" onChange={this._onChange} />
@@ -13,21 +23,25 @@ export class ToggleExample extends React.Component<{}, {}> {
         <Toggle defaultChecked={false} label="Enabled and unchecked" onText="On" offText="Off" onChange={this._onChange} />
         <Toggle defaultChecked={true} disabled={true} label="Disabled and checked" onText="On" offText="Off" />
         <Toggle defaultChecked={false} disabled={true} label="Disabled and unchecked" onText="On" offText="Off" />
+        <Toggle defaultChecked={false} label="Text prop overrides" onText="Shouldn't see me" offText="Shouldn't see me" text="Override" />
         <Toggle
           defaultChecked={true}
-          label="Functional Text Props"
-          onText={props => <Spinner {...props} />}
-          offText={props => (
-            <Label {...props} styles={{ root: { background: 'lightgrey' } }}>
-              Spinner Disabled
-            </Label>
-          )}
+          label="Custom On/Off render functions"
+          onChange={this._onCustomRenderChange}
+          text={props => {
+            return <Label {...props}>{checked ? <Spinner /> : 'Spinner Off'}</Label>;
+          }}
         />
       </div>
     );
   }
 
-  private _onChange(ev: React.MouseEvent<HTMLElement>, checked: boolean) {
+  private _onChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
     console.log('toggle is ' + (checked ? 'checked' : 'not checked'));
-  }
+  };
+
+  private _onCustomRenderChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
+    console.log('toggle is ' + (checked ? 'checked' : 'not checked'));
+    this.setState({ checked });
+  };
 }

--- a/packages/experiments/src/index.ts
+++ b/packages/experiments/src/index.ts
@@ -16,6 +16,7 @@ export * from './StaticList';
 export * from './Text';
 export * from './Tile';
 export * from './TilesList';
+export * from './Toggle';
 export * from './VirtualizedList';
 
 import './version';

--- a/packages/experiments/src/utilities/BaseState.tsx
+++ b/packages/experiments/src/utilities/BaseState.tsx
@@ -39,12 +39,19 @@ export class BaseState<TComponentProps extends IBaseProps, TViewProps, TState> e
   }
 
   public render(): JSX.Element | null {
+    const controlledProps = this._getControlledProps();
+
     let newProps = {
       ...(this.state as {}),
-      ...(this._getControlledProps() as {})
+      ...(controlledProps as {})
     } as TViewProps;
 
-    newProps = this._transformViewProps(newProps);
+    // Need to spread controlledProps again to make sure transformViewProps does not overwrite any controlled props.
+    // TODO: better way to do this than two spreads? filtered write? pass "setState" helper to transformViewProps?
+    newProps = {
+      ...(this._transformViewProps(newProps) as {}),
+      ...(controlledProps as {})
+    } as TViewProps;
 
     return this.props.renderView(newProps);
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Ran across a few issues with `Toggle` and `CollapsibleSection` while finalizing Slots/Tokens:
1. `CollapsibleSection` was creating new DOM elements every time its `checked` prop changed. This was as a result of `Toggle.view` having separate on and off slots, which have now been merged into one.
2. `CollapsibleSectionTitle` was not applying the `className` prop. It now gets native props from its props and applies them to root. This also resulted in some consolidation of `CollapsibleSectionTitle` props typing.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7794)

