### PR TITLE
Foundation: Factory & React Hierarchy Improvements

### DIFF
--- a/common/changes/@uifabric/experiments/jg-fix-react-hierarchy_2019-02-01-19-24.json
+++ b/common/changes/@uifabric/experiments/jg-fix-react-hierarchy_2019-02-01-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "CollapsibleSectionTitle: Use new factoryOptions prop. Name factory wrappers.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/jg-fix-react-hierarchy_2019-02-01-19-24.json
+++ b/common/changes/@uifabric/foundation/jg-fix-react-hierarchy_2019-02-01-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/foundation",
+      "comment": "Optimize React hierarchy by naming Unknowns and removing view layers.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
@@ -1,4 +1,4 @@
-import { createComponent, createFactory, ISlottableComponentType } from '../../Foundation';
+import { createComponent, ISlottableComponentType } from '../../Foundation';
 import { CollapsibleSectionTitleView as view } from './CollapsibleSectionTitle.view';
 import { getStyles as styles } from './CollapsibleSectionTitle.styles';
 import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
@@ -6,7 +6,8 @@ import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
 export const CollapsibleSectionTitle: ISlottableComponentType<ICollapsibleSectionTitleProps> = createComponent({
   displayName: 'CollapsibleSectionTitle',
   view,
-  styles
+  styles,
+  factoryOptions: {
+    defaultProp: 'text'
+  }
 });
-
-CollapsibleSectionTitle.create = createFactory(CollapsibleSectionTitle, { defaultProp: 'text' });

--- a/packages/experiments/src/utilities/factoryComponents.tsx
+++ b/packages/experiments/src/utilities/factoryComponents.tsx
@@ -4,22 +4,32 @@ import { Icon as FabricIcon, Label as FabricLabel, IIconProps, ILabelProps, IPer
 import { PersonaPresence as FabricPersonaPresence } from 'office-ui-fabric-react/lib/PersonaPresence';
 import { createFactory, ISlottableComponentType } from '../Foundation';
 
-// TODO: All contents of this file should be moved to each respective component after slots utilities are promoted.
-// TODO: This means that components would also have to be modified not to generate rendered output if their props don't call for it.
+// TODO: All contents of this file should eventually be removed.
+// TODO: createFactory should no longer have to be explicitly called with component options containing defaultProp.
+//       (Consider adding a defaultProp option to styled so that createFactory can be internalized similar to createComponent)
+// TODO: displayName will also be covered by createComponent argument.
+// TODO: These components will also have to be modified not to generate rendered output if their props don't call for it
+//       to eliminate the wrapper functions below.
 
 // Generally to avoid a bunch of "if slot prop exists" checks in parent components, components should
 // make sure they have content to render based on their props. For example here, if Icon has no iconName,
 // it has no rendered content and returns null. This prevents Button.view from having to check to
 // see if its icon Slot is defined.
+
+// These wrappers will temporarily add a layer to the hierarchy (identified with displayName) until their functionality
+// can be absorbed into their respective OUFR components.
 export const Icon: ISlottableComponentType<IIconProps> = props => (props.iconName ? <FabricIcon {...props} /> : null);
+Icon.displayName = 'Icon';
 Icon.create = createFactory(Icon, { defaultProp: 'iconName' });
 
 export const Label: ISlottableComponentType<ILabelProps> = props =>
   React.Children.count(props.children) > 0 ? <FabricLabel {...props} /> : null;
+Label.displayName = 'Label';
 Label.create = createFactory(Label);
 
 export const PersonaPresence: ISlottableComponentType<IPersonaPresenceProps> =
   // TODO: This is a bug in PersonaPresence that needs to be fixed. 'presence' prop comment mentions that it won't render
   //        if presence is undefined, but it does render. Check for undefined here for now.
   props => (props.presence !== undefined ? <FabricPersonaPresence {...props} /> : null);
+PersonaPresence.displayName = 'PersonaPresence';
 PersonaPresence.create = createFactory(PersonaPresence, { defaultProp: 'presence' });

--- a/packages/foundation/src/IComponent.ts
+++ b/packages/foundation/src/IComponent.ts
@@ -9,6 +9,11 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 //        Existing issue: https://github.com/Microsoft/TypeScript/issues/241
 
 /**
+ * Helper interface for accessing user props children.
+ */
+export type IPropsWithChildren<TProps> = TProps & { children?: React.ReactNode };
+
+/**
  * Helper type defining style sections, one for each component slot.
  */
 export type IComponentStyles<TSlots> = { [key in keyof TSlots]?: IStyle };
@@ -76,7 +81,7 @@ export type ICustomizationProps<TViewProps, TTokens, TStyleSet extends IStyleSet
  * Enforce props contract on state components, including the view prop and its shape.
  */
 export type IStateComponentProps<TComponentProps, TViewProps> = TComponentProps & {
-  renderView: React.StatelessComponent<TViewProps>;
+  renderView: IViewRenderer<TViewProps>;
 };
 
 /**
@@ -84,6 +89,16 @@ export type IStateComponentProps<TComponentProps, TViewProps> = TComponentProps 
  * prop that the StateComponent should make use of in its render output (and should be its only render output.)
  */
 export type IStateComponentType<TComponentProps, TViewProps> = React.ComponentType<IStateComponentProps<TComponentProps, TViewProps>>;
+
+/**
+ * Defines a view component.
+ */
+export type IViewComponent<TViewProps> = (props: IPropsWithChildren<TViewProps>) => JSX.Element | null;
+
+/**
+ * Handles rendering view component.
+ */
+export type IViewRenderer<TViewProps> = (props?: TViewProps) => JSX.Element | null;
 
 /**
  * Component used by foundation to tie elements together.
@@ -105,7 +120,7 @@ export interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSe
   /**
    * React view component.
    */
-  view: React.ComponentType<TViewProps>;
+  view: IViewComponent<TViewProps>;
   /**
    * Optional state component that processes TComponentProps into TViewProps.
    */
@@ -118,4 +133,18 @@ export interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSe
    * Tokens prop to pass into component.
    */
   tokens?: ITokenFunctionOrObject<TViewProps, TTokens>;
+  /**
+   * Default prop for which to map primitive values.
+   */
+  factoryOptions?: IFactoryOptions<TComponentProps>;
+}
+
+/**
+ * Factory options for creating component.
+ */
+export interface IFactoryOptions<TProps> {
+  /**
+   * Default prop for which to map primitive values.
+   */
+  defaultProp?: keyof TProps | 'children';
 }

