### PR TITLE
Fix the regression in DocumentCard role

### DIFF
--- a/common/changes/office-ui-fabric-react/yimwu-roleissue_2019-01-25-00-29.json
+++ b/common/changes/office-ui-fabric-react/yimwu-roleissue_2019-01-25-00-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix the regression in DocumentCard role by commit 5b8befe. It should always use props.role if it is defined. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "yimwu@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -42,7 +42,7 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
     }
 
     // if this element is actionable it should have an aria role
-    const role = this.props.role || actionable ? (onClick ? 'button' : 'link') : undefined;
+    const role = this.props.role || (actionable ? (onClick ? 'button' : 'link') : undefined);
     const tabIndex = actionable ? 0 : undefined;
 
     return (


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X ] Include a change request file using `$ npm run change`

#### Description of changes
Fix the regression in DocumentCard role by commit 5b8befe. It should always use props.role if it is defined.

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7796)

