### PR TITLE
Panel: Enabling the addition of new buttons (or other components) to the Navigation region.

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2019-02-11-22-01.json
+++ b/common/changes/office-ui-fabric-react/master_2019-02-11-22-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Enabling the addition of new buttons (or other components) to the Navigation region",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "nerios@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9195,6 +9195,7 @@ interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   onRenderFooterContent?: IRenderFunction<IPanelProps>;
   onRenderHeader?: IPanelHeaderRenderer;
   onRenderNavigation?: IRenderFunction<IPanelProps>;
+  onRenderNavigationContent?: IRenderFunction<IPanelProps>;
   styles?: IStyleFunctionOrObject<IPanelStyleProps, IPanelStyles>;
   theme?: ITheme;
   type?: PanelType;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -238,6 +238,11 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   }
 
   private _onRenderNavigation = (props: IPanelProps): JSX.Element | null => {
+    const { onRenderNavigationContent = this._onRenderNavigationContent } = this.props;
+    return <div className={this._classNames.navigation}>{onRenderNavigationContent(props, this._onRenderNavigationContent)}</div>;
+  };
+
+  private _onRenderNavigationContent = (props: IPanelProps): JSX.Element | null => {
     const { closeButtonAriaLabel, hasCloseButton } = props;
     const theme = getTheme();
     if (hasCloseButton) {
@@ -246,28 +251,26 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       // ? (this._classNames.subComponentStyles.iconButton as IStyleFunctionOrObject<IButtonStyleProps, IButtonStyles>)
       // : undefined;
       return (
-        <div className={this._classNames.navigation}>
-          <IconButton
-            // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
-            // className={iconButtonStyles}
-            styles={{
-              root: {
-                height: 'auto',
-                width: '44px',
-                color: theme.palette.neutralSecondary,
-                fontSize: IconFontSizes.large
-              },
-              rootHovered: {
-                color: theme.palette.neutralPrimary
-              }
-            }}
-            className={this._classNames.closeButton}
-            onClick={this._onPanelClick}
-            ariaLabel={closeButtonAriaLabel}
-            data-is-visible={true}
-            iconProps={{ iconName: 'Cancel' }}
-          />
-        </div>
+        <IconButton
+          // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
+          // className={iconButtonStyles}
+          styles={{
+            root: {
+              height: 'auto',
+              width: '44px',
+              color: theme.palette.neutralSecondary,
+              fontSize: IconFontSizes.large
+            },
+            rootHovered: {
+              color: theme.palette.neutralPrimary
+            }
+          }}
+          className={this._classNames.closeButton}
+          onClick={this._onPanelClick}
+          ariaLabel={closeButtonAriaLabel}
+          data-is-visible={true}
+          iconProps={{ iconName: 'Cancel' }}
+        />
       );
     }
     return null;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
@@ -3,6 +3,7 @@ import { IDocPageProps } from '../../common/DocPage.types';
 import { PanelCustomExample } from './examples/Panel.Custom.Example';
 import { PanelExtraLargeExample } from './examples/Panel.ExtraLarge.Example';
 import { PanelFooterExample } from './examples/Panel.Footer.Example';
+import { PanelNavigationExample } from './examples/Panel.Navigation.Example';
 import { PanelHandleDismissTargetExample } from './examples/Panel.HandleDismissTarget.Example';
 import { PanelHiddenOnDismissExample } from './examples/Panel.HiddenOnDismiss.Example';
 import { PanelLargeExample } from './examples/Panel.Large.Example';
@@ -32,6 +33,7 @@ const PanelLightDismissExampleCode = require('!raw-loader!office-ui-fabric-react
 const PanelLightDismissCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx') as string;
 const PanelNonModalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.NonModal.Example.tsx') as string;
 const PanelFooterExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Footer.Example.tsx') as string;
+const PanelNavigationExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Navigation.Example.tsx') as string;
 const PanelPreventDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.PreventDefault.Example.tsx') as string;
 const PanelHandleDismissTargetExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx') as string;
 const PanelScrollExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Scroll.Example.tsx') as string;
@@ -107,6 +109,11 @@ export const PanelPageProps: IDocPageProps = {
       title: 'Panel - Footer',
       code: PanelFooterExampleCode,
       view: <PanelFooterExample />
+    },
+    {
+      title: 'Panel - Navigation',
+      code: PanelNavigationExampleCode,
+      view: <PanelNavigationExample />
     },
     {
       title: 'Panel - Prevent Default Sample',

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -164,9 +164,14 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   onOuterClick?: () => void;
 
   /**
-   * Optional custom renderer navigation region. Replaces current close button.
+   * Optional custom renderer navigation region. Replaces the region that contains the close button.
    */
   onRenderNavigation?: IRenderFunction<IPanelProps>;
+
+  /**
+   * Optional custom renderer for content in the navigation region. Replaces current close button.
+   */
+  onRenderNavigationContent?: IRenderFunction<IPanelProps>;
 
   /**
    * Optional custom renderer for header region. Replaces current title

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Navigation.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Navigation.Example.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
+import { Panel, PanelType, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { getTheme, IconFontSizes } from 'office-ui-fabric-react/lib/Styling';
+import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
+
+export class PanelNavigationExample extends React.Component<
+  {},
+  {
+    showPanel: boolean;
+  }
+> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { showPanel: false };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <DefaultButton secondaryText="Opens the Sample Panel" onClick={this._onShowPanel} text="Open Panel" />
+        <Panel
+          isOpen={this.state.showPanel}
+          type={PanelType.smallFixedFar}
+          onDismiss={this._onClosePanel}
+          isFooterAtBottom={true}
+          headerText="Panel with custom navigation content"
+          closeButtonAriaLabel="Close"
+          onRenderNavigationContent={this._onRenderNavigationContent}
+        >
+          <span>Content goes here.</span>
+        </Panel>
+      </div>
+    );
+  }
+
+  private _onClosePanel = () => {
+    this.setState({ showPanel: false });
+  };
+
+  private _onRenderNavigationContent = (props: IPanelProps, defaultRender: IRenderFunction<IPanelProps>): JSX.Element => {
+    const theme = getTheme();
+
+    return (
+      <React.Fragment>
+        <SearchBox
+          placeholder="Search here..."
+          styles={{
+            root: {
+              margin: '5px',
+              height: 'auto',
+              width: '100%'
+            }
+          }}
+        />
+        <IconButton
+          styles={{
+            root: {
+              height: 'auto',
+              width: '44px',
+              color: theme.palette.neutralSecondary,
+              fontSize: IconFontSizes.large
+            },
+            menuIcon: {
+              display: 'none'
+            },
+            rootHovered: {
+              color: theme.palette.neutralPrimary
+            }
+          }}
+          menuProps={{
+            items: [
+              {
+                key: 'home',
+                text: 'Home',
+                iconProps: {
+                  iconName: 'Home'
+                }
+              },
+              {
+                key: 'refresh',
+                text: 'Refresh',
+                iconProps: {
+                  iconName: 'Refresh'
+                }
+              },
+              {
+                key: 'back',
+                text: 'Back',
+                iconProps: {
+                  iconName: 'Back'
+                }
+              },
+              {
+                key: 'forward',
+                text: 'Forward',
+                iconProps: {
+                  iconName: 'Forward'
+                }
+              }
+            ]
+          }}
+          data-is-visible={true}
+          iconProps={{
+            iconName: 'MoreVertical'
+          }}
+        />
+        {defaultRender(props)}
+      </React.Fragment>
+    );
+  };
+
+  private _onShowPanel = () => {
+    this.setState({ showPanel: true });
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Navigation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Navigation.Example.tsx.shot
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Panel.Navigation.Example.tsx correctly 1`] = `
+<div>
+  <button
+    aria-describedby="id__1"
+    aria-labelledby="id__0"
+    className=
+        ms-Button
+        ms-Button--default
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #f4f4f4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #333333;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #eaeaea;
+          color: #212121;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #c8c8c8;
+          color: #212121;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Open Panel
+        </div>
+      </div>
+    </div>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Panel component currently allows a developer to replace the entire Navigation area, but that means that the close button (along with its handler) as well as the styles of the region are lost.

This PR adds a new render prop for the content of the Navigation region, making it easy to add new components as well as rendering the close button via the defaultRender.

This same pattern is in use today for the Footer (onRenderFooter, onRenderFooterContent).

![panel-with-navigation-buttons](https://user-images.githubusercontent.com/33673026/52596886-468f7900-2e06-11e9-981c-83f9606382f6.jpg)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7956)