### PR TITLE
Pivot cleanup

### DIFF
--- a/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
+++ b/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
@@ -122,13 +122,13 @@ export class ColorsPage extends BaseComponent<{}, IColorsPageState> {
           </p>
         </div>
         {/* Hello! You've found hidden functionality for generating a theme from an image. This uses Microsoft's
-          * Cognitive Vision API, documented here:
-          * https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts/javascript
-          * We use that API to identify the most prominent background and foreground colors, and the accent color,
-          * and generate a theme based off of those.
-          * Since this API requires a personal subscription key, you'll have to enlist and insert your subscription
-          * key in _makeThemeFromImg() @ https://raw.githubusercontent.com/cliffkoh/office-ui-fabric-react/9c95e9b92f8caa1fe5ffb9da769ce0921a5272ed/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
-          * Then, just uncomment this section. */}
+         * Cognitive Vision API, documented here:
+         * https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts/javascript
+         * We use that API to identify the most prominent background and foreground colors, and the accent color,
+         * and generate a theme based off of those.
+         * Since this API requires a personal subscription key, you'll have to enlist and insert your subscription
+         * key in _makeThemeFromImg() @ https://raw.githubusercontent.com/cliffkoh/office-ui-fabric-react/9c95e9b92f8caa1fe5ffb9da769ce0921a5272ed/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGeneratorPage.tsx
+         * Then, just uncomment this section. */}
         {/*}
         <div style={ { display: 'flex' } }>
           <div>URL to image:&nbsp;</div>
@@ -140,23 +140,20 @@ export class ColorsPage extends BaseComponent<{}, IColorsPageState> {
         {*/}
 
         {/* the shared popup color picker for slots */}
-        {colorPickerVisible &&
-          colorPickerSlotRule !== null &&
-          colorPickerSlotRule !== undefined &&
-          colorPickerElement && (
-            <Callout
-              key={colorPickerSlotRule.name}
-              gapSpace={10}
-              target={colorPickerElement}
-              setInitialFocus={true}
-              onDismiss={this._colorPickerOnDismiss}
-            >
-              <ColorPicker
-                color={colorPickerSlotRule.color!.str}
-                onColorChanged={this._semanticSlotRuleChanged.bind(this, colorPickerSlotRule)}
-              />
-            </Callout>
-          )}
+        {colorPickerVisible && colorPickerSlotRule !== null && colorPickerSlotRule !== undefined && colorPickerElement && (
+          <Callout
+            key={colorPickerSlotRule.name}
+            gapSpace={10}
+            target={colorPickerElement}
+            setInitialFocus={true}
+            onDismiss={this._colorPickerOnDismiss}
+          >
+            <ColorPicker
+              color={colorPickerSlotRule.color!.str}
+              onColorChanged={this._semanticSlotRuleChanged.bind(this, colorPickerSlotRule)}
+            />
+          </Callout>
+        )}
 
         {/* the three base slots, prominently displayed at the top of the page */}
         <div style={{ display: 'flex' }}>
