### PR TITLE
Nav link styling

### DIFF
--- a/common/changes/office-ui-fabric-react/navLinkStyling_2019-02-05-01-47.json
+++ b/common/changes/office-ui-fabric-react/navLinkStyling_2019-02-05-01-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav: add semantic colors styling to link",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -109,6 +109,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         overflow: 'hidden',
         paddingLeft: leftPadding,
         paddingRight: rightPadding,
+        color: semanticColors.bodyText,
         selectors: {
           '.ms-Nav-compositeLink:hover &': {
             backgroundColor: palette.neutralLighterAlt,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7884
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Half of the Nav links currently get their color from `semanticColors.bodyText` while the other half inherit from something that has color `palette.neutralPrimary`. These are the same color. This sets color to `semanticColors.bodyText` for all links to allow for more consistent styling when given a certain theme.

The snapshots are all the same, and now, all of the Navs will be styled appropriately when given theme, not just half of the links and the chevrons.

Here's a before and after for setting `theme.semanticColors.bodyText` to '#be23c0' (pink).

Before (note the styled chevron):
<img width="263" alt="screen shot 2019-02-05 at 10 01 04 am" src="https://user-images.githubusercontent.com/14134000/52294012-04a99300-292d-11e9-8813-50b31fdd0b77.png">

After:
<img width="263" alt="screen shot 2019-02-05 at 10 00 30 am" src="https://user-images.githubusercontent.com/14134000/52294006-02473900-292d-11e9-8a8c-736dbdaaa253.png">

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7902)