### PR TITLE
Make ChoiceGroupOptions stylable

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-stylableOptions_2019-02-08-00-59.json
+++ b/common/changes/office-ui-fabric-react/phkuo-stylableOptions_2019-02-08-00-59.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Make ChoiceGroupOptions stylable",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/phkuo-stylableOptions_2019-02-08-00-59.json
+++ b/common/changes/office-ui-fabric-react/phkuo-stylableOptions_2019-02-08-00-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make ChoiceGroupOptions stylable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2459,6 +2459,7 @@ interface IChoiceGroupOption extends React.HTMLAttributes<HTMLElement | HTMLInpu
   onRenderField?: IRenderFunction<IChoiceGroupOption>;
   onRenderLabel?: (option: IChoiceGroupOption) => JSX.Element;
   selectedImageSrc?: string;
+  styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
   text: string;
 }
 
@@ -2471,7 +2472,6 @@ interface IChoiceGroupOptionProps extends IChoiceGroupOption {
   onChange?: OnChangeCallback;
   onFocus?: OnFocusCallback;
   required?: boolean;
-  styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
   theme?: ITheme;
 }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { IIconProps } from '../../Icon';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
+import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption/ChoiceGroupOption.types';
 
 export interface IChoiceGroup {
   /**
@@ -144,6 +145,11 @@ export interface IChoiceGroupOption extends React.HTMLAttributes<HTMLElement | H
    * The aria label of the ChoiceGroupOption for the benefit of screen readers.
    */
   ariaLabel?: string;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
 }
 
 export interface IChoiceGroupStyleProps {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -10,7 +10,8 @@ const GlobalClassNames = {
   innerField: 'ms-ChoiceField-innerField',
   imageWrapper: 'ms-ChoiceField-imageWrapper',
   iconWrapper: 'ms-ChoiceField-iconWrapper',
-  labelWrapper: 'ms-ChoiceField-labelWrapper'
+  labelWrapper: 'ms-ChoiceField-labelWrapper',
+  checked: 'is-checked'
 };
 
 const labelWrapperLineHeight = 15;
@@ -257,6 +258,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
     ],
     field: [
       classNames.field,
+      checked && classNames.checked,
       {
         display: 'inline-block',
         cursor: 'pointer',

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ITheme, IStyle } from '../../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../../Utilities';
+import { IRefObject } from '../../../Utilities';
 import { IChoiceGroupOption } from '../../ChoiceGroup/ChoiceGroup.types';
 
 export type OnFocusCallback = (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
@@ -37,11 +37,6 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
    * Theme (provided through customization.)
    */
   theme?: ITheme;
-
-  /**
-   * Call to provide customized styling that will layer on top of the variant rules.
-   */
-  styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
 
   /**
    * If true, it specifies that an option must be selected in the ChoiceGroup before submitting the form

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -304,6 +304,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       <label
         className=
             ms-ChoiceField-field
+            is-checked
             {
               border-color: #0078d4;
               cursor: pointer;
@@ -529,6 +530,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       <label
         className=
             ms-ChoiceField-field
+            is-checked
             {
               border-color: #0078d4;
               cursor: default;
@@ -1091,6 +1093,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
       <label
         className=
             ms-ChoiceField-field
+            is-checked
             ms-ChoiceField--icon
             {
               align-items: center;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
@@ -32,7 +32,12 @@ export class ChoiceGroupCustomExample extends React.Component {
             },
             {
               key: 'B',
-              text: 'Option B'
+              text: 'Option B',
+              styles: {
+                root: {
+                  border: '1px solid green'
+                }
+              }
             },
             {
               key: 'C',

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -225,6 +225,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             <label
               className=
                   ms-ChoiceField-field
+                  is-checked
                   {
                     border-color: #0078d4;
                     cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -363,7 +363,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 align-items: center;
-                border: none;
+                border: 1px solid green;
                 box-sizing: border-box;
                 color: #333333;
                 display: flex;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -406,6 +406,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             <label
               className=
                   ms-ChoiceField-field
+                  is-checked
                   {
                     border-color: #0078d4;
                     cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -120,6 +120,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
             <label
               className=
                   ms-ChoiceField-field
+                  is-checked
                   ms-ChoiceField-field--image
                   {
                     align-items: center;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -196,6 +196,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
             <label
               className=
                   ms-ChoiceField-field
+                  is-checked
                   {
                     border-color: #0078d4;
                     cursor: pointer;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-422:hover + .headerDividerBar-423 {
+      & .headerDivider-423:hover + .headerDividerBar-424 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1) Backwards compat fix: re-add the `is-checked` class that was present in Fabric 5.
2) Add a pass-through prop so that users of `ChoiceGroup` can style the children `ChoiceGroupOption`s.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7932)