### PR TITLE
7935 - Clicking Prefix/Suffix in TextField does not result in the focus being set.

### DIFF
--- a/apps/vr-tests/src/stories/TextField.stories.tsx
+++ b/apps/vr-tests/src/stories/TextField.stories.tsx
@@ -49,3 +49,35 @@ storiesOf('TextField', module)
       rtl: true
     }
   );
+
+storiesOf('TextField', module)
+  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .click('.ms-TextField-suffix')
+        .snapshot('click', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Click Suffix', () => <TextField label="Suffix" suffix=".com" value="example" />);
+
+storiesOf('TextField', module)
+  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .click('.ms-TextField-prefix')
+        .snapshot('click', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Click Prefix', () => (
+    <TextField label="Prefix" prefix="https://" value="example.com" />
+  ));

--- a/common/changes/office-ui-fabric-react/Issue-7935_2019-02-08-17-08.json
+++ b/common/changes/office-ui-fabric-react/Issue-7935_2019-02-08-17-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Clicking on 'prefix' or 'suffix' of TextField now results in input field receiving focus.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "patrik@themediaexchange.nl"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -232,15 +232,21 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
           {onRenderLabel(this.props, this._onRenderLabel)}
           <div className={this._classNames.fieldGroup}>
             {(addonString !== undefined || this.props.onRenderAddon) && (
-              <div className={this._classNames.prefix}>{onRenderAddon(this.props, this._onRenderAddon)}</div>
+              <label htmlFor={this._id} className={this._classNames.prefix}>
+                {onRenderAddon(this.props, this._onRenderAddon)}
+              </label>
             )}
             {(prefix !== undefined || this.props.onRenderPrefix) && (
-              <div className={this._classNames.prefix}>{onRenderPrefix(this.props, this._onRenderPrefix)}</div>
+              <label htmlFor={this._id} className={this._classNames.prefix}>
+                {onRenderPrefix(this.props, this._onRenderPrefix)}
+              </label>
             )}
             {multiline ? this._renderTextArea() : this._renderInput()}
             {(iconClass || iconProps) && <Icon className={this._classNames.icon} {...iconProps} />}
             {(suffix !== undefined || this.props.onRenderSuffix) && (
-              <div className={this._classNames.suffix}>{onRenderSuffix(this.props, this._onRenderSuffix)}</div>
+              <label htmlFor={this._id} className={this._classNames.suffix}>
+                {onRenderSuffix(this.props, this._onRenderSuffix)}
+              </label>
             )}
           </div>
         </div>

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.deprecated.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`TextField deprecated renders with deprecated props affecting styling 1`
             border-color: Highlight;
           }
     >
