### PR TITLE
Fixes for Rating A11y Pass

### DIFF
--- a/common/changes/office-ui-fabric-react/rating_2019-02-11-20-51.json
+++ b/common/changes/office-ui-fabric-react/rating_2019-02-11-20-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix color contrast ratio of unchecked Rating stars",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshack4@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
@@ -38,7 +38,7 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
   const ratingVerticalPadding = 8;
   const ratingHorizontalPadding = 2;
 
-  const ratingStarUncheckedColor = palette.neutralTertiary;
+  const ratingStarUncheckedColor = palette.neutralSecondaryAlt;
   const ratingStarUncheckedHoverColor = palette.themePrimary;
   const ratingStarUncheckedHoverSelectedColor = palette.themeDark;
   const ratingStarCheckedColor = semanticColors.bodyTextChecked;

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -85,13 +85,13 @@ exports[`Rating Renders Rating correctly 1`] = `
             cursor: default;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
@@ -152,7 +152,7 @@ exports[`Rating Renders Rating correctly 1`] = `
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                color: #a6a6a6;
+                color: #767676;
                 display: inline-block;
                 font-family: "FabricMDL2Icons";
                 font-style: normal;
@@ -241,13 +241,13 @@ exports[`Rating Renders Rating correctly 1`] = `
             cursor: default;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
@@ -307,7 +307,7 @@ exports[`Rating Renders Rating correctly 1`] = `
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                color: #a6a6a6;
+                color: #767676;
                 display: inline-block;
                 font-family: "FabricMDL2Icons";
                 font-style: normal;
@@ -396,13 +396,13 @@ exports[`Rating Renders Rating correctly 1`] = `
             cursor: default;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
@@ -462,7 +462,7 @@ exports[`Rating Renders Rating correctly 1`] = `
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                color: #a6a6a6;
+                color: #767676;
                 display: inline-block;
                 font-family: "FabricMDL2Icons";
                 font-style: normal;
@@ -551,13 +551,13 @@ exports[`Rating Renders Rating correctly 1`] = `
             cursor: default;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
@@ -617,7 +617,7 @@ exports[`Rating Renders Rating correctly 1`] = `
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                color: #a6a6a6;
+                color: #767676;
                 display: inline-block;
                 font-family: "FabricMDL2Icons";
                 font-style: normal;
