### PR TITLE
Callouts: Fixing the implementation of the hidden prop wrt to focus, bounds and unnecessary mounts

### DIFF
--- a/common/changes/office-ui-fabric-react/kushaly-CalloutHidden_2019-02-01-22-48.json
+++ b/common/changes/office-ui-fabric-react/kushaly-CalloutHidden_2019-02-01-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing the implementation of the hidden prop wrt to focus, bounds and unnecessary mounts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -102,7 +102,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       getClassNames
     } = this.props;
 
-    const { menuProps } = this.state;
     // Button is disabled if the whole button (in case of splitbutton is disabled) or if the primary action is disabled
     const isPrimaryButtonDisabled = disabled || primaryDisabled;
 
@@ -115,7 +114,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           menuIconProps && menuIconProps.className,
           isPrimaryButtonDisabled!,
           checked!,
-          !!menuProps,
+          this._isMenuExpanded(),
           this.props.split,
           !!allowDisabledFocus
         )
@@ -128,7 +127,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           menuIconProps && menuIconProps.className,
           isPrimaryButtonDisabled!,
           checked!,
-          !!menuProps,
+          this._isMenuExpanded(),
           this.props.split
         );
 
@@ -357,6 +356,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     // before the refactor that introduced this function. _onRenderTextContents does not require props.text to be undefined in order
     // for props.children to be used as a fallback. Purely a code maintainability/reuse issue, but logged as Issue #4979
     return this.props.text !== null && (this.props.text !== undefined || typeof this.props.children === 'string');
