### PR TITLE
Fix DetailsList tsc warnings by casting document.activeElement to HTMLElement

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-DetailsList-test-tsc-warnings_2019-02-13-21-24.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-DetailsList-test-tsc-warnings_2019-02-13-21-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix DetailsList compiler warnings in test by casting document.activeElement to HTMLElement",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -193,8 +193,8 @@ describe('DetailsList', () => {
     expect(component).toBeDefined();
     (component as IDetailsList).focusIndex(2);
     setTimeout(() => {
-      expect(document.activeElement.querySelector('[data-automationid=DetailsRowCell]')!.textContent).toEqual('2');
-      expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
+      expect((document.activeElement as HTMLElement).querySelector('[data-automationid=DetailsRowCell]')!.textContent).toEqual('2');
+      expect((document.activeElement as HTMLElement).className.split(' ')).toContain('ms-DetailsRow');
     }, 0);
     jest.runOnlyPendingTimers();
   });
@@ -248,24 +248,24 @@ describe('DetailsList', () => {
     expect(component).toBeDefined();
     (component as IDetailsList).focusIndex(3);
     setTimeout(() => {
-      expect(document.activeElement.querySelector('[data-automationid=DetailsRowCell]')!.textContent).toEqual('3');
-      expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
+      expect((document.activeElement as HTMLElement).querySelector('[data-automationid=DetailsRowCell]')!.textContent).toEqual('3');
+      expect((document.activeElement as HTMLElement).className.split(' ')).toContain('ms-DetailsRow');
     }, 0);
     jest.runOnlyPendingTimers();
 
     // Set element visibility manually as a test workaround
     (component as IDetailsList).focusIndex(4);
     setTimeout(() => {
-      (document.activeElement.children[1] as any).isVisible = true;
-      (document.activeElement.children[1].children[0] as any).isVisible = true;
-      (document.activeElement.children[1].children[0].children[0] as any).isVisible = true;
+      ((document.activeElement as HTMLElement).children[1] as any).isVisible = true;
+      ((document.activeElement as HTMLElement).children[1].children[0] as any).isVisible = true;
+      ((document.activeElement as HTMLElement).children[1].children[0].children[0] as any).isVisible = true;
     }, 0);
 
     jest.runOnlyPendingTimers();
     (component as IDetailsList).focusIndex(4, true);
     setTimeout(() => {
-      expect(document.activeElement.textContent).toEqual('4');
-      expect(document.activeElement.className.split(' ')).toContain('test-column');
+      expect((document.activeElement as HTMLElement).textContent).toEqual('4');
+      expect((document.activeElement as HTMLElement).className.split(' ')).toContain('test-column');
     }, 0);
     jest.runOnlyPendingTimers();
   });
@@ -302,8 +302,8 @@ describe('DetailsList', () => {
     // verify that focusedItemIndex is reset to 0 and 0th row is focused
     setTimeout(() => {
       expect(component.state.focusedItemIndex).toEqual(0);
-      expect(document.activeElement.querySelector('[data-automationid=DetailsRowCell]')!.textContent).toEqual('0');
-      expect(document.activeElement.className.split(' ')).toContain('ms-DetailsRow');
+      expect((document.activeElement as HTMLElement).querySelector('[data-automationid=DetailsRowCell]')!.textContent).toEqual('0');
+      expect((document.activeElement as HTMLElement).className.split(' ')).toContain('ms-DetailsRow');
     }, 0);
     jest.runOnlyPendingTimers();
   });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Small change-set to `DetailsList.test.tsx` which properly casts `document.activeElement` to `HTMLElement` to avoid null warnings by `tsc`. The rationale for the fix is that I find red errors in an IDE distracting while authoring unit tests.

#### Focus areas to test

Tests should pass as part of PR CI.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7988)