### PR TITLE
Add Stories for Tile component

### DIFF
--- a/apps/vr-tests/src/stories/FolderCover.stories.tsx
+++ b/apps/vr-tests/src/stories/FolderCover.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@uifabric/experiments';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { ISize, fitContentToBounds } from 'office-ui-fabric-react';
+import { ISize, fitContentToBounds, Fabric } from 'office-ui-fabric-react';
 import { FabricDecorator } from '../utilities';
 
 interface IFolderCoverWithImageProps extends IFolderCoverProps {
@@ -20,7 +20,7 @@ const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps>
 ): JSX.Element => {
   const { originalImageSize, ...folderCoverProps } = props;
 
-  const folderCover = <FolderCover style={{ fontFamily: 'Segoe UI' }} {...folderCoverProps} />;
+  const folderCover = <FolderCover {...folderCoverProps} />;
 
   const { contentSize } = getFolderCoverLayout(folderCover);
 
@@ -38,6 +38,9 @@ const FolderCoverWithImage: React.StatelessComponent<IFolderCoverWithImageProps>
 };
 
 storiesOf('FolderCover', module)
+  .addDecorator(story => (
+    <Fabric>{story()}</Fabric>
+  ))
   .addDecorator(FabricDecorator)
   .addDecorator(story =>
     // prettier-ignore

--- a/apps/vr-tests/src/stories/Tile.stories.tsx
+++ b/apps/vr-tests/src/stories/Tile.stories.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import {
+  Tile,
+  SignalField,
+  TrendingSignal,
+  CommentsSignal,
+  NewSignal,
+  SharedSignal
+} from '@uifabric/experiments';
+import Screener from 'screener-storybook/src/screener';
+import { storiesOf } from '@storybook/react';
+import { ISize, fitContentToBounds } from 'office-ui-fabric-react';
+import { FabricDecorator } from '../utilities';
+
+interface IDocumentItem { name: string; activity: string; }
+
+interface IDocumentTileWithThumbnailProps {
+  originalImageSize: ISize;
+  item: IDocumentItem;
+}
+
+const DocumentTileBox = (props: React.Props<{}>): JSX.Element => {
+  return (
+    <div style={{
+      position: 'relative',
+      width: '176px',
+      height: '171px',
+      fontFamily: 'Segoe UI'
+    }}>{props.children}</div>
+  );
+};
+
+const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumbnailProps> = (
+  props: IDocumentTileWithThumbnailProps
+): JSX.Element => {
+  function renderForeground(foregroundProps: { foregroundSize?: ISize; }) {
+    const {
+      foregroundSize = { width: 0, height: 0 }
+    } = foregroundProps;
+
+    const imageSize = fitContentToBounds({
+      contentSize: props.originalImageSize,
+      boundsSize: foregroundSize,
+      mode: 'contain'
+    });
+
+    return (
+      <img
+        src={`//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`}
+        style={{ display: 'block' }}
+      />
+    );
+  }
+
+  return (
+    <DocumentTileBox>
+      <Tile
+        contentSize={{
+          width: 176,
+          height: 171
+        }}
+        itemName={<SignalField before={<TrendingSignal />}>{props.item.name}</SignalField>}
+        itemActivity={<SignalField before={<CommentsSignal>{'12'}</CommentsSignal>}>{props.item.activity}</SignalField>}
+        foreground={renderForeground}
+        showForegroundFrame={true}
+      />
+    </DocumentTileBox>
+  );
+};
+
+storiesOf('Tile', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
+  .addStory('Document tile with fit landscape image', () => (
+    <DocumentTileWithThumbnail
+      item={{
+        name: 'Test Name',
+        activity: 'Test Activity'
+      }}
+      originalImageSize={{
+        width: 200,
+        height: 150
+      }}
+    />
+  ))
+  .addStory('Document tile with fit portrait image', () => (
+    <DocumentTileWithThumbnail
+      item={{
+        name: 'Test Name',
+        activity: 'Test Activity'
+      }}
+      originalImageSize={{
+        width: 150,
+        height: 200
+      }}
+    />
+  ))
+  .addStory('Document tile with icon-sized image', () => (
+    <DocumentTileWithThumbnail
+      item={{
+        name: 'Test Name',
+        activity: 'Test Activity'
+      }}
+      originalImageSize={{
+        width: 16,
+        height: 16
+      }}
+    />
+  ))
+  .addStory('Document tile with icon', () => (
+    <DocumentTileBox>
+      <Tile
+        itemName={<SignalField before={<NewSignal />}>{'Test Name'}</SignalField>}
+        itemActivity={<SignalField before={<SharedSignal />}>{'Test Activity'}</SignalField>}
+        foreground={
+          <img
+            src={`https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/docx_48x1.svg`}
+            style={{
+              display: 'block',
+              width: '64px',
+              height: '64px',
+              margin: '16px'
+            }}
+          />
+        }
+        showForegroundFrame={true}
+      />
+    </DocumentTileBox>
+  ))
+  .addStory('Tile with no content and long text', () => (
+    <DocumentTileBox>
+      <Tile
+        itemName={<SignalField before={<NewSignal />}>{'This is a name which should overflow'}</SignalField>}
+        itemActivity={<SignalField before={<SharedSignal />}>{'This is an activity which should overflow'}</SignalField>}
+        showForegroundFrame={false}
+      />
+    </DocumentTileBox>
+  ));

--- a/apps/vr-tests/src/stories/Tile.stories.tsx
+++ b/apps/vr-tests/src/stories/Tile.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '@uifabric/experiments';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { ISize, fitContentToBounds } from 'office-ui-fabric-react';
+import { ISize, fitContentToBounds, Fabric } from 'office-ui-fabric-react';
 import { FabricDecorator } from '../utilities';
 
 interface IDocumentItem { name: string; activity: string; }
@@ -24,8 +24,7 @@ const DocumentTileBox = (props: React.Props<{}>): JSX.Element => {
     <div style={{
       position: 'relative',
       width: '176px',
-      height: '171px',
-      fontFamily: 'Segoe UI'
+      height: '171px'
     }}>{props.children}</div>
   );
 };
@@ -69,6 +68,9 @@ const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumb
 };
 
 storiesOf('Tile', module)
