### PR TITLE
Make remove button on Suggestion visible on focus

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-suggestions-keyboard-remove_2019-02-06-22-49.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-suggestions-keyboard-remove_2019-02-06-22-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make remove button on Suggestion display on focus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -81,13 +81,13 @@
   width: 100%;
   font-size: 12px;
   &:hover {
-    background-color: $ms-color-neutralLight;
-    cursor: pointer;
+      background-color: $ms-color-neutralLight;
+      cursor: pointer;
   }
   // TODO: Works in Chrome, but not working in IE
   &:focus,
   &:active {
-    background-color: $ms-color-themeLight;
+      background-color: $ms-color-themeLight;
   }
 
   :global(.ms-Button-icon) {
@@ -183,6 +183,6 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip: rect(0,0,0,0);
   border: 0;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -19,6 +19,12 @@
     }
   }
 
+  // Force the close button to appear on focus of the itemButton
+  // so it is accessible to keyboard-only users
+  .itemButton:focus + .closeButton {
+    display: block;
+  }
+
   &.suggestionsItemIsSuggested {
     background: $ms-color-neutralLight;
 
@@ -75,13 +81,13 @@
   width: 100%;
   font-size: 12px;
   &:hover {
-      background-color: $ms-color-neutralLight;
-      cursor: pointer;
+    background-color: $ms-color-neutralLight;
+    cursor: pointer;
   }
   // TODO: Works in Chrome, but not working in IE
   &:focus,
   &:active {
-      background-color: $ms-color-themeLight;
+    background-color: $ms-color-themeLight;
   }
 
   :global(.ms-Button-icon) {
@@ -177,6 +183,6 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   border: 0;
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -11,19 +11,31 @@
   width: 100%;
   position: relative;
 
-  &:hover {
+  // Declare as a mixin with 2 uses so browsers without :focus-within
+  // support don't invalidate the selector.
+  @mixin hovered-or-focused() {
     background: $ms-color-neutralLighter;
 
     .closeButton {
       display: block;
     }
   }
+  &:hover {
+    @include hovered-or-focused();
+  }
+  &:focus-within {
+    @include hovered-or-focused();
+  }
 
-  // Force the close button to appear on focus of the itemButton
-  // so it is accessible to keyboard-only users
-  .itemButton:focus + .closeButton {
+  // Required for IE + Edge keyboard accesibility.
+  // This selector pair doesn't work for Chrome or Firefox.
+  //
+  // Presumably they calculate the new display status of .closeButton
+  // before focus moves to it.
+  .itemButton:focus + .closeButton, .closeButton:focus {
     display: block;
   }
+
 
   &.suggestionsItemIsSuggested {
     background: $ms-color-neutralLight;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -30,6 +30,11 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
           },
           '&:hover .ms-Suggestions-closeButton': {
             display: 'block'
+          },
+          // Make the close button visible if its preceeding peer (the item)
+          // is focused. Needed for keyboard accessibility.
+          [`& ${classNames.itemButton}:focus + .ms-Suggestions-closeButton`]: {
+            display: 'block'
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -28,12 +28,20 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
           '&:hover': {
             background: palette.neutralLighter
           },
-          '&:hover .ms-Suggestions-closeButton': {
+          [`&:hover .${classNames.closeButton}`]: {
             display: 'block'
           },
-          // Make the close button visible if its preceeding peer (the item)
-          // is focused. Needed for keyboard accessibility.
-          [`& ${classNames.itemButton}:focus + .ms-Suggestions-closeButton`]: {
+          // Declare as a separate selector so browsers without :focus-within
+          // support don't invalidate the selector.
+          [`&:focus-within .${classNames.closeButton}`]: {
+            display: 'block'
+          },
+          // Required for IE + Edge keyboard accesibility.
+          // This selector pair doesn't work for Chrome or Firefox.
+          //
+          // Presumably they calculate the new display status of .closeButton
+          // before focus moves to it.
+          [`.${classNames.itemButton}:focus + .${classNames.itemButton}, .${classNames.itemButton}:focus`]: {
             display: 'block'
           }
         }

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -31,6 +31,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
             @media screen and (-ms-high-contrast: active){& {
               -ms-high-contrast-adjust: none;
               background: Highlight;
@@ -165,6 +171,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -292,6 +304,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -423,6 +441,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -550,6 +574,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -681,6 +711,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -808,6 +844,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -939,6 +981,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -1066,6 +1114,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -1197,6 +1251,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -1324,6 +1384,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -1455,6 +1521,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -1582,6 +1654,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -1713,6 +1791,12 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -1840,6 +1924,12 @@ exports[`Suggestions renders a list properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -2001,6 +2091,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
             @media screen and (-ms-high-contrast: active){& {
               -ms-high-contrast-adjust: none;
               background: Highlight;
@@ -2135,6 +2231,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -2262,6 +2364,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -2393,6 +2501,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -2520,6 +2634,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -2651,6 +2771,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -2778,6 +2904,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -2909,6 +3041,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -3036,6 +3174,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -3167,6 +3311,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -3294,6 +3444,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -3425,6 +3581,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -3552,6 +3714,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -3683,6 +3851,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -3810,6 +3984,12 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -3974,6 +4154,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -4101,6 +4287,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -4232,6 +4424,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -4359,6 +4557,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -4490,6 +4694,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -4617,6 +4827,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -4748,6 +4964,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -4875,6 +5097,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -5006,6 +5234,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #c8c8c8;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -5142,6 +5376,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -5269,6 +5509,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -5400,6 +5646,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -5527,6 +5779,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >
@@ -5658,6 +5916,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
+              display: block;
+            }
       >
         <button
           className=
@@ -5785,6 +6049,12 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
               background: #f4f4f4;
             }
             &:hover .ms-Suggestions-closeButton {
+              display: block;
+            }
+            &:focus-within .ms-Suggestions-closeButton {
+              display: block;
+            }
+            & .ms-Suggestions-itemButton:focus + .ms-Suggestions-itemButton, & .ms-Suggestions-itemButton:focus {
               display: block;
             }
       >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7913
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Because the remove button on the Suggestion item is tied to hover,
it was not keyboard accessible.

This PR makes the button appear when the adjacent item is focused,
so it can be used by keyboard-only users. (Fixes #7913).

#### Focus areas to test

FloatingPeoplePicker + Suggestions


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7915)