### PR TITLE
Add flexGrow: 1 to Panel contentInner

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-height_2019-01-29-01-18.json
+++ b/common/changes/office-ui-fabric-react/panel-height_2019-01-29-01-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: add flex-grow: 1 to contentInner",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -284,6 +284,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       {
         display: 'flex',
         flexDirection: 'column',
+        flexGrow: 1,
         maxHeight: '100%',
         overflowY: 'hidden',
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -315,6 +315,7 @@ exports[`Panel renders Panel correctly 1`] = `
                 {
                   display: flex;
                   flex-direction: column;
+                  flex-grow: 1;
                   max-height: 100%;
                   overflow-y: hidden;
                 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -396,6 +396,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                   {
                     display: flex;
                     flex-direction: column;
+                    flex-grow: 1;
                     max-height: 100%;
                     overflow-y: hidden;
                   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7606 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Panel styling changed from v5 to v6. This change styles the `contentInner` div of Panel (adding `flexGrow: 1`).

v5:
![v5](https://user-images.githubusercontent.com/6687333/51877616-c0613600-2321-11e9-9203-8c5cb0d376d7.png)

v6 - before adding `flexGrow: 1`:
![v6-before](https://user-images.githubusercontent.com/6687333/51877632-cfe07f00-2321-11e9-8267-58c5541a8f6b.png)

v6 - after adding `flexGrow: 1`:
<img width="921" alt="v6-after" src="https://user-images.githubusercontent.com/6687333/51877640-d7078d00-2321-11e9-8090-270aa78b5d7c.png">



#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7830)