+  }
+
+  private _isMenuExpanded(): boolean {
+    const { menuProps } = this.state;
+    return !!menuProps && !menuProps.hidden;
   }
 
   private _onRenderChildren = (): JSX.Element | null => {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -420,6 +420,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         {...menuProps}
         shouldFocusOnContainer={this.state.menuProps ? this.state.menuProps.shouldFocusOnContainer : undefined}
         shouldFocusOnMount={this.state.menuProps ? this.state.menuProps.shouldFocusOnMount : undefined}
+        hidden={this.state.menuProps ? this.state.menuProps.hidden : undefined}
         className={css('ms-BaseButton-menuhost', menuProps.className)}
         target={this._isSplitButton ? this._splitButtonContainer.current : this._buttonElement.current}
         onDismiss={onDismiss}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -65,7 +65,7 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
   private _hostElement = React.createRef<HTMLDivElement>();
   private _calloutElement = React.createRef<HTMLDivElement>();
   private _targetWindow: Window;
-  private _bounds: IRectangle;
+  private _bounds: IRectangle | undefined;
   private _positionAttempts: number;
   private _target: Element | MouseEvent | IPoint | null;
   private _setHeightOffsetTimer: number;
@@ -88,8 +88,8 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
   }
 
   public componentDidUpdate() {
-    this._setInitialFocus();
     if (!this.props.hidden) {
+      this._setInitialFocus();
       if (!this._hasListeners) {
         this._addListeners();
       }
@@ -122,11 +122,13 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
       this._setHeightOffsetEveryFrame();
     }
 
-    // if the callout becomes hidden, then remove any positions that were placed on it.
+    // if the callout becomes hidden, then remove any positions, bounds that were placed on it.
     if (newProps.hidden && newProps.hidden !== this.props.hidden) {
       this.setState({
         positions: undefined
       });
+      this._didSetInitialFocus = false;
+      this._bounds = undefined;
     }
 
     this._blockResetHeight = false;
@@ -203,21 +205,19 @@ export class CalloutContentBase extends BaseComponent<ICalloutProps, ICalloutSta
         >
           {beakVisible && <div className={this._classNames.beak} style={this._getBeakPosition()} />}
           {beakVisible && <div className={this._classNames.beakCurtain} />}
-          {!this.props.hidden && (
-            <Popup
-              role={role}
-              ariaLabel={ariaLabel}
-              ariaDescribedBy={ariaDescribedBy}
-              ariaLabelledBy={ariaLabelledBy}
-              className={this._classNames.calloutMain}
-              onDismiss={this.dismiss}
-              onScroll={onScroll}
-              shouldRestoreFocus={true}
-              style={overflowStyle}
-            >
-              {children}
-            </Popup>
-          )}
+          <Popup
+            role={role}
+            ariaLabel={ariaLabel}
+            ariaDescribedBy={ariaDescribedBy}
+            ariaLabelledBy={ariaLabelledBy}
+            className={this._classNames.calloutMain}
+            onDismiss={this.dismiss}
+            onScroll={onScroll}
+            shouldRestoreFocus={true}
+            style={overflowStyle}
+          >
+            {children}
+          </Popup>
         </div>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
@@ -16,8 +16,10 @@ import { ContextualMenuWithScrollBarExample } from './examples/ContextualMenu.Sc
 import { ContextualMenuWithCustomMenuItemExample } from './examples/ContextualMenu.CustomMenuItem.Example';
 import { ContextualMenuWithCustomMenuListExample } from './examples/ContextualMenu.CustomMenuList.Example';
 import { ContextualMenuHeaderExample } from './examples/ContextualMenu.Header.Example';
+import { ContextualMenuPersistedExample } from './examples/ContextualMenu.Persisted.Example';
 
 const ContextualMenuBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx') as string;
+const ContextualMenuPersistedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Persisted.Example.tsx') as string;
 const ContextualMenuBasicExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/ContextualMenu/ContextualMenu.Basic.Example.Codepen.txt') as string;
 const ContextualMenuIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx') as string;
 const ContextualMenuIconSecondaryTextExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx') as string;
@@ -44,6 +46,11 @@ export const ContextualMenuPageProps: IDocPageProps = {
       code: ContextualMenuBasicExampleCode,
       view: <ContextualMenuBasicExample />,
       codepenJS: ContextualMenuBasicExampleCodepen
+    },
+    {
+      title: 'ContextualMenu which is persisted in the DOM',
+      code: ContextualMenuPersistedExampleCode,
+      view: <ContextualMenuPersistedExample />
     },
     {
       title: 'ContextualMenu with icons',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Persisted.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Persisted.Example.tsx
@@ -1,0 +1,83 @@
+// @codepen
+import * as React from 'react';
+import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import './ContextualMenuExample.scss';
+
+export class ContextualMenuPersistedExample extends React.Component {
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      showCallout: false
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <DefaultButton
+          id="ContextualMenuPersistedExample"
+          text="Click for ContextualMenu"
+          persistMenu={true}
+          menuProps={{
+            shouldFocusOnMount: true,
+            shouldFocusOnContainer: true,
+            items: [
+              {
+                key: 'newItem',
+                text: 'New',
+                onClick: () => console.log('New clicked')
+              },
+              {
+                key: 'divider_1',
+                itemType: ContextualMenuItemType.Divider
+              },
+              {
+                key: 'rename',
+                text: 'Rename',
+                onClick: () => console.log('Rename clicked')
+              },
+              {
+                key: 'edit',
+                text: 'Edit',
+                onClick: () => console.log('Edit clicked')
+              },
+              {
+                key: 'properties',
+                text: 'Properties',
+                onClick: () => console.log('Properties clicked')
+              },
+              {
+                key: 'linkNoTarget',
+                text: 'Link same window',
+                href: 'http://bing.com'
+              },
+              {
+                key: 'linkWithTarget',
+                text: 'Link new window',
+                href: 'http://bing.com',
+                target: '_blank'
+              },
+              {
+                key: 'linkWithOnClick',
+                name: 'Link click',
+                href: 'http://bing.com',
+                onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+                  alert('Link clicked');
+                  ev.preventDefault();
+                },
+                target: '_blank'
+              },
+              {
+                key: 'disabled',
+                text: 'Disabled item',
+                disabled: true,
+                onClick: () => console.error('Disabled item should not be clickable.')
+              }
+            ]
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
@@ -233,7 +233,89 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
             }
           }
           tabIndex={-1}
-        />
+        >
+          <div
+            aria-describedby="callout-description-1"
+            aria-labelledby="callout-label-1"
+            className=
+                ms-Callout-main
+                {
+                  background-color: #ffffff;
+                  overflow-x: hidden;
+                  overflow-y: auto;
+                  position: relative;
+                }
+            onKeyDown={[Function]}
+            role="alertdialog"
+            style={
+              Object {
+                "maxHeight": 750,
+                "overflowY": undefined,
+              }
+            }
+            tabIndex={-1}
+          >
+            <div
+              className="ms-CalloutExample-header"
+            >
+              <p
+                className="ms-CalloutExample-title"
+                id="callout-label-1"
+              >
+                All of your favorite people
+              </p>
+            </div>
+            <div
+              className="ms-CalloutExample-inner"
+            >
+              <div
+                className="ms-CalloutExample-content"
+              >
+                <p
+                  className="ms-CalloutExample-subText"
+                  id="callout-description-1"
+                >
+                  Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
+                </p>
+              </div>
+              <div
+                className="ms-CalloutExample-actions"
+              >
+                <a
+                  className=
+                      ms-Link
+                      ms-CalloutExample-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #0078d4;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: inherit;
+                        font-weight: inherit;
+                        outline: none;
+                        text-decoration: none;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid #666666;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #0078d4;
+                      }
+                  href="http://microsoft.com"
+                  onClick={[Function]}
+                >
+                  Go to microsoft
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
@@ -1,0 +1,1378 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders ContextualMenu.Persisted.Example.tsx correctly 1`] = `
+<div>
+  <button
+    aria-expanded={false}
+    aria-haspopup={true}
+    aria-owns="id__0-menu"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+    data-is-focusable={true}
+    id="ContextualMenuPersistedExample"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Click for ContextualMenu
+        </div>
+      </div>
+      <i
+        className=
+            ms-Button-menuIcon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
+        data-icon-name="ChevronDown"
+        role="presentation"
+      >
+        
+      </i>
+      <span
+        className="ms-layer"
+      >
+        <div
+          className=
+              ms-Fabric
+              ms-Layer-content
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #333333;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                visibility: visible;
+              }
+              & button {
+                font-family: inherit;
+              }
+              & input {
+                font-family: inherit;
+              }
+              & textarea {
+                font-family: inherit;
+              }
+              button {
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow: visible;
+              }
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onDrag={[Function]}
+          onDragEnd={[Function]}
+          onDragEnter={[Function]}
+          onDragExit={[Function]}
+          onDragLeave={[Function]}
+          onDragOver={[Function]}
+          onDragStart={[Function]}
+          onDrop={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseMove={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+          onMouseUp={[Function]}
+          onSubmit={[Function]}
+        >
+          <div
+            className=
+                ms-Callout-container
+                {
+                  position: relative;
+                }
+            style={
+              Object {
+                "visibility": "hidden",
+              }
+            }
+          >
+            <div
+              className=
+                  ms-Callout
+                  ms-ContextualMenu-Callout
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-color: #eaeaea;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-shadow: 0 0 5px 0px rgba(0,0,0,0.4);
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    outline: transparent;
+                    position: absolute;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                    border-style: solid;
+                    border-width: 1px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0px;
+                  }
+              hidden={true}
+              onScroll={[Function]}
+              style={
+                Object {
+                  "filter": "opacity(0)",
+                  "opacity": 0,
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className=
+                    ms-Callout-main
+                    {
+                      background-color: #ffffff;
+                      overflow-x: hidden;
+                      overflow-y: auto;
+                      position: relative;
+                    }
+                onKeyDown={[Function]}
+                onScroll={[Function]}
+                style={
+                  Object {
+                    "maxHeight": 750,
+                    "overflowY": undefined,
+                  }
+                }
+                tabIndex={-1}
+              >
+                <div
+                  aria-labelledby="id__0"
+                  className=
+                      ms-ContextualMenu-container
+                      &:focus {
+                        outline: 0px;
+                      }
+                  id="id__0-menu"
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  role="menu"
+                  tabIndex={0}
+                >
+                  <div
+                    className=
+                        ms-FocusZone
+                        ms-ContextualMenu
+                        is-open
+                        ms-BaseButton-menuhost
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: #ffffff;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          min-width: 180px;
+                        }
+                    data-focuszone-id="FocusZone4"
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseDownCapture={[Function]}
+                    role="presentation"
+                  >
+                    <ul
+                      className=
+                          ms-ContextualMenu-list
+                          is-open
+                          {
+                            list-style-type: none;
+                            margin-bottom: 0;
+                            margin-left: 0;
+                            margin-right: 0;
+                            margin-top: 0;
+                            padding-bottom: 0;
+                            padding-left: 0;
+                            padding-right: 0;
+                            padding-top: 0;
+                          }
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      role="menu"
+                    >
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <button
+                          aria-disabled={false}
+                          aria-posinset={1}
+                          aria-setsize={8}
+                          className=
+                              ms-ContextualMenu-link
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                background-color: transparent;
+                                border: none;
+                                color: #333333;
+                                cursor: pointer;
+                                display: block;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                height: 32px;
+                                line-height: 32px;
+                                outline: transparent;
+                                padding-bottom: 0;
+                                padding-left: 4px;
+                                padding-right: 8px;
+                                padding-top: 0px;
+                                position: relative;
+                                text-align: left;
+                                width: 100%;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #666666;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              &:active {
+                                background-color: #eaeaea;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:active {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:hover {
+                                background: inherit;
+                              }
+                          onClick={[Function]}
+                          onKeyDown={null}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseMove={[Function]}
+                          role="menuitem"
+                        >
+                          <div
+                            className=
+                                ms-ContextualMenu-linkContent
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: inherit;
+                                  max-width: 100%;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span
+                              className=
+                                  ms-ContextualMenu-itemText
+                                  {
+                                    display: inline-block;
+                                    flex-grow: 1;
+                                    margin-bottom: 0;
+                                    margin-left: 4px;
+                                    margin-right: 4px;
+                                    margin-top: 0;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;
+                                    vertical-align: middle;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              New
+                            </span>
+                          </div>
+                        </button>
+                      </li>
+                      <li
+                        aria-hidden="true"
+                        className=
+                            ms-ContextualMenu-divider
+                            {
+                              background-color: #eaeaea;
+                              display: block;
+                              height: 1px;
+                              position: relative;
+                            }
+                        role="separator"
+                      />
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <button
+                          aria-disabled={false}
+                          aria-posinset={2}
+                          aria-setsize={8}
+                          className=
+                              ms-ContextualMenu-link
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                background-color: transparent;
+                                border: none;
+                                color: #333333;
+                                cursor: pointer;
+                                display: block;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                height: 32px;
+                                line-height: 32px;
+                                outline: transparent;
+                                padding-bottom: 0;
+                                padding-left: 4px;
+                                padding-right: 8px;
+                                padding-top: 0px;
+                                position: relative;
+                                text-align: left;
+                                width: 100%;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #666666;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              &:active {
+                                background-color: #eaeaea;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:active {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:hover {
+                                background: inherit;
+                              }
+                          onClick={[Function]}
+                          onKeyDown={null}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseMove={[Function]}
+                          role="menuitem"
+                        >
+                          <div
+                            className=
+                                ms-ContextualMenu-linkContent
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: inherit;
+                                  max-width: 100%;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span
+                              className=
+                                  ms-ContextualMenu-itemText
+                                  {
+                                    display: inline-block;
+                                    flex-grow: 1;
+                                    margin-bottom: 0;
+                                    margin-left: 4px;
+                                    margin-right: 4px;
+                                    margin-top: 0;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;
+                                    vertical-align: middle;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              Rename
+                            </span>
+                          </div>
+                        </button>
+                      </li>
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <button
+                          aria-disabled={false}
+                          aria-posinset={3}
+                          aria-setsize={8}
+                          className=
+                              ms-ContextualMenu-link
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                background-color: transparent;
+                                border: none;
+                                color: #333333;
+                                cursor: pointer;
+                                display: block;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                height: 32px;
+                                line-height: 32px;
+                                outline: transparent;
+                                padding-bottom: 0;
+                                padding-left: 4px;
+                                padding-right: 8px;
+                                padding-top: 0px;
+                                position: relative;
+                                text-align: left;
+                                width: 100%;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #666666;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              &:active {
+                                background-color: #eaeaea;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:active {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:hover {
+                                background: inherit;
+                              }
+                          onClick={[Function]}
+                          onKeyDown={null}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseMove={[Function]}
+                          role="menuitem"
+                        >
+                          <div
+                            className=
+                                ms-ContextualMenu-linkContent
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: inherit;
+                                  max-width: 100%;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span
+                              className=
+                                  ms-ContextualMenu-itemText
+                                  {
+                                    display: inline-block;
+                                    flex-grow: 1;
+                                    margin-bottom: 0;
+                                    margin-left: 4px;
+                                    margin-right: 4px;
+                                    margin-top: 0;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;
+                                    vertical-align: middle;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              Edit
+                            </span>
+                          </div>
+                        </button>
+                      </li>
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <button
+                          aria-disabled={false}
+                          aria-posinset={4}
+                          aria-setsize={8}
+                          className=
+                              ms-ContextualMenu-link
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                background-color: transparent;
+                                border: none;
+                                color: #333333;
+                                cursor: pointer;
+                                display: block;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                height: 32px;
+                                line-height: 32px;
+                                outline: transparent;
+                                padding-bottom: 0;
+                                padding-left: 4px;
+                                padding-right: 8px;
+                                padding-top: 0px;
+                                position: relative;
+                                text-align: left;
+                                width: 100%;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #666666;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              &:active {
+                                background-color: #eaeaea;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:active {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                background-color: #f4f4f4;
+                              }
+                              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                -ms-high-contrast-adjust: none;
+                                background-color: Highlight;
+                                border-color: Highlight;
+                                color: HighlightText;
+                              }
+                              .ms-Fabric--isFocusVisible &:hover {
+                                background: inherit;
+                              }
+                          onClick={[Function]}
+                          onKeyDown={null}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseMove={[Function]}
+                          role="menuitem"
+                        >
+                          <div
+                            className=
+                                ms-ContextualMenu-linkContent
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: inherit;
+                                  max-width: 100%;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span
+                              className=
+                                  ms-ContextualMenu-itemText
+                                  {
+                                    display: inline-block;
+                                    flex-grow: 1;
+                                    margin-bottom: 0;
+                                    margin-left: 4px;
+                                    margin-right: 4px;
+                                    margin-top: 0;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;
+                                    vertical-align: middle;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              Properties
+                            </span>
+                          </div>
+                        </button>
+                      </li>
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <div>
+                          <a
+                            aria-disabled={false}
+                            aria-posinset={5}
+                            aria-setsize={8}
+                            className=
+                                ms-ContextualMenu-link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  border: none;
+                                  box-sizing: border-box;
+                                  color: inherit;
+                                  cursor: pointer;
+                                  display: block;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 32px;
+                                  letter-spacing: normal;
+                                  line-height: 32px;
+                                  outline: transparent;
+                                  padding-bottom: 0;
+                                  padding-left: 4px;
+                                  padding-right: 8px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  text-align: left;
+                                  text-decoration: none;
+                                  text-indent: 0px;
+                                  text-rendering: auto;
+                                  text-shadow: none;
+                                  text-transform: none;
+                                  width: 100%;
+                                  word-spacing: normal;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #666666;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                &:active {
+                                  background-color: #eaeaea;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:hover {
+                                  background: inherit;
+                                }
+                            href="http://bing.com"
+                            onClick={[Function]}
+                            onKeyDown={null}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            role="menuitem"
+                          >
+                            <div
+                              className=
+                                  ms-ContextualMenu-linkContent
+                                  {
+                                    align-items: center;
+                                    display: flex;
+                                    height: inherit;
+                                    max-width: 100%;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span
+                                className=
+                                    ms-ContextualMenu-itemText
+                                    {
+                                      display: inline-block;
+                                      flex-grow: 1;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      overflow: hidden;
+                                      text-overflow: ellipsis;
+                                      vertical-align: middle;
+                                      white-space: nowrap;
+                                    }
+                              >
+                                Link same window
+                              </span>
+                            </div>
+                          </a>
+                        </div>
+                      </li>
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <div>
+                          <a
+                            aria-disabled={false}
+                            aria-posinset={6}
+                            aria-setsize={8}
+                            className=
+                                ms-ContextualMenu-link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  border: none;
+                                  box-sizing: border-box;
+                                  color: inherit;
+                                  cursor: pointer;
+                                  display: block;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 32px;
+                                  letter-spacing: normal;
+                                  line-height: 32px;
+                                  outline: transparent;
+                                  padding-bottom: 0;
+                                  padding-left: 4px;
+                                  padding-right: 8px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  text-align: left;
+                                  text-decoration: none;
+                                  text-indent: 0px;
+                                  text-rendering: auto;
+                                  text-shadow: none;
+                                  text-transform: none;
+                                  width: 100%;
+                                  word-spacing: normal;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #666666;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                &:active {
+                                  background-color: #eaeaea;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:hover {
+                                  background: inherit;
+                                }
+                            href="http://bing.com"
+                            onClick={[Function]}
+                            onKeyDown={null}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            rel="nofollow noopener noreferrer"
+                            role="menuitem"
+                            target="_blank"
+                          >
+                            <div
+                              className=
+                                  ms-ContextualMenu-linkContent
+                                  {
+                                    align-items: center;
+                                    display: flex;
+                                    height: inherit;
+                                    max-width: 100%;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span
+                                className=
+                                    ms-ContextualMenu-itemText
+                                    {
+                                      display: inline-block;
+                                      flex-grow: 1;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      overflow: hidden;
+                                      text-overflow: ellipsis;
+                                      vertical-align: middle;
+                                      white-space: nowrap;
+                                    }
+                              >
+                                Link new window
+                              </span>
+                            </div>
+                          </a>
+                        </div>
+                      </li>
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <div>
+                          <a
+                            aria-disabled={false}
+                            aria-posinset={7}
+                            aria-setsize={8}
+                            className=
+                                ms-ContextualMenu-link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  border: none;
+                                  box-sizing: border-box;
+                                  color: inherit;
+                                  cursor: pointer;
+                                  display: block;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 32px;
+                                  letter-spacing: normal;
+                                  line-height: 32px;
+                                  outline: transparent;
+                                  padding-bottom: 0;
+                                  padding-left: 4px;
+                                  padding-right: 8px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  text-align: left;
+                                  text-decoration: none;
+                                  text-indent: 0px;
+                                  text-rendering: auto;
+                                  text-shadow: none;
+                                  text-transform: none;
+                                  width: 100%;
+                                  word-spacing: normal;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #666666;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                &:active {
+                                  background-color: #eaeaea;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:hover {
+                                  background: inherit;
+                                }
+                            href="http://bing.com"
+                            name="Link click"
+                            onClick={[Function]}
+                            onKeyDown={null}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            rel="nofollow noopener noreferrer"
+                            role="menuitem"
+                            target="_blank"
+                          >
+                            <div
+                              className=
+                                  ms-ContextualMenu-linkContent
+                                  {
+                                    align-items: center;
+                                    display: flex;
+                                    height: inherit;
+                                    max-width: 100%;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span
+                                className=
+                                    ms-ContextualMenu-itemText
+                                    {
+                                      display: inline-block;
+                                      flex-grow: 1;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      overflow: hidden;
+                                      text-overflow: ellipsis;
+                                      vertical-align: middle;
+                                      white-space: nowrap;
+                                    }
+                              >
+                                Link click
+                              </span>
+                            </div>
+                          </a>
+                        </div>
+                      </li>
+                      <li
+                        className=
+                            ms-ContextualMenu-item
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              box-sizing: border-box;
+                              color: #333333;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              position: relative;
+                            }
+                        role="presentation"
+                      >
+                        <button
+                          aria-disabled={true}
+                          aria-posinset={8}
+                          aria-setsize={8}
+                          className=
+                              ms-ContextualMenu-link
+                              is-disabled
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                background-color: transparent;
+                                border: none;
+                                color: #a6a6a6;
+                                cursor: default;
+                                display: block;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                height: 32px;
+                                line-height: 32px;
+                                outline: transparent;
+                                padding-bottom: 0;
+                                padding-left: 4px;
+                                padding-right: 8px;
+                                padding-top: 0px;
+                                pointer-events: none;
+                                position: relative;
+                                text-align: left;
+                                width: 100%;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #666666;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              @media screen and (-ms-high-contrast: active){& {
+                                color: GrayText;
+                                opacity: 1;
+                              }
+                          onClick={[Function]}
+                          onKeyDown={null}
+                          onMouseDown={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseMove={[Function]}
+                          role="menuitem"
+                        >
+                          <div
+                            className=
+                                ms-ContextualMenu-linkContent
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: inherit;
+                                  max-width: 100%;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span
+                              className=
+                                  ms-ContextualMenu-itemText
+                                  {
+                                    display: inline-block;
+                                    flex-grow: 1;
+                                    margin-bottom: 0;
+                                    margin-left: 4px;
+                                    margin-right: 4px;
+                                    margin-top: 0;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;
+                                    vertical-align: middle;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              Disabled item
+                            </span>
+                          </div>
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+    </div>
+  </button>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-395:hover + .headerDividerBar-396 {
+      & .headerDivider-422:hover + .headerDividerBar-423 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -754,7 +754,89 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                     }
                   }
                   tabIndex={-1}
-                />
+                >
+                  <div
+                    aria-describedby="callout-description-1"
+                    aria-labelledby="callout-label-1"
+                    className=
+                        ms-Callout-main
+                        {
+                          background-color: #ffffff;
+                          overflow-x: hidden;
+                          overflow-y: auto;
+                          position: relative;
+                        }
+                    onKeyDown={[Function]}
+                    role="alertdialog"
+                    style={
+                      Object {
+                        "maxHeight": 750,
+                        "overflowY": undefined,
+                      }
+                    }
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="ms-CalloutExample-header"
+                    >
+                      <p
+                        className="ms-CalloutExample-title"
+                        id="callout-label-1"
+                      >
+                        All of your favorite people
+                      </p>
+                    </div>
+                    <div
+                      className="ms-CalloutExample-inner"
+                    >
+                      <div
+                        className="ms-CalloutExample-content"
+                      >
+                        <p
+                          className="ms-CalloutExample-subText"
+                          id="callout-description-1"
+                        >
+                          Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
+                        </p>
+                      </div>
+                      <div
+                        className="ms-CalloutExample-actions"
+                      >
+                        <a
+                          className=
+                              ms-Link
+                              ms-CalloutExample-link
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                color: #0078d4;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: inherit;
+                                font-weight: inherit;
+                                outline: none;
+                                text-decoration: none;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus {
+                                outline: 1px solid #666666;
+                              }
+                              &:active, &:hover, &:active:hover {
+                                color: #004578;
+                              }
+                              @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                                text-decoration: underline;
+                              }
+                              &:focus {
+                                color: #0078d4;
+                              }
+                          href="http://microsoft.com"
+                          onClick={[Function]}
+                        >
+                          Go to microsoft
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </span>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The hidden prop is used to persist a menu's DOM. However, it has a few bugs.

1. We unmount the Popup component when the callout is hidden using the hidden prop.
2. We do not reset bounds and focus when a callout is hidden.
3. BaseButton does not pass in the hidden prop correctly to a contextual menu. You cannot actually open a contextual menu the second time (show, hide, show)

This PR fixes the following things - 
1. The Popup component is not unmounted and the whole DOM for the callout/menu persists even when hidden. From Chrome performance tab, I verified that the ContextualMenu/Callout are not mounted but instead only updated when shown again after being hidden.
2. The BaseButton now passes in the hidden prop to its ContextualMenu.
3. Focus works correctly both when using a mouse and keyboard.
4. Bounds are set correctly every time a callout is reshown. Previously, once calculated, bounds were not calculated again. This means the callout would not be positioned correctly if the browser window is resized between times a when a callout is shown.

I also added an example that shows a ContextualMenu with the hidden prop working.

#### Focus areas to test

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7883)