### PR TITLE
HoverCard: add a story that actually renders a HoverCard

### DIFF
--- a/apps/vr-tests/src/stories/HoverCard.stories.tsx
+++ b/apps/vr-tests/src/stories/HoverCard.stories.tsx
@@ -27,8 +27,7 @@ storiesOf('HoverCard', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
-        .hover('.ms-HoverCard-host')
-        .wait(2000)
+        .click('.ms-HoverCard-host')
         .snapshot('fully expanded with test content', { cropTo: '.ms-Layer' })
         .end()}
     >

--- a/apps/vr-tests/src/stories/HoverCard.stories.tsx
+++ b/apps/vr-tests/src/stories/HoverCard.stories.tsx
@@ -5,13 +5,19 @@ import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { HoverCard } from 'office-ui-fabric-react';
 
-const onRenderCompactCard = (item: any) => {
-  return <div>Content</div>;
+const onRenderCardContent = (item: any) => {
+  return (
+    <div style={{ padding: '10px' }}>
+      <div>Card content goes here.</div>
+      <div>Test string passed to cards: {item.test}</div>
+    </div>
+  );
 };
 
 const expandingCardProps = {
-  onRenderCompactCard: onRenderCompactCard,
-  renderData: 'New York'
+  onRenderCompactCard: onRenderCardContent,
+  onRenderExpandedCard: onRenderCardContent,
+  renderData: { test: 'Hello World!' }
 };
 
 storiesOf('HoverCard', module)
@@ -21,6 +27,9 @@ storiesOf('HoverCard', module)
     <Screener
       steps={new Screener.Steps()
         .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.ms-HoverCard-host')
+        .wait(2000)
+        .snapshot('fully expanded with test content', { cropTo: '.ms-Layer' })
         .end()}
     >
       {story()}


### PR DESCRIPTION
#### Pull request checklist
 This is how the stories for `HoverCard` were looking before this:

![screen shot 2019-02-15 at 4 04 34 pm](https://user-images.githubusercontent.com/29514833/52894311-3c4de180-315c-11e9-9a72-c822a1b9c5b5.png)

So I added another one which is actually rendering a card to screenshot 😄 

![screen shot 2019-02-15 at 7 57 42 pm](https://user-images.githubusercontent.com/29514833/52894327-5e476400-315c-11e9-9ffd-7da825db3af7.png)
![screen shot 2019-02-15 at 7 57 55 pm](https://user-images.githubusercontent.com/29514833/52894328-61daeb00-315c-11e9-8839-e77cbedb7725.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8022)