### PR TITLE
Fix id usage in examples

### DIFF
--- a/common/changes/@uifabric/experiments/ids2_2019-02-12-20-10.json
+++ b/common/changes/@uifabric/experiments/ids2_2019-02-12-20-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix id usage in examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/ids2_2019-02-12-20-10.json
+++ b/common/changes/office-ui-fabric-react/ids2_2019-02-12-20-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix id usage in examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/experiments/src/components/Announced/examples/Announced.Asynchronous.Example.tsx
+++ b/packages/experiments/src/components/Announced/examples/Announced.Asynchronous.Example.tsx
@@ -57,12 +57,7 @@ export class AnnouncedAsynchronousExample extends React.Component<IAnnouncedAsyn
 
         if (this.state.timeSinceLastAnnounce === DELAY || this.state.percentComplete === 1) {
           this.setState({
-            announced: (
-              <Announced
-                message={`${this.state.total} of ${this.state.photos.length} photos loaded`}
-                id={'announced-' + this.state.total}
-              />
-            ),
+            announced: <Announced message={`${this.state.total} of ${this.state.photos.length} photos loaded`} />,
             timeSinceLastAnnounce: 0
           });
         }
@@ -140,17 +135,7 @@ export class AnnouncedAsynchronousExample extends React.Component<IAnnouncedAsyn
     ) {
       this.setState({
         timeSinceLastAnnounce: 0,
-        announced: (
-          <Announced
-            message={`Photo loading`}
-            id={
-              'announced-photo-' +
-              (document.activeElement.getAttribute('aria-posinset')
-                ? document.activeElement.getAttribute('aria-posinset')
-                : this.state.total)
-            }
-          />
-        )
+        announced: <Announced message={`Photo loading`} />
       });
     }
   }

--- a/packages/experiments/src/components/Announced/examples/Announced.SearchResults.Example.tsx
+++ b/packages/experiments/src/components/Announced/examples/Announced.SearchResults.Example.tsx
@@ -92,7 +92,6 @@ export class AnnouncedSearchResultsExample extends React.Component<
       return (
         <Announced
           message={numberOfSuggestions === 1 ? `${numberOfSuggestions} Color Tag Found` : `${numberOfSuggestions} Color Tags Found`}
-          id={`announced-${numberOfSuggestions}`}
         />
       );
     }

