### PR TITLE
Spinbutton a11y pass

### DIFF
--- a/common/changes/office-ui-fabric-react/spinbutton_a11y_2019-02-12-21-57.json
+++ b/common/changes/office-ui-fabric-react/spinbutton_a11y_2019-02-12-21-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing SpinButton A11y Pass Bug 2 where Up/Down buttons aren't discernable.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
@@ -16,6 +16,8 @@ export class SpinButtonBasicExample extends React.Component<any, any> {
           // tslint:disable:jsx-no-lambda
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
+          incrementButtonAriaLabel={'Increase value by 1'}
+          decrementButtonAriaLabel={'Decrease value by 1'}
         />
         <SpinButton
           defaultValue="0"
@@ -25,6 +27,8 @@ export class SpinButtonBasicExample extends React.Component<any, any> {
           step={0.1}
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
+          incrementButtonAriaLabel={'Increase value by 0.1'}
+          decrementButtonAriaLabel={'Decrease value by 0.1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicDisabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicDisabled.Example.tsx
@@ -15,6 +15,8 @@ export class SpinButtonBasicDisabledExample extends React.Component<any, any> {
           // tslint:disable:jsx-no-lambda
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
+          incrementButtonAriaLabel={'Increase value by 1'}
+          decrementButtonAriaLabel={'Decrease value by 1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithEndPosition.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithEndPosition.Example.tsx
@@ -17,6 +17,8 @@ export class SpinButtonBasicWithEndPositionExample extends React.Component<any, 
           // tslint:disable:jsx-no-lambda
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
+          incrementButtonAriaLabel={'Increase value by 1'}
+          decrementButtonAriaLabel={'Decrease value by 1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithIcon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithIcon.Example.tsx
@@ -15,6 +15,8 @@ export class SpinButtonBasicWithIconExample extends React.Component<any, any> {
           // tslint:disable:jsx-no-lambda
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
+          incrementButtonAriaLabel={'Increase value by 1'}
+          decrementButtonAriaLabel={'Decrease value by 1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithIconDisabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.BasicWithIconDisabled.Example.tsx
@@ -13,6 +13,8 @@ export class SpinButtonBasicWithIconDisabledExample extends React.Component<any,
           min={0}
           max={100}
           step={1}
+          incrementButtonAriaLabel={'Increase value by 1'}
+          decrementButtonAriaLabel={'Decrease value by 1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.CustomStyled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.CustomStyled.Example.tsx
@@ -39,6 +39,8 @@ export class SpinButtonCustomStyledExample extends React.Component<any, any> {
           min={0}
           max={100}
           step={1}
+          incrementButtonAriaLabel={'Increase value by 1'}
+          decrementButtonAriaLabel={'Decrease value by 1'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
@@ -29,6 +29,8 @@ export class SpinButtonStatefulExample extends React.Component<any, any> {
           }}
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
+          incrementButtonAriaLabel={'Increase value by 2'}
+          decrementButtonAriaLabel={'Decrease value by 2'}
         />
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -176,6 +176,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
             }
       >
         <button
+          aria-label="Increase value by 1"
           checked={false}
           className=
               ms-Button
@@ -302,6 +303,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           </div>
         </button>
         <button
+          aria-label="Decrease value by 1"
           checked={false}
           className=
               ms-Button
@@ -575,6 +577,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
             }
       >
         <button
+          aria-label="Increase value by 0.1"
           checked={false}
           className=
               ms-Button
@@ -701,6 +704,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
           </div>
         </button>
         <button
+          aria-label="Decrease value by 0.1"
           checked={false}
           className=
               ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -161,6 +161,7 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
       >
         <button
           aria-disabled={true}
+          aria-label="Increase value by 1"
           checked={false}
           className=
               ms-Button
@@ -288,6 +289,7 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
         </button>
         <button
           aria-disabled={true}
+          aria-label="Decrease value by 1"
           checked={false}
           className=
               ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -176,6 +176,7 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
             }
       >
         <button
+          aria-label="Increase value by 1"
           checked={false}
           className=
               ms-Button
@@ -302,6 +303,7 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
           </div>
         </button>
         <button
+          aria-label="Decrease value by 1"
           checked={false}
           className=
               ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -176,6 +176,7 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
             }
       >
         <button
+          aria-label="Increase value by 1"
           checked={false}
           className=
               ms-Button
@@ -302,6 +303,7 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
           </div>
         </button>
         <button
+          aria-label="Decrease value by 1"
           checked={false}
           className=
               ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -185,6 +185,7 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
       >
         <button
           aria-disabled={true}
+          aria-label="Increase value by 1"
           checked={false}
           className=
               ms-Button
@@ -312,6 +313,7 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
         </button>
         <button
           aria-disabled={true}
+          aria-label="Decrease value by 1"
           checked={false}
           className=
               ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -147,6 +147,7 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
             }
       >
         <button
+          aria-label="Increase value by 1"
           checked={false}
           className=
               ms-Button
@@ -273,6 +274,7 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
           </div>
         </button>
         <button
+          aria-label="Decrease value by 1"
           checked={false}
           className=
               ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -153,6 +153,7 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
             }
       >
         <button
+          aria-label="Increase value by 2"
           checked={false}
           className=
               ms-Button
@@ -279,6 +280,7 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
           </div>
         </button>
         <button
+          aria-label="Decrease value by 2"
           checked={false}
           className=
               ms-Button


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7217 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Bug 2: Added aria-labels to SpinButton's examples so that Up/Down buttons are discernible & announced by the ATs like Narrator
![image](https://user-images.githubusercontent.com/4161791/52670838-75712200-2ece-11e9-99f6-fa4f0cfe5697.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7969)