--- a/packages/foundation/src/ISlots.ts
+++ b/packages/foundation/src/ISlots.ts
@@ -1,5 +1,5 @@
 import { IStyle } from '@uifabric/styling';
-import { IComponentStyles } from './IComponent';
+import { IComponentStyles, IPropsWithChildren } from './IComponent';
 
 /**
  * Signature of components that have component factories.
@@ -24,19 +24,6 @@ export type ISlottableReactType<TProps> = React.ReactType<TProps> & ISlotCreator
 export interface IProcessedSlotProps {
   className?: string;
 }
-
-/**
- * Factory options for creating component.
- */
-export interface IFactoryOptions<TProps> {
-  /** Default prop for which to map primitive values. */
-  defaultProp: keyof TProps | 'children';
-}
-
-/**
- * Helper interface for accessing user props children.
- */
-export type IPropsWithChildren<TProps> = TProps & { children?: React.ReactNode };
 
 /**
  * An interface for defining slots. Each key in TSlot must point to an ISlottableType.

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { concatStyleSets, IStyleSet, ITheme } from '@uifabric/styling';
 import { Customizations, CustomizerContext, ICustomizerContext } from '@uifabric/utilities';
+import { createFactory } from './slots';
 import { assign } from './utilities';
 
-import { IComponent, ICustomizationProps, IStyleableComponentProps, IStylesFunctionOrObject, IToken } from './IComponent';
-import { IDefaultSlotProps } from './ISlots';
+import { IComponent, ICustomizationProps, IStyleableComponentProps, IStylesFunctionOrObject, IToken, IViewRenderer } from './IComponent';
+import { IDefaultSlotProps, ISlotCreator } from './ISlots';
 
 /**
  * Assembles a higher order component based on the following: styles, theme, view, and state.
@@ -35,6 +36,9 @@ export function createComponent<
   TViewProps = TComponentProps,
   TStatics = {}
 >(component: IComponent<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React.StatelessComponent<TComponentProps> & TStatics {
+  const { factoryOptions = {} } = component;
+  const { defaultProp } = factoryOptions;
+
   const result: React.StatelessComponent<TComponentProps> = (componentProps: TComponentProps) => {
     return (
       // TODO: createComponent is also affected by https://github.com/OfficeDev/office-ui-fabric-react/issues/6603
@@ -54,7 +58,7 @@ export function createComponent<
             component.fields
           );
 
-          const renderView = (viewProps?: TViewProps & IStyleableComponentProps<TViewProps, TTokens, TStyleSet>) => {
+          const renderView: IViewRenderer<TViewProps> = viewProps => {
             // The approach here is to allow state components to provide only the props they care about, automatically
             //    merging user props and state props together. This ensures all props are passed properly to view,
             //    including children and styles.
@@ -77,7 +81,7 @@ export function createComponent<
               _defaultStyles: styles
             };
 
-            return <component.view {...viewComponentProps} />;
+            return component.view(viewComponentProps);
           };
           return component.state ? <component.state {...componentProps} renderView={renderView} /> : renderView();
         }}
@@ -86,6 +90,11 @@ export function createComponent<
   };
 
   result.displayName = component.displayName;
+
+  // If a shorthand prop is defined, create a factory for the component.
+  if (defaultProp) {
+    (result as ISlotCreator<TComponentProps>).create = createFactory(result, { defaultProp });
+  }
 
   assign(result, component.statics);
 

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -92,6 +92,8 @@ export function createComponent<
   result.displayName = component.displayName;
 
   // If a shorthand prop is defined, create a factory for the component.
+  // TODO: This shouldn't be a concern of createComponent.. factoryOptions should just be forwarded.
+  //       Need to weigh creating default factories on component creation vs. memozing them on use in slots.tsx.
   if (defaultProp) {
     (result as ISlotCreator<TComponentProps>).create = createFactory(result, { defaultProp });
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7012
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR addresses the following issues with fixes:
* There should be no need for components to explicitly call `createFactory`. Their only concern is defining a shorthand `defaultProp`.
    * Absorb `createFactory` call inside of `createComponent`. Add new `factoryOptions` arg to `createComponent` options bag.
* `Unknowns` and `view` layers are appearing in React hierarchy.
    * View components were being instantiated using JSX (triggering a call to `React.createElement`), which caused them to appear in the hierarchy. They are now evaluated as functions with typings changed to more clearly indicate they shouldn't be used as React components going forward.
    * Some `Unknowns` are actually factory component wrappers that we need to short circuit render output for slots. They are needed for now, but this PR names them and adds comments explaining the rationale.

#### Before:
![unknownbefore](https://user-images.githubusercontent.com/26070760/52144958-94410000-2614-11e9-9faf-c94f26fa56b7.png)

#### After:
![unknownafter](https://user-images.githubusercontent.com/26070760/52144963-96a35a00-2614-11e9-9968-8aaa5356c911.png)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7876)