### PR TITLE
Minor build improvements

### DIFF
--- a/common/changes/office-ui-fabric-react/build_2019-02-07-06-26.json
+++ b/common/changes/office-ui-fabric-react/build_2019-02-07-06-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -26,7 +26,8 @@
     "update-sass-theme-files": "node ./scripts/generateDefaultThemeSassFiles.js",
     "update-snapshots": "node ../../scripts/just.js jest -u",
     "update-api": "node ../../scripts/update-api.js",
-    "codepen": "node ../../scripts/local-codepen.js"
+    "codepen": "node ../../scripts/local-codepen.js",
+    "build-codepen-examples": "node ../../scripts/tasks/build-codepen-examples.js"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/scripts/write-config.js
+++ b/scripts/write-config.js
@@ -20,11 +20,8 @@ function writeConfig(file, newValue) {
 
   const oldContents = fs.readFileSync(file, 'utf8');
   const newContents = jju.update(oldContents, newValue, {
-    mode: 'jsonc',
-    indent: 2,
-    quote: '"',
-    quote_keys: true,
-    no_trailing_comma: true
+    mode: 'cjson',
+    indent: 2
   });
   fs.writeFileSync(file, newContents);
   return true;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: somewhat related to #7907
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add an npm script to rebuild the codepen examples.

Fix some incorrect/unnecessary params I was passing for updating rush.json ('jsonc' is not a valid mode for 'jju', and once the mode is changed to 'cjson', the other options aren't needed).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7921)