### PR TITLE
Sticky: set nonStickyPlaceHolder width for scrolling

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-sticky-placeHolder-width_2019-01-25-21-48.json
+++ b/common/changes/office-ui-fabric-react/fix-sticky-placeHolder-width_2019-01-25-21-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "width is not required for sticky placeholder as it won't affect horizontal scrolling. For a detailsGroupedList, if horizontal scrollbar is present when detailsHeader is in non-sticky state, it should be there even when detailsHeader becomes sticky. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "hatrived@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -125,9 +125,14 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       isStickyBottom !== nextState.isStickyBottom ||
       this.props.stickyPosition !== nextProps.stickyPosition ||
       this.props.children !== nextProps.children ||
-      _isHeightOrWidthDifferent(this._nonStickyContent, this._placeHolder) ||
-      _isHeightOrWidthDifferent(this._nonStickyContent, this._stickyContentTop) ||
-      _isHeightOrWidthDifferent(this._nonStickyContent, this._stickyContentBottom)) as boolean;
+      (this._nonStickyContent &&
+        this._nonStickyContent.current &&
+        ((this._placeHolder &&
+          this._placeHolder.current &&
+          (this._nonStickyContent.current.offsetHeight !== this._placeHolder.current.offsetHeight ||
+            this._nonStickyContent.current.scrollWidth !== this._placeHolder.current.scrollWidth)) ||
+          (this.stickyContentTop && this._nonStickyContent.current.offsetHeight !== this.stickyContentTop.offsetHeight) ||
+          (this.stickyContentBottom && this._nonStickyContent.current.offsetHeight !== this.stickyContentBottom.offsetHeight)))) as boolean;
   }
 
   public render(): JSX.Element {
@@ -150,7 +155,7 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
             <div style={this._getStickyPlaceholderHeight(isStickyBottom)} />
           </div>
         )}
-        <div style={this._getNonStickyPlaceholderHeight()} ref={this._placeHolder}>
+        <div style={this._getNonStickyPlaceholderHeightAndWidth()} ref={this._placeHolder}>
           <div
             ref={this._nonStickyContent}
             className={isStickyTop || isStickyBottom ? stickyClassName : undefined}
@@ -198,20 +203,14 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
   }
 
   private _getStickyPlaceholderHeight(isSticky: boolean): React.CSSProperties {
-    let height = 0,
-      width = 0;
-    if (this.nonStickyContent) {
-      height = this.nonStickyContent.offsetHeight;
-      width = this.nonStickyContent.scrollWidth;
-    }
+    const height = this.nonStickyContent ? this.nonStickyContent.offsetHeight : 0;
     return {
       visibility: isSticky ? 'hidden' : 'visible',
-      height: isSticky ? 0 : height,
-      width: isSticky ? 0 : width
+      height: isSticky ? 0 : height
     };
   }
 
