### PR TITLE
Stack: Adding 'reversed' prop, updating styles, and adding examples, snapshot tests and vr-tests

### DIFF
--- a/apps/vr-tests/src/stories/Stack.stories.tsx
+++ b/apps/vr-tests/src/stories/Stack.stories.tsx
@@ -82,6 +82,15 @@ storiesOf('Stack', module)
     ),
     { rtl: true }
   )
+  .addStory(
+    'Vertical Stack - Reversed',
+    () => (
+      <Fabric>
+        <Stack reversed {...defaultProps} />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
   .addStory('Vertical Stack - Padding', () => (
     <Fabric>
       <Stack {...defaultProps} padding={10} />
@@ -222,6 +231,15 @@ storiesOf('Stack', module)
     () => (
       <Fabric>
         <Stack horizontal {...defaultProps} />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Horizontal Stack - Reversed',
+    () => (
+      <Fabric>
+        <Stack horizontal reversed {...defaultProps} />
       </Fabric>
     ),
     { rtl: true }

--- a/common/changes/@uifabric/experiments/stackAPI_2019-01-24-23-55.json
+++ b/common/changes/@uifabric/experiments/stackAPI_2019-01-24-23-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Stack: Adding 'reversed' prop, updating styles, and adding examples, snapshot tests and vr-tests.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -19,6 +19,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
     maxWidth,
     maxHeight,
     horizontal,
+    reversed,
     gap,
     verticalGap,
     grow,
@@ -118,7 +119,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
           [horizontal ? 'alignItems' : 'justifyContent']: nameMap[vertAlign] || vertAlign
         },
         horizontal && {
-          flexDirection: 'row',
+          flexDirection: reversed ? 'row-reverse' : 'row',
 
           // avoid unnecessary calc() calls if vertical gap is 0
           height: vGap.value === 0 ? '100%' : `calc(100% + ${vGap.value}${vGap.unit})`,
@@ -130,7 +131,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
           }
         },
         !horizontal && {
-          flexDirection: 'column',
+          flexDirection: reversed ? 'column-reverse' : 'column',
           height: `calc(100% + ${vGap.value}${vGap.unit})`,
 
           selectors: {
@@ -148,7 +149,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
       classNames.root,
       {
         display: 'flex',
-        flexDirection: horizontal ? 'row' : 'column',
+        flexDirection: horizontal ? (reversed ? 'row-reverse' : 'row') : reversed ? 'column-reverse' : 'column',
         flexWrap: 'nowrap',
         width: horizontalFill && !wrap ? '100%' : 'auto',
         height: verticalFill && !wrap ? '100%' : 'auto',
@@ -160,8 +161,9 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
         selectors: {
           '> *': childStyles,
 
-          // apply gap margin to every direct child except the first direct child
-          '> *:not(:first-child)': [
+          // apply gap margin to every direct child except the first direct child if the direction is not reversed,
+          // and the last direct one if it is
+          [reversed ? '> *:not(:last-child)' : '> *:not(:first-child)']: [
             horizontal && {
               marginLeft: `${hGap.value}${hGap.unit}`
             },
@@ -169,6 +171,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
               marginTop: `${vGap.value}${vGap.unit}`
             }
           ],
+
           ...commonSelectors
         }
       },

--- a/packages/experiments/src/components/Stack/Stack.test.tsx
+++ b/packages/experiments/src/components/Stack/Stack.test.tsx
@@ -37,9 +37,31 @@ describe('Stack', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders reversed vertical Stack correctly', () => {
+    const component = renderer.create(
+      <Stack reversed>
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </Stack>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders default horizontal Stack correctly', () => {
     const component = renderer.create(
       <Stack horizontal>
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </Stack>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders reversed horizontal Stack correctly', () => {
+    const component = renderer.create(
+      <Stack horizontal reversed>
         <div>Item 1</div>
         <div>Item 2</div>
       </Stack>

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -45,6 +45,13 @@ export interface IStackProps
   horizontal?: boolean;
 
   /**
+   * Defines whether to render Stack child elements in the opposite direction (bottom-to-top if it's a Vertical Stack and
+   * right-to-left if it's a Horizontal Stack).
+   * @defaultvalue false
+   */
+  reversed?: boolean;
+
+  /**
    * Defines how to align Stack child elements horizontally (along the x-axis).
    */
   horizontalAlign?: Alignment;

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -45,8 +45,8 @@ export interface IStackProps
   horizontal?: boolean;
 
   /**
-   * Defines whether to render Stack child elements in the opposite direction (bottom-to-top if it's a Vertical Stack and
-   * right-to-left if it's a Horizontal Stack).
+   * Defines whether to render Stack child elements in the opposite direction (bottom-to-top if it's a vertical Stack and
+   * right-to-left if it's a horizontal Stack).
    * @defaultvalue false
    */
   reversed?: boolean;

--- a/packages/experiments/src/components/Stack/StackPage.tsx
+++ b/packages/experiments/src/components/Stack/StackPage.tsx
@@ -5,6 +5,9 @@ import { ExampleCard, IComponentDemoPageProps, ComponentPage, PageMarkdown, Prop
 import { VerticalStackBasicExample } from './examples/Stack.Vertical.Basic.Example';
 const VerticalStackBasicExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx') as string;
 
+import { VerticalStackReversedExample } from './examples/Stack.Vertical.Reversed.Example';
+const VerticalStackReversedExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Stack/examples/Stack.Vertical.Reversed.Example.tsx') as string;
+
 import { VerticalStackSpacingExample } from './examples/Stack.Vertical.Spacing.Example';
 const VerticalStackSpacingExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Stack/examples/Stack.Vertical.Spacing.Example.tsx') as string;
 
@@ -35,6 +38,9 @@ const VerticalStackConfigureExampleCode = require('!raw-loader!@uifabric/experim
 // Horizontal Stack Examples
 import { HorizontalStackBasicExample } from './examples/Stack.Horizontal.Basic.Example';
 const HorizontalStackBasicExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Stack/examples/Stack.Horizontal.Basic.Example.tsx') as string;
+
+import { HorizontalStackReversedExample } from './examples/Stack.Horizontal.Reversed.Example';
+const HorizontalStackReversedExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Stack/examples/Stack.Horizontal.Reversed.Example.tsx') as string;
 
 import { HorizontalStackSpacingExample } from './examples/Stack.Horizontal.Spacing.Example';
 const HorizontalStackSpacingExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Stack/examples/Stack.Horizontal.Spacing.Example.tsx') as string;
@@ -74,6 +80,9 @@ export class StackPage extends React.Component<IComponentDemoPageProps, {}> {
             <ExampleCard title="Basic Vertical Stack" code={VerticalStackBasicExampleCode}>
               <VerticalStackBasicExample />
             </ExampleCard>
+            <ExampleCard title="Reversed Basic Vertical Stack" code={VerticalStackReversedExampleCode}>
+              <VerticalStackReversedExample />
+            </ExampleCard>
             <ExampleCard title="Vertical Stack - Gap and Padding Sizes" code={VerticalStackSpacingExampleCode}>
               <VerticalStackSpacingExample />
             </ExampleCard>
@@ -103,6 +112,9 @@ export class StackPage extends React.Component<IComponentDemoPageProps, {}> {
             </ExampleCard>
             <ExampleCard title="Basic Horizontal Stack" code={HorizontalStackBasicExampleCode}>
               <HorizontalStackBasicExample />
+            </ExampleCard>
+            <ExampleCard title="Reversed Basic Horizontal Stack" code={HorizontalStackReversedExampleCode}>
+              <HorizontalStackReversedExample />
             </ExampleCard>
             <ExampleCard title="Horizontal Stack - Gap and Padding Sizes" code={HorizontalStackSpacingExampleCode}>
               <HorizontalStackSpacingExample />

--- a/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -646,6 +646,70 @@ exports[`Stack renders horizontal Stack with vertical and horizontal fill correc
 </div>
 `;
 
+exports[`Stack renders reversed horizontal Stack correctly 1`] = `
+<div
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: row-reverse;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      & > *:not(:last-child) {
+        margin-left: 0px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 0;
+      }
+>
+  <div>
+    Item 1
+  </div>
+  <div>
+    Item 2
+  </div>
+</div>
+`;
+
+exports[`Stack renders reversed vertical Stack correctly 1`] = `
+<div
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column-reverse;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      & > *:not(:last-child) {
+        margin-top: 0px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 0;
+      }
+>
+  <div>
+    Item 1
+  </div>
+  <div>
+    Item 2
+  </div>
+</div>
+`;
+
 exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
 <div
   className=

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Reversed.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Reversed.Example.tsx
@@ -1,0 +1,69 @@
+// @codepen
+import * as React from 'react';
+import { Stack } from '../Stack';
+import { mergeStyleSets, DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+
+export class HorizontalStackReversedExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    const styles = mergeStyleSets({
+      root: {
+        background: DefaultPalette.themeTertiary
+      },
+
+      item: {
+        color: DefaultPalette.white,
+        background: DefaultPalette.themePrimary,
+        padding: 5
+      }
+    });
+
+    return (
+      <Stack gap={5}>
+        <span>Default horizontal stack</span>
+        <Stack horizontal reversed className={styles.root}>
+          <span>Item One</span>
+          <span>Item Two</span>
+          <span>Item Three</span>
+        </Stack>
+
+        <span>Horizontal gap between items</span>
+        <Stack horizontal reversed gap={10} padding={10} className={styles.root}>
+          <span>Item One</span>
+          <span>Item Two</span>
+          <span>Item Three</span>
+        </Stack>
+
+        <span>Item alignments</span>
+        <Stack horizontal reversed gap={5} padding={10} className={styles.root} styles={{ root: { height: 100 } }}>
+          <Stack.Item align="auto" className={styles.item}>
+            <span>Auto-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="stretch" className={styles.item}>
+            <span>Stretch-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="baseline" className={styles.item}>
+            <span>Baseline-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="start" className={styles.item}>
+            <span>Start-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="center" className={styles.item}>
+            <span>Center-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="end" className={styles.item}>
+            <span>End-aligned item</span>
+          </Stack.Item>
+        </Stack>
+
+        <span>Clickable stack</span>
+        <Stack horizontal onClick={this._onClick} padding={10} className={styles.root}>
+          <span>Click inside this box</span>
+        </Stack>
+      </Stack>
+    );
+  }
+
+  private _onClick = (): void => {
+    alert('Clicked Stack');
+  };
+}

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.Reversed.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.Reversed.Example.tsx
@@ -1,0 +1,69 @@
+// @codepen
+import * as React from 'react';
+import { Stack } from '../Stack';
+import { mergeStyleSets, DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+
+export class VerticalStackReversedExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    const styles = mergeStyleSets({
+      root: {
+        background: DefaultPalette.themeTertiary
+      },
+
+      item: {
+        color: DefaultPalette.white,
+        background: DefaultPalette.themePrimary,
+        padding: 5
+      }
+    });
+
+    return (
+      <Stack gap={5}>
+        <span>Default vertical stack</span>
+        <Stack reversed className={styles.root}>
+          <span>Item One</span>
+          <span>Item Two</span>
+          <span>Item Three</span>
+        </Stack>
+
+        <span>Vertical gap between items</span>
+        <Stack reversed gap={10} padding={10} className={styles.root}>
+          <span>Item One</span>
+          <span>Item Two</span>
+          <span>Item Three</span>
+        </Stack>
+
+        <span>Item alignments</span>
+        <Stack reversed gap={5} padding={10} className={styles.root}>
+          <Stack.Item align="auto" className={styles.item}>
+            <span>Auto-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="stretch" className={styles.item}>
+            <span>Stretch-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="baseline" className={styles.item}>
+            <span>Baseline-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="start" className={styles.item}>
+            <span>Start-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="center" className={styles.item}>
+            <span>Center-aligned item</span>
+          </Stack.Item>
+          <Stack.Item align="end" className={styles.item}>
+            <span>End-aligned item</span>
+          </Stack.Item>
+        </Stack>
+
+        <span>Clickable vertical stack</span>
+        <Stack onClick={this._onClick} padding={10} className={styles.root}>
+          <span>Click inside this box</span>
+        </Stack>
+      </Stack>
+    );
+  }
+
+  private _onClick = (): void => {
+    alert('Clicked VerticalStack');
+  };
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

From the discussions we had during the `Stack` API review, we determined it would be good to add a `reversed` prop to abstract reversed flex directions. This is done as part of this PR, updating the styles as necessary and adding examples representing this for both Horizontal and Vertical Stacks, as well as snapshot and vr-tests.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7795)

