### PR TITLE
Rename style from 'previewFileTypeIcon' to 'icon'

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-document-card-preview-icon-name_2019-01-25-15-58.json
+++ b/common/changes/office-ui-fabric-react/miwhea-document-card-preview-icon-name_2019-01-25-15-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCard: Renames 'previewFileTypeIcon' to 'icon' to fix a regression",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7499,7 +7499,7 @@ interface IDocumentCardPreviewStyles {
   // (undocumented)
   fileListOverflowText: IStyle;
   // (undocumented)
-  previewFileTypeIcon: IStyle;
+  icon: IStyle;
   // (undocumented)
   previewIcon: IStyle;
   // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -69,7 +69,7 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
               maxHeight: '106px',
               maxWidth: '144px'
             },
-            [`.${previewClassNames.previewFileTypeIcon}`]: {
+            [`.${previewClassNames.icon}`]: {
               maxHeight: '32px',
               maxWidth: '32px'
             },

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -65,7 +65,7 @@ export class DocumentCardPreviewBase extends BaseComponent<IDocumentCardPreviewP
 
     let icon;
     if (previewImage.iconSrc) {
-      icon = <Image className={this._classNames.previewFileTypeIcon} src={previewImage.iconSrc} role="presentation" alt="" />;
+      icon = <Image className={this._classNames.icon} src={previewImage.iconSrc} role="presentation" alt="" />;
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.styles.ts
@@ -4,8 +4,7 @@ import { IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles } from './Do
 export const DocumentCardPreviewGlobalClassNames = {
   root: 'ms-DocumentCardPreview',
   icon: 'ms-DocumentCardPreview-icon',
-  iconContainer: 'ms-DocumentCardPreview-iconContainer',
-  previewFileTypeIcon: 'ms-DocumentCardPreview-previewFileTypeIcon'
+  iconContainer: 'ms-DocumentCardPreview-iconContainer'
 };
 
 export const getStyles = (props: IDocumentCardPreviewStyleProps): IDocumentCardPreviewStyles => {
@@ -34,8 +33,8 @@ export const getStyles = (props: IDocumentCardPreviewStyleProps): IDocumentCardP
         height: '100%'
       }
     ],
-    previewFileTypeIcon: [
-      classNames.previewFileTypeIcon,
+    icon: [
+      classNames.icon,
       {
         left: '10px',
         bottom: '10px',

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.types.ts
@@ -135,7 +135,7 @@ export interface IDocumentCardPreviewStyleProps {
 export interface IDocumentCardPreviewStyles {
   root: IStyle;
   previewIcon: IStyle;
-  previewFileTypeIcon: IStyle;
+  icon: IStyle;
   fileList: IStyle;
   fileListIcon: IStyle;
   fileListOverflowText: IStyle;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -96,7 +96,7 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
       <div
         className=
             ms-Image
-            ms-DocumentCardPreview-previewFileTypeIcon
+            ms-DocumentCardPreview-icon
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -42,7 +42,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           max-height: 106px;
           max-width: 144px;
         }
-        & .ms-DocumentCardPreview-previewFileTypeIcon {
+        & .ms-DocumentCardPreview-icon {
           max-height: 32px;
           max-width: 32px;
         }
@@ -583,7 +583,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           max-height: 106px;
           max-width: 144px;
         }
-        & .ms-DocumentCardPreview-previewFileTypeIcon {
+        & .ms-DocumentCardPreview-icon {
           max-height: 32px;
           max-width: 32px;
         }
@@ -652,7 +652,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         <div
           className=
               ms-Image
-              ms-DocumentCardPreview-previewFileTypeIcon
+              ms-DocumentCardPreview-icon
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -936,7 +936,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           max-height: 106px;
           max-width: 144px;
         }
-        & .ms-DocumentCardPreview-previewFileTypeIcon {
+        & .ms-DocumentCardPreview-icon {
           max-height: 32px;
           max-width: 32px;
         }
@@ -1247,7 +1247,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           max-height: 106px;
           max-width: 144px;
         }
-        & .ms-DocumentCardPreview-previewFileTypeIcon {
+        & .ms-DocumentCardPreview-icon {
           max-height: 32px;
           max-width: 32px;
         }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A, reported by email
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I introduced a bug in #7584 by renaming DocumentPreview's `icon` style to `previewFileTypeIcon`. This caused a regression for those who were targeting the `ms-DocumentCardPreview-icon` global class.

This PR renames it back to `icon` to ensure that CSS style overrides are applied as expected.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7801)

