### PR TITLE
Fix RTL handling for SignalsField

### DIFF
--- a/apps/fabric-website/src/components/Table/Table.module.scss
+++ b/apps/fabric-website/src/components/Table/Table.module.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+@import '~office-ui-fabric-react/src/common/common';
 
 .table {
   color: $ms-color-neutralPrimary;
@@ -15,7 +16,7 @@
     th {
       font-weight: $ms-font-weight-semibold;
       color: $ms-color-neutralSecondary;
-      @include ms-text-align(left);
+      @include text-align(left);
     }
   }
 

--- a/common/changes/@uifabric/experiments/signals-text-align_2019-02-20-17-54.json
+++ b/common/changes/@uifabric/experiments/signals-text-align_2019-02-20-17-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fix RTL handling in SignalsField",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/signals-text-align_2019-02-20-20-57.json
+++ b/common/changes/@uifabric/fabric-website/signals-text-align_2019-02-20-20-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix usage of 'ms-text-align'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "tmichon@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/signals-text-align_2019-02-20-20-57.json
+++ b/common/changes/office-ui-fabric-react/signals-text-align_2019-02-20-20-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix usage of 'ms-text-align'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/signals/SignalField.scss
+++ b/packages/experiments/src/components/signals/SignalField.scss
@@ -19,6 +19,6 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  @include ms-text-align(left);
+  @include text-align(left);
   flex: 1 1 auto;
 }

--- a/packages/experiments/src/components/signals/SignalField.scss
+++ b/packages/experiments/src/components/signals/SignalField.scss
@@ -19,6 +19,6 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  text-align: left;
+  @include ms-text-align(left);
   flex: 1 1 auto;
 }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.scss
@@ -13,7 +13,7 @@
   margin: 0;
   padding: 0px;
   position: relative;
-  @include ms-text-align(left);
+  @include text-align(left);
   width: 100%;
   font-size: 12px;
   &:hover {

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -71,7 +71,7 @@
   position: relative;
   border-top: 1px solid $ms-color-neutralLight;
   height: 40px;
-  @include ms-text-align(left);
+  @include text-align(left);
   width: 100%;
   font-size: 12px;
   &:hover {


### PR DESCRIPTION
Fixed the styling of `SignalsField` to use RTL-aware assignment of `text-align`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8052)