### PR TITLE
Added subComponentStyle to datepicker textfield

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker_2019-02-04-22-40.json
+++ b/common/changes/office-ui-fabric-react/datepicker_2019-02-04-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds subComponentStyles to DatePicker to allow textField styling",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6748,9 +6748,7 @@ interface IDatePickerStyleProps {
   className?: string;
   // (undocumented)
   disabled?: boolean;
-  // (undocumented)
   isDatePickerShown?: boolean;
-  // (undocumented)
   label?: boolean;
   theme: ITheme;
 }
@@ -6762,8 +6760,14 @@ interface IDatePickerStyles {
   // (undocumented)
   icon: IStyle;
   root: IStyle;
+  subComponentStyles: IDatePickerSubComponentStyles;
   // (undocumented)
   textField: IStyle;
+}
+
+// @public (undocumented)
+interface IDatePickerSubComponentStyles {
+  textField: IStyleFunctionOrObject<ITextFieldStyleProps, any>;
 }
 
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -8,6 +8,8 @@ import { DirectionalHint } from '../../common/DirectionalHint';
 import { TextField, ITextField } from '../../TextField';
 import { compareDates, compareDatePart } from '../../utilities/dateMath/DateMath';
 import { FocusTrapZone } from '../../FocusTrapZone';
+import { IStyleFunctionOrObject } from '@uifabric/utilities';
+import { ITextFieldStyleProps, ITextFieldStyles } from '../TextField';
 
 const getClassNames = classNamesFunction<IDatePickerStyleProps, IDatePickerStyles>();
 
@@ -180,6 +182,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     const calloutId = getId('DatePicker-Callout');
     const nativeProps = getNativeProps(this.props, divProperties, ['value']);
 
+    const textFieldStyles = classNames.subComponentStyles
+      ? (classNames.subComponentStyles.textField as IStyleFunctionOrObject<ITextFieldStyleProps, ITextFieldStyles>)
+      : undefined;
+
     return (
       <div {...nativeProps} className={classNames.root}>
         <div
@@ -192,6 +198,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
           <TextField
             id={this._id + '-label'}
             className={classNames.textField}
+            styles={textFieldStyles}
             label={label}
             ariaLabel={ariaLabel}
             aria-controls={isDatePickerShown ? calloutId : undefined}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -5,11 +5,10 @@ import { Calendar, ICalendar, DayOfWeek } from '../../Calendar';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { Callout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { TextField, ITextField } from '../../TextField';
+import { TextField, ITextField, ITextFieldStyleProps, ITextFieldStyles } from '../../TextField';
 import { compareDates, compareDatePart } from '../../utilities/dateMath/DateMath';
 import { FocusTrapZone } from '../../FocusTrapZone';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { ITextFieldStyleProps, ITextFieldStyles } from '../TextField';
 
 const getClassNames = classNamesFunction<IDatePickerStyleProps, IDatePickerStyles>();
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.styles.ts
@@ -54,6 +54,7 @@ export const styles = (props: IDatePickerStyleProps): IDatePickerStyles => {
           cursor: 'pointer'
         }
       ]
-    ]
+    ],
+    subComponentStyles: { textField: {} }
   };
 };

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -2,8 +2,9 @@ import { DayOfWeek, ICalendarProps } from '../../Calendar';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { ICalendarFormatDateCallbacks } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IBaseProps, IStyleFunction, IComponentAs } from '../../Utilities';
+import { IRefObject, IBaseProps, IStyleFunction, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { ICalloutProps } from '../../Callout';
+import { ITextFieldStyleProps } from '../TextField';
 
 export interface IDatePicker {
   /** Sets focus to the text field */
@@ -312,7 +313,15 @@ export interface IDatePickerStyleProps {
 
   // Insert DatePicker style props below
   disabled?: boolean;
+
+  /**
+   * Whether to show a label
+   */
   label?: boolean;
+
+  /**
+   * Whether the date picker is shown
+   */
   isDatePickerShown?: boolean;
 }
 
@@ -324,4 +333,14 @@ export interface IDatePickerStyles {
   textField: IStyle;
   callout: IStyle;
   icon: IStyle;
+
+  /**
+   * SubComponent styles.
+   */
+  subComponentStyles: IDatePickerSubComponentStyles;
+}
+
+export interface IDatePickerSubComponentStyles {
+  /** Refers to the textField that hosts the DatePicker options */
+  textField: IStyleFunctionOrObject<ITextFieldStyleProps, any>;
 }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -4,7 +4,7 @@ import { ICalendarFormatDateCallbacks } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IBaseProps, IStyleFunction, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { ICalloutProps } from '../../Callout';
-import { ITextFieldStyleProps } from '../TextField';
+import { ITextFieldStyleProps } from '../../TextField';
 
 export interface IDatePicker {
   /** Sets focus to the text field */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7890
- [x] Include a change request file using `$ npm run change`

#### Description of changes

To allow sub component styling of error messages, DatePicker needs to support subComponentStyles

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7895)