### PR TITLE
fluent-folder-cover: position shared signal icon on the right

### DIFF
--- a/common/changes/@uifabric/experiments/fluentFolder_2019-02-20-20-49.json
+++ b/common/changes/@uifabric/experiments/fluentFolder_2019-02-20-20-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Fluent folder: positioned signal-icon on the right",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "huaxi@microsoft.com"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -77,7 +77,11 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
     } = this.props;
 
     const assets = ASSETS[size][type];
-    const metadataIcon = metadata ? <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span> : null;
+    const metadataIcon = metadata ? (
+      <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span>
+    ) : (
+      <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)} />
+    );
 
     const signalIcon = signal ? (
       <span className={css('ms-FolderCover-signal', FolderCoverStyles.signal, isFluent ? SignalStyles.isFluent : SignalStyles.dark)}>

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -77,17 +77,13 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
     } = this.props;
 
     const assets = ASSETS[size][type];
-    const metadataIcon = metadata ? (
-      <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span>
-    ) : (
-      <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)} />
-    );
+    const metadataIcon = <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span>;
 
-    const signalIcon = signal ? (
+    const signalIcon = (
       <span className={css('ms-FolderCover-signal', FolderCoverStyles.signal, isFluent ? SignalStyles.isFluent : SignalStyles.dark)}>
         {signal}
       </span>
-    ) : null;
+    );
     return (
       <div
         {...divProps}

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -40,6 +40,37 @@ export class FolderCoverBasicExample extends React.Component<{}, {}> {
           metadata={20}
           signal={<SharedSignal />}
         />
+        <h3>Fluent Large Default Cover</h3>
+        <FolderCoverWithImage
+          isFluent={true}
+          originalImageSize={{
+            width: 200,
+            height: 150
+          }}
+          folderCoverSize="large"
+          metadata={20}
+          signal={<SharedSignal />}
+        />
+        <h3>Fluent Large Default Cover -- item count only</h3>
+        <FolderCoverWithImage
+          isFluent={true}
+          originalImageSize={{
+            width: 200,
+            height: 150
+          }}
+          folderCoverSize="large"
+          metadata={20}
+        />
+        <h3>Large Default Cover -- signal icon only</h3>
+        <FolderCoverWithImage
+          isFluent={true}
+          originalImageSize={{
+            width: 200,
+            height: 150
+          }}
+          folderCoverSize="large"
+          signal={<SharedSignal />}
+        />
         <h3>Small Default Cover</h3>
         <FolderCoverWithImage
           isFluent={false}

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -81,6 +81,16 @@ export class FolderCoverBasicExample extends React.Component<{}, {}> {
           folderCoverSize="small"
           metadata={15}
         />
+        <h3>Fluent Small Default Cover - metadata only</h3>
+        <FolderCoverWithImage
+          isFluent={true}
+          originalImageSize={{
+            width: 200,
+            height: 150
+          }}
+          folderCoverSize="small"
+          metadata={15}
+        />
         <h3>Large Media Cover</h3>
         <FolderCoverWithImage
           isFluent={false}
@@ -103,6 +113,17 @@ export class FolderCoverBasicExample extends React.Component<{}, {}> {
           folderCoverSize="small"
           folderCoverType="media"
           metadata={15}
+        />
+        <h3>Small Media Cover -- signal icon only</h3>
+        <FolderCoverWithImage
+          isFluent={true}
+          originalImageSize={{
+            width: 200,
+            height: 150
+          }}
+          folderCoverSize="small"
+          folderCoverType="media"
+          signal={<SharedSignal />}
         />
         <h3>Shared Cover</h3>
         <FolderCoverWithImage


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #0000
- [x ] Include a change request file using `$ npm run change`

#### Description of changes
Positioned fluent folder's signal icon always on the right.

#### Focus areas to test
Folder cover


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8056)