+  .addDecorator(story => (
+    <Fabric>{story()}</Fabric>
+  ))
   .addDecorator(FabricDecorator)
   .addDecorator(story =>
     // prettier-ignore

--- a/common/changes/@uifabric/experiments/tile-stories_2019-02-20-18-48.json
+++ b/common/changes/@uifabric/experiments/tile-stories_2019-02-20-18-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add render-prop pattern to Tile and FolderCover components",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -69,7 +69,6 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
       folderCoverSize: size = 'large',
       folderCoverType: type = 'default',
       hideContent = false,
-      ref,
       metadata,
       signal,
       children,
@@ -98,11 +97,7 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
         })}
       >
         <Icon aria-hidden={true} className={css('ms-FolderCover-back', FolderCoverStyles.back)} iconName={assets.back} />
-        {children ? (
-          <span className={css('ms-FolderCover-content', FolderCoverStyles.content)}>
-            <span className={css('ms-FolderCover-frame', FolderCoverStyles.frame)}>{children}</span>
-          </span>
-        ) : null}
+        {this._renderChildren({ children })}
         <Icon aria-hidden={true} className={css('ms-FolderCover-front', FolderCoverStyles.front)} iconName={assets.front} />
         {isFluent ? (
           <React.Fragment>
@@ -118,6 +113,16 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
       </div>
     );
   }
