### PR TITLE
HoverCard dismissing with `sticky` prop true on mouse leave

### DIFF
--- a/common/changes/office-ui-fabric-react/hover-card-sticky-dismissal_2019-02-05-05-40.json
+++ b/common/changes/office-ui-fabric-react/hover-card-sticky-dismissal_2019-02-05-05-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "In HoverCard, do not dismiss the card when the  prop is true and the event prompting the dismissal is the 'mouseleave' event from the card itself. Clicking outside, escape, etc will still dismiss the card.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "sllynn8907@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
@@ -118,7 +118,7 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
       firstFocus: setInitialFocus || openMode === OpenCardMode.hotKey,
       targetElement: this._getTargetElement(),
       onEnter: this._cardOpen,
-      onLeave: this._executeCardDismiss
+      onLeave: this._cardMouseOut
     };
 
     const finalExpandedCardProps: IExpandingCardProps = { ...expandingCardProps, ...commonCardProps, mode };
@@ -197,6 +197,16 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
     if (!this.props.sticky && (this._currentMouseTarget === ev.currentTarget || ev.which === KeyCodes.escape)) {
       this._executeCardDismiss();
     }
+  };
+
+  private _cardMouseOut = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+    // If this is a hover event and the component is sticky,
+    // do not dismiss.
+    if (this.props.sticky && ev.nativeEvent instanceof MouseEvent && ev.type === 'mouseleave') {
+      return;
+    }
+
+    this._executeCardDismiss();
   };
 
   private _executeCardDismiss = (): void => {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
@@ -48,19 +48,20 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
   public componentDidMount(): void {
     const target = this._getTargetElement();
 
+    const nativeEventDismiss = this._cardDismiss.bind(this, true);
     this._events.on(target, 'mouseenter', this._cardOpen);
-    this._events.on(target, 'mouseleave', this._cardDismiss);
+    this._events.on(target, 'mouseleave', nativeEventDismiss);
     if (this.props.trapFocus) {
       this._events.on(target, 'keydown', this._cardOpen);
     } else {
       this._events.on(target, 'focus', this._cardOpen);
-      this._events.on(target, 'blur', this._cardDismiss);
+      this._events.on(target, 'blur', nativeEventDismiss);
     }
     if (this.props.instantOpenOnClick) {
       this._events.on(target, 'click', this._instantOpenAsExpanded);
     } else {
-      this._events.on(target, 'mousedown', this._cardDismiss);
-      this._events.on(target, 'keydown', this._cardDismiss);
+      this._events.on(target, 'mousedown', nativeEventDismiss);
+      this._events.on(target, 'keydown', nativeEventDismiss);
     }
   }
 
@@ -118,7 +119,7 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
       firstFocus: setInitialFocus || openMode === OpenCardMode.hotKey,
       targetElement: this._getTargetElement(),
       onEnter: this._cardOpen,
-      onLeave: this._cardMouseOut
+      onLeave: this._cardDismiss.bind(this, false)
     };
 
     const finalExpandedCardProps: IExpandingCardProps = { ...expandingCardProps, ...commonCardProps, mode };
@@ -187,26 +188,36 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
     }, this.props.cardOpenDelay!);
   };
 
-  // Hide HoverCard
-  private _cardDismiss = (ev: MouseEvent) => {
-    if (ev.type === 'keydown' && ev.which !== KeyCodes.escape) {
-      return;
-    }
+  /**
+   * Hide HoverCard
+   * How we dismiss the card depends on where the callback is coming from.
+   * This is provided by the `isNativeEvent` argument.
+   *  true: Event is coming from event listeners set up in componentDidMount.
+   *  false: Event is coming from the `onLeave` prop from the HoverCard component.
+   */
+  private _cardDismiss = (isNativeEvent: boolean, ev: MouseEvent | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+    if (isNativeEvent) {
+      // We expect these to be MouseEvents, If not, return.
+      if (!(ev instanceof MouseEvent)) {
+        return;
+      }
 
-    // Dismiss if not sticky and currentTarget is the same element that mouse last entered
-    if (!this.props.sticky && (this._currentMouseTarget === ev.currentTarget || ev.which === KeyCodes.escape)) {
+      if (ev.type === 'keydown' && ev.which !== KeyCodes.escape) {
+        return;
+      }
+
+      // Dismiss if not sticky and currentTarget is the same element that mouse last entered
+      if (!this.props.sticky && (this._currentMouseTarget === ev.currentTarget || ev.which === KeyCodes.escape)) {
+        this._executeCardDismiss();
+      }
+    } else {
+      // If this is a mouseleave event and the component is sticky, do not dismiss.
+      if (this.props.sticky && !(ev instanceof MouseEvent) && ev.nativeEvent instanceof MouseEvent && ev.type === 'mouseleave') {
+        return;
+      }
+
       this._executeCardDismiss();
     }
-  };
-
-  private _cardMouseOut = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
-    // If this is a hover event and the component is sticky,
-    // do not dismiss.
-    if (this.props.sticky && ev.nativeEvent instanceof MouseEvent && ev.type === 'mouseleave') {
-      return;
-    }
-
-    this._executeCardDismiss();
   };
 
   private _executeCardDismiss = (): void => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7848
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In `HoverCard`, do not dismiss the card when the prop is true and the event prompting the dismissal is the `mouseleave` event from the card itself. Clicking outside, escape, etc will still dismiss the card.

#### Focus areas to test

I mostly want to verify that I am not missing an assumption with how `HoverCard` is meant to function.

Note: I am investigating adding a test for this now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7898)