### PR TITLE
IconNames: Deprecate due to const enum usage

### DIFF
--- a/common/changes/@uifabric/icons/jg-7110-deprecate-iconNames_2019-02-14-21-59.json
+++ b/common/changes/@uifabric/icons/jg-7110-deprecate-iconNames_2019-02-14-21-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/icons",
+      "comment": "Deprecate iconNames due to const enum usage.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-7110-deprecate-iconNames_2019-02-14-23-04.json
+++ b/common/changes/office-ui-fabric-react/jg-7110-deprecate-iconNames_2019-02-14-23-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecate IconNames due to const enum usage.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/icons/src/IconNames.ts
+++ b/packages/icons/src/IconNames.ts
@@ -1678,8 +1678,5 @@ export const enum IconNames {
   SizeLegacy = 'SizeLegacy'
 }
 
-/**
- * @deprecate IconNames is deprecated.
- */
 // tslint:disable-next-line:deprecation
 export type IconNamesInput = keyof typeof IconNames;

--- a/packages/icons/src/IconNames.ts
+++ b/packages/icons/src/IconNames.ts
@@ -1678,4 +1678,8 @@ export const enum IconNames {
   SizeLegacy = 'SizeLegacy'
 }
 
+/**
+ * @deprecate IconNames is deprecated.
+ */
+// tslint:disable-next-line:deprecation
 export type IconNamesInput = keyof typeof IconNames;

--- a/packages/icons/src/IconNames.ts
+++ b/packages/icons/src/IconNames.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Const enum use is deprecated. See github issue #7110: https://github.com/OfficeDev/office-ui-fabric-react/issues/7110
+ */
 export const enum IconNames {
   GlobalNavButton = 'GlobalNavButton',
   InternetSharing = 'InternetSharing',

--- a/packages/icons/src/iconNames.test.ts
+++ b/packages/icons/src/iconNames.test.ts
@@ -1,5 +1,6 @@
 import { IconNames, IconNamesInput } from './IconNames';
 
+// tslint:disable-next-line:deprecation
 declare const allIconNamesValues: IconNames;
 
 function validateIconNamesValues(allowedIconNamesValues: IconNamesInput): void {

--- a/packages/icons/tslint.json
+++ b/packages/icons/tslint.json
@@ -1,4 +1,8 @@
 {
-  "extends": ["@uifabric/tslint-rules"],
-  "rules": {}
+  "extends": [
+    "@uifabric/tslint-rules"
+  ],
+  "rules": {
+    "deprecation": false
+  }
 }

--- a/packages/icons/tslint.json
+++ b/packages/icons/tslint.json
@@ -1,8 +1,4 @@
 {
-  "extends": [
-    "@uifabric/tslint-rules"
-  ],
-  "rules": {
-    "deprecation": false
-  }
+  "extends": ["@uifabric/tslint-rules"],
+  "rules": {}
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -3057,7 +3057,7 @@ module IconFontSizes {
 
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 enum IconNames {
   // (undocumented)
   AADLogo = "AADLogo",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7110, Fixes #8003
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Per #7110 deprecate `IconNames` due to its usage of `const enum`.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8005)