### PR TITLE
Stack: Updating API based on feedback from review

### DIFF
--- a/apps/vr-tests/src/stories/Stack.stories.tsx
+++ b/apps/vr-tests/src/stories/Stack.stories.tsx
@@ -190,7 +190,7 @@ storiesOf('Stack', module)
     </Stack>
   ))
   .addStory('Vertical Stack - Shrinking items', () => (
-    <Stack {...defaultProps} gap={10} shrinkItems className={styles.fixedHeight}>
+    <Stack {...defaultProps} gap={10} className={styles.fixedHeight}>
       <Stack.Item className={styles.verticalShrinkItem}>1</Stack.Item>
       <Stack.Item preventShrink className={styles.verticalShrinkItem}>
         2 (does not shrink)
@@ -347,7 +347,7 @@ storiesOf('Stack', module)
     </Stack>
   ))
   .addStory('Horizontal Stack - Shrinking items', () => (
-    <Stack horizontal {...defaultProps} gap={10} shrinkItems>
+    <Stack horizontal {...defaultProps} gap={10}>
       <Stack.Item className={styles.horizontalShrinkItem}>1</Stack.Item>
       <Stack.Item preventShrink className={styles.horizontalShrinkItem}>
         2 (does not shrink)

--- a/common/changes/@uifabric/experiments/stackAPI_2019-01-25-22-58.json
+++ b/common/changes/@uifabric/experiments/stackAPI_2019-01-25-22-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Stack: Updating API based on feedback from review.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/Stack.styles.ts
+++ b/packages/experiments/src/components/Stack/Stack.styles.ts
@@ -14,7 +14,6 @@ const GlobalClassNames = {
 
 export const styles: IStackComponent['styles'] = (props, theme): IStackStylesReturnType => {
   const {
-    horizontalFill,
     verticalFill,
     maxWidth,
     maxHeight,
@@ -27,7 +26,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
     padding,
     horizontalAlign,
     verticalAlign,
-    shrinkItems,
+    preventShrink,
     className
   } = props;
 
@@ -57,7 +56,7 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
   const commonSelectors = {
     // flexShrink styles are applied by the StackItem
     '> *:not(.ms-StackItem)': {
-      flexShrink: shrinkItems ? 1 : 0
+      flexShrink: preventShrink ? 0 : 1
     }
   };
 
@@ -151,8 +150,8 @@ export const styles: IStackComponent['styles'] = (props, theme): IStackStylesRet
         display: 'flex',
         flexDirection: horizontal ? (reversed ? 'row-reverse' : 'row') : reversed ? 'column-reverse' : 'column',
         flexWrap: 'nowrap',
-        width: horizontalFill && !wrap ? '100%' : 'auto',
-        height: verticalFill && !wrap ? '100%' : 'auto',
+        width: 'auto',
+        height: verticalFill ? '100%' : 'auto',
         maxWidth,
         maxHeight,
         padding: parsePadding(padding, theme),

--- a/packages/experiments/src/components/Stack/Stack.test.tsx
+++ b/packages/experiments/src/components/Stack/Stack.test.tsx
@@ -92,9 +92,9 @@ describe('Stack', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders vertical Stack with vertical and horizontal fill correctly', () => {
+  it('renders vertical Stack with vertical fill correctly', () => {
     const component = renderer.create(
-      <Stack horizontalFill verticalFill>
+      <Stack verticalFill>
         <div>Item 1</div>
         <div>Item 2</div>
       </Stack>
@@ -103,9 +103,9 @@ describe('Stack', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders horizontal Stack with vertical and horizontal fill correctly', () => {
+  it('renders horizontal Stack with vertical fill correctly', () => {
     const component = renderer.create(
-      <Stack horizontal horizontalFill verticalFill>
+      <Stack horizontal verticalFill>
         <div>Item 1</div>
         <div>Item 2</div>
       </Stack>
@@ -190,7 +190,7 @@ describe('Stack', () => {
 
   it('renders vertical Stack with shrinking StackItems correctly', () => {
     const component = renderer.create(
-      <Stack shrinkItems>
+      <Stack>
         <Stack.Item>Item 1</Stack.Item>
         <Stack.Item>Item 2</Stack.Item>
       </Stack>
@@ -201,7 +201,7 @@ describe('Stack', () => {
 
   it('renders horizontal Stack with shrinking StackItems correctly', () => {
     const component = renderer.create(
-      <Stack horizontal shrinkItems>
+      <Stack horizontal>
         <Stack.Item>Item 1</Stack.Item>
         <Stack.Item>Item 2</Stack.Item>
       </Stack>
@@ -212,7 +212,7 @@ describe('Stack', () => {
 
   it('renders vertical Stack with shrinking StackItems correctly', () => {
     const component = renderer.create(
-      <Stack shrinkItems>
+      <Stack>
         <Stack.Item>Item 1</Stack.Item>
         <Stack.Item preventShrink>Item 2</Stack.Item>
       </Stack>
@@ -223,7 +223,7 @@ describe('Stack', () => {
 
   it('renders horizontal Stack with shrinking StackItems correctly', () => {
     const component = renderer.create(
-      <Stack horizontal shrinkItems>
+      <Stack horizontal>
         <Stack.Item>Item 1</Stack.Item>
         <Stack.Item preventShrink>Item 2</Stack.Item>
       </Stack>

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -10,7 +10,7 @@ import { getNativeProps, htmlElementProperties } from '../../Utilities';
 const StackItemType = (<StackItem /> as React.ReactElement<IStackItemProps>).type;
 
 const view: IStackComponent['view'] = props => {
-  const { as: RootType = 'div', shrinkItems, wrap, ...rest } = props;
+  const { as: RootType = 'div', preventShrink, wrap, ...rest } = props;
 
   const stackChildren: (React.ReactChild | null)[] = React.Children.map(
     props.children,
@@ -21,7 +21,7 @@ const view: IStackComponent['view'] = props => {
 
       if (child.type === StackItemType) {
         const defaultItemProps: IStackItemProps = {
-          shrink: shrinkItems
+          shrink: !preventShrink
         };
 
         return React.cloneElement(child, {

--- a/packages/experiments/src/components/Stack/Stack.types.ts
+++ b/packages/experiments/src/components/Stack/Stack.types.ts
@@ -62,19 +62,17 @@ export interface IStackProps
   verticalAlign?: 'top' | 'bottom' | Alignment;
 
   /**
-   * Defines whether the Stack should take up 100% of the width of its parent.
-   */
-  horizontalFill?: boolean;
-
-  /**
    * Defines whether the Stack should take up 100% of the height of its parent.
+   * This property is required to be set to true when using the `grow` flag on children elements.
+   * @defaultvalue false
    */
   verticalFill?: boolean;
 
   /**
-   * Defines whether Stack child elements should shrink to fit the available space.
+   * Defines whether Stack children elements should not shrink to fit the available space.
+   * @defaultvalue false
    */
-  shrinkItems?: boolean;
+  preventShrink?: boolean;
 
   /**
    * Defines how much to grow the Stack in proportion to its siblings.

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.styles.ts
@@ -11,7 +11,7 @@ const alignMap: { [key: string]: string } = {
 };
 
 export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemStylesReturnType => {
-  const { grow, shrink, preventShrink, align, fillHorizontal, fillVertical, className } = props;
+  const { grow, shrink, preventShrink, align, verticalFill, className } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -20,8 +20,8 @@ export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemS
       theme.fonts.medium,
       classNames.root,
       {
-        width: fillHorizontal ? '100%' : 'auto',
-        height: fillVertical ? '100%' : 'auto'
+        width: 'auto',
+        height: verticalFill ? '100%' : 'auto'
       },
       grow && { flexGrow: grow === true ? 1 : grow },
       (preventShrink || (!grow && !shrink)) && {

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -14,12 +14,12 @@ export type IStackItemStylesReturnType = ReturnType<Extract<IStackItemComponent[
 
 export interface IStackItemProps extends IStackItemSlots, IStyleableComponentProps<IStackItemProps, IStackItemTokens, IStackItemStyles> {
   /**
-   * How to render the StackItem.
+   * Defines how to render the StackItem.
    */
   as?: string | React.ReactType<IStackItemProps>;
 
   /**
-   * CSS class name used to style the StackItem.
+   * Defines a CSS class name used to style the StackItem.
    */
   className?: string;
 
@@ -29,35 +29,30 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
   children?: (React.ReactElement<IStackItemProps> | string)[] | React.ReactElement<IStackItemProps> | string;
 
   /**
-   * How much to grow the StackItem in proportion to its siblings.
+   * Defines how much to grow the StackItem in proportion to its siblings.
    */
   grow?: boolean | number | 'inherit' | 'initial' | 'unset';
 
   /**
-   * Whether the StackItem should shrink to fit the available space.
+   * Defines at what ratio should the StackItem shrink to fit the available space.
    */
-  shrink?: boolean;
+  shrink?: boolean | number | 'inherit' | 'initial' | 'unset';
 
   /**
-   * Whether the StackItem should be prevented from shrinking.
+   * Defines whether the StackItem should be prevented from shrinking.
    * This can be used to prevent a StackItem from shrinking when it is inside of a Stack that has shrinkItems set to true.
    */
   preventShrink?: boolean;
 
   /**
-   * How to align the StackItem along the x-axis (for vertical Stacks) or the y-axis (for horizontal Stacks).
+   * Defines how to align the StackItem along the x-axis (for vertical Stacks) or the y-axis (for horizontal Stacks).
    */
   align?: 'auto' | 'stretch' | 'baseline' | 'start' | 'center' | 'end';
 
   /**
-   * Whether the StackItem should take up 100% of the width of its parent.
+   * Defines whether the StackItem should take up 100% of the height of its parent.
    */
-  fillHorizontal?: boolean;
-
-  /**
-   * Whether the StackItem should take up 100% of the height of its parent.
-   */
-  fillVertical?: boolean;
+  verticalFill?: boolean;
 }
 
 export interface IStackItemTokens {}

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -40,7 +40,8 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
 
   /**
    * Defines whether the StackItem should be prevented from shrinking.
-   * This can be used to prevent a StackItem from shrinking when it is inside of a Stack that has shrinkItems set to true.
+   * This can be used to prevent a StackItem from shrinking when it is inside of a Stack that has shrinking items.
+   * @defaultvalue false
    */
   preventShrink?: boolean;
 
@@ -51,6 +52,7 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
 
   /**
    * Defines whether the StackItem should take up 100% of the height of its parent.
+   * @defaultvalue true
    */
   verticalFill?: boolean;
 }

--- a/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Stack accepts custom className on child items 1`] = `
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -30,7 +30,7 @@ exports[`Stack accepts custom className on child items 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           background: red;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -72,7 +72,7 @@ exports[`Stack renders default horizontal Stack correctly 1`] = `
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -104,7 +104,7 @@ exports[`Stack renders default vertical Stack correctly 1`] = `
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -136,7 +136,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -146,7 +146,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: auto;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -163,7 +163,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: stretch;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -180,7 +180,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: baseline;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -197,7 +197,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: flex-start;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -214,7 +214,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: center;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -231,7 +231,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: flex-end;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -264,7 +264,7 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -273,7 +273,7 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -289,7 +289,7 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -322,7 +322,7 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
         margin-left: 10px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -331,7 +331,7 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -347,7 +347,7 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -380,7 +380,7 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div
@@ -404,7 +404,7 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
           margin-left: 0px;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     Item 1
@@ -430,7 +430,7 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
           margin-left: 0px;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     Item 2
@@ -456,7 +456,7 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
           margin-left: 0px;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     Item 3
@@ -602,7 +602,7 @@ exports[`Stack renders horizontal Stack with vertical and horizontal alignment c
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -614,7 +614,7 @@ exports[`Stack renders horizontal Stack with vertical and horizontal alignment c
 </div>
 `;
 
-exports[`Stack renders horizontal Stack with vertical and horizontal fill correctly 1`] = `
+exports[`Stack renders horizontal Stack with vertical fill correctly 1`] = `
 <div
   className=
       ms-Stack
@@ -624,7 +624,7 @@ exports[`Stack renders horizontal Stack with vertical and horizontal fill correc
         flex-direction: row;
         flex-wrap: nowrap;
         height: 100%;
-        width: 100%;
+        width: auto;
       }
       & > * {
         text-overflow: ellipsis;
@@ -634,7 +634,7 @@ exports[`Stack renders horizontal Stack with vertical and horizontal fill correc
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -666,7 +666,7 @@ exports[`Stack renders reversed horizontal Stack correctly 1`] = `
         margin-left: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -698,7 +698,7 @@ exports[`Stack renders reversed vertical Stack correctly 1`] = `
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -730,7 +730,7 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -739,7 +739,7 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -755,7 +755,7 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -788,7 +788,7 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
         margin-top: 10px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -797,7 +797,7 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -813,7 +813,7 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -846,7 +846,7 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div
@@ -870,7 +870,7 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
           margin-top: 0px;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     Item 1
@@ -896,7 +896,7 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
           margin-top: 0px;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     Item 2
@@ -922,7 +922,7 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
           margin-top: 0px;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     Item 3
@@ -950,7 +950,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <span
@@ -960,7 +960,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: auto;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -977,7 +977,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: stretch;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -994,7 +994,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: baseline;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -1011,7 +1011,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: flex-start;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -1028,7 +1028,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: center;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -1045,7 +1045,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           align-self: flex-end;
-          flex-shrink: 0;
+          flex-shrink: 1;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -1196,7 +1196,7 @@ exports[`Stack renders vertical Stack with vertical and horizontal alignment cor
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -1208,7 +1208,7 @@ exports[`Stack renders vertical Stack with vertical and horizontal alignment cor
 </div>
 `;
 
-exports[`Stack renders vertical Stack with vertical and horizontal fill correctly 1`] = `
+exports[`Stack renders vertical Stack with vertical fill correctly 1`] = `
 <div
   className=
       ms-Stack
@@ -1218,7 +1218,7 @@ exports[`Stack renders vertical Stack with vertical and horizontal fill correctl
         flex-direction: column;
         flex-wrap: nowrap;
         height: 100%;
-        width: 100%;
+        width: auto;
       }
       & > * {
         text-overflow: ellipsis;
@@ -1228,7 +1228,7 @@ exports[`Stack renders vertical Stack with vertical and horizontal fill correctl
         margin-top: 0px;
       }
       & > *:not(.ms-StackItem) {
-        flex-shrink: 0;
+        flex-shrink: 1;
       }
 >
   <div>
@@ -1279,7 +1279,7 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           white-space: nowrap;
         }
         & > *:not(.ms-StackItem) {
-          flex-shrink: 0;
+          flex-shrink: 1;
         }
   >
     <span
@@ -1288,7 +1288,7 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            flex-shrink: 0;
+            flex-shrink: 1;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
@@ -1304,7 +1304,7 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            flex-shrink: 0;
+            flex-shrink: 1;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
@@ -1320,7 +1320,7 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            flex-shrink: 0;
+            flex-shrink: 1;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Configure.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Configure.Example.tsx
@@ -16,7 +16,7 @@ export interface IExampleState {
   preventOverflow: boolean;
   wrap: boolean;
   wrapperWidth: number;
-  shrink: boolean;
+  preventShrink: boolean;
   gap: number;
   verticalGap: number;
   paddingLeft: number;
@@ -38,7 +38,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
       preventOverflow: false,
       wrap: false,
       wrapperWidth: 100,
-      shrink: false,
+      preventShrink: true,
       gap: 0,
       verticalGap: 0,
       paddingLeft: 0,
@@ -59,7 +59,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
       preventOverflow,
       wrap,
       wrapperWidth,
-      shrink,
+      preventShrink,
       gap,
       verticalGap,
       paddingLeft,
@@ -251,7 +251,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
         <Stack
           horizontal
           wrap={wrap}
-          shrinkItems={shrink}
+          preventShrink={preventShrink}
           gap={gap}
           verticalGap={verticalGap}
           padding={`${paddingTop}px ${paddingRight}px ${paddingBottom}px ${paddingLeft}px`}
@@ -301,7 +301,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
   };
 
   private _onShrinkChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean): void => {
-    this.setState({ shrink: isChecked });
+    this.setState({ preventShrink: !isChecked });
   };
 
   private _onWrapperWidthChange = (value: number): void => {

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Shrink.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Shrink.Example.tsx
@@ -46,7 +46,7 @@ export class HorizontalStackShrinkExample extends React.Component<{}, IExampleSt
           showValue={true}
           onChange={this._onWidthChange}
         />
-        <Stack horizontal gap={5} shrinkItems padding={10} className={styles.root}>
+        <Stack horizontal gap={5} padding={10} className={styles.root}>
           <Stack.Item grow className={styles.item}>
             I shrink
           </Stack.Item>

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.Configure.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.Configure.Example.tsx
@@ -14,7 +14,7 @@ export interface IExampleState {
   numItems: number;
   showBoxShadow: boolean;
   preventOverflow: boolean;
-  shrinkItems: boolean;
+  preventShrink: boolean;
   wrap: boolean;
   stackHeight: number;
   autoHeight: boolean;
@@ -36,7 +36,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
       numItems: 5,
       showBoxShadow: false,
       preventOverflow: false,
-      shrinkItems: false,
+      preventShrink: true,
       wrap: false,
       stackHeight: 200,
       autoHeight: true,
@@ -57,7 +57,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
       numItems,
       showBoxShadow,
       preventOverflow,
-      shrinkItems,
+      preventShrink,
       wrap,
       stackHeight,
       autoHeight,
@@ -230,7 +230,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
         </Stack>
 
         <Stack
-          shrinkItems={shrinkItems}
+          preventShrink={preventShrink}
           wrap={wrap}
           gap={gap}
           padding={`${paddingTop}px ${paddingRight}px ${paddingBottom}px ${paddingLeft}px`}
@@ -275,7 +275,7 @@ export class VerticalStackConfigureExample extends React.Component<{}, IExampleS
   };
 
   private _onShrinkItemsChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean): void => {
-    this.setState({ shrinkItems: isChecked });
+    this.setState({ preventShrink: !isChecked });
   };
 
   private _onWrapChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean): void => {

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.Shrink.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.Shrink.Example.tsx
@@ -50,7 +50,7 @@ export class VerticalStackShrinkExample extends React.Component<{}, IExampleStat
           onChange={this._onHeightChange}
         />
         <div className={styles.container}>
-          <Stack shrinkItems gap={5} padding={10} className={styles.root}>
+          <Stack gap={5} padding={10} className={styles.root}>
             <Stack.Item grow className={styles.item}>
               I shrink
             </Stack.Item>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updating the Stack API based on feedback gathered from its API review:
- Adding comment on `verticalFill` prop in `IStackProps` indicating that it is required when using the `grow` prop on children elements.
- Removing `horizontalFill` prop from both `IStackProps` and `IStackItemProps`.
- Renaming `shrinkItems` prop in `IStackProps` to `preventShrink` and changing logic in styles so that the default can be that items shrink.
- Renaming `fillVertical` prop in `IStackItemProps` to `verticalFill` to have naming consistency.
- Replacing the signature of the `shrink` prop in `IStackItemProps` to have the same signature that the `grow` prop has, accepting also numerical values.
- Making the comments for props in `IStackItemProps` adhere to the new proposed standard.
- Updating examples and tests that broke because of these changes.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7810)