### PR TITLE
Fix edge browser thumbnail list focus items alignment issue

### DIFF
--- a/common/changes/@uifabric/dashboard/thumbnailFocusIssue_2019-01-29-10-10.json
+++ b/common/changes/@uifabric/dashboard/thumbnailFocusIssue_2019-01-29-10-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Fix edge browser thumbnail list focus items alignment issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "v-ragor@microsoft.com"
+}

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.styles.ts
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.styles.ts
@@ -58,7 +58,7 @@ export const getThumbnailItemStyles = (): IThumbnailItemStyles => {
           marginLeft: '52px',
           maxHeight: '52px',
           overflow: 'hidden',
-          width: '100%',
+          width: 'calc(100% - 52px)',
           selectors: {
             ':focus': {
               border: 'solid black 0.5px'


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix edge browser thumbnail list focus items alignment issue


(give an overview)

#### Focus areas to test

(optional)

####screenshot 
<img width="956" alt="thumbnailfocus" src="https://user-images.githubusercontent.com/13463251/51900206-b8190180-23da-11e9-9e55-a2443f1e9ef4.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7833)