### PR TITLE
Fix merge styles bug 7827

### DIFF
--- a/common/changes/@uifabric/merge-styles/fix-merge-styles-bug-7827_2019-01-29-12-47.json
+++ b/common/changes/@uifabric/merge-styles/fix-merge-styles-bug-7827_2019-01-29-12-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Fix bug where multiple selectors in :global() would not be processed correctly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/merge-styles/src/styleToClassName.test.ts
+++ b/packages/merge-styles/src/styleToClassName.test.ts
@@ -204,6 +204,72 @@ describe('styleToClassName', () => {
     expect(_stylesheet.getRules()).toEqual('.ms-button:hover .css-0{background:red;}');
   });
 
+  it('can register multiple selectors within a global wrapper', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(.class1, .class2, .class3)': { top: 140 }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.class1, .class2, .class3{top:140px;}');
+  });
+
+  it('can register multiple selectors wrapped within a global wrappers', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(.class1), :global(.class2), :global(.class3)': { top: 140 }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.class1, .class2, .class3{top:140px;}');
+  });
+
+  it('can process a ":global(.class3, button)" selector', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(.class3, button)': { top: 140 }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.class3, button{top:140px;}');
+  });
+
+  it('can process a ":global(.class3 button)" selector', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(.class3 button)': { top: 140 }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.class3 button{top:140px;}');
+  });
+
+  it('can process a "button:focus, :global(.class1, .class2, .class3)" selector', () => {
+    const className = styleToClassName({
+      selectors: {
+        'button:focus, :global(.class1, .class2, .class3)': { top: 140 }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.css-0 button:focus, .class1, .class2, .class3{top:140px;}');
+  });
+
+  it('can process a complex multiple global selector', () => {
+    const className = styleToClassName({
+      selectors: {
+        ':global(.css20, .css50, #myId) button:hover :global(.class1, .class2, .class3)': { top: 140 }
+      }
+    });
+
+    expect(className).toEqual('css-0');
+    expect(_stylesheet.getRules()).toEqual('.css20, .css50, #myId button:hover .class1, .class2, .class3{top:140px;}');
+  });
+
   it('can expand an array of rules', () => {
     styleToClassName([{ background: 'red' }, { background: 'white' }]);
     expect(_stylesheet.getRules()).toEqual('.css-0{background:white;}');

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -22,9 +22,56 @@ function getDisplayName(rules?: { [key: string]: IRawStyle }): string | undefine
   return rootStyle ? (rootStyle as IRawStyle).displayName : undefined;
 }
 
+const globalSelectorRegExp = /\:global\((.+?)\)/g;
+
+type ReplacementInfo = [number, number, string];
+
+/**
+ * Finds comma separated selectors in a :global() e.g. ":global(.class1, .class2, .class3)"
+ * and wraps them each in their own global ":global(.class1), :global(.class2), :global(.class3)"
+ *
+ * @param selector The selector to process
+ * @returns The updated selector
+ */
+function expandCommaSeparatedGlobals(selector: string): string {
+  // We the selector does not have a :global() we can shortcut
+  if (!globalSelectorRegExp.test(selector)) {
+    return selector;
+  }
+
+  const replacementInfo: ReplacementInfo[] = [];
+
+  const findGlobal = /\:global\((.+?)\)/g;
+  let match = null;
+  // Create a result list for global selectors so we can replace them.
+  while ((match = findGlobal.exec(selector))) {
+    // Only if the found selector is a comma separated list we'll process it.
+    if (match[1].indexOf(',') > -1) {
+      replacementInfo.push([
+        match.index,
+        match.index + match[0].length,
+        // Wrap each of the found selectors in :global()
+        match[1]
+          .split(',')
+          .map((v: string) => `:global(${v.trim()})`)
+          .join(', ')
+      ]);
+    }
+  }
+
+  // Replace the found selectors with their wrapped variants in reverse order
+  return replacementInfo.reverse().reduce((newSelector: string, [matchIndex, matchEndIndex, replacement]: ReplacementInfo) => {
+    const prefix = newSelector.slice(0, matchIndex);
+    const suffix = newSelector.slice(matchEndIndex);
+    const updatedSelector = prefix + replacement + suffix;
+
+    return updatedSelector;
+  }, selector);
+}
+
 function expandSelector(newSelector: string, currentSelector: string): string {
   if (newSelector.indexOf(':global(') >= 0) {
-    return newSelector.replace(/:global\((.+?)\)/g, '$1');
+    return newSelector.replace(globalSelectorRegExp, '$1');
   } else if (newSelector.indexOf(':') === 0) {
     return currentSelector + newSelector;
   } else if (newSelector.indexOf('&') < 0) {
@@ -70,7 +117,9 @@ function extractRules(args: IStyle[], rules: IRuleSet = { __order: [] }, current
                 newSelector = newSelector + '{' + currentSelector;
                 extractRules([selectorValue], rules, newSelector);
               } else if (newSelector.indexOf(',') > -1) {
-                const commaSeparatedSelectors = newSelector.split(/,/g).map((s: string) => s.trim());
+                const commaSeparatedSelectors = expandCommaSeparatedGlobals(newSelector)
+                  .split(/,/g)
+                  .map((s: string) => s.trim());
                 extractRules(
                   [selectorValue],
                   rules,

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -30,13 +30,13 @@ type ReplacementInfo = [number, number, string];
  * Finds comma separated selectors in a :global() e.g. ":global(.class1, .class2, .class3)"
  * and wraps them each in their own global ":global(.class1), :global(.class2), :global(.class3)"
  *
- * @param selector The selector to process
+ * @param selectorWithGlobals The selector to process
  * @returns The updated selector
  */
-function expandCommaSeparatedGlobals(selector: string): string {
+function expandCommaSeparatedGlobals(selectorWithGlobals: string): string {
   // We the selector does not have a :global() we can shortcut
-  if (!globalSelectorRegExp.test(selector)) {
-    return selector;
+  if (!globalSelectorRegExp.test(selectorWithGlobals)) {
+    return selectorWithGlobals;
   }
 
   const replacementInfo: ReplacementInfo[] = [];
@@ -44,7 +44,7 @@ function expandCommaSeparatedGlobals(selector: string): string {
   const findGlobal = /\:global\((.+?)\)/g;
   let match = null;
   // Create a result list for global selectors so we can replace them.
-  while ((match = findGlobal.exec(selector))) {
+  while ((match = findGlobal.exec(selectorWithGlobals))) {
     // Only if the found selector is a comma separated list we'll process it.
     if (match[1].indexOf(',') > -1) {
       replacementInfo.push([
@@ -60,13 +60,12 @@ function expandCommaSeparatedGlobals(selector: string): string {
   }
 
   // Replace the found selectors with their wrapped variants in reverse order
-  return replacementInfo.reverse().reduce((newSelector: string, [matchIndex, matchEndIndex, replacement]: ReplacementInfo) => {
-    const prefix = newSelector.slice(0, matchIndex);
-    const suffix = newSelector.slice(matchEndIndex);
-    const updatedSelector = prefix + replacement + suffix;
+  return replacementInfo.reverse().reduce((selector: string, [matchIndex, matchEndIndex, replacement]: ReplacementInfo) => {
+    const prefix = selector.slice(0, matchIndex);
+    const suffix = selector.slice(matchEndIndex);
 
-    return updatedSelector;
-  }, selector);
+    return prefix + replacement + suffix;
+  }, selectorWithGlobals);
 }
 
 function expandSelector(newSelector: string, currentSelector: string): string {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7827
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Bandaid fix for #7827 

The PR changes `:global()` statements with multiple selectors by processing them as separate `:global()`s

A :global selector that has multiple comma separated selectors
```
:global(.class1, class2, .class3){top:140px;}
```

Will be pre-processed into the following, before we throw it through the `expandSelector` and `extractRules`.
```
:global(.class1), :global(.class2), :global(.class3){top:140px;}
```

#### Focus areas to test

This will make using `:global()` selectors in a selector that contains a comma bit slower. But scenario should be fairly limited as would be the performance impact and probably an acceptable trade off until we have a proper selector parser.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7834)