### PR TITLE
 Fixing Stack shrinking issues in component examples after shrinkItems was replaced with preventShrink

### DIFF
--- a/common/changes/@uifabric/experiments/examples_2019-01-29-17-22.json
+++ b/common/changes/@uifabric/experiments/examples_2019-01-29-17-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": " Fixing shrinking issues in component examples after shrinkItems was replaced with preventShrink.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/examples/Button.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Example.tsx
@@ -11,7 +11,7 @@ const headingGap = 16;
 const buttonGap = 12;
 
 const ButtonStack = (props: { children: JSX.Element[] | JSX.Element }) => (
-  <Stack horizontal gap={buttonGap}>
+  <Stack horizontal preventShrink gap={buttonGap}>
     {props.children}
   </Stack>
 );

--- a/packages/experiments/src/components/Button/examples/Button.Styles.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Styles.Example.tsx
@@ -21,7 +21,7 @@ const menuItems = [{ key: 'a', name: 'Item a' }, { key: 'b', name: 'Item b' }];
 const buttonMenu = (props: IContextualMenuProps) => <ContextualMenu {...props} items={menuItems} />;
 
 const ButtonStack = (props: { children: JSX.Element[] | JSX.Element }) => (
-  <Stack horizontal gap={buttonGap}>
+  <Stack horizontal preventShrink gap={buttonGap}>
     {props.children}
   </Stack>
 );

