### PR TITLE
git hooks: fix precommit

### DIFF
--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -3,6 +3,8 @@
 # exit with non-zero status after issuing an appropriate message if
 # it wants to stop the commit.
 
+PATH=$PATH:/usr/local/bin:/usr/local/sbin
+
 echo --------------------------------------------
 echo Starting Git hook: pre-commit
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Some Mac users were coming across the following error when invoking the pre-commit git hook:

```
.git/hooks/pre-commit: line 10: node: command not found
```

As mentioned in [this post](https://stackoverflow.com/questions/12881975/git-pre-commit-hook-failing-in-github-for-mac-works-on-command-line), the $PATH variable available in GUI environments is different than the one available in terminal. These changes ensure that /usr/local/bin is in the path.

#### Focus areas to test

Run "rush install" to update .git/hooks/pre-commit. Make a change to the code that will trigger the pre-commit script, and ensure that the pre-commit succeeds. 

I tested on MacOS and Windows, but let me know if you see anything strange.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7807)