### PR TITLE
Fluent: Fix padding right on dialog title

### DIFF
--- a/common/changes/@uifabric/fluent-theme/edwl-2019-02-fixFluentDialogPadding_2019-02-15-00-23.json
+++ b/common/changes/@uifabric/fluent-theme/edwl-2019-02-fixFluentDialogPadding_2019-02-15-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Dialog: Adjust right padding of title",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -17,7 +17,7 @@ export const DialogContentStyles = (props: IDialogContentStyleProps): Partial<ID
     title: {
       fontSize: FontSizes.size20,
       fontWeight: FontWeights.semibold,
-      padding: '16px 24px 24px 24px',
+      padding: '16px 46px 24px 24px',
       lineHeight: 'normal'
     },
     topButton: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adjusts padding right to be same width as close button (+ close button right padding).

**BEFORE**:
![image](https://user-images.githubusercontent.com/1291968/52826167-a0957600-3074-11e9-9e7c-92247d092ad1.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/1291968/52826173-ab500b00-3074-11e9-90f6-a7164439ebf0.png)



#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8009)