### PR TITLE
Popup: Set tabindex to -1 to fix Esc on keydown event handler

### DIFF
--- a/common/changes/office-ui-fabric-react/u-jehell-popup-tabindex_2019-01-29-21-05.json
+++ b/common/changes/office-ui-fabric-react/u-jehell-popup-tabindex_2019-01-29-21-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Support ESC after clicking in Popup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jehell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`Callout renders Callout correctly 1`] = `
           "overflowY": undefined,
         }
       }
+      tabIndex={-1}
     >
       Content
     </div>

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
               "overflowY": "hidden",
             }
           }
+          tabIndex={-1}
         >
           <div
             onFocusCapture={[Function]}
@@ -295,6 +296,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
               "overflowY": undefined,
             }
           }
+          tabIndex={-1}
         >
           <div
             onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`Modal renders Modal correctly 1`] = `
           "overflowY": undefined,
         }
       }
+      tabIndex={-1}
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`Panel renders Panel correctly 1`] = `
           "overflowY": undefined,
         }
       }
+      tabIndex={-1}
     >
       <div
         aria-hidden={false}

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -68,6 +68,7 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
 
     return (
       <div
+        tabIndex={-1}
         ref={this._root}
         {...getNativeProps(this.props, divProperties)}
         className={className}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
           "overflowY": "hidden",
         }
       }
+      tabIndex={-1}
     >
       <div>
         <div

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
               "overflowY": undefined,
             }
           }
+          tabIndex={-1}
         >
           <div
             role="tooltip"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -190,6 +190,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
             "overflowY": undefined,
           }
         }
+        tabIndex={-1}
       >
         <div
           aria-hidden={false}


### PR DESCRIPTION
#### Description of changes

Popups - like Callout or Modal - have an issue where when you click inside of a Fabric popup (but not on an actual keyboard focusable item – just in the blank area of the popup) and then hit ESC, the popup does not close.  
 
This is happening because clicking in the popup causes focus to go to the document <body> itself which is outside of the popup so the appropriate keydown event handler on the popup is not hit.  

This change adds a tabindex of -1 to the Popup component so that focus will go to the Popup itself on click, allowing the appropriate keydown event handler to be trigger.  

#### Focus areas to test

All Popup components, especially as relates to keyboard focus, tab order and clicking.  


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7839)