### PR TITLE
Fix the links to the customizations section of component for deeplinks

### DIFF
--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -792,7 +792,7 @@ export const AppState: IAppState = {
         },
         {
           title: 'Customization',
-          url: '#/components/customization',
+          url: '#/components/customizations',
           className: 'componentsPage',
           isCategory: true,
           component: () => <LoadingComponent title="Customization" />,
@@ -801,7 +801,7 @@ export const AppState: IAppState = {
           pages: [
             {
               title: 'Themes',
-              url: '#/customizations/themes',
+              url: '#/components/customizations/themes',
               isFilterable: true,
               component: () => <LoadingComponent title="Themes" />,
               getComponent: cb =>
@@ -809,7 +809,7 @@ export const AppState: IAppState = {
             },
             {
               title: 'Colors',
-              url: '#/customizations/colors',
+              url: '#/components/customizations/colors',
               isFilterable: true,
               component: () => <LoadingComponent title="Colors" />,
               getComponent: cb =>

--- a/common/changes/@uifabric/fabric-website/website_2019-02-04-21-40.json
+++ b/common/changes/@uifabric/fabric-website/website_2019-02-04-21-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix site links to allow for deeplinks to the customizations",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7888
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The customizations section isn't actually a top level section. As it is defined, these are under "components", so the logic fails. This PR corrects it.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7894)