@@ -390,7 +387,7 @@ export class ColorsPage extends BaseComponent<{}, IColorsPageState> {
         <h2 id="Output">Output</h2>
         <div className={'ms-themer-output-root'}>
           <Pivot styles={{ root: { padding: 10 } }}>
-            <PivotItem linkText="Code">
+            <PivotItem headerText="Code">
               <textarea readOnly={true} spellCheck={false} value={codeHeader + themeAsCode} style={{ width: 350 }} />
               <p>
                 This code block initializes the theme you have configured above and loads it using the loadTheme utility function. Calling
@@ -399,7 +396,7 @@ export class ColorsPage extends BaseComponent<{}, IColorsPageState> {
               </p>
               <CodepenComponent jsContent={codepenHeader + themeAsCode + codepenSamples} buttonAs={PrimaryButton} />
             </PivotItem>
-            <PivotItem linkText="JSON">
+            <PivotItem headerText="JSON">
               <textarea
                 readOnly={true}
                 spellCheck={false}
@@ -407,7 +404,7 @@ export class ColorsPage extends BaseComponent<{}, IColorsPageState> {
                 style={{ width: 350 }}
               />
             </PivotItem>
-            <PivotItem linkText="PowerShell">
+            <PivotItem headerText="PowerShell">
               <textarea
                 readOnly={true}
                 spellCheck={false}

--- a/apps/todo-app/src/components/TodoTabs.tsx
+++ b/apps/todo-app/src/components/TodoTabs.tsx
@@ -49,7 +49,7 @@ export default class TodoTabs extends React.Component<ITodoTabsProps, {}> {
   private _renderPivotItemList(tasks: ITodoItem[], tabName: string): React.ReactElement<IPivotProps> {
     // @todo #219004 make isInnerZoneKeystroke be rtl safe.
     return (
-      <PivotItem linkText={`${tabName} (${tasks.length})`}>
+      <PivotItem headerText={`${tabName} (${tasks.length})`}>
         <FocusZone direction={FocusZoneDirection.vertical} isInnerZoneKeystroke={this._isInnerZoneKeystroke}>
           <List className={styles.todoList} items={tasks} onRenderCell={this._onRenderTodoItem} />
         </FocusZone>
@@ -62,13 +62,6 @@ export default class TodoTabs extends React.Component<ITodoTabsProps, {}> {
   };
 
   private _onRenderTodoItem(item: ITodoItem): React.ReactElement<ITodoItemProps> {
-    return (
-      <TodoItem
-        key={item.id}
-        item={item}
-        onToggleComplete={this.props.onToggleComplete}
-        onDeleteItem={this.props.onDeleteItem}
-      />
-    );
+    return <TodoItem key={item.id} item={item} onToggleComplete={this.props.onToggleComplete} onDeleteItem={this.props.onDeleteItem} />;
   }
 }

--- a/apps/vr-tests/src/stories/Pivot.stories.tsx
+++ b/apps/vr-tests/src/stories/Pivot.stories.tsx
@@ -19,49 +19,49 @@ storiesOf('Pivot', module)
   )
   .addStory('Root', () => (
     <Pivot>
-      <PivotItem linkText="My Files">Content</PivotItem>
-      <PivotItem linkText="Recent" />
-      <PivotItem linkText="Shared with me" />
+      <PivotItem headerText="My Files">Content</PivotItem>
+      <PivotItem headerText="Recent" />
+      <PivotItem headerText="Shared with me" />
     </Pivot>
   ))
   .addStory(
     'Count and icon',
     () => (
       <Pivot>
-        <PivotItem linkText="My Files" itemCount={42} itemIcon="Emoji2">
+        <PivotItem headerText="My Files" itemCount={42} itemIcon="Emoji2">
           Content
         </PivotItem>
         <PivotItem itemCount="20+" itemIcon="Recent" />
         <PivotItem itemIcon="Globe" />
-        <PivotItem linkText="Shared with me" itemIcon="Ringer" itemCount={1} />
+        <PivotItem headerText="Shared with me" itemIcon="Ringer" itemCount={1} />
       </Pivot>
     ),
     { rtl: true }
   )
   .addStory('Large', () => (
     <Pivot linkSize={PivotLinkSize.large}>
-      <PivotItem linkText="My Files">Content</PivotItem>
-      <PivotItem linkText="Recent" />
-      <PivotItem linkText="Shared with me" />
+      <PivotItem headerText="My Files">Content</PivotItem>
+      <PivotItem headerText="Recent" />
+      <PivotItem headerText="Shared with me" />
     </Pivot>
   ))
   .addStory(
     'Tabs',
     () => (
       <Pivot linkFormat={PivotLinkFormat.tabs}>
-        <PivotItem linkText="Foo">Content</PivotItem>
-        <PivotItem linkText="Bar" />
-        <PivotItem linkText="Bas" />
-        <PivotItem linkText="Biz" />
+        <PivotItem headerText="Foo">Content</PivotItem>
+        <PivotItem headerText="Bar" />
+        <PivotItem headerText="Bas" />
+        <PivotItem headerText="Biz" />
       </Pivot>
     ),
     { rtl: true }
   )
   .addStory('Tabs large', () => (
     <Pivot linkFormat={PivotLinkFormat.tabs} linkSize={PivotLinkSize.large}>
-      <PivotItem linkText="Foo">Content</PivotItem>
-      <PivotItem linkText="Bar" />
-      <PivotItem linkText="Bas" />
-      <PivotItem linkText="Biz" />
+      <PivotItem headerText="Foo">Content</PivotItem>
+      <PivotItem headerText="Bar" />
+      <PivotItem headerText="Bas" />
+      <PivotItem headerText="Biz" />
     </Pivot>
   ));

--- a/common/changes/@uifabric/example-app-base/pivot_2019-02-13-21-35.json
+++ b/common/changes/@uifabric/example-app-base/pivot_2019-02-13-21-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Switch PivotItems to use headerText not linkText",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/pivot_2019-02-13-21-35.json
+++ b/common/changes/@uifabric/fabric-website-resources/pivot_2019-02-13-21-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website-resources",
+      "comment": "Switch PivotItems to use headerText not linkText",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/pivot_2019-02-14-00-40.json
+++ b/common/changes/@uifabric/utilities/pivot_2019-02-14-00-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/pivot_2019-02-13-21-35.json
+++ b/common/changes/office-ui-fabric-react/pivot_2019-02-13-21-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Pivot cleanup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.tsx
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.tsx
@@ -87,10 +87,10 @@ export class FeedbackList extends React.Component<IFeedbackListProps, IFeedbackL
       <div>
         {submitButton}
         <Pivot className="FeedbackList-pivot">
-          <PivotItem linkText="Open Issues">
+          <PivotItem headerText="Open Issues">
             <List items={openIssues} onRenderCell={this._onRenderCell} data-is-scrollable={true} className="FeedbackList-issueList" />
           </PivotItem>
-          <PivotItem linkText="Closed Issues">
+          <PivotItem headerText="Closed Issues">
             <List items={closedIssues} onRenderCell={this._onRenderCell} data-is-scrollable={true} className="FeedbackList-issueList" />
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9505,9 +9505,13 @@ interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
 interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   componentRef?: IRefObject<IPivot>;
+  defaultSelectedIndex?: number;
+  defaultSelectedKey?: string;
   getTabId?: (itemKey: string, index: number) => string;
   headersOnly?: boolean;
+  // @deprecated
   initialSelectedIndex?: number;
+  // @deprecated
   initialSelectedKey?: string;
   linkFormat?: PivotLinkFormat;
   linkSize?: PivotLinkSize;
@@ -9517,14 +9521,12 @@ interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTMLAttrib
   theme?: ITheme;
 }
 
-// @public
+// @public (undocumented)
 interface IPivotState {
   // (undocumented)
   links: IPivotItemProps[];
   // (undocumented)
-  selectedKey: string;
-  // (undocumented)
-  selectedTabId: string;
+  selectedKey: string | undefined;
 }
 
 // @public (undocumented)
@@ -11721,7 +11723,7 @@ enum PersonaSize {
   tiny = 0
 }
 
-// @public (undocumented)
+// @public
 class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
   constructor(props: IPivotProps);
   // (undocumented)
@@ -11733,6 +11735,7 @@ class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
 
 // @public (undocumented)
 class PivotItem extends BaseComponent<IPivotItemProps, {}> {
+  constructor(props: IPivotItemProps);
   // (undocumented)
   render(): JSX.Element;
 }

--- a/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/examples/Keytips.Basic.Example.tsx
@@ -17,7 +17,7 @@ export class KeytipsBasicExample extends React.Component<{}> {
       <div>
         <p>For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content are shown.</p>
         <Pivot>
-          <PivotItem linkText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={{ width: 500, paddingTop: 20 }}>
+          <PivotItem headerText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={{ width: 500, paddingTop: 20 }}>
             <SpinButton className="u-marginBottom" label={'Spin Button'} keytipProps={keytipMap.SpinButtonKeytip} />
             <Toggle className="u-marginBottom" keytipProps={keytipMap.ToggleKeytip} onText={'Yes'} offText={'No'} />
             <p>
@@ -27,11 +27,11 @@ export class KeytipsBasicExample extends React.Component<{}> {
               </Link>
             </p>
           </PivotItem>
-          <PivotItem linkText="Pivot 2" keytipProps={keytipMap.Pivot2Keytip} style={{ width: 500, paddingTop: 20 }}>
+          <PivotItem headerText="Pivot 2" keytipProps={keytipMap.Pivot2Keytip} style={{ width: 500, paddingTop: 20 }}>
             <Checkbox className="u-marginBottom" keytipProps={keytipMap.CheckboxKeytip} label={'Checkbox'} />
             <Dropdown label={'Dropdown'} keytipProps={keytipMap.DropdownKeytip} options={this._sampleOptions} />
           </PivotItem>
-          <PivotItem linkText="Pivot 3" keytipProps={keytipMap.Pivot3Keytip} style={{ width: 500, paddingTop: 20 }}>
+          <PivotItem headerText="Pivot 3" keytipProps={keytipMap.Pivot3Keytip} style={{ width: 500, paddingTop: 20 }}>
             <ComboBox label={'Combo Box'} options={this._sampleOptions} keytipProps={keytipMap.ComboBoxKeytip} />
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -200,18 +200,14 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
     React.Children.map(props.children, (child: any, index: number) => {
       if (typeof child === 'object' && child.type === PivotItemType) {
         const pivotItem = child as PivotItem;
-        const pivotItemProps = pivotItem.props;
+        const { linkText, ...pivotItemProps } = pivotItem.props;
         const itemKey = pivotItem.props.itemKey || index.toString();
 
         links.push({
-          headerText: pivotItemProps.headerText || pivotItemProps.linkText,
-          headerButtonProps: pivotItemProps.headerButtonProps,
-          ariaLabel: pivotItemProps.ariaLabel,
-          itemKey: itemKey,
-          itemCount: pivotItemProps.itemCount,
-          itemIcon: pivotItemProps.itemIcon,
-          onRenderItemLink: pivotItemProps.onRenderItemLink,
-          keytipProps: pivotItemProps.keytipProps
+          // Use linkText (deprecated) if headerText is not provided
+          headerText: linkText,
+          ...pivotItemProps,
+          itemKey: itemKey
         });
         this._keyToIndexMapping[itemKey] = index;
         this._keyToTabIds[itemKey] = this._getTabId(itemKey, index);

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -11,22 +11,6 @@ import { Icon } from '../../Icon';
 
 const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
 
-/*
- *  Usage:
- *
- *   <Pivot>
- *     <PivotItem headerText="Foo">
- *       <Label>Pivot #1</Label>
- *     </PivotItem>
- *     <PivotItem headerText="Bar">
- *       <Label>Pivot #2</Label>
- *     </PivotItem>
- *     <PivotItem headerText="Bas">
- *       <Label>Pivot #3</Label>
- *     </PivotItem>
- *   </Pivot>
- */
-
 export interface IPivotState {
   links: IPivotItemProps[];
   selectedKey: string | undefined;
@@ -34,6 +18,21 @@ export interface IPivotState {
 
 const PivotItemType = (<PivotItem /> as React.ReactElement<IPivotItemProps>).type;
 
+/**
+ *  Usage:
+ *
+ *     <Pivot>
+ *       <PivotItem headerText="Foo">
+ *         <Label>Pivot #1</Label>
+ *       </PivotItem>
+ *       <PivotItem headerText="Bar">
+ *         <Label>Pivot #2</Label>
+ *       </PivotItem>
+ *       <PivotItem headerText="Bas">
+ *         <Label>Pivot #3</Label>
+ *       </PivotItem>
+ *     </Pivot>
+ */
 export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
   private _keyToIndexMapping: { [key: string]: number };
   private _keyToTabIds: { [key: string]: string };
@@ -43,16 +42,29 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
 
   constructor(props: IPivotProps) {
     super(props);
+
+    this._warnDeprecations({
+      initialSelectedKey: 'defaultSelectedKey',
+      initialSelectedIndex: 'defaultSelectedIndex'
+    });
+
     this._pivotId = getId('Pivot');
-    const links: IPivotItemProps[] = this._getPivotLinks(this.props);
+    const links: IPivotItemProps[] = this._getPivotLinks(props);
+
+    const {
+      defaultSelectedKey = props.initialSelectedKey,
+      defaultSelectedIndex = props.initialSelectedIndex,
+      selectedKey: selectedKeyFromProps
+    } = props;
+
     let selectedKey: string | undefined;
 
-    if (props.initialSelectedKey) {
-      selectedKey = props.initialSelectedKey;
-    } else if (props.initialSelectedIndex) {
-      selectedKey = links[props.initialSelectedIndex].itemKey!;
-    } else if (props.selectedKey) {
-      selectedKey = props.selectedKey;
+    if (defaultSelectedKey) {
+      selectedKey = defaultSelectedKey;
+    } else if (typeof defaultSelectedIndex === 'number') {
+      selectedKey = links[defaultSelectedIndex].itemKey!;
+    } else if (selectedKeyFromProps) {
+      selectedKey = selectedKeyFromProps;
     } else if (links.length) {
       selectedKey = links[0].itemKey!;
     }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -15,13 +15,13 @@ const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
  *  Usage:
  *
  *   <Pivot>
- *     <PivotItem linkText="Foo">
+ *     <PivotItem headerText="Foo">
  *       <Label>Pivot #1</Label>
  *     </PivotItem>
- *     <PivotItem linkText="Bar">
+ *     <PivotItem headerText="Bar">
  *       <Label>Pivot #2</Label>
  *     </PivotItem>
- *     <PivotItem linkText="Bas">
+ *     <PivotItem headerText="Bas">
  *       <Label>Pivot #3</Label>
  *     </PivotItem>
  *   </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.deprecated.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import * as WarnUtil from '@uifabric/utilities/lib-commonjs/warn';
+import { resetIds } from '../../Utilities';
+
+import { Pivot, PivotItem } from './index';
+
+describe('Pivot', () => {
+  beforeAll(() => {
+    // Prevent warn deprecations from failing test
+    jest.spyOn(WarnUtil, 'warnDeprecations').mockImplementation(() => {
+      /** no impl **/
+    });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    // Resetting ids to create predictability in generated ids.
+    resetIds();
+  });
+
+  it('renders link Pivot correctly', () => {
+    const component = renderer.create(
+      <Pivot>
+        <PivotItem linkText="Test Link 1" />
+        <PivotItem linkText="" />
+      </Pivot>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
@@ -14,8 +14,8 @@ describe('Pivot', () => {
   it('renders link Pivot correctly', () => {
     const component = renderer.create(
       <Pivot>
-        <PivotItem linkText="Test Link 1" />
-        <PivotItem linkText="" />
+        <PivotItem headerText="Test Link 1" />
+        <PivotItem headerText="" />
       </Pivot>
     );
     const tree = component.toJSON();
@@ -25,8 +25,8 @@ describe('Pivot', () => {
   it('renders large link Pivot correctly', () => {
     const component = renderer.create(
       <Pivot linkSize={PivotLinkSize.large}>
-        <PivotItem linkText="Test Link 1" />
-        <PivotItem linkText="" />
+        <PivotItem headerText="Test Link 1" />
+        <PivotItem headerText="" />
       </Pivot>
     );
     const tree = component.toJSON();
@@ -36,8 +36,8 @@ describe('Pivot', () => {
   it('renders tabbed Pivot correctly', () => {
     const component = renderer.create(
       <Pivot linkFormat={PivotLinkFormat.tabs}>
-        <PivotItem linkText="Test Link 1" />
-        <PivotItem linkText="" />
+        <PivotItem headerText="Test Link 1" />
+        <PivotItem headerText="" />
       </Pivot>
     );
     const tree = component.toJSON();
@@ -47,8 +47,8 @@ describe('Pivot', () => {
   it('renders large tabbed Pivot correctly', () => {
     const component = renderer.create(
       <Pivot linkFormat={PivotLinkFormat.tabs} linkSize={PivotLinkSize.large}>
-        <PivotItem linkText="Test Link 1" />
-        <PivotItem linkText="" />
+        <PivotItem headerText="Test Link 1" />
+        <PivotItem headerText="" />
       </Pivot>
     );
     const tree = component.toJSON();
@@ -58,8 +58,8 @@ describe('Pivot', () => {
   it('renders Pivot correctly with custom className', () => {
     const component = renderer.create(
       <Pivot className="specialClassName">
-        <PivotItem linkText="Test Link 1" className="specialClassName" />
-        <PivotItem linkText="Test Link 2" />
+        <PivotItem headerText="Test Link 1" className="specialClassName" />
+        <PivotItem headerText="Test Link 2" />
       </Pivot>
     );
     const tree = component.toJSON();
@@ -70,8 +70,8 @@ describe('Pivot', () => {
     const component = renderer.create(
       <Pivot>
         <PivotItem itemCount={12} />
-        <PivotItem linkText="Test Link" itemCount={12} />
-        <PivotItem linkText="Text with icon" itemIcon="Recent" />
+        <PivotItem headerText="Test Link" itemCount={12} />
+        <PivotItem headerText="Text with icon" itemIcon="Recent" />
       </Pivot>
     );
     const tree = component.toJSON();
@@ -81,8 +81,8 @@ describe('Pivot', () => {
   it('renders Pivot correctly when itemCount is a string', () => {
     const component = renderer.create(
       <Pivot>
-        <PivotItem linkText="test" />
-        <PivotItem linkText="Test Link" itemCount="20+" />
+        <PivotItem headerText="test" />
+        <PivotItem headerText="Test Link" itemCount="20+" />
       </Pivot>
     );
     const tree = component.toJSON();

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -35,50 +35,68 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
   className?: string;
 
   /**
-   * The index of the pivot item initially selected.
+   * Default selected key for the pivot. Only provide this if the pivot is an uncontrolled component;
+   * otherwise, use the `selectedKey` property.
    *
-   * It only works when initialSelectedKey is not defined. You must not use them together.
+   * This property is also mutually exclusive with `defaultSelectedIndex`.
+   */
+  defaultSelectedKey?: string;
+
+  /**
+   * Default selected index for the pivot. Only provide this if the pivot is an uncontrolled component;
+   * otherwise, use the `selectedKey` property.
+   *
+   * This property is also mutually exclusive with `defaultSelectedKey`.
+   */
+  defaultSelectedIndex?: number;
+
+  /**
+   * Index of the pivot item initially selected. Mutually exclusive with `initialSelectedKey`.
+   * Only provide this if the pivot is an uncontrolled component; otherwise, use `selectedKey`.
+   *
+   * @deprecated Use `defaultSelectedIndex`
    */
   initialSelectedIndex?: number;
 
   /**
-   * The key of the pivot item initially selected.
+   * Key of the pivot item initially selected. Mutually exclusive with `initialSelectedIndex`.
+   * Only provide this if the pivot is an uncontrolled component; otherwise, use `selectedKey`.
    *
-   * It will make initialSelectedIndex not work. You must not use them together.
+   * @deprecated Use `defaultSelectedKey`
    */
   initialSelectedKey?: string;
 
   /**
-   * The key of the selected pivot item.
-   *
-   * If set, this will override the Pivot's selected item state.
+   * Key of the selected pivot item. Updating this will override the Pivot's selected item state.
+   * Only provide this if the pivot is a controlled component where you are maintaining the
+   * current state; otherwise, use `defaultSelectedKey`.
    */
   selectedKey?: string;
 
   /**
-   * Callback issued when the selected pivot item is changed
+   * Callback for when the selected pivot item is changed.
    */
   onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<HTMLElement>) => void;
 
   /**
-   * Specify the PivotLinkSize to use (normal, large)
+   * PivotLinkSize to use (normal, large)
    */
   linkSize?: PivotLinkSize;
 
   /**
-   * Specify the PivotLinkFormat to use (links, tabs)
+   * PivotLinkFormat to use (links, tabs)
    */
   linkFormat?: PivotLinkFormat;
 
   /**
-   * Specify whether to skip rendering the tabpanel with the content of the selected tab.
+   * Whether to skip rendering the tabpanel with the content of the selected tab.
    * Use this prop if you plan to separately render the tab content
    * and don't want to leave an empty tabpanel in the page that may confuse Screen Readers.
    */
   headersOnly?: boolean;
 
   /**
-   * Optional. Specify how IDs are generated for each tab header.
+   * Callback to customize how IDs are generated for each tab header.
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
@@ -3,6 +3,14 @@ import { BaseComponent, getNativeProps, divProperties } from '../../Utilities';
 import { IPivotItemProps } from './PivotItem.types';
 
 export class PivotItem extends BaseComponent<IPivotItemProps, {}> {
+  constructor(props: IPivotItemProps) {
+    super(props);
+
+    this._warnDeprecations({
+      linkText: 'headerText'
+    });
+  }
+
   public render(): JSX.Element {
     return <div {...getNativeProps(this.props, divProperties)}>{this.props.children}</div>;
   }

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -1,0 +1,350 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pivot renders link Pivot correctly 1`] = `
+<div>
+  <div
+    className="ms-FocusZone"
+    data-focuszone-id="FocusZone1"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+    role="presentation"
+  >
+    <div
+      className=
+          ms-Pivot
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
+          }
+      role="tablist"
+    >
+      <button
+        aria-selected={true}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              height: 40px;
+              line-height: 40px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              color: #000000;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              border-bottom: 2px solid #0078d4;
+              bottom: 0px;
+              box-sizing: border-box;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: background-color 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(title);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #666666;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              border-bottom-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="Test Link 1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <div
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              Test Link 1
+            </span>
+          </span>
+        </div>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #333333;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 40px;
+              line-height: 40px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              color: #212121;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              color: #000000;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: background-color 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(title);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #666666;
+            }
+            &:hover::before {
+              border-bottom: 2px solid transparent;
+              box-sizing: border-box;
+            }
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name=""
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <div
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              
+            </span>
+          </span>
+        </div>
+      </button>
+    </div>
+  </div>
+  <div
+    aria-labelledby="Pivot0-Tab0"
+    role="tabpanel"
+  >
+    <div />
+  </div>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
@@ -11,7 +11,6 @@ export class PivotBasicExample extends React.Component<any, any> {
         <Pivot>
           <PivotItem
             headerText="My Files"
-            linkText="I am deprecated. &quot;headerText&quot; overwrites me"
             headerButtonProps={{
               'data-order': 1,
               'data-title': 'My Files Title'
@@ -19,10 +18,10 @@ export class PivotBasicExample extends React.Component<any, any> {
           >
             <Label className={exampleStyles.exampleLabel}>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText="Recent">
+          <PivotItem headerText="Recent">
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText="Shared with me">
+          <PivotItem headerText="Shared with me">
             <Label>Pivot #3</Label>
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Fabric.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Fabric.Example.tsx
@@ -11,15 +11,15 @@ export class PivotFabricExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot linkFormat={PivotLinkFormat.links} linkSize={PivotLinkSize.normal}>
-          <PivotItem linkText="Callout">
+          <PivotItem headerText="Callout">
             <Label>Callout Example</Label>
             <CalloutBasicExample />
           </PivotItem>
-          <PivotItem linkText="Spinner">
+          <PivotItem headerText="Spinner">
             <Label>Spinner Example</Label>
             <SpinnerBasicExample />
           </PivotItem>
-          <PivotItem linkText="Persona">
+          <PivotItem headerText="Persona">
             <Label>Persona Example</Label>
             <PersonaBasicExample />
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
@@ -8,7 +8,7 @@ export class PivotIconCountExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot>
-          <PivotItem linkText="My Files" itemCount={42} itemIcon="Emoji2">
+          <PivotItem headerText="My Files" itemCount={42} itemIcon="Emoji2">
             <Label>Pivot #1</Label>
           </PivotItem>
           <PivotItem itemCount={23} itemIcon="Recent">
@@ -17,10 +17,10 @@ export class PivotIconCountExample extends React.Component<any, any> {
           <PivotItem itemIcon="Globe">
             <Label>Pivot #3</Label>
           </PivotItem>
-          <PivotItem linkText="Shared with me" itemIcon="Ringer" itemCount={1}>
+          <PivotItem headerText="Shared with me" itemIcon="Ringer" itemCount={1}>
             <Label>Pivot #4</Label>
           </PivotItem>
-          <PivotItem linkText="Customized Rendering" itemIcon="Globe" itemCount={10} onRenderItemLink={this._customRenderer}>
+          <PivotItem headerText="Customized Rendering" itemIcon="Globe" itemCount={10} onRenderItemLink={this._customRenderer}>
             <Label>Customized Rendering</Label>
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx
@@ -7,13 +7,13 @@ export class PivotLargeExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot linkSize={PivotLinkSize.large}>
-          <PivotItem linkText="My Files">
+          <PivotItem headerText="My Files">
             <Label>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText="Recent">
+          <PivotItem headerText="Recent">
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText="Shared with me">
+          <PivotItem headerText="Shared with me">
             <Label>Pivot #3</Label>
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx
@@ -7,16 +7,16 @@ export class PivotOnChangeExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot linkSize={PivotLinkSize.large} linkFormat={PivotLinkFormat.tabs} onLinkClick={this.onLinkClick}>
-          <PivotItem linkText="Foo">
+          <PivotItem headerText="Foo">
             <Label>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText="Bar">
+          <PivotItem headerText="Bar">
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText="Bas">
+          <PivotItem headerText="Bas">
             <Label>Pivot #3</Label>
           </PivotItem>
-          <PivotItem linkText="Biz">
+          <PivotItem headerText="Biz">
             <Label>Pivot #4</Label>
           </PivotItem>
         </Pivot>
@@ -25,6 +25,6 @@ export class PivotOnChangeExample extends React.Component<any, any> {
   }
 
   public onLinkClick(item: PivotItem): void {
-    alert(item.props.linkText);
+    alert(item.props.headerText);
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx
@@ -18,13 +18,13 @@ export class PivotOverrideExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot selectedKey={`${this.state.selectedKey}`}>
-          <PivotItem linkText="My Files" itemKey="0">
+          <PivotItem headerText="My Files" itemKey="0">
             <Label>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText="Recent" itemKey="1">
+          <PivotItem headerText="Recent" itemKey="1">
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText="Shared with me" itemKey="2">
+          <PivotItem headerText="Shared with me" itemKey="2">
             <Label>Pivot #3</Label>
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx
@@ -25,7 +25,7 @@ export class PivotRemoveExample extends React.Component<any, IPivotOnChangeExamp
 
     if (this.state.shouldShowFirstPivotItem) {
       pivotArray.push(
-        <PivotItem linkText="Foo" itemKey="Foo" key="Foo">
+        <PivotItem headerText="Foo" itemKey="Foo" key="Foo">
           <Label>Click the button below to show/hide this pivot item.</Label>
           <Label>The selected item will not change when the number of pivot items changes.</Label>
           <Label>If the selected item was removed, the new first item will be selected.</Label>
@@ -34,13 +34,13 @@ export class PivotRemoveExample extends React.Component<any, IPivotOnChangeExamp
     }
 
     pivotArray = pivotArray.concat(
-      <PivotItem linkText="Bar" itemKey="Bar" key="Bar">
+      <PivotItem headerText="Bar" itemKey="Bar" key="Bar">
         <Label>Pivot #2</Label>
       </PivotItem>,
-      <PivotItem linkText="Bas" itemKey="Bas" key="Bas">
+      <PivotItem headerText="Bas" itemKey="Bas" key="Bas">
         <Label>Pivot #3</Label>
       </PivotItem>,
-      <PivotItem linkText="Biz" itemKey="Biz" key="Biz">
+      <PivotItem headerText="Biz" itemKey="Biz" key="Biz">
         <Label>Pivot #4</Label>
       </PivotItem>
     );

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Separate.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Separate.Example.tsx
@@ -18,9 +18,9 @@ export class PivotSeparateExample extends React.Component<any, any> {
           }}
         />
         <Pivot selectedKey={this.state.selectedKey} onLinkClick={this._handleLinkClick} headersOnly={true} getTabId={this._getTabId}>
-          <PivotItem linkText="Rectangle red" itemKey="rectangleRed" />
-          <PivotItem linkText="Square red" itemKey="squareRed" />
-          <PivotItem linkText="Rectangle green" itemKey="rectangleGreen" />
+          <PivotItem headerText="Rectangle red" itemKey="rectangleRed" />
+          <PivotItem headerText="Square red" itemKey="squareRed" />
+          <PivotItem headerText="Rectangle green" itemKey="rectangleGreen" />
         </Pivot>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx
@@ -7,16 +7,16 @@ export class PivotTabsExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot linkFormat={PivotLinkFormat.tabs}>
-          <PivotItem linkText="Foo">
+          <PivotItem headerText="Foo">
             <Label>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText="Bar">
+          <PivotItem headerText="Bar">
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText="Bas">
+          <PivotItem headerText="Bas">
             <Label>Pivot #3</Label>
           </PivotItem>
-          <PivotItem linkText="Biz">
+          <PivotItem headerText="Biz">
             <Label>Pivot #4</Label>
           </PivotItem>
         </Pivot>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx
@@ -7,16 +7,16 @@ export class PivotTabsLargeExample extends React.Component<any, any> {
     return (
       <div>
         <Pivot linkFormat={PivotLinkFormat.tabs} linkSize={PivotLinkSize.large}>
-          <PivotItem linkText="Foo">
+          <PivotItem headerText="Foo">
             <Label>Pivot #1</Label>
           </PivotItem>
-          <PivotItem linkText="Bar">
+          <PivotItem headerText="Bar">
             <Label>Pivot #2</Label>
           </PivotItem>
-          <PivotItem linkText="Bas">
+          <PivotItem headerText="Bas">
             <Label>Pivot #3</Label>
           </PivotItem>
-          <PivotItem linkText="Biz">
+          <PivotItem headerText="Biz">
             <Label>Pivot #4</Label>
           </PivotItem>
         </Pivot>

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -40,9 +40,9 @@ export function resetMemoizations(): void {
 }
 
 /**
- * Memoize decorator to be used on class methods. Note that the "this" reference
- * will be inaccessible within a memoized method, given that a cached method's this
- * would not be instance specific.
+ * Memoize decorator to be used on class methods. WARNING: the `this` reference
+ * will be inaccessible within a memoized method, given that a cached method's `this`
+ * would not be instance-specific.
  *
  * @public
  */


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Was supposed to be looking at Pivot for the purpose of converting it to use derived state, but I got distracted by general messiness in the component. So this PR fixes it up a bit.

The changes to things other than the core Pivot files are to replace usage of the deprecated `IPivotItemProps.linkText` with `headerText` (and I added a deprecation warning for `linkText`).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7989)