### PR TITLE
Fluent-theme: pickers fluent styles adjustments.

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-Pickers_2019-02-07-00-35.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-Pickers_2019-02-07-00-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Pickers: adds minor adjustments to align to new fluent style patterns.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -1,8 +1,10 @@
+import { BasePickerStyles } from './styles/BasePicker.styles';
 import { BreadcrumbStyles } from './styles/Breadcrumb.styles';
 import { CheckStyles, DetailsRowStyles } from './styles/DetailsList.styles';
 import { CalloutContentStyles } from './styles/Callout.styles';
 import { CheckboxStyles } from './styles/Checkbox.styles';
 import { ChoiceGroupOptionStyles } from './styles/ChoiceGroupOption.styles';
+import { ColorPickerGridCellStyles } from './styles/ColorPickerGridCell.styles';
 import { ColorPickerStyles, ColorRectangleStyles, ColorSliderStyles } from './styles/ColorPicker.styles';
 import { ComboBoxStyles } from './styles/ComboBox.styles';
 import { CommandBarStyles } from './styles/CommandBar.styles';
@@ -19,16 +21,18 @@ import { IconButtonStyles } from './styles/IconButton.styles';
 import { LabelStyles } from './styles/Label.styles';
 import { LinkStyles } from './styles/Link.styles';
 import { ModalStyles } from './styles/Modal.styles';
+import { PeoplePickerItemStyles } from './styles/PeoplePicker.styles';
 import { PersonaStyles } from './styles/Persona.styles';
 import { PivotStyles } from './styles/Pivot.styles';
 import { PrimaryButtonStyles } from './styles/PrimaryButton.styles';
 import { RatingStyles } from './styles/Rating.styles';
 import { SliderStyles } from './styles/Slider.styles';
 import { SpinButtonStyles } from './styles/SpinButton.styles';
+import { SuggestionItemStyles, SuggestionsStyles } from './styles/PickerSuggestions.styles';
+import { TagItemStyles } from './styles/TagPicker.styles';
 import { TeachingBubbleStyles, TeachingBubbleContentStyles } from './styles/TeachingBubble.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
-import { ColorPickerGridCellStyles } from './styles/ColorPickerGridCell.styles';
 
 // Roll up all style overrides in a single "Fluent theme" object
 
@@ -75,6 +79,9 @@ export const FluentStyles: any = {
   ComboBox: {
     styles: ComboBoxStyles
   },
+  CompactPeoplePicker: {
+    styles: BasePickerStyles
+  },
   ContextualMenu: {
     styles: ContextualMenuStyles
   },
@@ -111,8 +118,17 @@ export const FluentStyles: any = {
   Link: {
     styles: LinkStyles
   },
+  ListPeoplePicker: {
+    styles: BasePickerStyles
+  },
   Modal: {
     styles: ModalStyles
+  },
+  NormalPeoplePicker: {
+    styles: BasePickerStyles
+  },
+  PeoplePickerItem: {
+    styles: PeoplePickerItemStyles
   },
   Persona: {
     styles: PersonaStyles
@@ -134,6 +150,18 @@ export const FluentStyles: any = {
   },
   SpinButton: {
     styles: SpinButtonStyles
+  },
+  Suggestions: {
+    styles: SuggestionsStyles
+  },
+  SuggestionItem: {
+    styles: SuggestionItemStyles
+  },
+  TagItem: {
+    styles: TagItemStyles
+  },
+  TagPicker: {
+    styles: BasePickerStyles
   },
   TeachingBubble: {
     styles: TeachingBubbleStyles

--- a/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
@@ -1,0 +1,13 @@
+import { IBasePickerStyleProps, IBasePickerStyles } from 'office-ui-fabric-react/lib/Pickers';
+import { fluentBorderRadius } from './styleConstants';
+
+export const BasePickerStyles = (props: IBasePickerStyleProps): Partial<IBasePickerStyles> => {
+  return {
+    text: {
+      borderRadius: fluentBorderRadius
+    },
+    input: {
+      borderRadius: fluentBorderRadius
+    }
+  };
+};

--- a/packages/fluent-theme/src/fluent/styles/PeoplePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PeoplePicker.styles.ts
@@ -1,0 +1,20 @@
+import { IPeoplePickerItemSelectedStyleProps, IPeoplePickerItemSelectedStyles } from 'office-ui-fabric-react/lib/Pickers';
+
+export const PeoplePickerItemStyles = (props: IPeoplePickerItemSelectedStyleProps): Partial<IPeoplePickerItemSelectedStyles> => {
+  const { selected, theme } = props;
+  const { palette } = theme;
+
+  return {
+    removeButton: [
+      {
+        background: 'transparent'
+      },
+      !selected && {
+        color: palette.neutralPrimary
+      },
+      selected && {
+        color: palette.white
+      }
+    ]
+  };
+};

--- a/packages/fluent-theme/src/fluent/styles/PickerSuggestions.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PickerSuggestions.styles.ts
@@ -1,0 +1,22 @@
+import {
+  ISuggestionsItemStyleProps,
+  ISuggestionsItemStyles,
+  ISuggestionsStyleProps,
+  ISuggestionsStyles
+} from 'office-ui-fabric-react/lib/Pickers';
+
+export const SuggestionItemStyles = (props: ISuggestionsItemStyleProps): Partial<ISuggestionsItemStyles> => {
+  return {
+    closeButton: {
+      background: 'transparent'
+    }
+  };
+};
+
+export const SuggestionsStyles = (props: ISuggestionsStyleProps): Partial<ISuggestionsStyles> => {
+  return {
+    suggestionsContainer: {
+      borderBottom: 'none'
+    }
+  };
+};

--- a/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
@@ -1,0 +1,14 @@
+import { ITagItemStyleProps, ITagItemStyles } from 'office-ui-fabric-react/lib/Pickers';
+import { fluentBorderRadius } from './styleConstants';
+
+export const TagItemStyles = (props: ITagItemStyleProps): Partial<ITagItemStyles> => {
+  return {
+    root: {
+      borderRadius: fluentBorderRadius
+    },
+    close: {
+      background: 'transparent',
+      borderRadius: `0 ${fluentBorderRadius} ${fluentBorderRadius} 0`
+    }
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7068, Fixes #7067 , Fixes #7066, Fixes #7310 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds some fluent styles to pickers (PeoplePicker and TagPicker) in the fluent-theme package. Unfortunately, due to the inheritance pattern used within pickers, all the custom pickers build by inheriting from BasePicker class will not pick up any fluent changes when the fluent theme is applied.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7919)