### PR TITLE
Use React.ComponentType in picker for render props 

### DIFF
--- a/common/changes/office-ui-fabric-react/picker-use-componenttype_2019-02-01-20-17.json
+++ b/common/changes/office-ui-fabric-react/picker-use-componenttype_2019-02-01-20-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Use React.ComponentType in ExtendedPeoplePicker for render props",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -198,9 +198,9 @@ class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extends BaseC
   // (undocumented)
   render(): JSX.Element;
   // (undocumented)
-  protected renderSelectedItemsList(): JSX.Element;
+  protected renderFloatingPicker(): JSX.Element;
   // (undocumented)
-  protected renderSuggestions(): JSX.Element;
+  protected renderSelectedItemsList(): JSX.Element;
   // (undocumented)
   protected root: React.RefObject<HTMLDivElement>;
   // (undocumented)
@@ -1782,8 +1782,8 @@ interface IBaseExtendedPickerProps<T> {
   onItemSelected?: (selectedItem?: T) => T | PromiseLike<T>;
   onItemsRemoved?: (removedItems: T[]) => void;
   onPaste?: (pastedText: string) => T[];
-  onRenderFloatingPicker: (props: IBaseFloatingPickerProps<T>) => JSX.Element;
-  onRenderSelectedItems: (props: IBaseSelectedItemsListProps<T>) => JSX.Element;
+  onRenderFloatingPicker: React.ComponentType<IBaseFloatingPickerProps<T>>;
+  onRenderSelectedItems: React.ComponentType<IBaseSelectedItemsListProps<T>>;
   selectedItems?: T[];
   selectedItemsListProps: IBaseSelectedItemsListProps<T>;
   suggestionItems?: T[];
@@ -10054,7 +10054,7 @@ interface ISelectedPeopleProps extends IBaseSelectedItemsListProps<IExtendedPers
   // (undocumented)
   onExpandGroup?: (item: IExtendedPersonaProps) => void;
   // (undocumented)
-  onRenderFloatingPicker?: (props: IBaseFloatingPickerProps<IPersonaProps>) => JSX.Element;
+  onRenderFloatingPicker?: React.ComponentType<IBaseFloatingPickerProps<IPersonaProps>>;
   // (undocumented)
   removeMenuItemText?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -150,7 +150,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
   }
 
   protected renderFloatingPicker(): JSX.Element {
-    const FloatingPicker = this.props.onRenderFloatingPicker;
+    const FloatingPicker: React.ComponentType<IBaseFloatingPickerProps<T>> = this.props.onRenderFloatingPicker;
     return (
       <FloatingPicker
         componentRef={this.floatingPicker}
@@ -164,7 +164,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
   }
 
   protected renderSelectedItemsList(): JSX.Element {
-    const SelectedItems = this.props.onRenderSelectedItems;
+    const SelectedItems: React.ComponentType<IBaseSelectedItemsListProps<T>> = this.props.onRenderSelectedItems;
     return (
       <SelectedItems
         componentRef={this.selectedItemsList}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -135,7 +135,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
             </div>
           </SelectionZone>
         </FocusZone>
-        {this.renderSuggestions()}
+        {this.renderFloatingPicker()}
       </div>
     );
   }
@@ -149,27 +149,31 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
     return itemLimit === undefined || this.items.length < itemLimit;
   }
 
