### PR TITLE
Stack: Modifying StackItem so that it can render multiple children

### DIFF
--- a/common/changes/@uifabric/experiments/stackItem_2019-02-06-01-22.json
+++ b/common/changes/@uifabric/experiments/stackItem_2019-02-06-01-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Stack: Modifying StackItem so that it can render multiple children.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "makotom@microsoft.com"
+}

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.test.tsx
@@ -61,9 +61,9 @@ describe('Stack Item', () => {
       </Stack>
     );
 
-    const stackItem = wrapper.find('span').at(0);
+    const stackItem = wrapper.find('div').at(1);
     const stackItemClass = stackItem.props().className;
-    const child = wrapper.find('span').at(1);
+    const child = wrapper.find('span').at(0);
     const childClass = child.props().className;
 
     expect(stackItemClass).toContain(stackItemClassName);

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
@@ -5,17 +5,18 @@ import { IStackItemComponent, IStackItemProps, IStackItemSlots } from './StackIt
 import { styles } from './StackItem.styles';
 
 const view: IStackItemComponent['view'] = props => {
-  const childNodes: React.ReactElement<{}>[] = React.Children.toArray(props.children) as React.ReactElement<{}>[];
+  const { children } = props;
+  const childNodes: React.ReactElement<{}>[] = React.Children.toArray(children) as React.ReactElement<{}>[];
   const first = childNodes[0];
   if (!first) {
     return null;
   }
 
   const Slots = getSlots<IStackItemProps, IStackItemSlots>(props, {
-    root: 'span'
+    root: 'div'
   });
 
-  return <Slots.root>{first}</Slots.root>;
+  return <Slots.root>{children}</Slots.root>;
 };
 
 export const StackItem: React.StatelessComponent<IStackItemProps> = createComponent({

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.tsx
@@ -6,9 +6,7 @@ import { styles } from './StackItem.styles';
 
 const view: IStackItemComponent['view'] = props => {
   const { children } = props;
-  const childNodes: React.ReactElement<{}>[] = React.Children.toArray(children) as React.ReactElement<{}>[];
-  const first = childNodes[0];
-  if (!first) {
+  if (React.Children.count(children) < 1) {
     return null;
   }
 

--- a/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/experiments/src/components/Stack/StackItem/StackItem.types.ts
@@ -24,11 +24,6 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
   className?: string;
 
   /**
-   * @internal Internal use only - gives the Stack component a handle on the children of its Stack.Items
-   */
-  children?: (React.ReactElement<IStackItemProps> | string)[] | React.ReactElement<IStackItemProps> | string;
-
-  /**
    * Defines how much to grow the StackItem in proportion to its siblings.
    */
   grow?: boolean | number | 'inherit' | 'initial' | 'unset';

--- a/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/experiments/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Stack accepts custom className on child items 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -38,7 +38,7 @@ exports[`Stack accepts custom className on child items 1`] = `
         }
   >
     Item 1
-  </span>
+  </div>
   <div
     className=
 
@@ -135,7 +135,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -151,8 +151,8 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         }
   >
     Auto
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -168,8 +168,8 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         }
   >
     Stretch
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -185,8 +185,8 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         }
   >
     Baseline
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -202,8 +202,8 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         }
   >
     Start
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -219,8 +219,8 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         }
   >
     Center
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -236,7 +236,7 @@ exports[`Stack renders horizontal Stack item alignments correctly 1`] = `
         }
   >
     End
-  </span>
+  </div>
 </div>
 `;
 
@@ -262,7 +262,7 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -277,8 +277,8 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -293,7 +293,7 @@ exports[`Stack renders horizontal Stack with StackItems correctly 1`] = `
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -319,7 +319,7 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -334,8 +334,8 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -350,7 +350,7 @@ exports[`Stack renders horizontal Stack with a gap correctly 1`] = `
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -476,7 +476,7 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 1`] 
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -491,8 +491,8 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 1`] 
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -507,7 +507,7 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 1`] 
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -533,7 +533,7 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 2`] 
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -548,8 +548,8 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 2`] 
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -564,7 +564,7 @@ exports[`Stack renders horizontal Stack with shrinking StackItems correctly 2`] 
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -716,7 +716,7 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -731,8 +731,8 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -747,7 +747,7 @@ exports[`Stack renders vertical Stack with StackItems correctly 1`] = `
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -773,7 +773,7 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -788,8 +788,8 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -804,7 +804,7 @@ exports[`Stack renders vertical Stack with a gap correctly 1`] = `
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -930,7 +930,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -946,8 +946,8 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         }
   >
     Auto
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -963,8 +963,8 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         }
   >
     Stretch
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -980,8 +980,8 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         }
   >
     Baseline
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -997,8 +997,8 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         }
   >
     Start
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -1014,8 +1014,8 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         }
   >
     Center
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -1031,7 +1031,7 @@ exports[`Stack renders vertical Stack with item alignments correctly 1`] = `
         }
   >
     End
-  </span>
+  </div>
 </div>
 `;
 
