### PR TITLE
RTL Utilities: Check for body element before reading attributes

### DIFF
--- a/common/changes/@uifabric/utilities/jg-fix-rtl-body-exception_2019-02-19-19-09.json
+++ b/common/changes/@uifabric/utilities/jg-fix-rtl-body-exception_2019-02-19-19-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "getRTL: Check for existence of body element before reading attributes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/utilities/src/rtl.test.ts
+++ b/packages/utilities/src/rtl.test.ts
@@ -65,4 +65,19 @@ describe('getRTL', () => {
     document.documentElement.setAttribute('dir', 'rtl');
     expect(RTL.getRTL()).toBe(true);
   });
+
+  it('does not cause exception with null body element', () => {
+    const DOM = require('./dom');
+    jest.spyOn(DOM, 'getDocument').mockImplementation(() => {
+      return {
+        documentElement: document.documentElement,
+        body: null
+      };
+    });
+
+    document.documentElement.setAttribute('dir', 'rtl');
+    expect(RTL.getRTL()).toBe(true);
+
+    jest.restoreAllMocks();
+  });
 });

--- a/packages/utilities/src/rtl.ts
+++ b/packages/utilities/src/rtl.ts
@@ -22,7 +22,7 @@ export function getRTL(): boolean {
 
     let doc = getDocument();
     if (_isRTL === undefined && doc) {
-      _isRTL = (doc.body.getAttribute('dir') || doc.documentElement.getAttribute('dir')) === 'rtl';
+      _isRTL = ((doc.body && doc.body.getAttribute('dir')) || doc.documentElement.getAttribute('dir')) === 'rtl';
       mergeStylesSetRTL(_isRTL);
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

#7973 introduced an exception for cases where `getRTL` is used early in page loading before the `body` element is available. This PR fixes those cases.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8036)