### PR TITLE
DetailsList: set aria-expanded only if applicable to column

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2019-01-fixAriaExpanded_2019-01-26-18-11.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-01-fixAriaExpanded_2019-01-26-18-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Set aria-expanded attribute only if necessary",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -98,7 +98,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                   onContextMenu={this._onColumnContextMenu.bind(this, column)}
                   onClick={this._onColumnClick.bind(this, column)}
                   aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
-                  aria-expanded={column.columnActionsMode === ColumnActionsMode.hasDropdown && column.isMenuOpen}
+                  aria-expanded={column.columnActionsMode === ColumnActionsMode.hasDropdown && column.isMenuOpen ? true : undefined}
                 >
                   <span id={`${parentId}-${column.key}-name`} className={classNames.cellName}>
                     {(column.iconName || column.iconClassName) && <Icon className={classNames.iconClassName} iconName={column.iconName} />}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -98,7 +98,9 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                   onContextMenu={this._onColumnContextMenu.bind(this, column)}
                   onClick={this._onColumnClick.bind(this, column)}
                   aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
-                  aria-expanded={column.columnActionsMode === ColumnActionsMode.hasDropdown && column.isMenuOpen ? true : undefined}
+                  aria-expanded={
+                    column.columnActionsMode === ColumnActionsMode.hasDropdown ? (column.isMenuOpen ? true : false) : undefined
+                  }
                 >
                   <span id={`${parentId}-${column.key}-name`} className={classNames.cellName}>
                     {(column.iconName || column.iconClassName) && <Icon className={classNames.iconClassName} iconName={column.iconName} />}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -230,7 +230,7 @@ describe('DetailsColumn', () => {
     const columnHeader = component.find(DetailsColumn);
     const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
 
-    expect(columnHeaderTitle.getDOMNode().getAttribute('aria-expanded')).toBe('false');
+    expect(columnHeaderTitle.getDOMNode().getAttribute('aria-expanded')).toBe('undefined');
   });
 
   it('Examine aria-expanded value when columnActionMode is hasDropDown with isMenuOpen property set', () => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -230,7 +230,7 @@ describe('DetailsColumn', () => {
     const columnHeader = component.find(DetailsColumn);
     const columnHeaderTitle = columnHeader.find('.ms-DetailsHeader-cellTitle');
 
-    expect(columnHeaderTitle.getDOMNode().getAttribute('aria-expanded')).toBe('undefined');
+    expect(columnHeaderTitle.getDOMNode().getAttribute('aria-expanded')).toBe(null);
   });
 
   it('Examine aria-expanded value when columnActionMode is hasDropDown with isMenuOpen property set', () => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -336,7 +336,6 @@ exports[`DetailsHeader can render 1`] = `
           }
     >
       <span
-        aria-expanded={false}
         aria-haspopup={false}
         aria-labelledby="header0-a-name "
         className=
@@ -526,7 +525,6 @@ exports[`DetailsHeader can render 1`] = `
           }
     >
       <span
-        aria-expanded={false}
         aria-haspopup={false}
         aria-labelledby="header0-b-name "
         className=
@@ -737,6 +735,7 @@ exports[`DetailsHeader can render 1`] = `
           }
     >
       <span
+        aria-expanded={false}
         aria-haspopup={true}
         aria-labelledby="header0-c-name "
         className=
@@ -1205,7 +1204,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
           }
     >
       <span
-        aria-expanded={false}
         aria-haspopup={false}
         aria-labelledby="header4-a-name "
         className=
@@ -1396,7 +1394,6 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     >
       <span
         aria-describedby="header4-b-tooltip"
-        aria-expanded={false}
         aria-haspopup={false}
         aria-labelledby="header4-b-name "
         className=
@@ -1632,6 +1629,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     >
       <span
         aria-describedby="header4-c-tooltip"
+        aria-expanded={false}
         aria-haspopup={true}
         aria-labelledby="header4-c-name "
         className=

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -382,7 +382,6 @@ exports[`DetailsList renders List correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header6-key-name "
                 className=
@@ -964,7 +963,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             >
               <span
                 aria-describedby="header0-column_key_0-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-column_key_0-name "
                 className=
@@ -1120,7 +1118,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             >
               <span
                 aria-describedby="header0-column_key_1-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-column_key_1-name "
                 className=
@@ -1276,7 +1273,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             >
               <span
                 aria-describedby="header0-column_key_2-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-column_key_2-name "
                 className=
@@ -1432,7 +1428,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             >
               <span
                 aria-describedby="header0-column_key_3-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-column_key_3-name "
                 className=
@@ -1588,7 +1583,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             >
               <span
                 aria-describedby="header0-column_key_4-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-column_key_4-name "
                 className=
@@ -2136,7 +2130,6 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header12-key-name "
                 className=
@@ -2718,7 +2711,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header9-key-name "
                 className=
@@ -2907,7 +2899,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header9-name-name "
                 className=
@@ -3096,7 +3087,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header9-value-name "
                 className=
@@ -3678,7 +3668,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             >
               <span
                 aria-describedby="header3-column_key_0-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-column_key_0-name "
                 className=
@@ -3837,7 +3826,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             >
               <span
                 aria-describedby="header3-column_key_1-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-column_key_1-name "
                 className=
@@ -3996,7 +3984,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             >
               <span
                 aria-describedby="header3-column_key_2-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-column_key_2-name "
                 className=
@@ -4155,7 +4142,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             >
               <span
                 aria-describedby="header3-column_key_3-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-column_key_3-name "
                 className=
@@ -4314,7 +4300,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             >
               <span
                 aria-describedby="header3-column_key_4-tooltip"
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-column_key_4-name "
                 className=
@@ -4725,7 +4710,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header15-key-name "
                 className=

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -382,7 +382,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-key-name "
                 className=
@@ -515,7 +514,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-name-name "
                 className=
@@ -648,7 +646,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header0-value-name "
                 className=
@@ -1193,7 +1190,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header9-key-name "
                 className=
@@ -1326,7 +1322,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header9-name-name "
                 className=
@@ -1459,7 +1454,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header9-value-name "
                 className=
@@ -2536,7 +2530,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-key-name "
                 className=
@@ -2669,7 +2662,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-name-name "
                 className=
@@ -2802,7 +2794,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header3-value-name "
                 className=
@@ -3347,7 +3338,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header6-key-name "
                 className=
@@ -3480,7 +3470,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header6-name-name "
                 className=
@@ -3613,7 +3602,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                   }
             >
               <span
-                aria-expanded={false}
                 aria-haspopup={false}
                 aria-labelledby="header6-value-name "
                 className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7813
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Set `aria-expanded` to undefined in DetailsColumn if 
`column.columnActionsMode != ColumnActionsMode.hasDropdown`.

`Aria-expanded` should only exist if the column has a functioning drop down. 

***NOTE***: Need to update tests

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7816)