### PR TITLE
ARIA: Fix mergeAriaAttributeValues not producing space delimited ID reference lists

### DIFF
--- a/common/changes/@uifabric/utilities/keco-fix-merge-aria-attrs_2019-02-21-18-39.json
+++ b/common/changes/@uifabric/utilities/keco-fix-merge-aria-attrs_2019-02-21-18-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Modify mergeAriaAttributeValues to return space delimited string of values",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "keco@microsoft.com"
+}

--- a/packages/utilities/src/aria.ts
+++ b/packages/utilities/src/aria.ts
@@ -2,11 +2,9 @@
  * ARIA helper to concatenate attributes, returning undefined if all attributes
  * are undefined. (Empty strings are not a valid ARIA attribute value.)
  *
- * NOTE: This function will NOT insert whitespace between provided attributes.
- *
  * @param ariaAttributes - ARIA attributes to merge
  */
 export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined)[]): string | undefined {
-  const mergedAttribute = ariaAttributes.filter((arg: string | undefined) => arg !== undefined && arg !== null).join('');
+  const mergedAttribute = ariaAttributes.filter((arg: string | undefined) => arg !== undefined && arg !== null).join(' ');
   return mergedAttribute === '' ? undefined : mergedAttribute;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

## The Problem

Reviewing #8057 brought to my attention that `mergeAriaAttributeValues` is producing invalid values for `aria-describedby` when it receives _multiple input values_. That is because it is concatenating the values without a space which screen reader technology does not understand.

## Repro

[This Codepen illustrates the problem](https://codepen.io/kevintcoughlin/pen/KJLGbr) with Narrator enabled as you focus the two buttons. One of the buttons has its `aria-describedby` value space-delimited while the other does not. Narrator only reads the space-delimited values.

**Narrator Output**

```shell
Is read by narrator, button,
Description One Description Two, 
Is not read by Narrator, button,
```

[MDN states](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute#Value) that `aria-describedby` and similar attributes must have the value of:

>a space-separated list of element IDs

This "space-separated list of element IDs" is referred to as a "ID reference list" in the [W3 ARIA spec](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-describedby).

## How to resolve

Currently, `mergeAriaAttributeValues` usage is [confined to `aria-describedby` in a handful of call sites within OUFR](https://github.com/OfficeDev/office-ui-fabric-react/search?l=TypeScript&q=mergeAriaAttributeValues). However, it is also publicly exported as part of the API surface.

@JasonGore, I'm happy to patch this, but need your opinion from an API standpoint before proceeding. The options I see are:

1. We modify the default behavior of `mergeAriaAttributeValues` as done in this PR currently to space delimit the values. This makes sense to me if there aren't any valid ARIA use-cases for concatenated values without the space.

**OR**

2. We offer the ability to provide the delimiter with a default to `''` or `' '`. And perhaps offer a wrapper function for the `aria-describedby` use-case.


#### Focus areas to test

I'm going to let the tests fail while we discuss correct behavior here.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8066)