-      <div
+      <label
         className=
             ms-TextField-prefix
             {
@@ -67,6 +67,7 @@ exports[`TextField deprecated renders with deprecated props affecting styling 1`
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -77,7 +78,7 @@ exports[`TextField deprecated renders with deprecated props affecting styling 1`
         >
           test addonString
         </span>
-      </div>
+      </label>
       <input
         aria-invalid={false}
         className=

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -514,7 +514,7 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
             border-color: #a80000;
           }
     >
-      <div
+      <label
         className=
             ms-TextField-prefix
             {
@@ -529,6 +529,7 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -539,7 +540,7 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
         >
           test prefix
         </span>
-      </div>
+      </label>
       <input
         aria-describedby="TextFieldDescription1"
         aria-invalid={false}
@@ -590,7 +591,7 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
         type="text"
         value=""
       />
-      <div
+      <label
         className=
             ms-TextField-suffix
             {
@@ -605,6 +606,7 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -615,7 +617,7 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
         >
           test suffix
         </span>
-      </div>
+      </label>
     </div>
   </div>
   <span
@@ -729,7 +731,7 @@ exports[`TextField renders multiline TextField correctly with props affecting st
             border-color: #a80000;
           }
     >
-      <div
+      <label
         className=
             ms-TextField-prefix
             {
@@ -744,6 +746,7 @@ exports[`TextField renders multiline TextField correctly with props affecting st
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -754,7 +757,7 @@ exports[`TextField renders multiline TextField correctly with props affecting st
         >
           test prefix
         </span>
-      </div>
+      </label>
       <input
         aria-describedby="TextFieldDescription1"
         aria-invalid={false}
@@ -805,7 +808,7 @@ exports[`TextField renders multiline TextField correctly with props affecting st
         type="text"
         value=""
       />
-      <div
+      <label
         className=
             ms-TextField-suffix
             {
@@ -820,6 +823,7 @@ exports[`TextField renders multiline TextField correctly with props affecting st
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -830,7 +834,7 @@ exports[`TextField renders multiline TextField correctly with props affecting st
         >
           test suffix
         </span>
-      </div>
+      </label>
     </div>
   </div>
   <span
@@ -946,7 +950,7 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
             border-color: #a80000;
           }
     >
-      <div
+      <label
         className=
             ms-TextField-prefix
             {
@@ -961,6 +965,7 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -971,7 +976,7 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
         >
           test prefix
         </span>
-      </div>
+      </label>
       <input
         aria-describedby="TextFieldDescription1"
         aria-invalid={false}
@@ -1022,7 +1027,7 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
         type="text"
         value=""
       />
-      <div
+      <label
         className=
             ms-TextField-suffix
             {
@@ -1037,6 +1042,7 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
               padding-top: 0;
               white-space: nowrap;
             }
+        htmlFor="TextField0"
       >
         <span
           style={
@@ -1047,7 +1053,7 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
         >
           test suffix
         </span>
-      </div>
+      </label>
     </div>
   </div>
   <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Prefix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Prefix.Example.tsx.shot
@@ -55,7 +55,7 @@ exports[`Component Examples renders TextField.Prefix.Example.tsx correctly 1`] =
               border-color: Highlight;
             }
       >
-        <div
+        <label
           className=
               ms-TextField-prefix
               {
@@ -70,6 +70,7 @@ exports[`Component Examples renders TextField.Prefix.Example.tsx correctly 1`] =
                 padding-top: 0;
                 white-space: nowrap;
               }
+          htmlFor="TextField0"
         >
           <span
             style={
@@ -80,7 +81,7 @@ exports[`Component Examples renders TextField.Prefix.Example.tsx correctly 1`] =
           >
             https://
           </span>
-        </div>
+        </label>
         <input
           aria-invalid={false}
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -55,7 +55,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
               border-color: Highlight;
             }
       >
-        <div
+        <label
           className=
               ms-TextField-prefix
               {
@@ -70,6 +70,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 padding-top: 0;
                 white-space: nowrap;
               }
+          htmlFor="TextField0"
         >
           <span
             style={
@@ -80,7 +81,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           >
             https://
           </span>
-        </div>
+        </label>
         <input
           aria-invalid={false}
           className=
@@ -129,7 +130,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           type="text"
           value=""
         />
-        <div
+        <label
           className=
               ms-TextField-suffix
               {
@@ -144,6 +145,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 padding-top: 0;
                 white-space: nowrap;
               }
+          htmlFor="TextField0"
         >
           <span
             style={
@@ -154,7 +156,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           >
             .com
           </span>
-        </div>
+        </label>
       </div>
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Suffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Suffix.Example.tsx.shot
@@ -103,7 +103,7 @@ exports[`Component Examples renders TextField.Suffix.Example.tsx correctly 1`] =
           type="text"
           value=""
         />
-        <div
+        <label
           className=
               ms-TextField-suffix
               {
@@ -118,6 +118,7 @@ exports[`Component Examples renders TextField.Suffix.Example.tsx correctly 1`] =
                 padding-top: 0;
                 white-space: nowrap;
               }
+          htmlFor="TextField0"
         >
           <span
             style={
@@ -128,7 +129,7 @@ exports[`Component Examples renders TextField.Suffix.Example.tsx correctly 1`] =
           >
             .com
           </span>
-        </div>
+        </label>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7935 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
This will ensure clicking the prefix/suffix area of a textbox results in the input field receiving focus.

#### Focus areas to test


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7937)