@@ -1057,7 +1057,7 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 1`] = 
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -1072,8 +1072,8 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 1`] = 
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -1088,7 +1088,7 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 1`] = 
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -1114,7 +1114,7 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 2`] = 
         flex-shrink: 1;
       }
 >
-  <span
+  <div
     className=
         ms-StackItem
         {
@@ -1129,8 +1129,8 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 2`] = 
         }
   >
     Item 1
-  </span>
-  <span
+  </div>
+  <div
     className=
         ms-StackItem
         {
@@ -1145,7 +1145,7 @@ exports[`Stack renders vertical Stack with shrinking StackItems correctly 2`] = 
         }
   >
     Item 2
-  </span>
+  </div>
 </div>
 `;
 
@@ -1254,7 +1254,7 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           flex-shrink: 1;
         }
   >
-    <span
+    <div
       className=
           ms-StackItem
           {
@@ -1269,8 +1269,8 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           }
     >
       1
-    </span>
-    <span
+    </div>
+    <div
       className=
           ms-StackItem
           {
@@ -1285,8 +1285,8 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           }
     >
       2
-    </span>
-    <span
+    </div>
+    <div
       className=
           ms-StackItem
           {
@@ -1301,7 +1301,7 @@ exports[`Stack renders wrapped horizontal Stack correctly 1`] = `
           }
     >
       3
-    </span>
+    </div>
   </div>
 </div>
 `;

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx
@@ -21,9 +21,12 @@ export class VerticalStackBasicExample extends React.Component<{}, {}> {
       <Stack gap={5}>
         <span>Default vertical stack</span>
         <Stack className={styles.root}>
-          <span>Item One</span>
-          <span>Item Two</span>
-          <span>Item Three</span>
+          <Stack.Item />
+          <Stack.Item>
+            <span>Item One</span>
+            <span>Item Two</span>
+            <span>Item Three</span>
+          </Stack.Item>
         </Stack>
 
         <span>Vertical gap between items</span>

--- a/packages/experiments/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx
+++ b/packages/experiments/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx
@@ -21,12 +21,9 @@ export class VerticalStackBasicExample extends React.Component<{}, {}> {
       <Stack gap={5}>
         <span>Default vertical stack</span>
         <Stack className={styles.root}>
-          <Stack.Item />
-          <Stack.Item>
-            <span>Item One</span>
-            <span>Item Two</span>
-            <span>Item Three</span>
-          </Stack.Item>
+          <span>Item One</span>
+          <span>Item Two</span>
+          <span>Item Three</span>
         </Stack>
 
         <span>Vertical gap between items</span>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7901 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

An array wrapped by `StackItem` was only rendering one child. This PR changes this so that `StackItem` can render multiple children. As part of this, the representation of the `StackItem` `root` slot has been changed from a `span` to a `div` and the tests have been updated.

The exposed `children` property in `StackItem` has also been deleted since we can now use the `children` property inherited from `IComponent`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7908)