### PR TITLE
Tooltip: update some tooltip examples to better show how to do aria tags with tooltip

### DIFF
--- a/common/changes/office-ui-fabric-react/tooltip_2019-02-07-23-13.json
+++ b/common/changes/office-ui-fabric-react/tooltip_2019-02-07-23-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/tooltip_2019-02-09-01-00.json
+++ b/common/changes/office-ui-fabric-react/tooltip_2019-02-09-01-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: Updates examples to demonstrate how to tag aria attributes correctly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
@@ -8,8 +8,8 @@ export class TooltipBasicExample extends BaseComponent<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id="myID" calloutProps={{ gapSpace: 0 }}>
-          <DefaultButton aria-describedby="myID">Hover Over Me</DefaultButton>
+        <TooltipHost content="This is the tooltip" id="myID-base" calloutProps={{ gapSpace: 0 }}>
+          <DefaultButton aria-labelledby="myID-base">Hover Over Me</DefaultButton>
         </TooltipHost>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
@@ -8,8 +8,8 @@ export class TooltipBasicExample extends BaseComponent<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id="myID-base" calloutProps={{ gapSpace: 0 }}>
-          <DefaultButton aria-labelledby="myID-base">Hover Over Me</DefaultButton>
+        <TooltipHost content="This is the tooltip" id="baseicTooltipExample" calloutProps={{ gapSpace: 0 }}>
+          <DefaultButton aria-labelledby="baseicTooltipExample">Hover Over Me</DefaultButton>
         </TooltipHost>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
