### PR TITLE
MessageBar: ensure that native props don't override the innerText className

### DIFF
--- a/common/changes/office-ui-fabric-react/fixMessageBar_2019-02-12-21-19.json
+++ b/common/changes/office-ui-fabric-react/fixMessageBar_2019-02-12-21-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: exclude className from nativeProps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -133,7 +133,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderInnerText(): JSX.Element {
-    const nativeProps = getNativeProps(this.props, htmlElementProperties);
+    const nativeProps = getNativeProps(this.props, htmlElementProperties, ['className']);
 
     return (
       <div className={this._classNames.text} id={this.state.labelId}>

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.test.tsx
@@ -40,15 +40,19 @@ describe('MessageBar', () => {
         expect(dismissElement.exists()).toBe(false);
       });
 
-      it('mixes in native props to the inner text element', () => {
+      it('mixes in native props to the inner text element, except className', () => {
         const wrapper = mount(
-          <MessageBar aria-live={'polite'} isMultiline={false}>
+          <MessageBar aria-live={'polite'} isMultiline={false} className={'sampleClassName'}>
             Message
           </MessageBar>
         );
 
         const innerText = wrapper.find('.ms-MessageBar-innerText');
         expect(innerText.prop('aria-live')).toEqual('polite');
+
+        const singleLine = wrapper.find('.ms-MessageBar-singleline');
+        expect(singleLine.prop('className')).toContain('sampleClassName');
+        expect(innerText.prop('className')).not.toContain('sampleClassName');
       });
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The MessageBar takes in a className property, which gets applied to the root element of the MessageBar. However, since className is also considered a native property, when using object spread to assign the nativeProps onto the innerText element it applies the className there, too.

These changes ensure that the className prop does not get mixed into the innerText element's attributes and override the existing className.

#### Focus areas to test

I added a check for this case in the existing nativeProps test.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7968)