@@ -706,13 +706,13 @@ exports[`Rating Renders Rating correctly 1`] = `
             cursor: default;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
             color: WindowText;
           }
           &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-            color: #a6a6a6;
+            color: #767676;
           }
           @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
             color: WindowText;
@@ -772,7 +772,7 @@ exports[`Rating Renders Rating correctly 1`] = `
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                color: #a6a6a6;
+                color: #767676;
                 display: inline-block;
                 font-family: "FabricMDL2Icons";
                 font-style: normal;

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.ButtonControlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.ButtonControlled.Example.tsx
@@ -22,7 +22,14 @@ export class RatingButtonControlledExample extends React.Component<
 
     return (
       <div className="ms-RatingButtonControlledExample">
-        <Rating rating={this.state.rating} max={5} readOnly={true} allowZeroStars={true} />
+        <Rating
+          rating={this.state.rating}
+          max={5}
+          readOnly={true}
+          allowZeroStars={true}
+          getAriaLabel={this._getRatingComponentAriaLabel}
+          ariaLabelFormat={'{0} of {1} stars selected'}
+        />
         <PrimaryButton
           text={'Click to change rating to ' + (maxrating - this.state.rating)}
           onClick={e => {
@@ -35,5 +42,9 @@ export class RatingButtonControlledExample extends React.Component<
         />
       </div>
     );
+  }
+
+  private _getRatingComponentAriaLabel(rating: number, maxRating: number): string {
+    return `Rating value is ${rating} of ${maxRating}`;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -89,13 +89,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -156,7 +156,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -245,13 +245,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -311,7 +311,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -400,13 +400,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -466,7 +466,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -555,13 +555,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -621,7 +621,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -710,13 +710,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -776,7 +776,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -911,13 +911,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -977,7 +977,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -1066,13 +1066,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -1132,7 +1132,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -1221,13 +1221,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -1288,7 +1288,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -1377,13 +1377,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -1443,7 +1443,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -1532,13 +1532,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -1598,7 +1598,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -1733,13 +1733,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -1800,7 +1800,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -1889,13 +1889,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -1955,7 +1955,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2044,13 +2044,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -2110,7 +2110,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2199,13 +2199,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -2265,7 +2265,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2354,13 +2354,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -2420,7 +2420,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2509,13 +2509,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -2575,7 +2575,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2664,13 +2664,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -2730,7 +2730,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2819,13 +2819,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -2885,7 +2885,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -2974,13 +2974,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -3040,7 +3040,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -3129,13 +3129,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -3195,7 +3195,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -3948,7 +3948,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -4085,7 +4085,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -4223,7 +4223,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -4360,7 +4360,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -4497,7 +4497,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -4674,7 +4674,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons-11";
                   font-style: normal;
@@ -4811,7 +4811,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons-11";
                   font-style: normal;
@@ -4949,7 +4949,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons-11";
                   font-style: normal;
@@ -5086,7 +5086,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons-7";
                   font-style: normal;
@@ -5223,7 +5223,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons-7";
                   font-style: normal;
@@ -5358,13 +5358,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -5425,7 +5425,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -5514,13 +5514,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -5580,7 +5580,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -5669,13 +5669,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -5735,7 +5735,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -5824,13 +5824,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -5890,7 +5890,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -5979,13 +5979,13 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               cursor: default;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-back {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
               color: WindowText;
             }
             &:hover ~ .ms-Rating-button .ms-RatingStar-front {
-              color: #a6a6a6;
+              color: #767676;
             }
             @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
               color: WindowText;
@@ -6045,7 +6045,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -130,7 +130,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -267,7 +267,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -404,7 +404,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -541,7 +541,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;
@@ -678,7 +678,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a6a6a6;
+                  color: #767676;
                   display: inline-block;
                   font-family: "FabricMDL2Icons";
                   font-style: normal;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -5,7 +5,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
   className="ms-RatingButtonControlledExample"
 >
   <div
-    aria-label=""
+    aria-label="Rating value is 0 of 5"
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -113,7 +113,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-1"
         >
-          
+          1 of 5 stars selected
         </span>
         <div
           className=
@@ -250,7 +250,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-2"
         >
-          
+          2 of 5 stars selected
         </span>
         <div
           className=
@@ -387,7 +387,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-3"
         >
-          
+          3 of 5 stars selected
         </span>
         <div
           className=
@@ -524,7 +524,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-4"
         >
-          
+          4 of 5 stars selected
         </span>
         <div
           className=
@@ -661,7 +661,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-5"
         >
-          
+          5 of 5 stars selected
         </span>
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7096 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Bug 2: fixed color contrast ratio for unchecked Rating stars
Changing the color to neutralSecondaryAlt for when rating stars are unchecked so that it meets contrast ratio to 4.5:1
![image](https://user-images.githubusercontent.com/4161791/52592768-19d66400-2dfc-11e9-914c-5f26a14dbda0.png)

Small text at level aaa is the only one that fails but text will never be overlayed on these unchecked stars and I tried a bunch of the other colors in DefaultPalette.ts that would make sense in this situation and the only other one that fully passed was neutralPrimaryAlt but it's super dark to the point where unchecked state is indistinguishable from checked state:
![image](https://user-images.githubusercontent.com/4161791/52592868-57d38800-2dfc-11e9-8ff7-33f282a8ede0.png)

Bug 4: fixed Button Controlled Rating example so that it announces itself through Narrator
![image](https://user-images.githubusercontent.com/4161791/52601086-878d8a80-2e12-11e9-96a8-ae6af68ab457.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7955)