### PR TITLE
Add data viz separators

### DIFF
--- a/common/changes/@uifabric/charting/dataVizSeparators_2019-02-13-13-11.json
+++ b/common/changes/@uifabric/charting/dataVizSeparators_2019-02-13-13-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Add saparator 2px for data segments",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "v-ragor@microsoft.com"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
@@ -1,10 +1,14 @@
 import { IArcProps, IArcStyles } from './Arc.types';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
+
 export const getStyles = (props: IArcProps): IArcStyles => {
   const { color, href } = props;
   return {
     root: {
       fill: color,
-      cursor: href ? 'pointer' : 'default'
+      cursor: href ? 'pointer' : 'default',
+      stroke: DefaultPalette.white,
+      strokeWidth: 2
     }
   };
 };

--- a/packages/charting/src/components/PieChart/Arc/Arc.styles.ts
+++ b/packages/charting/src/components/PieChart/Arc/Arc.styles.ts
@@ -1,7 +1,8 @@
 import { IArcProps, IArcStyles } from './Arc.types';
+import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 export const getStyles = (props: IArcProps): IArcStyles => {
   const { color } = props;
   return {
-    root: { fill: color }
+    root: { fill: color, stroke: DefaultPalette.white, strokeWidth: 2 }
   };
 };

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -54,11 +54,15 @@ export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleP
     },
     opacityChangeOnHover: {
       opacity: shouldHighlight ? '' : '0.1',
-      cursor: href ? 'pointer' : 'default'
+      cursor: href ? 'pointer' : 'default',
+      stroke: theme.palette.white,
+      strokeWidth: 2
     },
     placeHolderOnHover: {
       opacity: shouldHighlight ? '' : '0.1',
-      cursor: 'default'
+      cursor: 'default',
+      stroke: theme.palette.white,
+      strokeWidth: '2'
     },
     legendContainer: {
       marginTop: '5px'

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.styles.ts
@@ -47,7 +47,9 @@ export const getStyles = (props: IStackedBarChartStyleProps): IStackedBarChartSt
     },
     opacityChangeOnHover: {
       opacity: shouldHighlight ? '' : '0.1',
-      cursor: href ? 'pointer' : 'default'
+      cursor: href ? 'pointer' : 'default',
+      stroke: theme.palette.white,
+      strokeWidth: 2
     },
     ratioNumerator: {
       fontSize: FontSizes.small,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Data viz in the dashboard cards accessible through the use of 2 pixel white separators between variables in the data viz elements.

(give an overview)

#### Screenshot
![donut](https://user-images.githubusercontent.com/13463251/52714263-6f0ea300-2fbf-11e9-807c-24fb1a06f83a.PNG)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7977)