### PR TITLE
FocusTrapZone: Fixed FocusTrapZone to use the relatedTarget

### DIFF
--- a/common/changes/office-ui-fabric-react/focus_2019-02-05-22-45.json
+++ b/common/changes/office-ui-fabric-react/focus_2019-02-05-22-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusTrapZone: Fixed FocusTrapZone to use the relatedTarget instead of document.activeElement to find what is losing focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -195,7 +195,7 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
 
   private _forceFocusInTrap(ev: FocusEvent): void {
     if (FocusTrapZone._focusStack.length && this === FocusTrapZone._focusStack[FocusTrapZone._focusStack.length - 1]) {
-      const focusedElement = document.activeElement as HTMLElement;
+      const focusedElement = (ev.relatedTarget as HTMLElement) || (document.activeElement as HTMLElement);
 
       if (!elementContains(this._root.current, focusedElement)) {
         this.focus();


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7891
- [x] Include a change request file using `$ npm run change`

#### Description of changes

FocusTrapZone: Fixed FocusTrapZone to use the relatedTarget instead of document.activeElement to find what is losing focus. document.activeElement wasn't accurate in the case inside a popup + with scrolling and tabindex=-1 from a recent change

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7906)