+
+  private _renderChildren({ children }: Pick<IFolderCoverProps, 'children'>): JSX.Element | null {
+    const finalChildren = typeof children === 'function' ? children(getFolderCoverLayoutFromProps(this.props)) : children;
+
+    return finalChildren ? (
+      <span className={css('ms-FolderCover-content', FolderCoverStyles.content)}>
+        <span className={css('ms-FolderCover-frame', FolderCoverStyles.frame)}>{finalChildren}</span>
+      </span>
+    ) : null;
+  }
 }
 
 export interface IFolderCoverLayout {
@@ -127,10 +132,13 @@ export interface IFolderCoverLayout {
 export function getFolderCoverLayout(element: JSX.Element): IFolderCoverLayout {
   const folderCoverProps: IFolderCoverProps = element.props;
 
-  const { folderCoverSize = 'large' } = folderCoverProps;
+  return getFolderCoverLayoutFromProps(folderCoverProps);
+}
+
+function getFolderCoverLayoutFromProps(folderCoverProps: IFolderCoverProps): IFolderCoverLayout {
+  const { folderCoverSize = 'large', isFluent } = folderCoverProps;
 
   const contentSize = { ...SIZES[folderCoverSize] };
-  const { isFluent } = element.props;
 
   if (isFluent) {
     contentSize.height -= 8;

--- a/packages/experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.types.ts
@@ -1,52 +1,42 @@
 import * as React from 'react';
-import { IBaseProps } from '../../Utilities';
-import { FolderCover } from './FolderCover';
+import { IBaseProps, ISize } from '../../Utilities';
 
 export type FolderCoverSize = 'small' | 'large';
 
 export type FolderCoverType = 'default' | 'media';
 
-export interface IFolderCoverProps extends IBaseProps, React.Props<FolderCover>, React.HTMLAttributes<HTMLDivElement> {
+export interface IFolderCoverChildrenProps {
+  contentSize: ISize;
+}
+
+export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<HTMLDivElement> {
   /**
    * The breakpoint size of the folder cover.
-   *
-   * @type {FolderCoverSize}
-   * @memberof IFolderCoverProps
    */
   folderCoverSize?: FolderCoverSize;
   /**
    * The display type of the folder cover.
-   *
-   * @type {FolderCoverType}
-   * @memberof IFolderCoverProps
    */
   folderCoverType?: FolderCoverType;
   /**
    * Whether or not the content should be hidden, even if specified.
    * Use this to "fade in" the content once it is loaded.
-   *
-   * @type {boolean}
-   * @memberof IFolderCoverProps
    */
   hideContent?: boolean;
   /**
    * A signal to display on the folder cover.
-   *
-   * @type {(React.ReactNode[] | React.ReactNode)}
-   * @memberof IFolderCoverProps
    */
-  signal?: React.ReactNode[] | React.ReactNode;
+  signal?: React.ReactNode;
   /**
    * A metadata value to display on the folder cover.
-   *
-   * @type {(React.ReactNode[] | React.ReactNode)}
-   * @memberof IFolderCoverProps
    */
-  metadata?: React.ReactNode[] | React.ReactNode;
+  metadata?: React.ReactNode;
   /**
    * Support fluent color, yellow folder cover.
-   * @type {boolean}
-   * @memberof IFolderCoverProps
    */
   isFluent?: boolean;
+  /**
+   * The children to pass into the content area of the folder cover.
+   */
+  children?: React.Props<{}>['children'] | ((childrenProps: IFolderCoverChildrenProps) => JSX.Element | null);
 }

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -167,21 +167,21 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         ) : null}
         {background
           ? this._onRenderBackground({
-            background: background,
-            hideBackground
-          })
+              background: background,
+              hideBackground
+            })
           : null}
         {foreground
           ? this._onRenderForeground({
-            foreground: foreground,
-            hideForeground
-          })
+              foreground: foreground,
+              hideForeground
+            })
           : null}
         {itemName || itemActivity
           ? this._onRenderNameplate({
-            name: itemName,
-            activity: itemActivity
-          })
+              name: itemName,
+              activity: itemActivity
+            })
           : null}
       </>
     );
@@ -234,8 +234,8 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         ) : null}
         {isSelectable
           ? this._onRenderCheck({
-            isSelected: isSelected
-          })
+              isSelected: isSelected
+            })
           : null}
       </div>
     );
