### PR TITLE
Huaxi/fluent folder top

### DIFF
--- a/common/changes/@uifabric/experiments/huaxi-fluent-folder-top_2019-02-14-07-21.json
+++ b/common/changes/@uifabric/experiments/huaxi-fluent-folder-top_2019-02-14-07-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "to useFluentIcon prop to change top padding in style",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "huaxi@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -53,6 +53,10 @@
   .hideContent & {
     opacity: 0;
   }
+
+  .isFluent & {
+    top: 12px;
+  }
 }
 
 .frame {

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -86,7 +86,7 @@
   color: $ms-color-white;
   position: relative;
 
-  &.isFluent{
+  .isFluent & {
     @include margin-left(8px);
     @include text-align(left);
     color: $ms-color-yellowDark;

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -124,12 +124,13 @@ export interface IFolderCoverLayout {
   contentSize: ISize;
 }
 
-export function getFolderCoverLayout(element: JSX.Element, isFluent?: boolean): IFolderCoverLayout {
+export function getFolderCoverLayout(element: JSX.Element): IFolderCoverLayout {
   const folderCoverProps: IFolderCoverProps = element.props;
 
   const { folderCoverSize = 'large' } = folderCoverProps;
 
   const contentSize = { ...SIZES[folderCoverSize] };
+  const { isFluent } = element.props;
 
   if (isFluent) {
     contentSize.height -= 8;

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -95,7 +95,8 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           [`ms-FolderCover--isLarge ${FolderCoverStyles.isLarge}`]: size === 'large',
           [`ms-FolderCover--isDefault ${FolderCoverStyles.isDefault}`]: type === 'default',
           [`ms-FolderCover--isMedia ${FolderCoverStyles.isMedia}`]: type === 'media',
-          [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent
+          [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent,
+          [`ms-FolderCover--isFluent ${FolderCoverStyles.isFluent}`]: isFluent
         })}
       >
         <Icon aria-hidden={true} className={css('ms-FolderCover-back', FolderCoverStyles.back)} iconName={assets.back} />

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -124,13 +124,19 @@ export interface IFolderCoverLayout {
   contentSize: ISize;
 }
 
-export function getFolderCoverLayout(element: JSX.Element): IFolderCoverLayout {
+export function getFolderCoverLayout(element: JSX.Element, isFluent?: boolean): IFolderCoverLayout {
   const folderCoverProps: IFolderCoverProps = element.props;
 
   const { folderCoverSize = 'large' } = folderCoverProps;
 
+  const contentSize = { ...SIZES[folderCoverSize] };
+
+  if (isFluent) {
+    contentSize.height -= 8;
+  }
+
   return {
-    contentSize: SIZES[folderCoverSize]
+    contentSize
   };
 }
 

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -78,9 +78,7 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
     } = this.props;
 
     const assets = ASSETS[size][type];
-    const metadataIcon = metadata ? (
-      <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata, isFluent && FolderCoverStyles.isFluent)}>{metadata}</span>
-    ) : null;
+    const metadataIcon = metadata ? <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span> : null;
 
     const signalIcon = signal ? (
       <span className={css('ms-FolderCover-signal', FolderCoverStyles.signal, isFluent ? SignalStyles.isFluent : SignalStyles.dark)}>

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -12,7 +12,7 @@ const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps>
 
   const folderCover = <FolderCover {...folderCoverProps} />;
 
-  const { contentSize } = getFolderCoverLayout(folderCover);
+  const { contentSize } = getFolderCoverLayout(folderCover, folderCoverProps.isFluent);
 
   const imageSize = fitContentToBounds({
     contentSize: originalImageSize,

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -12,7 +12,7 @@ const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps>
 
   const folderCover = <FolderCover {...folderCoverProps} />;
 
-  const { contentSize } = getFolderCoverLayout(folderCover, folderCoverProps.isFluent);
+  const { contentSize } = getFolderCoverLayout(folderCover);
 
   const imageSize = fitContentToBounds({
     contentSize: originalImageSize,


### PR DESCRIPTION
#### Pull request checklist

- [X ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Added a css class to enableFluentIcon feature in content's padding.

#### Focus areas to test
Fluent Folder Cover Icon
(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/7998)