-  protected renderSuggestions(): JSX.Element {
-    const onRenderFloatingPicker = this.props.onRenderFloatingPicker;
-    return onRenderFloatingPicker({
-      componentRef: this.floatingPicker,
-      onChange: this._onSuggestionSelected,
-      inputElement: this.input.current ? this.input.current.inputElement : undefined,
-      selectedItems: this.items,
-      suggestionItems: this.props.suggestionItems ? this.props.suggestionItems : undefined,
-      ...this.floatingPickerProps
-    });
+  protected renderFloatingPicker(): JSX.Element {
+    const FloatingPicker = this.props.onRenderFloatingPicker;
+    return (
+      <FloatingPicker
+        componentRef={this.floatingPicker}
+        onChange={this._onSuggestionSelected}
+        inputElement={this.input.current ? this.input.current.inputElement : undefined}
+        selectedItems={this.items}
+        suggestionItems={this.props.suggestionItems ? this.props.suggestionItems : undefined}
+        {...this.floatingPickerProps}
+      />
+    );
   }
 
   protected renderSelectedItemsList(): JSX.Element {
-    const onRenderSelectedItems = this.props.onRenderSelectedItems;
-    return onRenderSelectedItems({
-      componentRef: this.selectedItemsList,
-      selection: this.selection,
-      selectedItems: this.props.selectedItems ? this.props.selectedItems : undefined,
-      onItemsDeleted: this.props.selectedItems ? this.props.onItemsRemoved : undefined,
-      ...this.selectedItemsListProps
-    });
+    const SelectedItems = this.props.onRenderSelectedItems;
+    return (
+      <SelectedItems
+        componentRef={this.selectedItemsList}
+        selection={this.selection}
+        selectedItems={this.props.selectedItems ? this.props.selectedItems : undefined}
+        onItemsDeleted={this.props.selectedItems ? this.props.onItemsRemoved : undefined}
+        {...this.selectedItemsListProps}
+      />
+    );
   }
 
   protected onInputChange = (value: string): void => {

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -62,12 +62,12 @@ export interface IBaseExtendedPickerProps<T> {
   /**
    * Function that specifies how the floating picker will appear.
    */
-  onRenderFloatingPicker: (props: IBaseFloatingPickerProps<T>) => JSX.Element;
+  onRenderFloatingPicker: React.ComponentType<IBaseFloatingPickerProps<T>>;
 
   /**
    * Function that specifies how the floating picker will appear.
    */
-  onRenderSelectedItems: (props: IBaseSelectedItemsListProps<T>) => JSX.Element;
+  onRenderSelectedItems: React.ComponentType<IBaseSelectedItemsListProps<T>>;
 
   /**
    * Floating picker properties

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.doc.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import { ExtendedPeoplePickerTypesExample } from '../examples/ExtendedPeoplePicker.Basic.Example';
+import { ExtendedPeoplePickerBasicExample } from '../examples/ExtendedPeoplePicker.Basic.Example';
+import { ExtendedPeoplePickerUncontrolledExample } from '../examples/ExtendedPeoplePicker.Uncontrolled.Example';
+import { ExtendedPeoplePickerControlledExample } from '../examples/ExtendedPeoplePicker.Controlled.Example';
 
 import { IDocPageProps } from '../../../common/DocPage.types';
 
 const ExtendedPeoplePickerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx') as string;
+const ExtendedPeoplePickerUncontrolledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Uncontrolled.Example.tsx') as string;
+const ExtendedPeoplePickerControlledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Controlled.Example.tsx') as string;
+
 export const ExtendedPeoplePickerPageProps: IDocPageProps = {
   title: 'ExtendedPeoplePicker',
   componentName: 'ExtendedPeoplePicker',
@@ -13,7 +18,17 @@ export const ExtendedPeoplePickerPageProps: IDocPageProps = {
     {
       title: 'Extended People Picker',
       code: ExtendedPeoplePickerBasicExampleCode,
-      view: <ExtendedPeoplePickerTypesExample />
+      view: <ExtendedPeoplePickerBasicExample />
+    },
+    {
+      title: 'Extended People Picker (Uncontrolled)',
+      code: ExtendedPeoplePickerUncontrolledExampleCode,
+      view: <ExtendedPeoplePickerUncontrolledExample />
+    },
+    {
+      title: 'Extended People Picker (Controlled)',
+      code: ExtendedPeoplePickerControlledExampleCode,
+      view: <ExtendedPeoplePickerControlledExample />
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.doc.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
 import { ExtendedPeoplePickerBasicExample } from '../examples/ExtendedPeoplePicker.Basic.Example';
-import { ExtendedPeoplePickerUncontrolledExample } from '../examples/ExtendedPeoplePicker.Uncontrolled.Example';
-import { ExtendedPeoplePickerControlledExample } from '../examples/ExtendedPeoplePicker.Controlled.Example';
 
 import { IDocPageProps } from '../../../common/DocPage.types';
 
 const ExtendedPeoplePickerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx') as string;
-const ExtendedPeoplePickerUncontrolledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Uncontrolled.Example.tsx') as string;
-const ExtendedPeoplePickerControlledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Controlled.Example.tsx') as string;
-
 export const ExtendedPeoplePickerPageProps: IDocPageProps = {
   title: 'ExtendedPeoplePicker',
   componentName: 'ExtendedPeoplePicker',
@@ -19,16 +14,6 @@ export const ExtendedPeoplePickerPageProps: IDocPageProps = {
       title: 'Extended People Picker',
       code: ExtendedPeoplePickerBasicExampleCode,
       view: <ExtendedPeoplePickerBasicExample />
-    },
-    {
-      title: 'Extended People Picker (Uncontrolled)',
-      code: ExtendedPeoplePickerUncontrolledExampleCode,
-      view: <ExtendedPeoplePickerUncontrolledExample />
-    },
-    {
-      title: 'Extended People Picker (Controlled)',
-      code: ExtendedPeoplePickerControlledExampleCode,
-      view: <ExtendedPeoplePickerControlledExample />
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/examples/ExtendedPeoplePicker.Basic.Example.tsx
@@ -9,12 +9,7 @@ import {
   IBaseFloatingPickerProps,
   IBaseFloatingPickerSuggestionProps
 } from 'office-ui-fabric-react/lib/FloatingPicker';
-import {
-  IBaseSelectedItemsListProps,
-  ISelectedPeopleProps,
-  SelectedPeopleList,
-  IExtendedPersonaProps
-} from 'office-ui-fabric-react/lib/SelectedItemsList';
+import { ISelectedPeopleProps, SelectedPeopleList, IExtendedPersonaProps } from 'office-ui-fabric-react/lib/SelectedItemsList';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { IFocusZoneProps, FocusZoneTabbableElements } from 'office-ui-fabric-react/lib/FocusZone';
 // Helper imports to generate data for this particular examples. Not exported by any package.
@@ -33,7 +28,7 @@ export interface IPeoplePickerExampleState {
   controlledComponent: boolean;
 }
 
-export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeoplePickerExampleState> {
+export class ExtendedPeoplePickerBasicExample extends React.Component<{}, IPeoplePickerExampleState> {
   private _picker: ExtendedPeoplePicker;
   private _floatingPickerProps: IBaseFloatingPickerProps<IPersonaProps>;
   private _selectedItemsListProps: ISelectedPeopleProps;
@@ -138,7 +133,7 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
       copyMenuItemText: 'Copy name',
       editMenuItemText: 'Edit',
       getEditingItemText: this._getEditingItemText,
-      onRenderFloatingPicker: this._onRenderFloatingPicker,
+      onRenderFloatingPicker: FloatingPeoplePicker,
       floatingPickerProps: this._floatingPickerProps
     };
 
@@ -167,8 +162,8 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
         onItemsRemoved={this.state.controlledComponent ? this._onItemsRemoved : undefined}
         floatingPickerProps={this._floatingPickerProps}
         selectedItemsListProps={this._selectedItemsListProps}
-        onRenderFloatingPicker={this._onRenderFloatingPicker}
-        onRenderSelectedItems={this._onRenderSelectedItems}
+        onRenderFloatingPicker={FloatingPeoplePicker}
+        onRenderSelectedItems={SelectedPeopleList}
         className={'ms-PeoplePicker'}
         key={'normal'}
         inputProps={{
@@ -189,14 +184,6 @@ export class ExtendedPeoplePickerTypesExample extends React.Component<{}, IPeopl
 
   private _renderHeader(): JSX.Element {
     return <div data-is-focusable={true}>TO:</div>;
-  }
-
-  private _onRenderFloatingPicker(props: IBaseFloatingPickerProps<IPersonaProps>): JSX.Element {
-    return <FloatingPeoplePicker {...props} />;
-  }
-
-  private _onRenderSelectedItems(props: IBaseSelectedItemsListProps<IExtendedPersonaProps>): JSX.Element {
-    return <SelectedPeopleList {...props} />;
   }
 
   private _getEditingItemText(item: IExtendedPersonaProps): string {

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
@@ -16,7 +16,7 @@ const styles: any = stylesImport;
 export interface IEditingSelectedPeopleItemProps extends ISelectedPeopleItemProps {
   // tslint:disable-next-line:no-any
   onEditingComplete: (oldItem: any, newItem: any) => void;
-  onRenderFloatingPicker?: (props: IBaseFloatingPickerProps<IPersonaProps>) => JSX.Element;
+  onRenderFloatingPicker?: React.ComponentType<IBaseFloatingPickerProps<IPersonaProps>>;
   floatingPickerProps?: IBaseFloatingPickerProps<IPersonaProps>;
   getEditingItemText?: (item: IExtendedPersonaProps) => string;
 }

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -31,7 +31,7 @@ export interface ISelectedPeopleProps extends IBaseSelectedItemsListProps<IExten
   copyMenuItemText?: string;
   editMenuItemText?: string;
   getEditingItemText?: (item: IExtendedPersonaProps) => string;
-  onRenderFloatingPicker?: (props: IBaseFloatingPickerProps<IPersonaProps>) => JSX.Element;
+  onRenderFloatingPicker?: React.ComponentType<IBaseFloatingPickerProps<IPersonaProps>>;
   floatingPickerProps?: IBaseFloatingPickerProps<IPersonaProps>;
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Addresses some of the concerns raised in the conversation in #7871 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

in the picker, we're using React.ComponentType in a number of places
to basically just wrap a component render.

This change expands the definitions of the render props to
ComponentType, so the consumer can just pass in the relevant
ComponentClass instead of defining a pass-through render prop.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7877)