### PR TITLE
Make unknown persona coin colors truly static

### DIFF
--- a/common/changes/office-ui-fabric-react/make-unknown-persona-colors-truly-static_2019-02-18-13-55.json
+++ b/common/changes/office-ui-fabric-react/make-unknown-persona-colors-truly-static_2019-02-18-13-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Set colors for unknown persona coin to fixed values",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mark@thedutchies.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.styles.ts
@@ -28,8 +28,9 @@ export const getStyles = (props: IPersonaCoinStyleProps): IPersonaCoinStyles => 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   // Static colors used when displaying 'unknown persona' coin
-  const unknownPersonaBackgroundColor = palette.neutralLight;
-  const unknownPersonaFontColor = palette.redDark;
+  const unknownPersonaBackgroundColor = 'rgb(234, 234, 234)';
+  const unknownPersonaFontColor = 'rgb(168, 0, 0)';
+
   const dimension = coinSize || (props.size && sizeToPixels[props.size]) || 48;
 
   return {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -239,9 +239,9 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #eaeaea;
+              background-color: rgb(234, 234, 234);
               border-radius: 50%;
-              color: #a80000;
+              color: rgb(168, 0, 0);
               font-size: 17px;
               font-weight: 400;
               height: 48px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -239,9 +239,9 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #eaeaea;
+              background-color: rgb(234, 234, 234);
               border-radius: 50%;
-              color: #a80000;
+              color: rgb(168, 0, 0);
               font-size: 17px;
               font-weight: 400;
               height: 48px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
@@ -68,9 +68,9 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           className=
               ms-Persona-initials
               {
-                background-color: #eaeaea;
+                background-color: rgb(234, 234, 234);
                 border-radius: 50%;
-                color: #a80000;
+                color: rgb(168, 0, 0);
                 font-size: 14px;
                 font-weight: 400;
                 height: 40px;
@@ -264,9 +264,9 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
           className=
               ms-Persona-initials
               {
-                background-color: #eaeaea;
+                background-color: rgb(234, 234, 234);
                 border-radius: 50%;
-                color: #a80000;
+                color: rgb(168, 0, 0);
                 font-size: 28px;
                 font-weight: 400;
                 height: 72px;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The person coin for unknown person has clearly recognisable format, red on gray
![image](https://user-images.githubusercontent.com/2134901/52955634-72be7300-338d-11e9-8a55-c08770940996.png)

We can think of this as the "picture" we show for an unknown person. The same goes for text boys with initials. We do not change these text boys based on the theme the user has. 

We should therefore also not change the colors for the unknown persona coin. Currently the persona coin for unknown persona is affected by the theme. (The pop over uses the original unknown persona coin that is affected by the theme. The smaller picture above it has a local override to keep it the same.)
![image](https://user-images.githubusercontent.com/2134901/52955577-4d316980-338d-11e9-9e52-cec73a47fd8b.png)

This PR forces the colors for the unknown persona coin to always be the same colors no matter what theme is used.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8029)