### PR TITLE
Picker Suggestions: adding a little overflow-x on title line

### DIFF
--- a/common/changes/office-ui-fabric-react/floating_2019-02-08-23-05.json
+++ b/common/changes/office-ui-fabric-react/floating_2019-02-08-23-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Picker Suggestions: adding a little overflow-x on title line so close button can be shown even if width is more than 180px by consumers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -75,13 +75,13 @@
   width: 100%;
   font-size: 12px;
   &:hover {
-      background-color: $ms-color-neutralLight;
-      cursor: pointer;
+    background-color: $ms-color-neutralLight;
+    cursor: pointer;
   }
   // TODO: Works in Chrome, but not working in IE
   &:focus,
   &:active {
-      background-color: $ms-color-themeLight;
+    background-color: $ms-color-themeLight;
   }
 
   :global(.ms-Button-icon) {
@@ -142,6 +142,7 @@
 .itemButton.itemButton {
   width: 100%;
   padding: 0px;
+  overflow-x: hidden;
 
   /* once this is converted to js css, then specificity won't be an issue. */
   height: 100%;
@@ -177,6 +178,6 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   border: 0;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7912 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

... so close button can be shown even if width is more than 180px by consumers

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7943)