### PR TITLE
Breadcrumb: Remove the maximum width from items

### DIFF
--- a/common/changes/office-ui-fabric-react/miwhea-breadcrumb-remove-max-width_2019-02-01-23-32.json
+++ b/common/changes/office-ui-fabric-react/miwhea-breadcrumb-remove-max-width_2019-02-01-23-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove maximum width from Breadcrumb items",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.styles.ts
@@ -23,8 +23,6 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
   const { className, theme } = props;
 
   const overflowButtonFontSize = 16;
-  const itemMaxWidth = 160;
-  const itemMaxWidthSmall = 116;
   const chevronSmallFontSize = 8;
 
   return {
@@ -128,7 +126,6 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
         textDecoration: 'none',
         color: theme.semanticColors.bodyText,
         padding: '0 8px',
-        maxWidth: itemMaxWidth,
 
         selectors: {
           ':hover': {
@@ -149,12 +146,7 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
             color: theme.palette.neutralPrimary
           },
           [MediumScreenSelector]: theme.fonts.large,
-          [MinimumScreenSelector]: [
-            theme.fonts.medium,
-            {
-              maxWidth: itemMaxWidthSmall
-            }
-          ],
+          [MinimumScreenSelector]: [theme.fonts.medium],
           [`.${IsFocusVisibleClassName} &:focus`]: {
             outline: `none`
           }
@@ -167,7 +159,6 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
       {
         color: theme.semanticColors.bodyText,
         padding: '0 8px',
-        maxWidth: itemMaxWidth,
 
         selectors: {
           ':hover': {

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -169,7 +168,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -251,7 +249,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -333,7 +330,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -630,7 +626,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -712,7 +707,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -832,7 +826,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -888,7 +881,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -944,7 +936,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -1000,7 +991,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -1120,7 +1110,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -1379,7 +1368,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;
@@ -1499,7 +1487,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 5 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 21px;
                       font-weight: 100;
-                      max-width: 160px;
                       padding-bottom: 0;
                       padding-left: 8px;
                       padding-right: 8px;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -18,10 +18,10 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
           items={[
             { text: 'Files', key: 'Files', onClick: this._onBreadcrumbItemClicked },
             { text: 'This is folder 1', key: 'f1', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 2', key: 'f2', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 3', key: 'f3', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 2 with a long name', key: 'f2', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 3 long', key: 'f3', onClick: this._onBreadcrumbItemClicked },
             { text: 'This is folder 4', key: 'f4', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 5', key: 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true }
+            { text: 'This is folder 5 another', key: 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true }
           ]}
           ariaLabel={'Breadcrumb with no maxDisplayedItems'}
         />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -535,7 +535,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    This is folder 2
+                    This is folder 2 with a long name
                   </div>
                 </button>
                 <i
@@ -695,7 +695,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    This is folder 3
+                    This is folder 3 long
                   </div>
                 </button>
                 <i
@@ -1016,7 +1016,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    This is folder 5
+                    This is folder 5 another
                   </div>
                 </button>
               </li>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -127,7 +127,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -201,7 +200,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -289,7 +287,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -363,7 +360,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -451,7 +447,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -525,7 +520,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -613,7 +607,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -687,7 +680,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -775,7 +767,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -849,7 +840,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -938,7 +928,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1012,7 +1001,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1168,7 +1156,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1242,7 +1229,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1322,7 +1308,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1396,7 +1381,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1476,7 +1460,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1550,7 +1533,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1630,7 +1612,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1704,7 +1685,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1784,7 +1764,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1858,7 +1837,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1939,7 +1917,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -2013,7 +1990,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -2337,7 +2313,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 21px;
                         font-weight: 100;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -2400,7 +2375,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   href="#/examples/breadcrumb"
                   onClick={[Function]}
@@ -2478,7 +2452,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 21px;
                         font-weight: 100;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -2541,7 +2514,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   href="#/examples/breadcrumb"
                   onClick={[Function]}
@@ -2620,7 +2592,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 21px;
                         font-weight: 100;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -2683,7 +2654,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   href="#/examples/breadcrumb"
                   onClick={[Function]}
@@ -2828,7 +2798,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 21px;
                         font-weight: 100;
-                        max-width: 160px;
                         padding-bottom: 0;
                         padding-left: 8px;
                         padding-right: 8px;
@@ -3088,7 +3057,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 21px;
                         font-weight: 100;
-                        max-width: 160px;
                         padding-bottom: 0;
                         padding-left: 8px;
                         padding-right: 8px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -284,7 +284,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -358,7 +357,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -446,7 +444,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -520,7 +517,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"
@@ -609,7 +605,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        max-width: 160px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -683,7 +678,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 14px;
                         font-weight: 400;
-                        max-width: 116px;
                       }
                   onClick={[Function]}
                   type="button"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7725
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Breadcrumb had a maximum width for each item, after which it would be truncated with an ellipsis. This was carried over from a previous implementation where we didn't have `OverflowSet` to determine when to place items into the overflow menu. We had to keep the width limited to ensure the component never got too wide, but this also meant we frequently didn't make full use of the available space.

This PR removes the maximum width, allowing the Breadcrumb to fit as many full items into the available space as possible.

### Before (background added to show component size)
![screen shot 2019-02-01 at 3 30 49 pm](https://user-images.githubusercontent.com/1382445/52155352-235f0f80-2637-11e9-98ea-d27ff7f4f005.png)

### After (background added to show component size)
![screen shot 2019-02-01 at 3 31 55 pm](https://user-images.githubusercontent.com/1382445/52155334-0de9e580-2637-11e9-97a6-dc6bb40546e8.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7881)