### PR TITLE
Combobox: adds an autofillprops to allow maxlength behavior

### DIFF
--- a/common/changes/office-ui-fabric-react/combobox_2019-02-08-23-57.json
+++ b/common/changes/office-ui-fabric-react/combobox_2019-02-08-23-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: adds an autofillProps",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2906,7 +2906,7 @@ interface IComboBoxOptionStyles extends IButtonStyles {
 interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox> {
   allowFreeform?: boolean;
   autoComplete?: 'on' | 'off';
-  autofillProps?: IAutofillProps;
+  autofill?: IAutofillProps;
   buttonIconProps?: IIconProps;
   caretDownButtonStyles?: Partial<IButtonStyles>;
   comboBoxOptionStyles?: Partial<IComboBoxOptionStyles>;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2906,6 +2906,7 @@ interface IComboBoxOptionStyles extends IButtonStyles {
 interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox> {
   allowFreeform?: boolean;
   autoComplete?: 'on' | 'off';
+  autofillProps?: IAutofillProps;
   buttonIconProps?: IIconProps;
   caretDownButtonStyles?: Partial<IButtonStyles>;
   comboBoxOptionStyles?: Partial<IComboBoxOptionStyles>;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -326,7 +326,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       keytipProps,
       placeholder,
       tabIndex,
-      autofillProps
+      autofill
     } = this.props;
     const { isOpen, focused, suggestedDisplayValue } = this.state;
     this._currentVisibleValue = this._getVisibleValue();
@@ -396,7 +396,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 preventValueSelection={!focused}
                 placeholder={placeholder}
                 tabIndex={tabIndex}
-                {...autofillProps}
+                {...autofill}
               />
               <IconButton
                 className={'ms-ComboBox-CaretDown-button'}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -325,7 +325,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       title,
       keytipProps,
       placeholder,
-      tabIndex
+      tabIndex,
+      autofillProps
     } = this.props;
     const { isOpen, focused, suggestedDisplayValue } = this.state;
     this._currentVisibleValue = this._getVisibleValue();
@@ -395,6 +396,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 preventValueSelection={!focused}
                 placeholder={placeholder}
                 tabIndex={tabIndex}
+                {...autofillProps}
               />
               <IconButton
                 className={'ms-ComboBox-CaretDown-button'}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -6,6 +6,7 @@ import { IButtonStyles } from '../../Button';
 import { IRefObject, IRenderFunction } from '../../Utilities';
 import { IComboBoxClassNames } from './ComboBox.classNames';
 import { IKeytipProps } from '../../Keytip';
+import { IAutofillProps } from '../pickers/AutoFill/BaseAutoFill.types';
 
 export interface IComboBox {
   /**
@@ -117,6 +118,11 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
    * The IconProps to use for the button aspect of the combobox
    */
   buttonIconProps?: IIconProps;
+
+  /**
+   * The AutofillProps to be passed into the Autofill component inside combobox
+   */
+  autofillProps?: IAutofillProps;
 
   /**
    * Theme provided by HOC.

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -122,7 +122,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox>
   /**
    * The AutofillProps to be passed into the Autofill component inside combobox
    */
-  autofillProps?: IAutofillProps;
+  autofill?: IAutofillProps;
 
   /**
    * Theme provided by HOC.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7944 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

To solve #7944, we need to expose props that can be overridden by the consumers of combobox for the autofill "Slot" (we dont' have slots there yet, but it would be covered in that scenario in the future).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7945)