@@ -245,29 +245,33 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     background,
     hideBackground
   }: {
-    background: React.ReactNode | React.ReactNode[];
+    background: ITileProps['background'];
     hideBackground: boolean;
-  }): JSX.Element {
-    return (
+  }): JSX.Element | null {
+    const finalBackground = typeof background === 'function' ? background(getTileLayoutFromProps(this.props)) : background;
+
+    return finalBackground ? (
       <span
         key="background"
         className={css('ms-Tile-background', TileStyles.background, {
           [`ms-Tile-background--hide ${TileStyles.backgroundHide}`]: hideBackground
         })}
       >
-        {background}
+        {finalBackground}
       </span>
-    );
+    ) : null;
   }
 
   private _onRenderForeground({
     foreground,
     hideForeground
   }: {
-    foreground: React.ReactNode | React.ReactNode[];
+    foreground: ITileProps['foreground'];
     hideForeground: boolean;
-  }): JSX.Element {
-    return (
+  }): JSX.Element | null {
+    const finalForeground = typeof foreground === 'function' ? foreground(getTileLayoutFromProps(this.props)) : foreground;
+
+    return finalForeground ? (
       <span key="foreground" role="presentation" className={css('ms-Tile-aboveNameplate', TileStyles.aboveNameplate)}>
         <span role="presentation" className={css('ms-Tile-content', TileStyles.content)}>
           <span
@@ -276,20 +280,14 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
               [`ms-Tile-foreground--hide ${TileStyles.foregroundHide}`]: hideForeground
             })}
           >
-            {foreground}
+            {finalForeground}
           </span>
         </span>
       </span>
-    );
+    ) : null;
   }
 
