### PR TITLE
Remove theme colors from Fluent palette

### DIFF
--- a/common/changes/@uifabric/fluent-theme/miwhea-fluent-theme-remove-blues_2019-02-13-18-14.json
+++ b/common/changes/@uifabric/fluent-theme/miwhea-fluent-theme-remove-blues_2019-02-13-18-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Remove unnecessary theme colors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "miwhea@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,5 +1,5 @@
 import { createTheme, ITheme } from '@uifabric/styling';
-import { NeutralColors, CommunicationColors } from './FluentColors';
+import { NeutralColors } from './FluentColors';
 
 export const FluentTheme: ITheme = createTheme({
   palette: {
@@ -15,15 +15,7 @@ export const FluentTheme: ITheme = createTheme({
     neutralLight: NeutralColors.gray30,
     neutralLighter: NeutralColors.gray20,
     neutralLighterAlt: NeutralColors.gray10,
-    white: NeutralColors.white,
-    themeDarker: CommunicationColors.shade30,
-    themeDark: CommunicationColors.shade20,
-    themeDarkAlt: CommunicationColors.shade10,
-    themePrimary: CommunicationColors.primary,
-    themeSecondary: CommunicationColors.tint10,
-    themeLight: CommunicationColors.tint20,
-    themeLighter: CommunicationColors.tint30,
-    themeLighterAlt: CommunicationColors.tint40
+    white: NeutralColors.white
   }
 });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: N/A
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Fluent palette contained theme colors (e.g. themePrimary) that were not necessary, as there are no changes to these in Fluent. Including them makes it difficult for apps that other theme colors to use the Fluent theme. For example, the Fluent theme applied on top of Excel would result in a blue Excel where it should be green.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7982)