### PR TITLE
Use generic T instead of hardcoded IPersonaProps in onSuggestionRemove

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-onSuggestionRemove-types_2019-02-08-00-41.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-onSuggestionRemove-types_2019-02-08-00-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Re-type onItemRemove in Suggestions to support the suggestions Generic type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-onSuggestionRemove-types_2019-02-08-00-41.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-onSuggestionRemove-types_2019-02-08-00-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Re-type onItemRemove in Suggestions to support the suggestions Generic type",
+      "comment": "Pickers: Re-type onItemRemove in Suggestions to support the suggestions Generic type",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10776,7 +10776,7 @@ interface ISuggestionsProps<T> extends React.Props<any> {
   onRenderNoResultFound?: IRenderFunction<void>;
   onRenderSuggestion?: (props: T, suggestionItemProps: T) => JSX.Element;
   onSuggestionClick: (ev?: React.MouseEvent<HTMLElement>, item?: any, index?: number) => void;
-  onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: IPersonaProps, index?: number) => void;
+  onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: T | IPersonaProps, index?: number) => void;
   refocusSuggestions?: (keyCode: KeyCodes) => void;
   removeSuggestionAriaLabel?: string;
   resultsFooter?: (props: ISuggestionsProps<T>) => JSX.Element;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { IRefObject, IRenderFunction, KeyCodes, IStyleFunctionOrObject } from '../../../Utilities';
-import { IPersonaProps } from '../../Persona/Persona.types';
 import { IStyle, ITheme } from '../../../Styling';
 import { ISpinnerStyleProps } from '../../Spinner/Spinner.types';
 
@@ -154,7 +153,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
   /**
    * Function to fire when one of the optional remove buttons on a suggestion is clicked.
    */
-  onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: IPersonaProps, index?: number) => void;
+  onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: T, index?: number) => void;
 
   /**
    * Indicates if the text in resultsFooter or resultsFooterFull should be shown at the end of the suggestion list.

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { IRefObject, IRenderFunction, KeyCodes, IStyleFunctionOrObject } from '../../../Utilities';
+import { IPersonaProps } from '../../Persona/Persona.types';
 import { IStyle, ITheme } from '../../../Styling';
 import { ISpinnerStyleProps } from '../../Spinner/Spinner.types';
 
@@ -152,8 +153,10 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
 
   /**
    * Function to fire when one of the optional remove buttons on a suggestion is clicked.
+   *
+   * TODO (adjective-object) clean up
    */
-  onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: T, index?: number) => void;
+  onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: T | IPersonaProps, index?: number) => void;
 
   /**
    * Indicates if the text in resultsFooter or resultsFooterFull should be shown at the end of the suggestion list.

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -154,7 +154,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
   /**
    * Function to fire when one of the optional remove buttons on a suggestion is clicked.
    *
-   * TODO (adjective-object) clean up
+   * TODO (adjective-object) remove IPersonaprops before the next major version bump
    */
   onSuggestionRemove?: (ev?: React.MouseEvent<HTMLElement>, item?: T | IPersonaProps, index?: number) => void;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~Addresses an existing issue: Fixes #0000~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

https://github.com/OfficeDev/office-ui-fabric-react/blob/79b0b51adfef2da8b0e7c215b5d94c62ab553692/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsCore.tsx#L183-L187

in SuggestionsCore, onSuggestionsRemove is passing an item of generic type T. For some reason on the type contract, it is hardcoded to be an IPersonaProps.

Presumably no one that is consuming Suggestions is using it for anything other than a people picker so this hasn't come up yet, but I noticed it while trying to write a Suggestions storybook for another datatype in #7914



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7931)