-  private _onRenderNameplate({
-    name,
-    activity
-  }: {
-    name: React.ReactNode | React.ReactNode[];
-    activity: React.ReactNode | React.ReactNode[];
-  }): JSX.Element {
+  private _onRenderNameplate({ name, activity }: { name: React.ReactNode; activity: React.ReactNode }): JSX.Element {
     return (
       <span key="nameplate" className={css('ms-Tile-nameplate', TileStyles.nameplate)}>
         {name ? (
@@ -346,6 +344,10 @@ export interface ITileLayout {
 export function getTileLayout(tileElement: JSX.Element): ITileLayout {
   const tileProps: ITileProps = tileElement.props;
 
+  return getTileLayoutFromProps(tileProps);
+}
+
+function getTileLayoutFromProps(tileProps: ITileProps): ITileLayout {
   const { contentSize, tileSize = 'large' } = tileProps;
 
   if (!contentSize) {

--- a/packages/experiments/src/components/Tile/Tile.types.ts
+++ b/packages/experiments/src/components/Tile/Tile.types.ts
@@ -9,126 +9,84 @@ export type TileSize = keyof {
   large: 'large';
 };
 
+export interface ITileForegroundProps {
+  foregroundSize?: ISize;
+}
+
+export interface ITileBackgroundProps {
+  backgroundSize?: ISize;
+}
+
 export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpanElement | HTMLAnchorElement> {
   /**
    * The intended dimensions for the Tile.
-   *
-   * @type {ISize}
-   * @memberof ITileProps
    */
   contentSize?: ISize;
   /**
    * The breakpoint size for the Tile.
-   *
-   * @type {TileSize}
-   * @memberof ITileProps
    */
   tileSize?: TileSize;
   /**
    * Index of the item in the selection controller.
-   *
-   * @type {number}
-   * @memberof ITileProps
    */
   selectionIndex?: number;
   /**
    * Selection controller for the item rendered in the tile.
-   *
-   * @type {ISelection}
-   * @memberof ITileProps
    */
   selection?: ISelection;
   /**
    * Whether or not the item should be invoked if clicked.
-   *
-   * @type {boolean}
-   * @memberof ITileProps
    */
   invokeSelection?: boolean;
   /**
    * Name to use on the nameplate for the tile.
-   *
-   * @type {(React.ReactNode | React.ReactNode[])}
-   * @memberof ITileProps
    */
-  itemName?: React.ReactNode | React.ReactNode[];
+  itemName?: React.ReactNode;
   /**
    * Activity to use on the nameplate for the tile.
-   *
-   * @type {(React.ReactNode | React.ReactNode[])}
-   * @memberof ITileProps
    */
-  itemActivity?: React.ReactNode | React.ReactNode[];
+  itemActivity?: React.ReactNode;
   /**
    * Content to render as the full-size background of the tile.
-   *
-   * @type {(React.ReactNode | React.ReactNode[])}
-   * @memberof ITileProps
    */
-  background?: React.ReactNode | React.ReactNode[];
+  background?: React.ReactNode | ((backgroundProps: ITileBackgroundProps) => JSX.Element);
   /**
    * Whether or not to frame the background.
-   *
-   * @type {boolean}
-   * @memberof ITileProps
    */
   showBackgroundFrame?: boolean;
   /**
    * Whether or not to hide the background, regardless of whether it is present.
    * Use this to control when the background "fades in" if the content needs to be loaded.
-   *
-   * @type {boolean}
-   * @memberof ITileProps
    */
   hideBackground?: boolean;
   /**
    * Content to render as the foreground of the tile, bounded by padding and the nameplate.
-   *
-   * @type {(React.ReactNode | React.ReactNode[])}
-   * @memberof ITileProps
    */
-  foreground?: React.ReactNode | React.ReactNode[];
+  foreground?: React.ReactNode | ((foregroundProps: ITileForegroundProps) => JSX.Element);
   /**
    * Whether or not to frame the foreground.
-   *
-   * @type {boolean}
-   * @memberof ITileProps
    */
   showForegroundFrame?: boolean;
   /**
    * Whether or not to hide the foreground, regardless of whether it is present.
    * Use this to control when the foreground "fades in" if the content needs to be loaded.
-   *
-   * @type {boolean}
-   * @memberof ITileProps
    */
   hideForeground?: boolean;
   /**
    * The accessible label representing the tile and its content.
-   *
-   * @type {string}
-   * @memberof ITileProps
    */
   ariaLabel?: string;
   /**
    * The accessible label providing description or instructions for the tile.
-   *
-   * @type {string}
-   * @memberof ITileProps
    */
   descriptionAriaLabel?: string;
   /**
    * The accessible label for the selection checkbox.
-   *
-   * @type {string}
-   * @memberof ITileProps
    */
   toggleSelectionAriaLabel?: string;
 
   /**
    * Link ref
-   * @type {() => void}
-   * @memberof ITileProps
    */
   linkRef?: (element: HTMLAnchorElement | HTMLButtonElement | null) => void;
 }

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -37,7 +37,7 @@ export interface ITileCell<TItem> {
   aspectRatio: number;
   grid: ITileGrid;
   isPlaceholder?: boolean;
-  onRender(content: TItem, finalSize: { width: number; height: number }): React.ReactNode | React.ReactNode[];
+  onRender(content: TItem, finalSize: { width: number; height: number }): React.ReactNode;
 }
 
 interface IRowData {

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -26,7 +26,7 @@ export interface ITilesGridItem<TItem> {
    * Invoked to render the virtual DOM for the item.
    * This content will be rendered inside the cell allocated for the item.
    */
-  onRender: (content: TItem, finalSize?: ISize) => React.ReactNode | React.ReactNode[];
+  onRender: (content: TItem, finalSize?: ISize) => React.ReactNode;
 }
 
 export const enum TilesGridMode {

--- a/packages/experiments/src/components/signals/SignalField.tsx
+++ b/packages/experiments/src/components/signals/SignalField.tsx
@@ -6,8 +6,8 @@ export type SignalFieldMode = 'wide' | 'compact';
 
 export interface ISignalFieldProps extends React.HTMLAttributes<HTMLSpanElement> {
   signalsFieldMode?: SignalFieldMode;
-  before?: React.ReactNode | React.ReactNode[];
-  after?: React.ReactNode | React.ReactNode[];
+  before?: React.ReactNode;
+  after?: React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
This change adds Screener tests for the various configurations of the `Tile` component.

Specifically, it includes test for the alignment of the foreground content, as well as tests for the overflow of text when paired with signals, such as 'New' and 'Comments', to ensure their alignment is not disturbed.

In addition, to simplify things, this change also adds support for the render-prop pattern for `Tile` and `FolderCover` to pass the final content size back to the render flow. This has become standard in React, so might as well prefer that over the old `render___WithLayout` pattern!

Doing this in advance of switching to `merge-styles` to ensure no regressions occur during the transition.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8021)