### PR TITLE
Is sticky bottom scroll top

### DIFF
--- a/common/changes/office-ui-fabric-react/isStickyBottom-scrollTop_2019-01-28-09-24.json
+++ b/common/changes/office-ui-fabric-react/isStickyBottom-scrollTop_2019-01-28-09-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "scrollTop value may be in decimal.",
+      "comment": "scrollTop value may be in decimal. Taking floor of scrollTop to calculate isStickyBottom for a sticky component",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/isStickyBottom-scrollTop_2019-01-28-09-24.json
+++ b/common/changes/office-ui-fabric-react/isStickyBottom-scrollTop_2019-01-28-09-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "scrollTop value may be in decimal.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "hatrived@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -243,7 +243,8 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
       // Can sticky bottom if the scrollablePane - total sticky footer height is smaller than the sticky's distance from the top of the pane
       if (this.canStickyBottom && container.clientHeight - footerStickyContainer.offsetHeight <= this.distanceFromTop) {
         isStickyBottom =
-          this.distanceFromTop - container.scrollTop >= this._getStickyDistanceFromTopForFooter(container, footerStickyContainer);
+          this.distanceFromTop - Math.floor(container.scrollTop) >=
+          this._getStickyDistanceFromTopForFooter(container, footerStickyContainer);
       }
 
       this.setState({


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
[scrollTop ](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)value can in decimal. Thus, making sure a sticky component having stickyPosition below will be non-sticky only when there is a difference of -1 or less.
isStickyBottom =
          this.**distanceFromTop** **-** container.**scrollTop** **-** this._getStickyDistanceFromTopForFooter(container, footerStickyContainer) >= -1

Note: no change is required for isStickyTop (isStickyTop = distanceToStickTop < container.scrollTop).
#### Focus areas to test

Sticky


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7823)