--- a/packages/experiments/src/components/Button/examples/Button.Tokens.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Tokens.Example.tsx
@@ -22,7 +22,7 @@ const testTheme = createTheme({
 export class ButtonTokensExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     const ButtonSet = (props: IButtonProps) => (
-      <Stack horizontal verticalAlign="center" gap={8}>
+      <Stack horizontal preventShrink verticalAlign="center" gap={8}>
         <Button {...props} />
         <Button {...props} primary />
         <Button {...props} disabled />
@@ -54,7 +54,7 @@ export class ButtonTokensExample extends React.Component<{}, {}> {
           content="Menu button with icon"
           menu={buttonMenu}
         />
-        <Stack horizontal verticalAlign="center" gap={8}>
+        <Stack horizontal preventShrink verticalAlign="center" gap={8}>
           <Button
             primary
             icon="PeopleAdd"

--- a/packages/experiments/src/components/PersonaCoin/examples/PersonaCoin.Example.tsx
+++ b/packages/experiments/src/components/PersonaCoin/examples/PersonaCoin.Example.tsx
@@ -8,7 +8,7 @@ const headingGap = 16;
 const personaCoinGap = 12;
 
 const PersonaCoinStack = (props: { children: JSX.Element[] | JSX.Element }) => (
-  <Stack horizontal gap={personaCoinGap}>
+  <Stack horizontal preventShrink gap={personaCoinGap}>
     {props.children}
   </Stack>
 );

--- a/packages/experiments/src/components/PersonaCoin/examples/PersonaCoinSizeAndColor.Example.tsx
+++ b/packages/experiments/src/components/PersonaCoin/examples/PersonaCoinSizeAndColor.Example.tsx
@@ -14,7 +14,7 @@ export class PersonaCoinSizeAndColorExample extends React.Component<{}, {}> {
         <Stack gap={headingGap} padding={8}>
           <Stack gap={personaCoinGap}>
             <Text>Sizes</Text>
-            <Stack horizontal gap={personaCoinGap}>
+            <Stack horizontal preventShrink gap={personaCoinGap}>
               <PersonaCoin text="Kevin Jameson" size={10} />
               <PersonaCoin text="Kevin Jameson" size={24} />
               <PersonaCoin text="Kevin Jameson" size={28} />
@@ -24,7 +24,7 @@ export class PersonaCoinSizeAndColorExample extends React.Component<{}, {}> {
               <PersonaCoin text="Kevin Jameson" size={72} />
               <PersonaCoin text="Kevin Jameson" size={100} />
             </Stack>
-            <Stack horizontal gap={personaCoinGap}>
+            <Stack horizontal preventShrink gap={personaCoinGap}>
               <PersonaCoin text="Kevin Jameson" size={10} imageUrl={PersonaTestImages.personMale} />
               <PersonaCoin text="Kevin Jameson" size={24} imageUrl={PersonaTestImages.personMale} presence={1} />
               <PersonaCoin text="Kevin Jameson" size={28} imageUrl={PersonaTestImages.personMale} />
@@ -37,7 +37,7 @@ export class PersonaCoinSizeAndColorExample extends React.Component<{}, {}> {
           </Stack>
           <Stack gap={personaCoinGap}>
             <Text>Custom colors</Text>
-            <Stack horizontal gap={personaCoinGap}>
+            <Stack horizontal preventShrink gap={personaCoinGap}>
               <PersonaCoin text="Kevin Jameson" coinColor="red" initialsColor="black" />
               <PersonaCoin text="Kevin Jameson" coinColor="beige" initialsColor="black" />
               <PersonaCoin text="Kevin Jameson" coinColor="blue" />

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -25,8 +25,8 @@ const view: IStackComponent['view'] = props => {
         };
 
         return React.cloneElement(child, {
-          ...defaultItemProps,
-          ...child.props
+          ...child.props,
+          ...defaultItemProps
         });
       }
 

--- a/packages/experiments/src/components/Stack/Stack.tsx
+++ b/packages/experiments/src/components/Stack/Stack.tsx
@@ -25,8 +25,8 @@ const view: IStackComponent['view'] = props => {
         };
 
         return React.cloneElement(child, {
-          ...child.props,
-          ...defaultItemProps
+          ...defaultItemProps,
+          ...child.props
         });
       }
 

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Basic.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Basic.Example.tsx
@@ -20,21 +20,21 @@ export class HorizontalStackBasicExample extends React.Component<{}, {}> {
     return (
       <Stack gap={5}>
         <span>Default horizontal stack</span>
-        <Stack horizontal className={styles.root}>
+        <Stack horizontal preventShrink className={styles.root}>
           <span>Item One</span>
           <span>Item Two</span>
           <span>Item Three</span>
         </Stack>
 
         <span>Horizontal gap between items</span>
-        <Stack horizontal gap={10} padding={10} className={styles.root}>
+        <Stack horizontal preventShrink gap={10} padding={10} className={styles.root}>
           <span>Item One</span>
           <span>Item Two</span>
           <span>Item Three</span>
         </Stack>
 
         <span>Item alignments</span>
-        <Stack horizontal gap={5} padding={10} className={styles.root} styles={{ root: { height: 100 } }}>
+        <Stack horizontal preventShrink gap={5} padding={10} className={styles.root} styles={{ root: { height: 100 } }}>
           <Stack.Item align="auto" className={styles.item}>
             <span>Auto-aligned item</span>
           </Stack.Item>
@@ -56,7 +56,7 @@ export class HorizontalStackBasicExample extends React.Component<{}, {}> {
         </Stack>
 
         <span>Clickable stack</span>
-        <Stack horizontal onClick={this._onClick} padding={10} className={styles.root}>
+        <Stack horizontal preventShrink onClick={this._onClick} padding={10} className={styles.root}>
           <span>Click inside this box</span>
         </Stack>
       </Stack>

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Configure.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Configure.Example.tsx
@@ -106,7 +106,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
 
     return (
       <Stack gap={10}>
-        <Stack horizontal>
+        <Stack horizontal preventShrink>
           <Stack.Item grow>
             <Stack>
               <Slider
@@ -118,14 +118,14 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
                 showValue={true}
                 onChange={this._onNumItemsChange}
               />
-              <Stack horizontal>
+              <Stack horizontal preventShrink>
                 <Checkbox label="Shadow around items" onChange={this._onBoxShadowChange} styles={{ root: { marginRight: 10 } }} />
                 <Checkbox label="Prevent item overflow" onChange={this._onPreventOverflowChange} />
               </Stack>
             </Stack>
           </Stack.Item>
           <Stack.Item grow>
-            <Stack horizontal gap={20}>
+            <Stack horizontal preventShrink gap={20}>
               <Stack>
                 <Checkbox label="Wrap items" onChange={this._onWrapChange} styles={{ root: { marginBottom: 10 } }} />
                 <Checkbox label="Shrink items" onChange={this._onShrinkChange} />
@@ -145,7 +145,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
           </Stack.Item>
         </Stack>
 
-        <Stack horizontal gap={20}>
+        <Stack horizontal preventShrink gap={20}>
           <Stack.Item grow>
             <Stack>
               <Slider
@@ -214,7 +214,7 @@ export class HorizontalStackConfigureExample extends React.Component<{}, IExampl
           </Stack.Item>
         </Stack>
 
-        <Stack horizontal gap={20} verticalAlign="end">
+        <Stack horizontal preventShrink gap={20} verticalAlign="end">
           <Stack.Item grow>
             <Dropdown
               selectedKey={horizontalAlignment}

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Reversed.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Reversed.Example.tsx
@@ -20,21 +20,21 @@ export class HorizontalStackReversedExample extends React.Component<{}, {}> {
     return (
       <Stack gap={5}>
         <span>Default horizontal stack</span>
-        <Stack horizontal reversed className={styles.root}>
+        <Stack horizontal reversed preventShrink className={styles.root}>
           <span>Item One</span>
           <span>Item Two</span>
           <span>Item Three</span>
         </Stack>
 
         <span>Horizontal gap between items</span>
-        <Stack horizontal reversed gap={10} padding={10} className={styles.root}>
+        <Stack horizontal reversed preventShrink gap={10} padding={10} className={styles.root}>
           <span>Item One</span>
           <span>Item Two</span>
           <span>Item Three</span>
         </Stack>
 
         <span>Item alignments</span>
-        <Stack horizontal reversed gap={5} padding={10} className={styles.root} styles={{ root: { height: 100 } }}>
+        <Stack horizontal reversed preventShrink gap={5} padding={10} className={styles.root} styles={{ root: { height: 100 } }}>
           <Stack.Item align="auto" className={styles.item}>
             <span>Auto-aligned item</span>
           </Stack.Item>

--- a/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Spacing.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Horizontal.Spacing.Example.tsx
@@ -35,7 +35,7 @@ export class HorizontalStackSpacingExample extends React.Component<{}, {}> {
 
     return (
       <Stack gap={10}>
-        <Stack horizontal horizontalAlign="space-between">
+        <Stack horizontal preventShrink horizontalAlign="space-between">
           <Stack>
             <span>Numerical spacing</span>
             <Stack horizontal className={styles.root} gap={10} padding={10}>
@@ -54,7 +54,7 @@ export class HorizontalStackSpacingExample extends React.Component<{}, {}> {
           </Stack>
         </Stack>
 
-        <Stack horizontal horizontalAlign="space-between">
+        <Stack horizontal preventShrink horizontalAlign="space-between">
           <Stack>
             <span>Themed spacing (extra small)</span>
             <Stack horizontal className={styles.root} gap="s2" padding="s2">

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.Spacing.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.Spacing.Example.tsx
@@ -23,7 +23,7 @@ export class VerticalStackSpacingExample extends React.Component<{}, {}> {
 
     return (
       <Stack gap={10}>
-        <Stack horizontal gap={50}>
+        <Stack horizontal preventShrink gap={50}>
           <Stack>
             <span>Numerical spacing</span>
             <Stack className={styles.root} gap={10} padding={10}>
@@ -43,7 +43,7 @@ export class VerticalStackSpacingExample extends React.Component<{}, {}> {
           </Stack>
         </Stack>
 
-        <Stack horizontal horizontalAlign="space-between">
+        <Stack horizontal preventShrink horizontalAlign="space-between">
           <Stack>
             <span>Themed spacing (extra small)</span>
             <Stack className={styles.root} gap="s2" padding="s2">

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.VerticalAlign.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.VerticalAlign.Example.tsx
@@ -25,7 +25,7 @@ export class VerticalStackVerticalAlignExample extends React.Component<{}, {}> {
 
     return (
       <Stack gap={10}>
-        <Stack horizontal gap={30} horizontalAlign="space-between">
+        <Stack horizontal preventShrink gap={30} horizontalAlign="space-between">
           <Stack grow>
             <span>Top-aligned</span>
             <Stack verticalAlign="start" className={styles.root}>
@@ -54,7 +54,7 @@ export class VerticalStackVerticalAlignExample extends React.Component<{}, {}> {
           </Stack>
         </Stack>
 
-        <Stack horizontal gap={30} horizontalAlign="space-between">
+        <Stack horizontal preventShrink gap={30} horizontalAlign="space-between">
           <Stack grow>
             <span>Vertical space around items</span>
             <Stack verticalAlign="space-around" className={styles.root}>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When the Stack API was changed to replace the `shrinkItems` prop with `preventShrink`, there were a couple of component examples that were affected. This PR updates those examples by introducing the `preventShrink` prop were necessary so that they work exactly the same as before `shrinkItems` was replaced with `preventShrink`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7836)