### PR TITLE
DetailsRow & DetailsRowFields: Supply onRenderItemColumn return type instead of any

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-onRenderItemColumn-return-type_2019-02-20-00-57.json
+++ b/common/changes/office-ui-fabric-react/keco-onRenderItemColumn-return-type_2019-02-20-00-57.json
@@ -1,11 +1,9 @@
 {
-  "changes": [
-    {
-      "packageName": "office-ui-fabric-react",
-      "comment": "DetailsRow & DetailsRowFields: onRenderItemColumn return type as React.ReactNode",
-      "type": "none"
-    }
-  ],
+  "changes": [{
+    "packageName": "office-ui-fabric-react",
+    "comment": "DetailsRow & DetailsRowFields: onRenderItemColumn return type as React.ReactNode",
+    "type": "minor"
+  }],
   "packageName": "office-ui-fabric-react",
   "email": "keco@microsoft.com"
 }

--- a/common/changes/office-ui-fabric-react/keco-onRenderItemColumn-return-type_2019-02-20-00-57.json
+++ b/common/changes/office-ui-fabric-react/keco-onRenderItemColumn-return-type_2019-02-20-00-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsRow & DetailsRowFields: onRenderItemColumn return type as React.ReactNode",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6981,7 +6981,7 @@ interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProp
   itemIndex: number;
   onDidMount?: (row?: DetailsRowBase) => void;
   onRenderCheck?: (props: IDetailsRowCheckProps) => JSX.Element;
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => any;
+  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
   onWillUnmount?: (row?: DetailsRowBase) => void;
   rowFieldsAs?: React.StatelessComponent<IDetailsRowFieldsProps> | React.ComponentClass<IDetailsRowFieldsProps>;
   shimmer?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6902,7 +6902,7 @@ interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps
   onItemInvoked?: (item?: any, index?: number, ev?: Event) => void;
   onRenderDetailsFooter?: IRenderFunction<IDetailsFooterProps>;
   onRenderDetailsHeader?: IRenderFunction<IDetailsHeaderProps>;
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => any;
+  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
   onRenderMissingItem?: (index?: number, rowProps?: IDetailsRowProps) => React.ReactNode;
   onRenderRow?: IRenderFunction<IDetailsRowProps>;
   onRowDidMount?: (item?: any, index?: number) => void;
@@ -6962,7 +6962,7 @@ interface IDetailsRow {
 }
 
 // @public (undocumented)
-interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProps {
+interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderItemColumn'>, IBaseProps<IDetailsRow>, IDetailsItemProps {
   checkboxCellClassName?: string;
   checkButtonAriaLabel?: string;
   className?: string;
@@ -6981,7 +6981,6 @@ interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProp
   itemIndex: number;
   onDidMount?: (row?: DetailsRowBase) => void;
   onRenderCheck?: (props: IDetailsRowCheckProps) => JSX.Element;
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
   onWillUnmount?: (row?: DetailsRowBase) => void;
   rowFieldsAs?: React.StatelessComponent<IDetailsRowFieldsProps> | React.ComponentClass<IDetailsRowFieldsProps>;
   shimmer?: boolean;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -166,7 +166,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    * If provided, will be the "default" item column renderer method. This affects cells within the rows; not the rows themselves.
    * If a column definition provides its own onRender method, that will be used instead of this.
    */
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => any;
+  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
 
   /** Map of callback functions related to row drag and drop functionality. */
   dragDropEvents?: IDragDropEvents;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -108,7 +108,7 @@ export interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsI
   /**
    * Callback for rendering an item column
    */
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => any;
+  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
 
   /**
    * Handling drag and drop events

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DetailsRowBase } from './DetailsRow.base';
 import { IStyle, ITheme } from '../../Styling';
-import { IColumn, CheckboxVisibility } from './DetailsList.types';
+import { IColumn, CheckboxVisibility, IDetailsListProps } from './DetailsList.types';
 import { ISelection, SelectionMode } from '../../utilities/selection/interfaces';
 import { IDragDropHelper, IDragDropEvents } from '../../utilities/dragdrop/interfaces';
 import { IViewport } from '../../utilities/decorators/withViewport';
@@ -54,7 +54,7 @@ export interface IDetailsItemProps {
   cellStyleProps?: ICellStyleProps;
 }
 
-export interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsItemProps {
+export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderItemColumn'>, IBaseProps<IDetailsRow>, IDetailsItemProps {
   /**
    * Theme provided by styled() function
    */
@@ -104,11 +104,6 @@ export interface IDetailsRowBaseProps extends IBaseProps<IDetailsRow>, IDetailsI
    * Callback for rendering a checkbox
    */
   onRenderCheck?: (props: IDetailsRowCheckProps) => JSX.Element;
-
-  /**
-   * Callback for rendering an item column
-   */
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
 
   /**
    * Handling drag and drop events

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -1,10 +1,11 @@
 import { IColumn } from './DetailsList.types';
 import { IDetailsRowStyles, ICellStyleProps } from './DetailsRow.types';
 import { IBaseProps, IRefObject } from '../../Utilities';
+import { IDetailsListProps } from './DetailsList';
 
 export interface IDetailsRowFields {}
 
-export interface IDetailsRowFieldsProps extends IBaseProps<IDetailsRowFields> {
+export interface IDetailsRowFieldsProps extends Pick<IDetailsListProps, 'onRenderItemColumn'>, IBaseProps<IDetailsRowFields> {
   /**
    * Ref of component
    */
@@ -34,11 +35,6 @@ export interface IDetailsRowFieldsProps extends IBaseProps<IDetailsRowFields> {
    * whether to render as a compact field
    */
   compact?: boolean;
-
-  /**
-   * Callback for rendering an item column
-   */
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
 
   /**
    * Whether to show shimmer

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -38,7 +38,7 @@ export interface IDetailsRowFieldsProps extends IBaseProps<IDetailsRowFields> {
   /**
    * Callback for rendering an item column
    */
-  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => any;
+  onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
 
   /**
    * Whether to show shimmer


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The `DetailsRow` & `DetailsRowFields` `onRenderItemColumn` prop can be typed as `React.ReactNode` instead of `any`.

#### Focus areas to test

- Build should pass
- Existing tests should pass
- Change _should be_ OK w.r.t backwards compatibility since we are tightening the return type


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8046)