### PR TITLE
Remove unneeded cast in EditingItem

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-extendedpicker-demo_2019-02-08-21-31.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-extendedpicker-demo_2019-02-08-21-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pickers: fix bug in ExtendedPicker demo and remove unneeded cast in EditingItem",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
@@ -24,21 +24,16 @@ export interface IEditingSelectedPeopleItemProps extends ISelectedPeopleItemProp
 export class EditingItem extends BaseComponent<IEditingSelectedPeopleItemProps, IPeoplePickerItemState> {
   private _editingInput: HTMLInputElement;
   private _editingFloatingPicker = React.createRef<FloatingPeoplePicker>();
-  private _onRenderFloatingPicker: (props: IBaseFloatingPickerProps<IExtendedPersonaProps>) => JSX.Element;
-  private _floatingPickerProps: IBaseFloatingPickerProps<IExtendedPersonaProps>;
 
   constructor(props: IEditingSelectedPeopleItemProps) {
     super(props);
     this.state = { contextualMenuVisible: false };
-    this._onRenderFloatingPicker = this.props.onRenderFloatingPicker as (
-      props: IBaseFloatingPickerProps<IExtendedPersonaProps>
-    ) => JSX.Element;
-    this._floatingPickerProps = this.props.floatingPickerProps as IBaseFloatingPickerProps<IExtendedPersonaProps>;
   }
 
   public componentDidMount(): void {
     const getEditingItemText = this.props.getEditingItemText as (item: IExtendedPersonaProps) => string;
     const itemText = getEditingItemText(this.props.item);
+
     this._editingFloatingPicker.current && this._editingFloatingPicker.current.onQueryStringChanged(itemText);
     this._editingInput.value = itemText;
     this._editingInput.focus();
@@ -68,14 +63,20 @@ export class EditingItem extends BaseComponent<IEditingSelectedPeopleItemProps, 
   }
 
   private _renderEditingSuggestions = (): JSX.Element => {
-    const onRenderFloatingPicker = this._onRenderFloatingPicker;
-    return onRenderFloatingPicker({
-      componentRef: this._editingFloatingPicker,
-      onChange: this._onSuggestionSelected,
-      inputElement: this._editingInput,
-      selectedItems: [],
-      ...this._floatingPickerProps
-    });
+    const FloatingPicker = this.props.onRenderFloatingPicker;
+    const floatingPickerProps = this.props.floatingPickerProps;
+    if (!FloatingPicker || !floatingPickerProps) {
+      return <></>;
+    }
+    return (
+      <FloatingPicker
+        componentRef={this._editingFloatingPicker}
+        onChange={this._onSuggestionSelected}
+        inputElement={this._editingInput}
+        selectedItems={[]}
+        {...floatingPickerProps}
+      />
+    );
   };
 
   private _resolveInputRef = (ref: HTMLInputElement): void => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~Addresses an existing issue: Fixes #0000~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Because EditingItem performs a cast when assigning its local members, there was a bug in the ExtendedPicker demo (introduced with the demo changes in #7877).

Specifically, the EditingItem would attempt to render the editing item dropdown as a function, and not a component. When rendering the editing dropdown, the item would cause a render error with an unbound `this` in the render.

It looks like internally EditingItem was casting the property because the props were declared as optional on the type contract but were actually required. As part of this fix, I added null checks to the usages of the dropdown.

#### Focus areas to test

EditingItem,
ExtendedPeoplePicker demo


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7940)