### PR TITLE
Documentation: Add 'dir' attribute for Fabric Core

### DIFF
--- a/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/GetStarted/GetStartedPage.tsx
@@ -325,7 +325,7 @@ initializeIcons('https://my.cdn.com/path/to/icons/');`}
                 <code>&lt;body&gt;</code>, to set the font-family for all Fabric typography classes used within that element.
               </p>
               <CodeBlock language="html" isLightTheme={true}>
-                {`<body class="ms-Fabric">
+                {`<body class="ms-Fabric" dir="ltr">
   <span class="ms-font-su ms-fontColor-themePrimary">Big blue text</span>
 </body>`}
               </CodeBlock>

--- a/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
@@ -154,11 +154,11 @@ ReactDOM.render(<MyIconButton />, document.body.firstChild);
           <h3>Fabric Icons tool</h3>
 
           <p>
-            The Fabric Icons tool, <a href="https://aka.ms/uifabric-icons">https://aka.ms/uifabric-icons</a>, lets you search and browse all
-            of Fabric's icons. You can also use it to create and maintain subsets of the icon font to use in your web apps, which are
+            The Fabric Icons tool, <a href="https://aka.ms/uifabric-icons">{'https://aka.ms/uifabric-icons'}</a>, lets you search and browse
+            all of Fabric's icons. You can also use it to create and maintain subsets of the icon font to use in your web apps, which are
             drop-in replacements for the default Fabric Core and Fabric React icon sets. In addition, the Fabric Icons tool is updated with
             new icons several times a month, whereas the default Fabric set is updated only occasionally. You can see detailed docs for the
-            tool at <a href="https://aka.ms/uifabric-icons?help">https://aka.ms/uifabric-icons?help</a>.
+            tool at <a href="https://aka.ms/uifabric-icons?help">{'https://aka.ms/uifabric-icons?help'}</a>.
           </p>
         </div>
 

--- a/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/IconsPage/IconsPage.tsx
@@ -51,10 +51,24 @@ export class IconsPage extends React.Component<any, any> {
           <p>You can use Fabric's icons in a few ways, depending on if you're using Fabric React or Fabric Core.</p>
 
           <h3>Fabric Core</h3>
+          <p>
+            Begin by referencing the styles by adding this to the <code>head</code> element:
+          </p>
         </div>
 
         <CodeBlock language="html" isLightTheme={true}>
           {`<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css">`}
+        </CodeBlock>
+
+        <div className={pageStyles.u_maxTextWidth}>
+          <p>
+            Next, set the <code>dir</code> attribute on the body to indicate the reading direction for the page. This will select the
+            appropriate icon for the user's reading direction.
+          </p>
+        </div>
+
+        <CodeBlock language="html" isLightTheme={true}>
+          {`<body dir="ltr">`}
         </CodeBlock>
 
         <div className={pageStyles.u_maxTextWidth}>

--- a/common/changes/@uifabric/fabric-website/miwhea-core-dir-attribute_2019-02-12-17-46.json
+++ b/common/changes/@uifabric/fabric-website/miwhea-core-dir-attribute_2019-02-12-17-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Adds documentation for setting the 'dir' attribute for Fabric Core",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "miwhea@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7923
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updates the getting started and icons documentation for Fabric Core to show that a `dir` attribute is required on the body for directional icons to be used.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7964)