### PR TITLE
Add check for isTabIndexSet if role=button in isElementTabbable

### DIFF
--- a/common/changes/@uifabric/utilities/edwl-2019-02-fixIsElementTabbable_2019-02-01-23-20.json
+++ b/common/changes/@uifabric/utilities/edwl-2019-02-fixIsElementTabbable_2019-02-01-23-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Add check for tabIndex in isElementTabbable if role=button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/utilities/src/focus.test.tsx
+++ b/packages/utilities/src/focus.test.tsx
@@ -101,12 +101,12 @@ describe('isElementTabbable', () => {
     expect(isElementTabbable(div)).toEqual(true);
   });
 
-  it('returns true with role=button divs', () => {
+  it('returns false with role=button divs', () => {
     let div = document.createElement('div');
 
     div.setAttribute('role', 'button');
 
-    expect(isElementTabbable(div)).toEqual(true);
+    expect(isElementTabbable(div)).toEqual(false);
   });
 
   it('returns false with role=button disabled buttons', () => {

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -386,7 +386,7 @@ export function isElementTabbable(element: HTMLElement, checkTabIndex?: boolean)
       element.tagName === 'TEXTAREA' ||
       isFocusableAttribute === 'true' ||
       isTabIndexSet ||
-      (element.getAttribute && element.getAttribute('role') === 'button'));
+      (element.getAttribute && element.getAttribute('role') === 'button' && isTabIndexSet));
 
   return checkTabIndex ? tabIndex !== -1 && result : result;
 }

--- a/packages/utilities/src/focus.ts
+++ b/packages/utilities/src/focus.ts
@@ -385,8 +385,7 @@ export function isElementTabbable(element: HTMLElement, checkTabIndex?: boolean)
       element.tagName === 'INPUT' ||
       element.tagName === 'TEXTAREA' ||
       isFocusableAttribute === 'true' ||
-      isTabIndexSet ||
-      (element.getAttribute && element.getAttribute('role') === 'button' && isTabIndexSet));
+      isTabIndexSet);
 
   return checkTabIndex ? tabIndex !== -1 && result : result;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7789
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds check for tabIndex if element role=button inside of `isElementTabbable`

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7880)