### PR TITLE
Revert "TeachingBubble: remove keydown handler (#7837)"

### DIFF
--- a/common/changes/office-ui-fabric-react/fixTeachingBubbleDismiss_2019-02-13-17-07.json
+++ b/common/changes/office-ui-fabric-react/fixTeachingBubbleDismiss_2019-02-13-17-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TeachingBubble: revert PR #7837",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.base.tsx
@@ -57,8 +57,7 @@ export class TeachingBubbleBase extends BaseComponent<ITeachingBubbleProps, ITea
   }
 
   public render(): JSX.Element {
-    const { onDismiss, ...rest } = this.props;
-    const { calloutProps: setCalloutProps, targetElement, isWide, styles, theme } = rest;
+    const { calloutProps: setCalloutProps, targetElement, onDismiss, isWide, styles, theme } = this.props;
     const calloutProps = { ...this._defaultCalloutProps, ...setCalloutProps };
     const stylesProps: ITeachingBubbleStyleProps = {
       theme: theme!,
@@ -81,7 +80,7 @@ export class TeachingBubbleBase extends BaseComponent<ITeachingBubbleProps, ITea
         hideOverflow
       >
         <div ref={this.rootElement}>
-          <TeachingBubbleContent {...rest} />
+          <TeachingBubbleContent {...this.props} />
         </div>
       </Callout>
     );


### PR DESCRIPTION
This reverts commit 080e8d1c46934fee9a045b6053299d0e9d398057.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

TeachingBubbleContent needs `onDismiss` for its cancel/"x" button. We will revisit the ESC key issue in Edge following this PR.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7981)