### PR TITLE
Toggle hidden

### DIFF
--- a/common/changes/office-ui-fabric-react/toggle-hidden_2019-02-11-19-23.json
+++ b/common/changes/office-ui-fabric-react/toggle-hidden_2019-02-11-19-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: pass in native hidden prop to root element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -78,7 +78,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
     });
 
     return (
-      <RootType className={classNames.root}>
+      <RootType className={classNames.root} hidden={(toggleNativeProps as any).hidden}>
         {label && (
           <Label htmlFor={this._id} className={classNames.label}>
             {label}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -34,6 +34,12 @@ describe('Toggle', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders hidden toggle correctly', () => {
+    const component = renderer.create(<Toggle hidden />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders aria-label', () => {
     const component = mount(<Toggle label="Label" ariaLabel="AriaLabel" />);
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -1,5 +1,104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Toggle renders hidden toggle correctly 1`] = `
+<div
+  className=
+      ms-Toggle
+      is-enabled
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 8px;
+      }
+  hidden={true}
+>
+  <div
+    className=
+        ms-Toggle-innerContainer
+        {
+          display: inline-flex;
+          position: relative;
+        }
+  >
+    <button
+      aria-checked={false}
+      className=
+          ms-Toggle-background
+          {
+            align-items: center;
+            background: #ffffff;
+            border-color: #666666;
+            border-radius: 1em;
+            border-style: solid;
+            border-width: 1px;
+            box-sizing: border-box;
+            cursor: pointer;
+            display: flex;
+            font-size: 20px;
+            height: 1em;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: .2em;
+            padding-right: .2em;
+            padding-top: 0;
+            position: relative;
+            transition: all 0.1s ease;
+            width: 2.2em;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: -2px;
+            content: "";
+            left: -2px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: -2px;
+            top: -2px;
+            z-index: 1;
+          }
+          &:hover {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+            border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+      data-is-focusable={true}
+      hidden={true}
+      id="Toggle4"
+      onChange={[Function]}
+      onClick={[Function]}
+      role="switch"
+      type="button"
+    >
+      <div
+        className=
+            ms-Toggle-thumb
+            {
+              background-color: #333333;
+              border-color: transparent;
+              border-radius: .5em;
+              border-style: solid;
+              border-width: .28em;
+              box-sizing: border-box;
+              height: .5em;
+              transition: all 0.1s ease;
+              width: .5em;
+            }
+      />
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Toggle renders toggle correctly 1`] = `
 <div
   className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7951 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Toggle currently does not pass in any native props to its root element. When the user passes the native HTML `hidden` props to a Toggle, the Toggle is visible when it should be hidden. This change passes the `hidden` prop from `toggleNativeProps` to the RootType.

Discussion: should more native props be passed to RootType? The rest of the native props are currently passed in to the `button` element within the KeytipData container.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7952)