--- a/packages/experiments/src/components/LayoutGroup/examples/LayoutGroup.Basic.Example.tsx
+++ b/packages/experiments/src/components/LayoutGroup/examples/LayoutGroup.Basic.Example.tsx
@@ -18,7 +18,6 @@ export class LayoutGroupBasicExample extends React.Component<{}, {}> {
           <Dropdown
             placeholder="Select an Option"
             label="Basic uncontrolled example:"
-            id="Basicdrop1"
             ariaLabel="Basic dropdown example"
             options={[
               { key: 'A', text: 'Option a' },

--- a/packages/experiments/src/components/Sidebar/examples/Sidebar.Basic.Example.tsx
+++ b/packages/experiments/src/components/Sidebar/examples/Sidebar.Basic.Example.tsx
@@ -14,18 +14,17 @@ export class SidebarBasicExample extends React.Component {
     };
 
     /*
-         * Basic sidebar example, with position override so that the example fits into the example page.
-         * Here is the wrapper class. By default the sidebar takes all of the left height and is positioned on the left.
-         *
-         *   .sidebar-position-override {
-         *       top: auto;
-         *       bottom: auto;
-         *       left: auto;
-         *   }
-         */
+     * Basic sidebar example, with position override so that the example fits into the example page.
+     * Here is the wrapper class. By default the sidebar takes all of the left height and is positioned on the left.
+     *
+     *   .sidebar-position-override {
+     *       top: auto;
+     *       bottom: auto;
+     *       left: auto;
+     *   }
+     */
     return (
       <Sidebar
-        id={'sidebar-basic'}
         footerItems={[
           {
             key: 'basic-example-footer-item',

--- a/packages/experiments/src/components/Sidebar/examples/Sidebar.Collapsed.Example.tsx
+++ b/packages/experiments/src/components/Sidebar/examples/Sidebar.Collapsed.Example.tsx
@@ -14,18 +14,17 @@ export class SidebarCollapsibleExample extends React.Component {
     };
 
     /*
-         * Basic collapsible sidebar example, with position override so that the example fits into the example page.
-         * Here is the wrapper class. By default the sidebar takes all of the left height and is positioned on the left.
-         *
-         *   .sidebar-position-override {
-         *       top: auto !important;
-         *       bottom: auto !important;
-         *       left: auto !important;
-         *   }
-         */
+     * Basic collapsible sidebar example, with position override so that the example fits into the example page.
+     * Here is the wrapper class. By default the sidebar takes all of the left height and is positioned on the left.
+     *
+     *   .sidebar-position-override {
+     *       top: auto !important;
+     *       bottom: auto !important;
+     *       left: auto !important;
+     *   }
+     */
     return (
       <Sidebar
-        id={'sidebar-collapsed'}
         collapsible={true}
         theme={getTheme()}
         collapseButtonAriaLabel={'sitemap'}

--- a/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react';
 import { Dialog, DialogType, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
 import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import './Dialog.Basic.Example.scss';
 
-export class DialogBasicExample extends React.Component<
-  {},
-  {
-    hideDialog: boolean;
-  }
-> {
-  constructor(props: {}) {
-    super(props);
+export interface IDialogBasicExampleState {
+  hideDialog: boolean;
+}
 
-    this.state = {
-      hideDialog: true
-    };
-  }
+export class DialogBasicExample extends React.Component<{}, IDialogBasicExampleState> {
+  public state: IDialogBasicExampleState = {
+    hideDialog: true
+  };
+  // Use getId() to ensure that the IDs are unique on the page.
+  // (It's also okay to use plain strings without getId() and manually ensure uniqueness.)
+  private _labelId: string = getId('dialogLabel');
+  private _subTextId: string = getId('subTextLabel');
 
   public render() {
     return (
       <div>
         <DefaultButton secondaryText="Opens the Sample Dialog" onClick={this._showDialog} text="Open Dialog" />
-        <label id="myLabelId" className="screenReaderOnly">
+        <label id={this._labelId} className="screenReaderOnly">
           My sample Label
         </label>
-        <label id="mySubTextId" className="screenReaderOnly">
+        <label id={this._subTextId} className="screenReaderOnly">
           My Sample description
         </label>
 
@@ -37,13 +37,12 @@ export class DialogBasicExample extends React.Component<
             subText: 'Your Inbox has changed. No longer does it include favorites, it is a singular destination for your emails.'
           }}
           modalProps={{
-            titleAriaId: 'myLabelId',
-            subtitleAriaId: 'mySubTextId',
+            titleAriaId: this._labelId,
+            subtitleAriaId: this._subTextId,
             isBlocking: false,
             containerClassName: 'ms-dialogMainOverride'
           }}
         >
-          {null /** You can also include null values as the result of conditionals */}
           <DialogFooter>
             <PrimaryButton onClick={this._closeDialog} text="Save" />
             <DefaultButton onClick={this._closeDialog} text="Cancel" />

--- a/packages/office-ui-fabric-react/src/components/Label/examples/Label.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/examples/Label.Basic.Example.tsx
@@ -3,13 +3,20 @@ import * as React from 'react';
 
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
-export const LabelBasicExample = () => (
-  <div>
-    <Label>I'm a Label</Label>
-    <Label disabled={true}>I'm a disabled Label</Label>
-    <Label required={true}>I'm a required Label</Label>
-    <Label htmlFor="anInput">A Label for An Input</Label>
-    <TextField id="anInput" />
-  </div>
-);
+export const LabelBasicExample = () => {
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  const textFieldId = getId('anInput');
+
+  return (
+    <div>
+      <Label>I'm a Label</Label>
+      <Label disabled={true}>I'm a disabled Label</Label>
+      <Label required={true}>I'm a required Label</Label>
+      <Label htmlFor={textFieldId}>A Label for An Input</Label>
+      <TextField id={textFieldId} />
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Customizer } from '@uifabric/utilities';
+import { Customizer, getId } from '@uifabric/utilities';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { LayerHost } from 'office-ui-fabric-react/lib/Layer';
@@ -10,14 +10,13 @@ export interface ILayerCustomizedExampleState {
 }
 
 export class LayerCustomizedExample extends React.Component<{}, ILayerCustomizedExampleState> {
-  constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      showPanel: false,
-      trapPanel: false
-    };
-  }
+  public state: ILayerCustomizedExampleState = {
+    showPanel: false,
+    trapPanel: false
+  };
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  private _layerHostId: string = getId('layerHost');
 
   public render(): JSX.Element {
     return (
@@ -33,7 +32,7 @@ export class LayerCustomizedExample extends React.Component<{}, ILayerCustomized
             this.state.trapPanel
               ? {
                   Layer: {
-                    hostId: 'test'
+                    hostId: this._layerHostId
                   }
                 }
               : {}
@@ -55,7 +54,7 @@ export class LayerCustomizedExample extends React.Component<{}, ILayerCustomized
           )}
         </Customizer>
         <LayerHost
-          id="test"
+          id={this._layerHostId}
           style={{
             position: 'relative',
             height: '400px',

--- a/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Hosted.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/examples/Layer.Hosted.Example.tsx
@@ -3,26 +3,26 @@ import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { Layer, LayerHost } from 'office-ui-fabric-react/lib/Layer';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { AnimationClassNames } from 'office-ui-fabric-react/lib/Styling';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import './Layer.Example.scss';
 import * as exampleStylesImport from 'office-ui-fabric-react/lib/common/_exampleStyles.scss';
 const exampleStyles: any = exampleStylesImport;
 
-export class LayerHostedExample extends React.Component<
-  {},
-  {
-    showLayer: boolean;
-    showLayerNoId: boolean;
-    showHost: boolean;
-  }
-> {
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      showLayer: false,
-      showLayerNoId: false,
-      showHost: true
-    };
-  }
+export interface ILayerHostedExampleState {
+  showLayer: boolean;
+  showLayerNoId: boolean;
+  showHost: boolean;
+}
+
+export class LayerHostedExample extends React.Component<{}, ILayerHostedExampleState> {
+  public state: ILayerHostedExampleState = {
+    showLayer: false,
+    showLayerNoId: false,
+    showHost: true
+  };
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  private _layerHostId: string = getId('layerhost');
 
   public render(): JSX.Element {
     const { showLayer, showLayerNoId, showHost } = this.state;
@@ -32,9 +32,9 @@ export class LayerHostedExample extends React.Component<
       <div>
         <Toggle label="Show host" checked={showHost} onChange={this._onChangeToggle} />
 
-        {showHost && <LayerHost id="layerhost1" className="LayerExample-customHost" />}
+        {showHost && <LayerHost id={this._layerHostId} className="LayerExample-customHost" />}
 
-        <p id="foo">
+        <p>
           In some cases, you may need to contain layered content within an area. Create an instance of a LayerHost along with an id, and
           provide a hostId on the layer to render it within the specific host. (Note that it's important that you don't include children
           within the LayerHost. It's meant to contain Layered content only.)
@@ -42,14 +42,14 @@ export class LayerHostedExample extends React.Component<
 
         <Checkbox
           className={exampleStyles.exampleCheckbox}
-          label="Render the box below in a Layer and target it at hostId=layerhost1"
+          label={`Render the box below in a Layer and target it at hostId=${this._layerHostId}`}
           checked={showLayer}
           onChange={this._onChangeCheckbox}
         />
 
         {showLayer ? (
           <Layer
-            hostId="layerhost1"
+            hostId={this._layerHostId}
             onLayerDidMount={this._log('didmount')}
             onLayerWillUnmount={this._log('willunmount')}
             className={'exampleLayerClassName'}

--- a/packages/office-ui-fabric-react/src/components/Modal/examples/Modal.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/examples/Modal.Basic.Example.tsx
@@ -2,37 +2,38 @@
 import * as React from 'react';
 import { Modal } from 'office-ui-fabric-react/lib/Modal';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 import './Modal.Basic.Example.scss';
 
-export class ModalBasicExample extends React.Component<
-  {},
-  {
-    showModal: boolean;
-  }
-> {
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      showModal: false
-    };
-  }
+export interface IModalBasicExampleState {
+  showModal: boolean;
+}
+
+export class ModalBasicExample extends React.Component<{}, IModalBasicExampleState> {
+  public state: IModalBasicExampleState = {
+    showModal: false
+  };
+  // Use getId() to ensure that the IDs are unique on the page.
+  // (It's also okay to use plain strings without getId() and manually ensure uniqueness.)
+  private _titleId: string = getId('title');
+  private _subtitleId: string = getId('subText');
 
   public render(): JSX.Element {
     return (
       <div>
         <DefaultButton secondaryText="Opens the Sample Modal" onClick={this._showModal} text="Open Modal" />
         <Modal
-          titleAriaId="titleId"
-          subtitleAriaId="subtitleId"
+          titleAriaId={this._titleId}
+          subtitleAriaId={this._subtitleId}
           isOpen={this.state.showModal}
           onDismiss={this._closeModal}
           isBlocking={false}
           containerClassName="ms-modalExample-container"
         >
           <div className="ms-modalExample-header">
-            <span id="titleId">Lorem Ipsum</span>
+            <span id={this._titleId}>Lorem Ipsum</span>
           </div>
-          <div id="subtitleId" className="ms-modalExample-body">
+          <div id={this._subtitleId} className="ms-modalExample-body">
             <DefaultButton onClick={this._closeModal} text="Close" />
             <p>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas lorem nulla, malesuada ut sagittis sit amet, vulputate in

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
@@ -1,15 +1,19 @@
 // @codepen
 import * as React from 'react';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
-export class TooltipBasicExample extends BaseComponent<any, any> {
+export class TooltipBasicExample extends React.Component<any, any> {
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  private _hostId: string = getId('tooltipHost');
+
   public render(): JSX.Element {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id="baseicTooltipExample" calloutProps={{ gapSpace: 0 }}>
-          <DefaultButton aria-labelledby="baseicTooltipExample">Hover Over Me</DefaultButton>
+        <TooltipHost content="This is the tooltip" id={this._hostId} calloutProps={{ gapSpace: 0 }}>
+          <DefaultButton aria-labelledby={this._hostId}>Hover Over Me</DefaultButton>
         </TooltipHost>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost, TooltipDelay, DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
-export class TooltipCustomExample extends BaseComponent<any, any> {
+export class TooltipCustomExample extends React.Component<any, any> {
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  private _hostId: string = getId('tooltipHost');
+
   public render(): JSX.Element {
     return (
       <TooltipHost
@@ -21,10 +25,10 @@ export class TooltipCustomExample extends BaseComponent<any, any> {
           }
         }}
         delay={TooltipDelay.zero}
-        id="customID"
+        id={this._hostId}
         directionalHint={DirectionalHint.bottomCenter}
       >
-        <DefaultButton aria-labelledby="customID" text="Hover Over Me" />
+        <DefaultButton aria-labelledby={this._hostId} text="Hover Over Me" />
       </TooltipHost>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Display.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Display.Example.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
-export class TooltipDisplayExample extends BaseComponent<any, any> {
+export class TooltipDisplayExample extends React.Component<any, any> {
+  // Use getId() to ensure that the IDs are unique on the page.
+  // (It's also okay to use plain strings without getId() and manually ensure uniqueness.)
+  private _host1Id: string = getId('tooltipHost1');
+  private _host2Id: string = getId('tooltipHost2');
+
   public render(): JSX.Element {
     return (
       <div>
@@ -10,18 +15,18 @@ export class TooltipDisplayExample extends BaseComponent<any, any> {
           In some cases when TooltipHost is wrapping inline-block or inline elements the positioning of the Tooltip may be off so it is
           recommended to modify the display property of the TooltipHost as in the following example.
         </p>
-        <TooltipHost content="Incorrect positioning" id="myID-display1" calloutProps={{ gapSpace: 0 }}>
-          <button style={{ fontSize: '2em' }} aria-labelledby="myID-display1">
+        <TooltipHost content="Incorrect positioning" id={this._host1Id} calloutProps={{ gapSpace: 0 }}>
+          <button style={{ fontSize: '2em' }} aria-labelledby={this._host1Id}>
             Hover Over Me
           </button>
         </TooltipHost>{' '}
         <TooltipHost
           content="Correct positioning"
           styles={{ root: { display: 'inline-block' } }}
-          id="myID-display2"
+          id={this._host2Id}
           calloutProps={{ gapSpace: 0 }}
         >
-          <button style={{ fontSize: '2em' }} aria-labelledby="myID-display2">
+          <button style={{ fontSize: '2em' }} aria-labelledby={this._host2Id}>
             Hover Over Me
           </button>
         </TooltipHost>

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
-export class TooltipInteractiveExample extends BaseComponent<any, any> {
+export class TooltipInteractiveExample extends React.Component<any, any> {
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  private _hostId: string = getId('tooltipHost');
+
   public render() {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id="myID-interactive" calloutProps={{ gapSpace: 0 }} closeDelay={500}>
-          <DefaultButton aria-labelledby="myID-interactive">Interact with my tooltip</DefaultButton>
+        <TooltipHost content="This is the tooltip" id={this._hostId} calloutProps={{ gapSpace: 0 }} closeDelay={500}>
+          <DefaultButton aria-labelledby={this._hostId}>Interact with my tooltip</DefaultButton>
         </TooltipHost>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -3,8 +3,8 @@
 exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
+    aria-describedby="id__3"
+    aria-labelledby="id__2"
     className=
         ms-Button
         ms-Button--default
@@ -111,7 +111,7 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
               }
-          id="id__0"
+          id="id__2"
         >
           Open Dialog
         </div>
@@ -120,13 +120,13 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
   </button>
   <label
     className="screenReaderOnly"
-    id="myLabelId"
+    id="dialogLabel0"
   >
     My sample Label
   </label>
   <label
     className="screenReaderOnly"
-    id="mySubTextId"
+    id="subTextLabel1"
   >
     My Sample description
   </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -116,7 +116,7 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
-    htmlFor="anInput"
+    htmlFor="anInput0"
   >
     A Label for An Input
   </label>
@@ -211,7 +211,7 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 color: #666666;
                 opacity: 1;
               }
-          id="anInput"
+          id="anInput0"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -56,7 +56,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
             outline: 1px solid ActiveBorder;
           }
-      id="checkbox-0"
+      id="checkbox-1"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
@@ -87,7 +87,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-0"
+      htmlFor="checkbox-1"
     >
       <div
         className=
@@ -195,7 +195,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
             outline: 1px solid ActiveBorder;
           }
-      id="checkbox-1"
+      id="checkbox-2"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
@@ -226,7 +226,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             right: 0px;
             top: 0px;
           }
-      htmlFor="checkbox-1"
+      htmlFor="checkbox-2"
     >
       <div
         className=
@@ -290,7 +290,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
   <div />
   <div
     className="ms-LayerHost"
-    id="test"
+    id="layerHost0"
     style={
       Object {
         "border": "1px solid #ccc",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -41,7 +41,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Toggle0"
+      htmlFor="Toggle1"
     >
       Show host
     </label>
@@ -106,7 +106,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
               background-color: WindowText;
             }
         data-is-focusable={true}
-        id="Toggle0"
+        id="Toggle1"
         onChange={[Function]}
         onClick={[Function]}
         role="switch"
@@ -136,171 +136,10 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
   </div>
   <div
     className="ms-LayerHost LayerExample-customHost"
-    id="layerhost1"
+    id="layerhost0"
   />
-  <p
-    id="foo"
-  >
-    In some cases, you may need to contain layered content within an area. Create an instance of a LayerHost along with an id, and provide a hostId on the layer to render it within the specific host. (Note that it's important that you don't include children within the LayerHost. It's meant to contain Layered content only.)
-  </p>
-  <div
-    className=
-        ms-Checkbox
-        is-enabled
-        {
-          display: flex;
-          position: relative;
-        }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
-  >
-    <input
-      checked={false}
-      className=
-
-          {
-            background: none;
-            opacity: 0;
-            position: absolute;
-          }
-          .ms-Fabric--isFocusVisible &:focus + label::before {
-            outline-offset: 2px;
-            outline: 1px solid #666666;
-          }
-          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
-            outline: 1px solid ActiveBorder;
-          }
-      id="checkbox-1"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      type="checkbox"
-    />
-    <label
-      className=
-          ms-Checkbox-label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            align-items: flex-start;
-            cursor: pointer;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            position: relative;
-            text-align: left;
-            user-select: none;
-          }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-          }
-      htmlFor="checkbox-1"
-    >
-      <div
-        className=
-            ms-Checkbox-checkbox
-            {
-              align-items: center;
-              border-color: #666666;
-              border-style: solid;
-              border-width: 1px;
-              box-sizing: border-box;
-              display: flex;
-              flex-shrink: 0;
-              height: 20px;
-              justify-content: center;
-              margin-right: 4px;
-              overflow: hidden;
-              transition-duration: 200ms;
-              transition-property: background, border, border-color;
-              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-              width: 20px;
-            }
-      >
-        <i
-          className=
-              ms-Checkbox-checkmark
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #ffffff;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                opacity: 0;
-                speak: none;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: Window;
-              }
-          data-icon-name="CheckMark"
-          role="presentation"
-        >
-          
-        </i>
-      </div>
-      <span
-        className=
-            ms-Checkbox-text
-            {
-              color: #333333;
-              font-size: 14px;
-              line-height: 20px;
-              margin-left: 4px;
-            }
-      >
-        Render the box below in a Layer and target it at hostId=layerhost1
-      </span>
-    </label>
-  </div>
-  <div
-    className=
-        LayerExample-content
-        {
-          animation-duration: 0.367s;
-          animation-fill-mode: both;
-          animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:scale3d(.98,.98,1);}to{transform:scale3d(1,1,1);};
-          animation-timing-function: cubic-bezier(.1,.9,.2,1);
-        }
-  >
-    This is example layer content.
-  </div>
-  <div
-    className="LayerExample-nonLayered"
-  >
-    I am normally below the content.
-  </div>
   <p>
-    If you do not specify a hostId then the hosted layer will default to being fixed to the page by default.
+    In some cases, you may need to contain layered content within an area. Create an instance of a LayerHost along with an id, and provide a hostId on the layer to render it within the specific host. (Note that it's important that you don't include children within the LayerHost. It's meant to contain Layered content only.)
   </p>
   <div
     className=
@@ -381,6 +220,165 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             top: 0px;
           }
       htmlFor="checkbox-2"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-color: #666666;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-right: 4px;
+              overflow: hidden;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+      >
+        <i
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
+          data-icon-name="CheckMark"
+          role="presentation"
+        >
+          
+        </i>
+      </div>
+      <span
+        className=
+            ms-Checkbox-text
+            {
+              color: #333333;
+              font-size: 14px;
+              line-height: 20px;
+              margin-left: 4px;
+            }
+      >
+        Render the box below in a Layer and target it at hostId=layerhost0
+      </span>
+    </label>
+  </div>
+  <div
+    className=
+        LayerExample-content
+        {
+          animation-duration: 0.367s;
+          animation-fill-mode: both;
+          animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:scale3d(.98,.98,1);}to{transform:scale3d(1,1,1);};
+          animation-timing-function: cubic-bezier(.1,.9,.2,1);
+        }
+  >
+    This is example layer content.
+  </div>
+  <div
+    className="LayerExample-nonLayered"
+  >
+    I am normally below the content.
+  </div>
+  <p>
+    If you do not specify a hostId then the hosted layer will default to being fixed to the page by default.
+  </p>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #333333;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #333333;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
+        }
+  >
+    <input
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #666666;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid ActiveBorder;
+          }
+      id="checkbox-3"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            text-align: left;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-3"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -3,8 +3,8 @@
 exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
+    aria-describedby="id__3"
+    aria-labelledby="id__2"
     className=
         ms-Button
         ms-Button--default
@@ -111,7 +111,7 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
               }
-          id="id__0"
+          id="id__2"
         >
           Open Modal
         </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -14,7 +14,7 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
     onMouseLeave={[Function]}
   >
     <button
-      aria-labelledby="baseicTooltipExample"
+      aria-labelledby="tooltipHost0"
       className=
           ms-Button
           ms-Button--default
@@ -121,7 +121,7 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                 }
-            id="id__0"
+            id="id__1"
           >
             Hover Over Me
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
@@ -13,7 +13,7 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
   onMouseLeave={[Function]}
 >
   <button
-    aria-labelledby="customID"
+    aria-labelledby="tooltipHost0"
     className=
         ms-Button
         ms-Button--default
@@ -120,7 +120,7 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
               }
-          id="id__0"
+          id="id__1"
         >
           Hover Over Me
         </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Display.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Display.Example.tsx.shot
@@ -17,7 +17,7 @@ exports[`Component Examples renders Tooltip.Display.Example.tsx correctly 1`] = 
     onMouseLeave={[Function]}
   >
     <button
-      aria-labelledby="myID-display1"
+      aria-labelledby="tooltipHost10"
       style={
         Object {
           "fontSize": "2em",
@@ -40,7 +40,7 @@ exports[`Component Examples renders Tooltip.Display.Example.tsx correctly 1`] = 
     onMouseLeave={[Function]}
   >
     <button
-      aria-labelledby="myID-display2"
+      aria-labelledby="tooltipHost21"
       style={
         Object {
           "fontSize": "2em",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
@@ -14,7 +14,7 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
     onMouseLeave={[Function]}
   >
     <button
-      aria-labelledby="myID-interactive"
+      aria-labelledby="tooltipHost0"
       className=
           ms-Button
           ms-Button--default
@@ -121,7 +121,7 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
                   margin-right: 4px;
                   margin-top: 0;
                 }
-            id="id__0"
+            id="id__1"
           >
             Interact with my tooltip
           </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7946
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Many of the doc pages have elements with duplicate IDs due to people copy-pasting examples and not updating the IDs. This causes problems for screen readers and is just generally bad practice.

This PR contains two categories of fixes:
1. Remove IDs from examples that don't ever reference them 
2. Update examples that need IDs to generate them using `getId()`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7967)