### PR TITLE
Fix alignment of nav items when a link has long text

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2019-01-25-20-24.json
+++ b/common/changes/office-ui-fabric-react/master_2019-01-25-20-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ensure nav link text overflow still left aligned",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "inateeg@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/master_2019-01-25-20-24.json
+++ b/common/changes/office-ui-fabric-react/master_2019-01-25-20-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "ensure nav link text overflow still left aligned",
+      "comment": "Nav: Fixed an issue where nav link text overflow was not properly left aligned.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -79,6 +79,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         margin: '0 4px',
         overflow: 'hidden',
         verticalAlign: 'middle',
+        textAlign: 'left',
         textOverflow: 'ellipsis'
       }
     ],

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -211,6 +211,7 @@ exports[`Nav renders Nav correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.scss
@@ -3,7 +3,7 @@
 :global {
 
   .ms-NavExample-LeftPane {
-    width: 207px;
+    width: 208px;
     height: 500px;
     box-sizing: border-box;
     border: 1px solid #EEE;

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.scss
@@ -3,7 +3,7 @@
 :global {
 
   .ms-NavExample-LeftPane {
-    width: 208px;
+    width: 207px;
     height: 500px;
     box-sizing: border-box;
     border: 1px solid #EEE;

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
@@ -36,7 +36,7 @@ export class NavBasicExample extends React.Component<any, any> {
                 { name: 'Documents', url: 'http://example.com', key: 'key3', isExpanded: true },
                 { name: 'Pages', url: 'http://msn.com', key: 'key4' },
                 { name: 'Notebook', url: 'http://msn.com', key: 'key5' },
-                { name: 'Long Name Test for ellipse', url: 'http://msn.com', key: 'key6' },
+                { name: 'Communication and Media', url: 'http://msn.com', key: 'key6' },
                 {
                   name: 'News',
                   url: 'http://cnn.com',

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -302,6 +302,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             margin-right: 4px;
                             margin-top: 0;
                             overflow: hidden;
+                            text-align: left;
                             text-overflow: ellipsis;
                             vertical-align: middle;
                           }
@@ -480,6 +481,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                                 margin-right: 4px;
                                 margin-top: 0;
                                 overflow: hidden;
+                                text-align: left;
                                 text-overflow: ellipsis;
                                 vertical-align: middle;
                               }
@@ -647,6 +649,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                                 margin-right: 4px;
                                 margin-top: 0;
                                 overflow: hidden;
+                                text-align: left;
                                 text-overflow: ellipsis;
                                 vertical-align: middle;
                               }
@@ -828,6 +831,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             margin-right: 4px;
                             margin-top: 0;
                             overflow: hidden;
+                            text-align: left;
                             text-overflow: ellipsis;
                             vertical-align: middle;
                           }
@@ -995,6 +999,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             margin-right: 4px;
                             margin-top: 0;
                             overflow: hidden;
+                            text-align: left;
                             text-overflow: ellipsis;
                             vertical-align: middle;
                           }
@@ -1162,6 +1167,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             margin-right: 4px;
                             margin-top: 0;
                             overflow: hidden;
+                            text-align: left;
                             text-overflow: ellipsis;
                             vertical-align: middle;
                           }
@@ -1192,7 +1198,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       display: block;
                       position: relative;
                     }
-                name="Long Name Test for ellipse"
+                name="Communication and Media"
               >
                 <a
                   className=
@@ -1285,7 +1291,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                   onKeyUp={[Function]}
                   onMouseDown={[Function]}
                   onMouseUp={[Function]}
-                  title="Long Name Test for ellipse"
+                  title="Communication and Media"
                 >
                   <div
                     className=
@@ -1329,11 +1335,12 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             margin-right: 4px;
                             margin-top: 0;
                             overflow: hidden;
+                            text-align: left;
                             text-overflow: ellipsis;
                             vertical-align: middle;
                           }
                     >
-                      Long Name Test for ellipse
+                      Communication and Media
                     </div>
                   </div>
                 </a>
@@ -1503,6 +1510,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                             margin-right: 4px;
                             margin-top: 0;
                             overflow: hidden;
+                            text-align: left;
                             text-overflow: ellipsis;
                             vertical-align: middle;
                           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.ByKeys.Example.tsx.shot
@@ -211,6 +211,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }
@@ -378,6 +379,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }
@@ -545,6 +547,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }
@@ -712,6 +715,7 @@ exports[`Component Examples renders Nav.ByKeys.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -214,6 +214,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }
@@ -381,6 +382,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -297,6 +297,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }
@@ -550,6 +551,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           overflow: hidden;
+                          text-align: left;
                           text-overflow: ellipsis;
                           vertical-align: middle;
                         }


### PR DESCRIPTION
#### Description of changes

If the text in left navigation is long, it will not be aligned with other items.

For example, in the SharePoint left nav, the link text "Communication and Media" would trigger overflow text align center instead of left as rest of nodes do.

#### Focus areas to test
Updated the example to repro the issue then confirm fix solved the problem


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7806)