### PR TITLE
Add textField to IDatePickerProps

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker-expose-textinput_2019-01-29-20-02.json
+++ b/common/changes/office-ui-fabric-react/datepicker-expose-textinput_2019-01-29-20-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add textFieldProps to IDatePickerProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "evlevy@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/datepicker-expose-textinput_2019-01-29-20-02.json
+++ b/common/changes/office-ui-fabric-react/datepicker-expose-textinput_2019-01-29-20-02.json
@@ -1,11 +1,9 @@
 {
-  "changes": [
-    {
-      "packageName": "office-ui-fabric-react",
-      "comment": "Add textFieldProps to IDatePickerProps",
-      "type": "minor"
-    }
-  ],
+  "changes": [{
+    "packageName": "office-ui-fabric-react",
+    "comment": "Add textField to IDatePickerProps",
+    "type": "minor"
+  }],
   "packageName": "office-ui-fabric-react",
   "email": "evlevy@microsoft.com"
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6700,6 +6700,7 @@ interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAttributes
   strings?: IDatePickerStrings;
   styles?: IStyleFunction<IDatePickerStyleProps, IDatePickerStyles>;
   tabIndex?: number;
+  textFieldProps?: ITextFieldProps;
   theme?: ITheme;
   today?: Date;
   underlined?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6700,7 +6700,7 @@ interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAttributes
   strings?: IDatePickerStrings;
   styles?: IStyleFunction<IDatePickerStyleProps, IDatePickerStyles>;
   tabIndex?: number;
-  textFieldProps?: ITextFieldProps;
+  textField?: ITextFieldProps;
   theme?: ITheme;
   today?: Date;
   underlined?: boolean;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -180,7 +180,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     const calloutId = getId('DatePicker-Callout');
     const nativeProps = getNativeProps(this.props, divProperties, ['value']);
-    const customIconClassName = textFieldProps && textFieldProps.iconProps && textFieldProps && textFieldProps.iconProps.className;
+    const customIconClassName = textFieldProps && textFieldProps.iconProps && textFieldProps.iconProps.className;
 
     return (
       <div {...nativeProps} className={classNames.root}>

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -162,6 +162,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       showCloseButton,
       calendarProps,
       calloutProps,
+      textFieldProps,
       underlined,
       allFocusable,
       calendarAs: CalendarType = Calendar,
@@ -179,6 +180,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     const calloutId = getId('DatePicker-Callout');
     const nativeProps = getNativeProps(this.props, divProperties, ['value']);
+    const customIconClassName = textFieldProps && textFieldProps.iconProps && textFieldProps && textFieldProps.iconProps.className;
 
     return (
       <div {...nativeProps} className={classNames.root}>
@@ -190,31 +192,33 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
           aria-owns={isDatePickerShown ? calloutId : undefined}
         >
           <TextField
-            id={this._id + '-label'}
-            className={classNames.textField}
             label={label}
             ariaLabel={ariaLabel}
             aria-controls={isDatePickerShown ? calloutId : undefined}
             required={isRequired}
             disabled={disabled}
+            errorMessage={errorMessage}
+            placeholder={placeholder}
+            borderless={borderless}
+            value={formattedDate}
+            componentRef={this._textField}
+            underlined={underlined}
+            tabIndex={tabIndex}
+            readOnly={!allowTextInput}
+            {...textFieldProps}
+            id={this._id + '-label'}
+            className={css(classNames.textField, textFieldProps && textFieldProps.className)}
+            iconProps={{
+              iconName: 'Calendar',
+              ...(textFieldProps && textFieldProps.iconProps),
+              className: css(classNames.icon, customIconClassName),
+              onClick: this._onIconClick
+            }}
             onKeyDown={this._onTextFieldKeyDown}
             onFocus={this._onTextFieldFocus}
             onBlur={this._onTextFieldBlur}
             onClick={this._onTextFieldClick}
             onChange={this._onTextFieldChanged}
-            errorMessage={errorMessage}
-            placeholder={placeholder}
-            borderless={borderless}
-            iconProps={{
-              iconName: 'Calendar',
-              onClick: this._onIconClick,
-              className: classNames.icon
-            }}
-            readOnly={!allowTextInput}
-            value={formattedDate}
-            componentRef={this._textField}
-            underlined={underlined}
-            tabIndex={tabIndex}
           />
         </div>
         {isDatePickerShown && (

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -162,7 +162,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       showCloseButton,
       calendarProps,
       calloutProps,
-      textFieldProps,
+      textField: textFieldProps,
       underlined,
       allFocusable,
       calendarAs: CalendarType = Calendar,

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -180,7 +180,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     const calloutId = getId('DatePicker-Callout');
     const nativeProps = getNativeProps(this.props, divProperties, ['value']);
-    const customIconClassName = textFieldProps && textFieldProps.iconProps && textFieldProps.iconProps.className;
+    const iconProps = textFieldProps && textFieldProps.iconProps;
 
     return (
       <div {...nativeProps} className={classNames.root}>
@@ -210,8 +210,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             className={css(classNames.textField, textFieldProps && textFieldProps.className)}
             iconProps={{
               iconName: 'Calendar',
-              ...(textFieldProps && textFieldProps.iconProps),
-              className: css(classNames.icon, customIconClassName),
+              ...iconProps,
+              className: css(classNames.icon, iconProps && iconProps.className),
               onClick: this._onIconClick
             }}
             onKeyDown={this._onTextFieldKeyDown}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -4,6 +4,7 @@ import { ICalendarFormatDateCallbacks } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IBaseProps, IStyleFunction, IComponentAs } from '../../Utilities';
 import { ICalloutProps } from '../../Callout';
+import { ITextFieldProps } from '../TextField/TextField.types';
 
 export interface IDatePicker {
   /** Sets focus to the text field */
@@ -39,6 +40,11 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
    * Pass calendar props to calendar component
    */
   calendarProps?: ICalendarProps;
+
+  /**
+   * Pass textField props to textField component
+   */
+  textFieldProps?: ITextFieldProps;
 
   /**
    * Custom Calendar to be used for date picking

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -44,7 +44,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
   /**
    * Pass textField props to textField component
    */
-  textFieldProps?: ITextFieldProps;
+  textField?: ITextFieldProps;
 
   /**
    * Custom Calendar to be used for date picking

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -42,7 +42,8 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
   calendarProps?: ICalendarProps;
 
   /**
-   * Pass textField props to textField component
+   * Pass textField props to textField component.
+   * Prop name is "textField" for compatiblity with upcoming slots work.
    */
   textField?: ITextFieldProps;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7890
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Add `textField` (ITextFieldProps) to IDatePickerProps for increased customization of the DatePicker TextField and it's child components (e.g. Icon). Prop name is `textField` for slot-compatibility.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7849)