@@ -24,7 +24,7 @@ export class TooltipCustomExample extends BaseComponent<any, any> {
         id="customID"
         directionalHint={DirectionalHint.bottomCenter}
       >
-        <DefaultButton aria-describedby="customID" text="Hover Over Me" />
+        <DefaultButton aria-labelledby="customID" text="Hover Over Me" />
       </TooltipHost>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Display.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Display.Example.tsx
@@ -10,13 +10,18 @@ export class TooltipDisplayExample extends BaseComponent<any, any> {
           In some cases when TooltipHost is wrapping inline-block or inline elements the positioning of the Tooltip may be off so it is
           recommended to modify the display property of the TooltipHost as in the following example.
         </p>
-        <TooltipHost content="Incorrect positioning" id="myID" calloutProps={{ gapSpace: 0 }}>
-          <button style={{ fontSize: '2em' }} aria-describedby="myID">
+        <TooltipHost content="Incorrect positioning" id="myID-display1" calloutProps={{ gapSpace: 0 }}>
+          <button style={{ fontSize: '2em' }} aria-labelledby="myID-display1">
             Hover Over Me
           </button>
         </TooltipHost>{' '}
-        <TooltipHost content="Correct positioning" styles={{ root: { display: 'inline-block' } }} id="myID" calloutProps={{ gapSpace: 0 }}>
-          <button style={{ fontSize: '2em' }} aria-describedby="myID">
+        <TooltipHost
+          content="Correct positioning"
+          styles={{ root: { display: 'inline-block' } }}
+          id="myID-display2"
+          calloutProps={{ gapSpace: 0 }}
+        >
+          <button style={{ fontSize: '2em' }} aria-labelledby="myID-display2">
             Hover Over Me
           </button>
         </TooltipHost>

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx
@@ -7,8 +7,8 @@ export class TooltipInteractiveExample extends BaseComponent<any, any> {
   public render() {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id="myID" calloutProps={{ gapSpace: 0 }} closeDelay={500}>
-          <DefaultButton aria-describedby="myID">Interact with my tooltip</DefaultButton>
+        <TooltipHost content="This is the tooltip" id="myID-interactive" calloutProps={{ gapSpace: 0 }} closeDelay={500}>
+          <DefaultButton aria-labelledby="myID-interactive">Interact with my tooltip</DefaultButton>
         </TooltipHost>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
@@ -9,7 +9,7 @@ export class TooltipNoScrollExample extends BaseComponent<{}> {
   public render(): JSX.Element {
     return (
       <TooltipHost content="This is the tooltip" id={this.tooltipId} tooltipProps={{ style: { overflowY: 'auto' } }}>
-        <DefaultButton>Tooltip without scroll</DefaultButton>
+        <DefaultButton aria-describedby={this.tooltipId}>Tooltip without scroll</DefaultButton>
       </TooltipHost>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
@@ -9,7 +9,7 @@ export class TooltipNoScrollExample extends BaseComponent<{}> {
   public render(): JSX.Element {
     return (
       <TooltipHost content="This is the tooltip" id={this.tooltipId} tooltipProps={{ style: { overflowY: 'auto' } }}>
-        <DefaultButton aria-describedby={this.tooltipId}>Tooltip without scroll</DefaultButton>
+        <DefaultButton aria-labelledby={this.tooltipId}>Tooltip without scroll</DefaultButton>
       </TooltipHost>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Overflow.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Overflow.Example.tsx
@@ -46,7 +46,7 @@ export class TooltipOverflowExample extends BaseComponent<{}, ITooltipOverflowEx
               overflowMode={TooltipOverflowMode.Parent}
               onTooltipToggle={(isTooltipVisible: boolean) => this.setState({ isTooltipVisible })}
             >
-              <span aria-describedby={this.state.isTooltipVisible ? this.tooltipId : undefined}>
+              <span aria-labelledby={this.state.isTooltipVisible ? this.tooltipId : undefined}>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec volutpat lectus ut magna sodales, sit amet accumsan arcu
                 accumsan. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
               </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -14,8 +14,7 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
     onMouseLeave={[Function]}
   >
     <button
-      aria-describedby="myID"
-      aria-labelledby="id__0"
+      aria-labelledby="myID-base"
       className=
           ms-Button
           ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -14,7 +14,7 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
     onMouseLeave={[Function]}
   >
     <button
-      aria-labelledby="myID-base"
+      aria-labelledby="baseicTooltipExample"
       className=
           ms-Button
           ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
@@ -13,8 +13,7 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
   onMouseLeave={[Function]}
 >
   <button
-    aria-describedby="customID"
-    aria-labelledby="id__0"
+    aria-labelledby="customID"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Display.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Display.Example.tsx.shot
@@ -17,7 +17,7 @@ exports[`Component Examples renders Tooltip.Display.Example.tsx correctly 1`] = 
     onMouseLeave={[Function]}
   >
     <button
-      aria-describedby="myID"
+      aria-labelledby="myID-display1"
       style={
         Object {
           "fontSize": "2em",
@@ -40,7 +40,7 @@ exports[`Component Examples renders Tooltip.Display.Example.tsx correctly 1`] = 
     onMouseLeave={[Function]}
   >
     <button
-      aria-describedby="myID"
+      aria-labelledby="myID-display2"
       style={
         Object {
           "fontSize": "2em",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
@@ -14,8 +14,7 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
     onMouseLeave={[Function]}
   >
     <button
-      aria-describedby="myID"
-      aria-labelledby="id__0"
+      aria-labelledby="myID-interactive"
       className=
           ms-Button
           ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
@@ -13,6 +13,8 @@ exports[`Component Examples renders Tooltip.NoScroll.Example.tsx correctly 1`] =
   onMouseLeave={[Function]}
 >
   <button
+    aria-describedby="text-tooltip0"
+    aria-labelledby="id__1"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
@@ -13,8 +13,7 @@ exports[`Component Examples renders Tooltip.NoScroll.Example.tsx correctly 1`] =
   onMouseLeave={[Function]}
 >
   <button
-    aria-describedby="text-tooltip0"
-    aria-labelledby="id__1"
+    aria-labelledby="text-tooltip0"
     className=
         ms-Button
         ms-Button--default


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7926
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Nothing is truly wrong with the a11y pass on tooltip, just that the examples need to be updated to demo how to make the aria attributes work.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7929)