### PR TITLE
Coachmark: fixing how the theme is passed to styles plus some minor cleanup

### DIFF
--- a/common/changes/office-ui-fabric-react/fluent-CoachMarkShadow_2019-01-25-00-12.json
+++ b/common/changes/office-ui-fabric-react/fluent-CoachMarkShadow_2019-01-25-00-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Coachmark: updates how the the theme is passed to `getStyles` function. Adds 2 new props: `theme` and `className`. Minor cleanup.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2569,6 +2569,7 @@ interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
   beakHeight?: number;
   // @deprecated
   beakWidth?: number;
+  className?: string;
   // @deprecated
   collapsed?: boolean;
   color?: string;
@@ -2591,6 +2592,7 @@ interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
   target: HTMLElement | string | null;
   // @deprecated
   teachingBubbleRef?: ITeachingBubble;
+  theme?: ITheme;
   // @deprecated
   width?: number;
 }
@@ -2617,6 +2619,7 @@ interface ICoachmarkState {
 interface ICoachmarkStyleProps {
   beaconColorOne?: string;
   beaconColorTwo?: string;
+  className?: string;
   // @deprecated
   collapsed?: boolean;
   // (undocumented)
@@ -2629,6 +2632,7 @@ interface ICoachmarkStyleProps {
   isCollapsed: boolean;
   isMeasured: boolean;
   isMeasuring: boolean;
+  theme?: ITheme;
   transformOrigin?: string;
   width?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
@@ -20,7 +20,7 @@ import { DirectionalHint } from '../../common/DirectionalHint';
 
 // Coachmark
 import { ICoachmark, ICoachmarkProps, ICoachmarkStyles, ICoachmarkStyleProps } from './Coachmark.types';
-import { COACHMARK_HEIGHT, COACHMARK_WIDTH, getStyles } from './Coachmark.styles';
+import { COACHMARK_HEIGHT, COACHMARK_WIDTH } from './Coachmark.styles';
 import { FocusTrapZone } from '../../FocusTrapZone';
 
 const getClassNames = classNamesFunction<ICoachmarkStyleProps, ICoachmarkStyles>();
@@ -186,7 +186,10 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
       ariaLabelledBy,
       ariaLabelledByText,
       ariaAlertText,
-      delayBeforeCoachmarkAnimation
+      delayBeforeCoachmarkAnimation,
+      styles,
+      theme,
+      className
     } = this.props;
 
     const {
@@ -203,17 +206,19 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
       isMeasured
     } = this.state;
 
-    const classNames = getClassNames(getStyles, {
-      isCollapsed: isCollapsed,
-      isBeaconAnimating: isBeaconAnimating,
-      isMeasuring: isMeasuring,
+    const classNames = getClassNames(styles, {
+      theme,
+      className,
+      isCollapsed,
+      isBeaconAnimating,
+      isMeasuring,
+      color,
+      transformOrigin,
+      isMeasured,
       entityHostHeight: `${entityInnerHostRect.height}px`,
       entityHostWidth: `${entityInnerHostRect.width}px`,
       width: `${COACHMARK_WIDTH}px`,
       height: `${COACHMARK_HEIGHT}px`,
-      color: color,
-      transformOrigin: transformOrigin,
-      isMeasured: isMeasured,
       delayBeforeCoachmarkAnimation: `${delayBeforeCoachmarkAnimation}ms`
     });
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -1,4 +1,4 @@
-import { keyframes, PulsingBeaconAnimationStyles, ITheme, getTheme } from '../../Styling';
+import { keyframes, PulsingBeaconAnimationStyles } from '../../Styling';
 import { ICoachmarkStyleProps, ICoachmarkStyles } from './Coachmark.types';
 
 export const COACHMARK_WIDTH = 32;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -118,30 +118,48 @@ export const rotateOne: string = keyframes({
   }
 });
 
-export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme()): ICoachmarkStyles {
+export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
+  const {
+    theme,
+    className,
+    color,
+    beaconColorOne,
+    beaconColorTwo,
+    delayBeforeCoachmarkAnimation,
+    isCollapsed,
+    isBeaconAnimating,
+    isMeasuring,
+    isMeasured,
+    entityHostHeight,
+    entityHostWidth,
+    transformOrigin
+  } = props;
+
+  if (!theme) {
+    throw new Error('theme is undefined or null in base Dropdown getStyles function.');
+  }
+
   const animationInnerDimension = '35px';
   const animationOuterDimension = '150px';
   const animationBorderWidth = '10px';
 
   const ContinuousPulse: string = PulsingBeaconAnimationStyles.continuousPulseAnimationDouble(
-    props.beaconColorOne ? props.beaconColorOne : theme.palette.themePrimary,
-    props.beaconColorTwo ? props.beaconColorTwo : theme.palette.themeTertiary,
+    beaconColorOne ? beaconColorOne : theme.palette.themePrimary,
+    beaconColorTwo ? beaconColorTwo : theme.palette.themeTertiary,
     animationInnerDimension,
     animationOuterDimension,
     animationBorderWidth
   );
 
-  const ContinuousPulseAnimation = PulsingBeaconAnimationStyles.createDefaultAnimation(
-    ContinuousPulse,
-    props.delayBeforeCoachmarkAnimation
-  );
+  const ContinuousPulseAnimation = PulsingBeaconAnimationStyles.createDefaultAnimation(ContinuousPulse, delayBeforeCoachmarkAnimation);
 
   return {
     root: [
       theme.fonts.medium,
       {
         position: 'relative'
-      }
+      },
+      className
     ],
     pulsingBeacon: [
       {
@@ -155,7 +173,7 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         borderStyle: 'solid',
         opacity: '0'
       },
-      props.isCollapsed && props.isBeaconAnimating && ContinuousPulseAnimation
+      isCollapsed && isBeaconAnimating && ContinuousPulseAnimation
     ],
     // Translate Animation Layer
     translateAnimationContainer: [
@@ -163,7 +181,7 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         width: '100%',
         height: '100%'
       },
-      props.isCollapsed && {
+      isCollapsed && {
         animationDuration: '14s',
         animationTimingFunction: 'linear',
         animationDirection: 'normal',
@@ -173,7 +191,7 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         animationName: translateOne,
         transition: 'opacity 0.5s ease-in-out'
       },
-      !props.isCollapsed && {
+      !isCollapsed && {
         opacity: '1'
       }
     ],
@@ -183,7 +201,7 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         width: '100%',
         height: '100%'
       },
-      props.isCollapsed && {
+      isCollapsed && {
         animationDuration: '14s',
         animationTimingFunction: 'linear',
         animationDirection: 'normal',
@@ -199,7 +217,7 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         width: '100%',
         height: '100%'
       },
-      props.isCollapsed && {
+      isCollapsed && {
         animationDuration: '14s',
         animationTimingFunction: 'linear',
         animationDirection: 'normal',
@@ -208,7 +226,7 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         animationFillMode: 'forwards',
         animationName: rotateOne
       },
-      !props.isCollapsed && {
+      !isCollapsed && {
         opacity: '1'
       }
     ],
@@ -218,41 +236,41 @@ export function getStyles(props: ICoachmarkStyleProps, theme: ITheme = getTheme(
         position: 'relative',
         outline: 'none',
         overflow: 'hidden',
-        backgroundColor: props.color,
+        backgroundColor: color,
         borderRadius: COACHMARK_WIDTH,
         transition: 'border-radius 250ms, width 500ms, height 500ms cubic-bezier(0.5, 0, 0, 1)',
         visibility: 'hidden'
       },
-      !props.isMeasuring && {
+      !isMeasuring && {
         width: COACHMARK_WIDTH,
         height: COACHMARK_HEIGHT,
         visibility: 'visible'
       },
-      !props.isCollapsed && {
+      !isCollapsed && {
         borderRadius: '1px',
         opacity: '1',
-        width: props.entityHostWidth,
-        height: props.entityHostHeight
+        width: entityHostWidth,
+        height: entityHostHeight
       }
     ],
     entityInnerHost: [
       {
         transition: 'transform 500ms cubic-bezier(0.5, 0, 0, 1)',
-        transformOrigin: props.transformOrigin,
+        transformOrigin: transformOrigin,
         transform: 'scale(0)'
       },
-      !props.isCollapsed && {
-        width: props.entityHostWidth,
-        height: props.entityHostHeight,
+      !isCollapsed && {
+        width: entityHostWidth,
+        height: entityHostHeight,
         transform: 'scale(1)'
       },
-      !props.isMeasuring && {
+      !isMeasuring && {
         visibility: 'visible'
       }
     ],
     childrenContainer: [
       {
-        display: props.isMeasured && props.isCollapsed ? 'none' : 'block'
+        display: isMeasured && isCollapsed ? 'none' : 'block'
       }
     ],
     ariaContainer: {

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -1,4 +1,4 @@
-import { IStyle } from '../../Styling';
+import { IStyle, ITheme } from '../../Styling';
 import { IPositioningContainerProps } from './PositioningContainer/PositioningContainer.types';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { CoachmarkBase } from './Coachmark.base';
@@ -18,6 +18,11 @@ export interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<ICoachmark>;
+
+  /**
+   * If provided, additional class name to provide on the root element.
+   */
+  className?: string;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules
@@ -176,10 +181,25 @@ export interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
    * Callback when the Coachmark tries to close.
    */
   onDismiss?: (ev?: any) => void;
+
+  /**
+   * Theme provided by higher order component.
+   */
+  theme?: ITheme;
 }
 
 /** The props needed to construct styles. */
 export interface ICoachmarkStyleProps {
+  /**
+   * ClassName to provide on the root style area.
+   */
+  className?: string;
+
+  /**
+   * Current theme.
+   */
+  theme?: ITheme;
+
   /**
    * Is the Coachmark collapsed.
    * Deprecated, use `isCollapsed` instead.


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes come from when investigating some fluent styles for `Coachamark` and noticed that the theme was passed a little different from how is passed in the rest of the components by using `getTheme()`. Also, added a `className` prop which was also missing on the props interface

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7797)

