### PR TITLE
Add Pivot item container className

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-pivot-item-classname_2019-02-22-00-09.json
+++ b/common/changes/office-ui-fabric-react/keyou-pivot-item-classname_2019-02-22-00-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add className for Pivot item container div",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/keyou-pivot-item-classname_2019-02-22-00-09.json
+++ b/common/changes/office-ui-fabric-react/keyou-pivot-item-classname_2019-02-22-00-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Add className for Pivot item container div",
+      "comment": "Pivot: Add new stylable area for Pivot item container div.",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -9534,6 +9534,8 @@ interface IPivotStyles {
   // (undocumented)
   icon: IStyle;
   // (undocumented)
+  itemContainer?: IStyle;
+  // (undocumented)
   link: IStyle;
   // (undocumented)
   linkContent: IStyle;

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -194,7 +194,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
     const selectedTabId = this._keyToTabIds[itemKey];
 
     return (
-      <div role="tabpanel" aria-labelledby={selectedTabId}>
+      <div role="tabpanel" aria-labelledby={selectedTabId} className={this._classNames.itemContainer}>
         {React.Children.toArray(this.props.children)[index]}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -126,6 +126,7 @@ export interface IPivotStyles {
   text: IStyle;
   count: IStyle;
   icon: IStyle;
+  itemContainer?: IStyle;
 }
 
 export enum PivotLinkFormat {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add a className to the div surrounding the Pivot item to be able to be styled by a developer. Made optional so by default does not have any styles

This is in response to [this teams post](https://teams.microsoft.com/l/message/19:86b094239256467da9dfa96ba0897ca2@thread.skype/1550713063398?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=ffe264f2-14d0-48b5-9384-64f808b81294&parentMessageId=1550713063398&teamName=Microsoft%20UI%20Fabric&channelName=Fabric%20React&createdTime=1550713063398) (hopefully the link works)

#### Focus areas to test

Tested by adding that style in the Pivot demo pages and styles get applied as expected
