### PR TITLE
Fix ID usage in some examples

### DIFF
--- a/common/changes/office-ui-fabric-react/ids_2019-02-11-19-32.json
+++ b/common/changes/office-ui-fabric-react/ids_2019-02-11-19-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix ID usage in examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -111,7 +111,7 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
   private _getCustomDivider = (dividerProps: IDividerAsProps): JSX.Element => {
     const tooltipText = dividerProps.item ? dividerProps.item.text : '';
     return (
-      <TooltipHost content={`Show ${tooltipText} contents`} id="myID" calloutProps={{ gapSpace: 0 }}>
+      <TooltipHost content={`Show ${tooltipText} contents`} calloutProps={{ gapSpace: 0 }}>
         <span style={{ cursor: 'pointer' }}>/</span>
       </TooltipHost>
     );

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Basic.Example.tsx
@@ -3,6 +3,7 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { getTheme, FontWeights, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
 export interface ICalloutBasicExampleState {
   isCalloutVisible?: boolean;
@@ -50,15 +51,15 @@ const styles = mergeStyleSets({
 
 // Example code
 export class CalloutBasicExample extends React.Component<{}, ICalloutBasicExampleState> {
+  public state: ICalloutBasicExampleState = {
+    isCalloutVisible: false
+  };
+
   private _menuButtonElement = React.createRef<HTMLDivElement>();
-
-  public constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      isCalloutVisible: false
-    };
-  }
+  // Use getId() to ensure that the callout label and description IDs are unique on the page.
+  // (It's also okay to use plain strings without getId() and manually ensure their uniqueness.)
+  private _labelId: string = getId('callout-label');
+  private _descriptionId: string = getId('callout-description');
 
   public render(): JSX.Element {
     const { isCalloutVisible } = this.state;
@@ -66,13 +67,13 @@ export class CalloutBasicExample extends React.Component<{}, ICalloutBasicExampl
     return (
       <div>
         <div className={styles.buttonArea} ref={this._menuButtonElement}>
-          <DefaultButton id="toggleCallout" onClick={this._onShowMenuClicked} text={isCalloutVisible ? 'Hide callout' : 'Show callout'} />
+          <DefaultButton onClick={this._onShowMenuClicked} text={isCalloutVisible ? 'Hide callout' : 'Show callout'} />
         </div>
         <Callout
           className="ms-CalloutExample-callout"
-          ariaLabelledBy={'callout-label-1'}
-          ariaDescribedBy={'callout-description-1'}
-          role={'alertdialog'}
+          ariaLabelledBy={this._labelId}
+          ariaDescribedBy={this._descriptionId}
+          role="alertdialog"
           gapSpace={0}
           target={this._menuButtonElement.current}
           onDismiss={this._onCalloutDismiss}
@@ -80,13 +81,13 @@ export class CalloutBasicExample extends React.Component<{}, ICalloutBasicExampl
           hidden={!this.state.isCalloutVisible}
         >
           <div className="ms-CalloutExample-header">
-            <p className="ms-CalloutExample-title" id={'callout-label-1'}>
+            <p className="ms-CalloutExample-title" id={this._labelId}>
               All of your favorite people
             </p>
           </div>
           <div className="ms-CalloutExample-inner">
             <div className="ms-CalloutExample-content">
-              <p className="ms-CalloutExample-subText" id={'callout-description-1'}>
+              <p className="ms-CalloutExample-subText" id={this._descriptionId}>
                 Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
               </p>
             </div>

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx
@@ -2,29 +2,26 @@ import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusTrapCallout } from 'office-ui-fabric-react/lib/Callout';
 import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import './CalloutExample.scss';
 
 export interface ICalloutFocusTrapExampleProps {
   items: ICommandBarItemProps[];
 }
 
-export class CalloutFocusTrapExample extends React.Component<
-  ICalloutFocusTrapExampleProps,
-  {
-    isCalloutVisible: boolean;
-  }
-> {
+export interface ICalloutFocusTrapExampleState {
+  isCalloutVisible: boolean;
+}
+
+export class CalloutFocusTrapExample extends React.Component<ICalloutFocusTrapExampleProps, ICalloutFocusTrapExampleState> {
+  public state: ICalloutFocusTrapExampleState = {
+    isCalloutVisible: false
+  };
+
   private _menuButtonElement: HTMLElement | null;
-
-  public constructor(props: ICalloutFocusTrapExampleProps) {
-    super(props);
-
-    this._onDismiss = this._onDismiss.bind(this);
-
-    this.state = {
-      isCalloutVisible: false
-    };
-  }
+  // Use getId() to ensure that the callout title ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure its uniqueness.)
+  private _titleId: string = getId('callout-label');
 
   public render(): JSX.Element {
     const { isCalloutVisible } = this.state;
@@ -37,8 +34,8 @@ export class CalloutFocusTrapExample extends React.Component<
         {isCalloutVisible ? (
           <div>
             <FocusTrapCallout
-              role={'alertdialog'}
-              ariaLabelledBy={'callout-label-2'}
+              role="alertdialog"
+              ariaLabelledBy={this._titleId}
               className="ms-CalloutExample-callout"
               gapSpace={0}
               target={this._menuButtonElement}
@@ -46,7 +43,7 @@ export class CalloutFocusTrapExample extends React.Component<
               setInitialFocus={true}
             >
               <div className="ms-CalloutExample-header">
-                <p className="ms-CalloutExample-title" id={'callout-label-2'}>
+                <p className="ms-CalloutExample-title" id={this._titleId}>
                   Callout title here
                 </p>
               </div>
@@ -65,9 +62,9 @@ export class CalloutFocusTrapExample extends React.Component<
     );
   }
 
-  private _onDismiss(ev: any): void {
+  private _onDismiss = () => {
     this.setState({
       isCalloutVisible: !this.state.isCalloutVisible
     });
-  }
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Nested.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.Nested.Example.tsx
@@ -2,29 +2,26 @@ import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
 import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import './CalloutExample.scss';
 
 export interface ICalloutNestedExampleProps {
   items: ICommandBarItemProps[];
 }
 
-export class CalloutNestedExample extends React.Component<
-  ICalloutNestedExampleProps,
-  {
-    isCalloutVisible: boolean;
-  }
-> {
+export interface ICalloutNestedExampleState {
+  isCalloutVisible: boolean;
+}
+
+export class CalloutNestedExample extends React.Component<ICalloutNestedExampleProps, ICalloutNestedExampleState> {
+  public state: ICalloutNestedExampleState = {
+    isCalloutVisible: false
+  };
+
   private _menuButtonElement: HTMLElement | null;
-
-  public constructor(props: ICalloutNestedExampleProps) {
-    super(props);
-
-    this._onDismiss = this._onDismiss.bind(this);
-
-    this.state = {
-      isCalloutVisible: false
-    };
-  }
+  // Use getId() to ensure that the callout title ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure its uniqueness.)
+  private _titleId: string = getId('callout-label');
 
   public render(): JSX.Element {
     const { isCalloutVisible } = this.state;
@@ -37,8 +34,8 @@ export class CalloutNestedExample extends React.Component<
         {isCalloutVisible ? (
           <div>
             <Callout
-              role={'alertdialog'}
-              ariaLabelledBy={'callout-label-2'}
+              role="alertdialog"
+              ariaLabelledBy={this._titleId}
               className="ms-CalloutExample-callout"
               gapSpace={0}
               target={this._menuButtonElement}
@@ -46,7 +43,7 @@ export class CalloutNestedExample extends React.Component<
               setInitialFocus={true}
             >
               <div className="ms-CalloutExample-header">
-                <p className="ms-CalloutExample-title" id={'callout-label-2'}>
+                <p className="ms-CalloutExample-title" id={this._titleId}>
                   Callout title here
                 </p>
               </div>
@@ -65,9 +62,9 @@ export class CalloutNestedExample extends React.Component<
     );
   }
 
-  private _onDismiss(ev: any): void {
+  private _onDismiss = () => {
     this.setState({
       isCalloutVisible: !this.state.isCalloutVisible
     });
-  }
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.ImplementationExamples.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.ImplementationExamples.tsx
@@ -7,15 +7,9 @@ export interface ICheckboxBasicExampleState {
 }
 
 export class CheckboxImplementationExamples extends React.Component<{}, ICheckboxBasicExampleState> {
-  constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      isChecked: false
-    };
-
-    this._onCheckboxChange = this._onCheckboxChange.bind(this);
-  }
+  public state: ICheckboxBasicExampleState = {
+    isChecked: false
+  };
 
   public render(): JSX.Element {
     const { isChecked } = this.state;
@@ -42,11 +36,7 @@ export class CheckboxImplementationExamples extends React.Component<{}, ICheckbo
             }
           }}
           styles={checkboxStyles}
-          ariaLabelledBy={'labelID'}
         />
-        <label id="labelID" className="screenReaderOnly">
-          Uncontrolled checkbox label
-        </label>
 
         <Checkbox
           label="Uncontrolled checkbox with defaultChecked true"
@@ -74,19 +64,19 @@ export class CheckboxImplementationExamples extends React.Component<{}, ICheckbo
     );
   }
 
-  private _onCheckboxChange(ev: React.FormEvent<HTMLElement>, isChecked: boolean): void {
+  private _onCheckboxChange = (ev: React.FormEvent<HTMLElement>, isChecked: boolean) => {
     console.log(`The option has been changed to ${isChecked}.`);
-  }
+  };
 
   private _onControlledCheckboxChange = (ev: React.FormEvent<HTMLElement>, checked: boolean): void => {
     this.setState({ isChecked: checked! });
   };
 
-  private _renderLabelWithLink(props: ICheckboxProps): JSX.Element {
+  private _renderLabelWithLink = (props: ICheckboxProps) => {
     return (
       <span>
         This is a <a href="https://www.microsoft.com">link</a> inside a label.
       </span>
     );
-  }
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx
@@ -1,6 +1,7 @@
 // @codepen
 import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
 /**
  * Interface for ChoiceGroupLabelExample state.
@@ -10,18 +11,18 @@ export interface IChoiceGroupLabelExampleState {
 }
 
 export class ChoiceGroupLabelExample extends React.Component<{}, IChoiceGroupLabelExampleState> {
-  constructor(props: {}) {
-    super(props);
+  public state: IChoiceGroupLabelExampleState = {
+    imageKey: ''
+  };
 
-    this.state = {
-      imageKey: ''
-    };
-  }
+  // Use getId() to ensure that the label ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure its uniqueness.)
+  private _labelId: string = getId('labelElement');
 
   public render() {
     return (
       <div>
-        <div id="labelElement">Here is a custom label</div>
+        <div id={this._labelId}>Custom label</div>
         <ChoiceGroup
           defaultSelectedKey="B"
           options={[
@@ -46,7 +47,7 @@ export class ChoiceGroupLabelExample extends React.Component<{}, IChoiceGroupLab
             }
           ]}
           onChange={this._onChange}
-          ariaLabelledBy="labelElement"
+          ariaLabelledBy={this._labelId}
           required={true}
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -16,7 +16,6 @@ export class ContextualMenuBasicExample extends React.Component {
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuBasicExample"
           text="Click for ContextualMenu"
           menuProps={{
             shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx
@@ -16,7 +16,6 @@ export class ContextualMenuWithCustomMenuItemExample extends React.Component {
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuWithCustomMenuItemExample"
           text="Click for ContextualMenu"
           menuProps={{
             shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
@@ -79,7 +79,6 @@ export class ContextualMenuWithCustomMenuListExample extends React.Component<
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuWithCustomMenuListExample"
           text="Click for ContextualMenu"
           menuProps={{
             onRenderMenuList: this._renderMenuList,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
@@ -7,7 +7,6 @@ export class ContextualMenuHeaderExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <DefaultButton
-        id="ContextualMenuHeaderExample"
         text="Click for ContextualMenu"
         menuProps={{
           shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Persisted.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Persisted.Example.tsx
@@ -16,7 +16,6 @@ export class ContextualMenuPersistedExample extends React.Component {
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuPersistedExample"
           text="Click for ContextualMenu"
           persistMenu={true}
           menuProps={{

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.ScrollBar.Example.tsx
@@ -20,7 +20,6 @@ export class ContextualMenuWithScrollBarExample extends React.Component<
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuWithScrollBarExample"
           text="Click for ContextualMenu"
           menuProps={{
             shouldFocusOnMount: true,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Section.Example.tsx
@@ -8,7 +8,6 @@ export class ContextualMenuSectionExample extends React.Component<any, any> {
     return (
       <div>
         <DefaultButton
-          id="ContextualMenuSectionExample"
           text="Click for ContextualMenu"
           menuProps={{
             items: [

--- a/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.TopOffsetFixed.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.TopOffsetFixed.Example.tsx
@@ -2,23 +2,17 @@ import * as React from 'react';
 import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { ChoiceGroup } from 'office-ui-fabric-react/lib/ChoiceGroup';
-import './Dialog.Basic.Example.scss';
 
-export class DialogTopOffsetFixedExample extends React.Component<
-  {},
-  {
-    hideDialog: boolean;
-    optionSelected: string;
-  }
-> {
-  constructor(props: {}) {
-    super(props);
+export interface IDialogTopOffsetFixedExampleState {
+  hideDialog: boolean;
+  optionSelected: string;
+}
 
-    this.state = {
-      hideDialog: true,
-      optionSelected: 'A'
-    };
-  }
+export class DialogTopOffsetFixedExample extends React.Component<{}, IDialogTopOffsetFixedExampleState> {
+  public state: IDialogTopOffsetFixedExampleState = {
+    hideDialog: true,
+    optionSelected: 'A'
+  };
 
   public render() {
     const { optionSelected, hideDialog } = this.state;
@@ -26,12 +20,6 @@ export class DialogTopOffsetFixedExample extends React.Component<
     return (
       <div>
         <DefaultButton secondaryText="Opens the Sample Dialog" onClick={this._showDialog} text="Open Dialog" />
-        <label id="myLabelId" className="screenReaderOnly">
-          My sample Label
-        </label>
-        <label id="mySubTextId" className="screenReaderOnly">
-          My Sample description
-        </label>
 
         <Dialog
           hidden={hideDialog}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -30,7 +30,6 @@ export class DropdownBasicExample extends BaseComponent<
         <Dropdown
           placeholder="Select an Option"
           label="Basic uncontrolled example:"
-          id="Basicdrop1"
           ariaLabel="Basic dropdown example"
           options={[
             { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
@@ -18,7 +18,6 @@ export class DropdownCustomExample extends React.Component {
         <Dropdown
           placeholder="Select an Option"
           label="Custom example:"
-          id="Customdrop1"
           ariaLabel="Custom dropdown example"
           onRenderPlaceHolder={this._onRenderPlaceHolder}
           onRenderTitle={this._onRenderTitle}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx
@@ -14,7 +14,6 @@ export class DropdownErrorExample extends BaseComponent<{}, {}> {
         <Dropdown
           placeholder="Select an Option"
           label="Error message example:"
-          id="Errormessagedrop1"
           ariaLabel="Error message dropdown example"
           options={[
             { key: 'A', text: 'Option a' },

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx
@@ -49,7 +49,6 @@ export class ListScrollingExample extends React.Component<IListScrollingExampleP
         <Dropdown
           placeholder="Select an Option"
           label="Scroll To Mode:"
-          id="Scrolldrop1"
           ariaLabel="Scroll To Mode"
           defaultSelectedKey={'auto'}
           options={[

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
@@ -32,45 +32,41 @@ export class RatingBasicExample extends React.Component<
     this._customTheme.semanticColors.bodyTextChecked = '#1E9FE8';
   }
 
-  // tslint:disable:jsx-no-lambda
   public render(): JSX.Element {
     return (
       <div className="ms-RatingBasicExample">
         Large Stars:
         <Rating
-          id={'largeRatingStar'}
           min={1}
           max={5}
           size={RatingSize.Large}
           rating={this.state.largeStarRating}
           getAriaLabel={this._getRatingComponentAriaLabel}
           onChange={this._onLargeStarChange}
-          onFocus={() => console.log('onFocus called')}
-          onBlur={() => console.log('onBlur called')}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
           ariaLabelFormat={'{0} of {1} stars selected'}
         />
         Small Stars
         <Rating
-          id={'smallRatingStar'}
           min={1}
           max={5}
           rating={this.state.smallStarRating}
           onChange={this._onSmallStarChange}
           getAriaLabel={this._getRatingComponentAriaLabel}
-          onFocus={() => console.log('onFocus called')}
-          onBlur={() => console.log('onBlur called')}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
           ariaLabelFormat={'{0} of {1} stars selected'}
         />
         10 Small Stars
         <Rating
-          id={'tenRatingStar'}
           min={1}
           max={10}
           rating={this.state.tenStarRating}
           onChange={this._onTenStarChange}
           getAriaLabel={this._getRatingComponentAriaLabel}
-          onFocus={() => console.log('onFocus called')}
-          onBlur={() => console.log('onBlur called')}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
           ariaLabelFormat={'{0} of {1} stars selected'}
         />
         Disabled:
@@ -79,13 +75,12 @@ export class RatingBasicExample extends React.Component<
           max={5}
           rating={this.state.rating}
           disabled={true}
-          onFocus={() => console.log('onFocus called')}
-          onBlur={() => console.log('onBlur called')}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
           ariaLabelFormat={'{0} of {1} stars selected'}
         />
         Half star in readOnly mode:
         <Rating
-          id={'readOnlyRatingStar'}
           min={1}
           max={5}
           rating={2.5}
@@ -95,7 +90,6 @@ export class RatingBasicExample extends React.Component<
         />
         Custom icons:
         <Rating
-          id={'readOnlyRatingStar'}
           min={1}
           max={5}
           rating={2.5}
@@ -107,14 +101,13 @@ export class RatingBasicExample extends React.Component<
         />
         Themed star
         <Rating
-          id={'themedRatingStar'}
           min={1}
           max={5}
           rating={this.state.themedStarRating}
           onChange={this._onThemedStarChange}
           getAriaLabel={this._getRatingComponentAriaLabel}
-          onFocus={() => console.log('onFocus called')}
-          onBlur={() => console.log('onBlur called')}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
           ariaLabelFormat={'{0} of {1} stars selected'}
           theme={this._customTheme}
         />
@@ -122,28 +115,28 @@ export class RatingBasicExample extends React.Component<
     );
   }
 
+  private _onFocus = () => {
+    console.log('onFocus called');
+  };
+
+  private _onBlur = () => {
+    console.log('onBlur called');
+  };
+
   private _onLargeStarChange = (ev: React.FocusEvent<HTMLElement>, rating: number): void => {
-    this.setState({
-      largeStarRating: rating
-    });
+    this.setState({ largeStarRating: rating });
   };
 
   private _onSmallStarChange = (ev: React.FocusEvent<HTMLElement>, rating: number): void => {
-    this.setState({
-      smallStarRating: rating
-    });
+    this.setState({ smallStarRating: rating });
   };
 
   private _onTenStarChange = (ev: React.FocusEvent<HTMLElement>, rating: number): void => {
-    this.setState({
-      tenStarRating: rating
-    });
+    this.setState({ tenStarRating: rating });
   };
 
   private _onThemedStarChange = (ev: React.FocusEvent<HTMLElement>, rating: number): void => {
-    this.setState({
-      themedStarRating: rating
-    });
+    this.setState({ themedStarRating: rating });
   };
 
   private _getRatingComponentAriaLabel(rating: number, maxRating: number): string {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -2155,7 +2155,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         >
           <div
             className="ms-FocusZone"
-            data-focuszone-id="FocusZone14"
+            data-focuszone-id="FocusZone19"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -2846,7 +2846,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         >
           <div
             className="ms-FocusZone"
-            data-focuszone-id="FocusZone21"
+            data-focuszone-id="FocusZone26"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
@@ -81,7 +81,6 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
             color: #212121;
           }
       data-is-focusable={true}
-      id="toggleCallout"
       onClick={[Function]}
       onKeyDown={[Function]}
       onKeyPress={[Function]}
@@ -119,7 +118,7 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                 }
-            id="id__0"
+            id="id__2"
           >
             Show callout
           </div>
@@ -235,8 +234,8 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
           tabIndex={-1}
         >
           <div
-            aria-describedby="callout-description-1"
-            aria-labelledby="callout-label-1"
+            aria-describedby="callout-description1"
+            aria-labelledby="callout-label0"
             className=
                 ms-Callout-main
                 {
@@ -261,7 +260,7 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
             >
               <p
                 className="ms-CalloutExample-title"
-                id="callout-label-1"
+                id="callout-label0"
               >
                 All of your favorite people
               </p>
@@ -274,7 +273,7 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
               >
                 <p
                   className="ms-CalloutExample-subText"
-                  id="callout-description-1"
+                  id="callout-description1"
                 >
                   Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
                 </p>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.FocusTrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.FocusTrap.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Callout.FocusTrap.Example.tsx correctly 1`] 
                   margin-right: 4px;
                   margin-top: 0;
                 }
-            id="id__0"
+            id="id__1"
           >
             Show callout
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Nested.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Callout.Nested.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                 }
-            id="id__0"
+            id="id__1"
           >
             Show callout
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.ImplementationExamples.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
         }
   >
     <input
-      aria-labelledby="labelID"
       className=
 
           {
@@ -142,12 +141,6 @@ exports[`Component Examples renders Checkbox.ImplementationExamples.tsx correctl
       </span>
     </label>
   </div>
-  <label
-    className="screenReaderOnly"
-    id="labelID"
-  >
-    Uncontrolled checkbox label
-  </label>
   <div
     className=
         ms-Checkbox

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -3,9 +3,9 @@
 exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] = `
 <div>
   <div
-    id="labelElement"
+    id="labelElement0"
   >
-    Here is a custom label
+    Custom label
   </div>
   <div
     className=
@@ -13,7 +13,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
 
   >
     <div
-      aria-labelledby="labelElement"
+      aria-labelledby="labelElement0"
       className=
           ms-ChoiceFieldGroup
           {
@@ -71,8 +71,8 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   }
               data-automation-id="auto1"
               data-is-focusable={false}
-              id="ChoiceGroup0-A"
-              name="ChoiceGroup0"
+              id="ChoiceGroup1-A"
+              name="ChoiceGroup1"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -135,11 +135,11 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 0px;
                   }
-              htmlFor="ChoiceGroup0-A"
+              htmlFor="ChoiceGroup1-A"
             >
               <span
                 className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-A"
+                id="ChoiceGroupLabel2-A"
               >
                 Option A
               </span>
@@ -185,8 +185,8 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     top: 8px;
                   }
               data-is-focusable={true}
-              id="ChoiceGroup0-B"
-              name="ChoiceGroup0"
+              id="ChoiceGroup1-B"
+              name="ChoiceGroup1"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -260,11 +260,11 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   @media screen and (-ms-high-contrast: active){&:after {
                     border-color: Highlight;
                   }
-              htmlFor="ChoiceGroup0-B"
+              htmlFor="ChoiceGroup1-B"
             >
               <span
                 className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-B"
+                id="ChoiceGroupLabel2-B"
               >
                 Option B
               </span>
@@ -311,8 +311,8 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   }
               data-is-focusable={false}
               disabled={true}
-              id="ChoiceGroup0-C"
-              name="ChoiceGroup0"
+              id="ChoiceGroup1-C"
+              name="ChoiceGroup1"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -372,11 +372,11 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   @media screen and (-ms-high-contrast: active){& {
                     color: GrayText;
                   }
-              htmlFor="ChoiceGroup0-C"
+              htmlFor="ChoiceGroup1-C"
             >
               <span
                 className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-C"
+                id="ChoiceGroupLabel2-C"
               >
                 Option C
               </span>
@@ -423,8 +423,8 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   }
               data-is-focusable={false}
               disabled={true}
-              id="ChoiceGroup0-D"
-              name="ChoiceGroup0"
+              id="ChoiceGroup1-D"
+              name="ChoiceGroup1"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -484,11 +484,11 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                   @media screen and (-ms-high-contrast: active){& {
                     color: GrayText;
                   }
-              htmlFor="ChoiceGroup0-D"
+              htmlFor="ChoiceGroup1-D"
             >
               <span
                 className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-D"
+                id="ChoiceGroupLabel2-D"
               >
                 Option D
               </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuBasicExample"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuWithCustomMenuItemExample"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuList.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuList.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.CustomMenuList.Example.tsx co
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuWithCustomMenuListExample"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
@@ -74,7 +74,6 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
         color: #212121;
       }
   data-is-focusable={true}
-  id="ContextualMenuHeaderExample"
   onClick={[Function]}
   onKeyDown={[Function]}
   onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.Persisted.Example.tsx correct
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuPersistedExample"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuWithScrollBarExample"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
           color: #212121;
         }
     data-is-focusable={true}
-    id="ContextualMenuSectionExample"
     onClick={[Function]}
     onKeyDown={[Function]}
     onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.TopOffsetFixed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.TopOffsetFixed.Example.tsx.shot
@@ -118,17 +118,5 @@ exports[`Component Examples renders Dialog.TopOffsetFixed.Example.tsx correctly 
       </div>
     </div>
   </button>
-  <label
-    className="screenReaderOnly"
-    id="myLabelId"
-  >
-    My sample Label
-  </label>
-  <label
-    className="screenReaderOnly"
-    id="mySubTextId"
-  >
-    My Sample description
-  </label>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -34,13 +34,13 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Basicdrop1"
-      id="Basicdrop1-label"
+      htmlFor="Dropdown0"
+      id="Dropdown0-label"
     >
       Basic uncontrolled example:
     </label>
     <div
-      aria-describedby="Basicdrop1-option"
+      aria-describedby="Dropdown0-option"
       aria-expanded="false"
       aria-label="Basic dropdown example"
       className=
@@ -129,7 +129,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Basicdrop1"
+      id="Dropdown0"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -172,7 +172,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Basicdrop1-option"
+        id="Dropdown0-option"
         role="option"
       >
         <span>
@@ -330,7 +330,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
               }
-          id="id__0"
+          id="id__1"
         >
           Set focus
         </div>
@@ -367,16 +367,16 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Dropdown3"
-      id="Dropdown3-label"
+      htmlFor="Dropdown4"
+      id="Dropdown4-label"
     >
       Disabled uncontrolled example with defaultSelectedKey:
     </label>
     <div
-      aria-describedby="Dropdown3-option"
+      aria-describedby="Dropdown4-option"
       aria-disabled={true}
       aria-expanded="false"
-      aria-labelledby="Dropdown3-label"
+      aria-labelledby="Dropdown4-label"
       className=
           ms-Dropdown
           is-disabled
@@ -452,7 +452,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={false}
-      id="Dropdown3"
+      id="Dropdown4"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -496,7 +496,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               border: 1px solid GrayText;
               color: GrayText;
             }
-        id="Dropdown3-option"
+        id="Dropdown4-option"
       >
         <span>
           Option d
@@ -569,220 +569,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Dropdown4"
-      id="Dropdown4-label"
-    >
-      Controlled example:
-    </label>
-    <div
-      aria-describedby="Dropdown4-option"
-      aria-expanded="false"
-      aria-labelledby="Dropdown4-label"
-      className=
-          ms-Dropdown
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            outline: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            user-select: none;
-          }
-          &:hover .ms-Dropdown-title {
-            border-color: #212121;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:focus .ms-Dropdown-title {
-            border-color: #0078d4;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-            background-color: Highlight;
-            border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-title {
-            border-color: #005a9e;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:hover .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          &:focus .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          &:hover .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:focus .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:active .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:hover .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:active .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-      data-is-focusable={true}
-      id="Dropdown4"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      placeholder="Select an Option"
-      role="listbox"
-      tabIndex={0}
-    >
-      <span
-        aria-atomic={true}
-        aria-label="Select an Option"
-        aria-live="off"
-        aria-setsize={7}
-        className=
-            ms-Dropdown-title
-            ms-Dropdown-titleIsPlaceHolder
-            {
-              background-color: #ffffff;
-              border-color: #a6a6a6;
-              border-style: solid;
-              border-width: 1px;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #666666;
-              cursor: pointer;
-              display: block;
-              height: 32px;
-              line-height: 30px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow: hidden;
-              padding-bottom: 0;
-              padding-left: 12px;
-              padding-right: 32px;
-              padding-top: 0;
-              position: relative;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            }
-        id="Dropdown4-option"
-        role="option"
-      >
-        <span>
-          Select an Option
-        </span>
-      </span>
-      <span
-        className=
-            ms-Dropdown-caretDownWrapper
-            {
-              height: 32px;
-              line-height: 30px;
-              position: absolute;
-              right: 12px;
-              top: 1px;
-            }
-      >
-        <i
-          className=
-              ms-Dropdown-caretDown
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #666666;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-size: 12px;
-                font-style: normal;
-                font-weight: normal;
-                pointer-events: none;
-                speak: none;
-              }
-          data-icon-name="ChevronDown"
-          role="presentation"
-        >
-          
-        </i>
-      </span>
-    </div>
-  </div>
-  <div
-    className=
-        ms-Dropdown-container
-
-  >
-    <label
-      className=
-          ms-Label
-          ms-Dropdown-label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: inline-block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
       htmlFor="Dropdown5"
       id="Dropdown5-label"
     >
-      Multi-Select uncontrolled example:
+      Controlled example:
     </label>
     <div
       aria-describedby="Dropdown5-option"
@@ -876,19 +666,23 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       data-is-focusable={true}
       id="Dropdown5"
       onBlur={[Function]}
+      onChange={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      placeholder="Select options"
+      placeholder="Select an Option"
+      role="listbox"
       tabIndex={0}
     >
       <span
         aria-atomic={true}
-        aria-label="apple"
+        aria-label="Select an Option"
         aria-live="off"
+        aria-setsize={7}
         className=
             ms-Dropdown-title
+            ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
               border-color: #a6a6a6;
@@ -896,6 +690,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               border-width: 1px;
               box-shadow: none;
               box-sizing: border-box;
+              color: #666666;
               cursor: pointer;
               display: block;
               height: 32px;
@@ -914,9 +709,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               white-space: nowrap;
             }
         id="Dropdown5-option"
+        role="option"
       >
         <span>
-          apple, banana, orange
+          Select an Option
         </span>
       </span>
       <span
@@ -986,7 +782,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       htmlFor="Dropdown6"
       id="Dropdown6-label"
     >
-      Multi-Select controlled example:
+      Multi-Select uncontrolled example:
     </label>
     <div
       aria-describedby="Dropdown6-option"
@@ -1080,7 +876,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       data-is-focusable={true}
       id="Dropdown6"
       onBlur={[Function]}
-      onChange={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -1090,11 +885,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
-        aria-label="Select options"
+        aria-label="apple"
         aria-live="off"
         className=
             ms-Dropdown-title
-            ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
               border-color: #a6a6a6;
@@ -1102,7 +896,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               border-width: 1px;
               box-shadow: none;
               box-sizing: border-box;
-              color: #666666;
               cursor: pointer;
               display: block;
               height: 32px;
@@ -1123,7 +916,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
         id="Dropdown6-option"
       >
         <span>
-          Select options
+          apple, banana, orange
         </span>
       </span>
       <span
@@ -1193,13 +986,220 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       htmlFor="Dropdown7"
       id="Dropdown7-label"
     >
-      Disabled uncontrolled example with defaultSelectedKey:
+      Multi-Select controlled example:
     </label>
     <div
       aria-describedby="Dropdown7-option"
-      aria-disabled={true}
       aria-expanded="false"
       aria-labelledby="Dropdown7-label"
+      className=
+          ms-Dropdown
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            user-select: none;
+          }
+          &:hover .ms-Dropdown-title {
+            border-color: #212121;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:focus .ms-Dropdown-title {
+            border-color: #0078d4;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
+            -ms-high-contrast-adjust: none;
+          }
+          &:active .ms-Dropdown-title {
+            border-color: #005a9e;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:hover .ms-Dropdown-caretDown {
+            color: #212121;
+          }
+          &:focus .ms-Dropdown-caretDown {
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
+            -ms-high-contrast-adjust: none;
+          }
+          &:active .ms-Dropdown-caretDown {
+            color: #212121;
+          }
+          &:hover .ms-Dropdown-titleIsPlaceHolder {
+            color: #666666;
+          }
+          &:focus .ms-Dropdown-titleIsPlaceHolder {
+            color: #666666;
+          }
+          &:active .ms-Dropdown-titleIsPlaceHolder {
+            color: #666666;
+          }
+          &:hover .ms-Dropdown-title--hasError {
+            border-color: #a80000;
+          }
+          &:active .ms-Dropdown-title--hasError {
+            border-color: #a80000;
+          }
+          &:focus .ms-Dropdown-title--hasError {
+            border-color: #a80000;
+          }
+      data-is-focusable={true}
+      id="Dropdown7"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      placeholder="Select options"
+      tabIndex={0}
+    >
+      <span
+        aria-atomic={true}
+        aria-label="Select options"
+        aria-live="off"
+        className=
+            ms-Dropdown-title
+            ms-Dropdown-titleIsPlaceHolder
+            {
+              background-color: #ffffff;
+              border-color: #a6a6a6;
+              border-style: solid;
+              border-width: 1px;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #666666;
+              cursor: pointer;
+              display: block;
+              height: 32px;
+              line-height: 30px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 12px;
+              padding-right: 32px;
+              padding-top: 0;
+              position: relative;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        id="Dropdown7-option"
+      >
+        <span>
+          Select options
+        </span>
+      </span>
+      <span
+        className=
+            ms-Dropdown-caretDownWrapper
+            {
+              height: 32px;
+              line-height: 30px;
+              position: absolute;
+              right: 12px;
+              top: 1px;
+            }
+      >
+        <i
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                pointer-events: none;
+                speak: none;
+              }
+          data-icon-name="ChevronDown"
+          role="presentation"
+        >
+          
+        </i>
+      </span>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Dropdown-container
+
+  >
+    <label
+      className=
+          ms-Label
+          ms-Dropdown-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Dropdown8"
+      id="Dropdown8-label"
+    >
+      Disabled uncontrolled example with defaultSelectedKey:
+    </label>
+    <div
+      aria-describedby="Dropdown8-option"
+      aria-disabled={true}
+      aria-expanded="false"
+      aria-labelledby="Dropdown8-label"
       className=
           ms-Dropdown
           is-disabled
@@ -1275,7 +1275,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={false}
-      id="Dropdown7"
+      id="Dropdown8"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -1319,7 +1319,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               border: 1px solid GrayText;
               color: GrayText;
             }
-        id="Dropdown7-option"
+        id="Dropdown8-option"
       >
         <span>
           Option g, Option f

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -34,13 +34,13 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Customdrop1"
-      id="Customdrop1-label"
+      htmlFor="Dropdown0"
+      id="Dropdown0-label"
     >
       Custom example:
     </label>
     <div
-      aria-describedby="Customdrop1-option"
+      aria-describedby="Dropdown0-option"
       aria-expanded="false"
       aria-label="Custom dropdown example"
       className=
@@ -129,7 +129,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Customdrop1"
+      id="Dropdown0"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -172,7 +172,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Customdrop1-option"
+        id="Dropdown0-option"
         role="option"
       >
         <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -34,13 +34,13 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Errormessagedrop1"
-      id="Errormessagedrop1-label"
+      htmlFor="Dropdown0"
+      id="Dropdown0-label"
     >
       Error message example:
     </label>
     <div
-      aria-describedby="Errormessagedrop1-option"
+      aria-describedby="Dropdown0-option"
       aria-expanded="false"
       aria-label="Error message dropdown example"
       className=
@@ -129,7 +129,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Errormessagedrop1"
+      id="Dropdown0"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -173,7 +173,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Errormessagedrop1-option"
+        id="Dropdown0-option"
         role="option"
       >
         <span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -602,7 +602,6 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                     color: #212121;
                   }
               data-is-focusable={true}
-              id="toggleCallout"
               onClick={[Function]}
               onKeyDown={[Function]}
               onKeyPress={[Function]}
@@ -640,7 +639,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                         }
-                    id="id__11"
+                    id="id__13"
                   >
                     Show callout
                   </div>
@@ -756,8 +755,8 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                   tabIndex={-1}
                 >
                   <div
-                    aria-describedby="callout-description-1"
-                    aria-labelledby="callout-label-1"
+                    aria-describedby="callout-description12"
+                    aria-labelledby="callout-label11"
                     className=
                         ms-Callout-main
                         {
@@ -782,7 +781,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                     >
                       <p
                         className="ms-CalloutExample-title"
-                        id="callout-label-1"
+                        id="callout-label11"
                       >
                         All of your favorite people
                       </p>
@@ -795,7 +794,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                       >
                         <p
                           className="ms-CalloutExample-subText"
-                          id="callout-description-1"
+                          id="callout-description12"
                         >
                           Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.
                         </p>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: related to #7946
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Many of the doc pages have elements with duplicate IDs due to people copy-pasting examples and not updating the IDs. This causes problems for screen readers and is just generally bad practice.

This PR contains two categories of fixes:
1. Remove IDs from examples that don't ever reference them 
2. Update Callout and ChoiceGroup examples to generate IDs using `getId()` (more examples will need to be updated in the future)

To address @kenotron's feedback on the issue, I included a comment explaining what `getId()` does and that you don't actually have to use it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7953)