### PR TITLE
Clarify extended picker donts

### DIFF
--- a/common/changes/office-ui-fabric-react/clarify-extended-picker-donts_2019-02-01-16-33.json
+++ b/common/changes/office-ui-fabric-react/clarify-extended-picker-donts_2019-02-01-16-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Clarify extended picker dont documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/docs/ExtendedPeoplePickerDonts.md
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/docs/ExtendedPeoplePickerDonts.md
@@ -1,3 +1,3 @@
 - Use the ExtendedPeoplePicker to select something other than people
-- Use the ExtendedPeoplePicker to only display people
+- Use the ExtendedPeoplePicker to display people without an option to select them
 - Use the ExtendedPeoplePicker without sufficient space


### PR DESCRIPTION
Resolves ambiguous wording in the Don'ts for extended people picker to make it clear that consumers should make all items on the list selectable.

#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #7860
- [x ] Include a change request file using `$ npm run change`

#### Description of changes

Clarifies don'ts on extended picker


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7870)