-  private _getNonStickyPlaceholderHeight(): React.CSSProperties {
+  private _getNonStickyPlaceholderHeightAndWidth(): React.CSSProperties {
     const { isStickyTop, isStickyBottom } = this.state;
     if (isStickyTop || isStickyBottom) {
       let height = 0,

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -310,11 +310,3 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     return window.getComputedStyle(curr).getPropertyValue('background-color');
   }
 }
-
-function _isHeightOrWidthDifferent(a: React.RefObject<HTMLElement>, b: React.RefObject<HTMLDivElement>): boolean {
-  return (a &&
-    b &&
-    a.current &&
-    b.current &&
-    (a.current.offsetHeight !== b.current.offsetHeight || a.current.scrollWidth !== b.current.scrollWidth)) as boolean;
-}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -121,30 +121,14 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
     const { isStickyTop, isStickyBottom } = this.state;
 
-    const nonStickyContent =
-      this._nonStickyContent && this._nonStickyContent.current
-        ? {
-            offsetHeight: this._nonStickyContent.current.offsetHeight,
-            scrollWidth: this._nonStickyContent.current.scrollWidth
-          }
-        : undefined;
-    const placeHolder =
-      this._placeHolder && this._placeHolder.current
-        ? {
-            offsetHeight: this._placeHolder.current.offsetHeight,
-            scrollWidth: this._placeHolder.current.scrollWidth
-          }
-        : undefined;
-
     return (isStickyTop !== nextState.isStickyTop ||
       isStickyBottom !== nextState.isStickyBottom ||
       this.props.stickyPosition !== nextProps.stickyPosition ||
       this.props.children !== nextProps.children ||
-      (nonStickyContent &&
-        ((placeHolder &&
-          (nonStickyContent.offsetHeight !== placeHolder.offsetHeight || nonStickyContent.scrollWidth !== placeHolder.scrollWidth)) ||
-          (this.stickyContentTop && nonStickyContent.offsetHeight !== this.stickyContentTop.offsetHeight) ||
-          (this.stickyContentBottom && nonStickyContent.offsetHeight !== this.stickyContentBottom.offsetHeight)))) as boolean;
+      _isOffsetHeightDifferent(this._nonStickyContent, this._stickyContentTop) ||
+      _isOffsetHeightDifferent(this._nonStickyContent, this._stickyContentBottom) ||
+      _isOffsetHeightDifferent(this._nonStickyContent, this._placeHolder) ||
+      _isScrollWidthDifferent(this._nonStickyContent, this._placeHolder)) as boolean;
   }
 
   public render(): JSX.Element {
@@ -321,4 +305,12 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
     }
     return window.getComputedStyle(curr).getPropertyValue('background-color');
   }
+}
+
+function _isOffsetHeightDifferent(a: React.RefObject<HTMLElement>, b: React.RefObject<HTMLDivElement>): boolean {
+  return (a && b && a.current && b.current && a.current.offsetHeight !== b.current.offsetHeight) as boolean;
+}
+
+function _isScrollWidthDifferent(a: React.RefObject<HTMLElement>, b: React.RefObject<HTMLDivElement>): boolean {
+  return (a && b && a.current && b.current && a.current.scrollWidth !== b.current.scrollWidth) as boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -121,18 +121,30 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
     const { isStickyTop, isStickyBottom } = this.state;
 
+    const nonStickyContent =
+      this._nonStickyContent && this._nonStickyContent.current
+        ? {
+            offsetHeight: this._nonStickyContent.current.offsetHeight,
+            scrollWidth: this._nonStickyContent.current.scrollWidth
+          }
+        : undefined;
+    const placeHolder =
+      this._placeHolder && this._placeHolder.current
+        ? {
+            offsetHeight: this._placeHolder.current.offsetHeight,
+            scrollWidth: this._placeHolder.current.scrollWidth
+          }
+        : undefined;
+
     return (isStickyTop !== nextState.isStickyTop ||
       isStickyBottom !== nextState.isStickyBottom ||
       this.props.stickyPosition !== nextProps.stickyPosition ||
       this.props.children !== nextProps.children ||
-      (this._nonStickyContent &&
-        this._nonStickyContent.current &&
-        ((this._placeHolder &&
-          this._placeHolder.current &&
-          (this._nonStickyContent.current.offsetHeight !== this._placeHolder.current.offsetHeight ||
-            this._nonStickyContent.current.scrollWidth !== this._placeHolder.current.scrollWidth)) ||
-          (this.stickyContentTop && this._nonStickyContent.current.offsetHeight !== this.stickyContentTop.offsetHeight) ||
-          (this.stickyContentBottom && this._nonStickyContent.current.offsetHeight !== this.stickyContentBottom.offsetHeight)))) as boolean;
+      (nonStickyContent &&
+        ((placeHolder &&
+          (nonStickyContent.offsetHeight !== placeHolder.offsetHeight || nonStickyContent.scrollWidth !== placeHolder.scrollWidth)) ||
+          (this.stickyContentTop && nonStickyContent.offsetHeight !== this.stickyContentTop.offsetHeight) ||
+          (this.stickyContentBottom && nonStickyContent.offsetHeight !== this.stickyContentBottom.offsetHeight)))) as boolean;
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`
#7545 
#### Description of changes
setting width for stickyPlaceHolder is not required.
(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7809)