### PR TITLE
adding id props to dashboard components for analytics

### DIFF
--- a/packages/dashboard/src/components/Card/Card.types.ts
+++ b/packages/dashboard/src/components/Card/Card.types.ts
@@ -124,6 +124,12 @@ export interface ICardFrameContent {
 
 export interface ICardProps {
   /**
+   * Card  additional ID
+   */
+
+  cardId?: string;
+
+  /**
    * Card frame content, that contains the card title and array of card frame drop down options
    */
   cardFrameContent: ICardFrameContent;

--- a/packages/dashboard/src/components/Card/CompoundButtonStack/CompoundButtonStack.types.ts
+++ b/packages/dashboard/src/components/Card/CompoundButtonStack/CompoundButtonStack.types.ts
@@ -22,6 +22,11 @@ export interface ICompoundButtonStackStyles {
 
 export interface ICompoundAction {
   /**
+   * The id of the compound action.
+   */
+  id?: string;
+
+  /**
    * Defines the title of the button
    */
   title: string;

--- a/packages/dashboard/src/components/Card/GridList/GridList.types.ts
+++ b/packages/dashboard/src/components/Card/GridList/GridList.types.ts
@@ -109,6 +109,10 @@ export interface IGridRow {
  */
 export interface IGridListProps {
   /**
+   * The id of the grid list.
+   */
+  id?: string;
+  /**
    * Array of row items
    */
   gridRows: IGridRow[];

--- a/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.types.ts
+++ b/packages/dashboard/src/components/Card/ThumbnailList/ThumbnailList.types.ts
@@ -56,6 +56,11 @@ export interface IThumbnailItemProps {
 
 export interface IThumbnailListProps {
   /**
+   * The id of the thumbnail list.
+   */
+  id?: string;
+
+  /**
    * List of thumbnails
    */
 


### PR DESCRIPTION
add  optional  id props to  IThumbnailListProps, IGridListProps, ICompoundAction and  optional cardId to ICardProps

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7840)