### PR TITLE
TS3.1: Fix Stack / Text typings

### DIFF
--- a/common/changes/@uifabric/experiments/jg-fix-stack-typing_2019-02-15-22-59.json
+++ b/common/changes/@uifabric/experiments/jg-fix-stack-typing_2019-02-15-22-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Text: Fix 'as' prop circular reference",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-fix-stack-typing_2019-02-15-22-59.json
+++ b/common/changes/office-ui-fabric-react/jg-fix-stack-typing_2019-02-15-22-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Stack: Fix 'as' prop circular reference.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-fix-stack-typing_2019-02-15-22-59.json
+++ b/common/changes/office-ui-fabric-react/jg-fix-stack-typing_2019-02-15-22-59.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Stack: Fix 'as' prop circular reference.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/experiments/src/components/Text/Text.types.tsx
+++ b/packages/experiments/src/components/Text/Text.types.tsx
@@ -20,7 +20,7 @@ export interface ITextProps extends ITextSlots, IStyleableComponentProps<ITextPr
   /**
    * Optionally render the component as another component type or primitive.
    */
-  as?: string | React.ReactType<ITextProps>;
+  as?: React.ReactType<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * Optional class name for Text.

--- a/packages/experiments/src/slots/examples/Slots.Stack.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Stack.Example.tsx
@@ -3,13 +3,26 @@ import { Button } from '@uifabric/experiments';
 import { Stack } from 'office-ui-fabric-react';
 import { stackProps } from './SlotExampleUtils';
 
+class AsComponent extends React.Component<React.HTMLAttributes<HTMLElement>, {}> {
+  public render(): JSX.Element {
+    return <div {...this.props} />;
+  }
+}
+
+const AsComponentSFC: React.StatelessComponent<React.HTMLAttributes<HTMLElement>> = props => {
+  return <div {...this.props} />;
+};
+
 // tslint:disable:jsx-no-lambda
 // tslint:disable:jsx-key
 export class SlotsStackExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack {...stackProps}>
+        <Button icon="share" content="Stack: Props, as: 'AsComponent'" stack={{ as: AsComponent }} />
+        <Button icon="share" content="Stack: Props, as: 'AsComponentSFC'" stack={{ as: AsComponentSFC }} />
         <Button icon="share" content="Stack: Props, as: 'div'" stack={{ as: 'div' }} />
+        <Button icon="share" content="Stack: Props, as: 'span'" stack={{ as: 'span' }} />
         <Button icon="share" stack={{ horizontalAlign: 'start' }} content="Stack: Object, horizontalAlign: left" />
         <Button icon="share" stack={render => render((StackType, props) => <StackType {...props} />)} content="Stack: Function" />
         <Button

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10618,6 +10618,26 @@ interface ISpinnerStyles {
 export function isRelativeUrl(url: string): boolean;
 
 // @public (undocumented)
+interface IStackItemProps extends IStackItemSlots, IStyleableComponentProps<IStackItemProps, IStackItemTokens, IStackItemStyles> {
+  align?: 'auto' | 'stretch' | 'baseline' | 'start' | 'center' | 'end';
+  className?: string;
+  disableShrink?: boolean;
+  grow?: boolean | number | 'inherit' | 'initial' | 'unset';
+  shrink?: boolean | number | 'inherit' | 'initial' | 'unset';
+  verticalFill?: boolean;
+}
+
+// @public (undocumented)
+interface IStackItemSlots {
+  // (undocumented)
+  root?: IHTMLSlot;
+}
+
+// @public (undocumented)
+interface IStackItemTokens {
+}
+
+// @public (undocumented)
 interface IStackProps extends IStackSlots, IStyleableComponentProps<IStackProps, IStackStyles, IStackTokens>, React.HTMLAttributes<HTMLElement> {
   as?: React.ReactType<React.HTMLAttributes<HTMLElement>>;
   disableShrink?: boolean;
@@ -12956,6 +12976,10 @@ module ZIndexes {
 // WARNING: Unsupported export: Spinner
 // WARNING: Unsupported export: SpinnerLabelPosition
 // WARNING: Unsupported export: StackItem
+// WARNING: Unsupported export: IStackItemComponent
+// WARNING: Unsupported export: IStackItemTokenReturnType
+// WARNING: Unsupported export: IStackItemStylesReturnType
+// WARNING: Unsupported export: IStackItemStyles
 // WARNING: Unsupported export: Stack
 // WARNING: Unsupported export: Alignment
 // WARNING: Unsupported export: IStackComponent

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10619,7 +10619,7 @@ export function isRelativeUrl(url: string): boolean;
 
 // @public (undocumented)
 interface IStackProps extends IStackSlots, IStyleableComponentProps<IStackProps, IStackStyles, IStackTokens>, React.HTMLAttributes<HTMLElement> {
-  as?: string | React.ReactType<IStackProps>;
+  as?: React.ReactType<React.HTMLAttributes<HTMLElement>>;
   disableShrink?: boolean;
   gap?: number | string;
   grow?: boolean | number | 'inherit' | 'initial' | 'unset';

--- a/packages/office-ui-fabric-react/src/components/Stack/Stack.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/Stack.types.ts
@@ -36,7 +36,7 @@ export interface IStackProps
   /**
    * Defines how to render the Stack.
    */
-  as?: string | React.ReactType<IStackProps>;
+  as?: React.ReactType<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * Defines whether to render Stack children horizontally.

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
@@ -14,11 +14,6 @@ export type IStackItemStylesReturnType = ReturnType<Extract<IStackItemComponent[
 
 export interface IStackItemProps extends IStackItemSlots, IStyleableComponentProps<IStackItemProps, IStackItemTokens, IStackItemStyles> {
   /**
-   * Defines how to render the StackItem.
-   */
-  as?: React.ReactType<React.HTMLAttributes<HTMLElement>>;
-
-  /**
    * Defines a CSS class name used to style the StackItem.
    */
   className?: string;

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
@@ -16,7 +16,7 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
   /**
    * Defines how to render the StackItem.
    */
-  as?: string | React.ReactType<IStackItemProps>;
+  as?: React.ReactType<React.HTMLAttributes<HTMLElement>>;
 
   /**
    * Defines a CSS class name used to style the StackItem.

--- a/packages/office-ui-fabric-react/src/components/Stack/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/index.ts
@@ -1,3 +1,4 @@
 export * from './StackItem/StackItem';
+export * from './StackItem/StackItem.types';
 export * from './Stack';
 export * from './Stack.types';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

A consumer of OUFR v6.140.0 reported a TS 3.x error:

>node_modules/office-ui-fabric-react/lib-commonjs/components/Stack/Stack.types.d.ts(27,5): error TS2502: 'as' is referenced directly or indirectly in its own type annotation. 
>
> /node_modules/office-ui-fabric-react/lib-commonjs/components/Stack/StackItem/StackItem.types.d.ts(13,5): error TS2502: 'as' is referenced directly or indirectly in its own type annotation.

This is as the result of Stack's `as` prop creating a circular reference with `IStackProps`.

Stack's `as` prop should really just be of type `HTMLAttributes` because only native attributes are applied to the `as` component. `string` is also contained within `ReactType` and therefore does not need to be present in the `as` prop type.

This change also affects `Text`.

Also fixed:
* `StackItem`'s `as` prop is not being used so it has been removed. 
* `StackItem` types weren't being exported but are now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8017)