### PR TITLE
Toggle: Adding aria-label with discernible text

### DIFF
--- a/common/changes/@uifabric/experiments/toggleA11y_2019-02-22-19-46.json
+++ b/common/changes/@uifabric/experiments/toggleA11y_2019-02-22-19-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Toggle: Adding aria-label with discernible text.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/toggleA11y_2019-02-22-19-46.json
+++ b/common/changes/office-ui-fabric-react/toggleA11y_2019-02-22-19-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: Adding aria-label with discernible text.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Toggle/Toggle.state.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.state.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IToggle, IToggleProps, IToggleViewProps } from './Toggle.types';
 import { BaseState } from '../../utilities/BaseState';
 
-export type IToggleState = Pick<IToggleViewProps, 'checked' | 'onChange' | 'onClick' | 'text' | 'toggleButtonRef'>;
+export type IToggleState = Pick<IToggleViewProps, 'ariaLabel' | 'checked' | 'onChange' | 'onClick' | 'text' | 'toggleButtonRef'>;
 
 export class ToggleState extends BaseState<IToggleProps, IToggleViewProps, IToggleState> implements IToggle {
   private _toggleButtonRef = React.createRef<HTMLButtonElement>();
@@ -16,7 +16,11 @@ export class ToggleState extends BaseState<IToggleProps, IToggleViewProps, ITogg
       }
     });
 
+    let label: string = typeof props.label === 'string' ? props.label : 'No label';
+    label += !!props.defaultChecked ? ': On' : ': Off';
+
     this.state = {
+      ariaLabel: props.ariaLabel ? props.ariaLabel : label,
       checked: !!props.defaultChecked,
       text: !!props.defaultChecked ? props.onText : props.offText,
       onChange: this._noop,
@@ -32,12 +36,15 @@ export class ToggleState extends BaseState<IToggleProps, IToggleViewProps, ITogg
   };
 
   private _onClick = (ev: React.MouseEvent<HTMLElement>) => {
-    const { disabled, onChange } = this.props;
+    const { label, disabled, onChange } = this.props;
     const { checked } = this.state;
 
     if (!disabled) {
+      let ariaLabel: string = typeof label === 'string' ? label : 'No label';
+      ariaLabel += !checked ? ': On' : ': Off';
+
       // Only update the state if the user hasn't provided it.
-      this.setState({ checked: !checked });
+      this.setState({ ariaLabel: ariaLabel, checked: !checked });
 
       if (onChange) {
         onChange(ev, !checked);

--- a/packages/experiments/src/components/Toggle/Toggle.state.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.state.ts
@@ -12,15 +12,20 @@ export class ToggleState extends BaseState<IToggleProps, IToggleViewProps, ITogg
       controlledProps: ['checked', 'text'],
       transformViewProps: (newProps: IToggleViewProps) => {
         newProps.text = newProps.checked ? props.onText : props.offText;
+
+        // If the user provides an ariaLabel, then let that be the label for the Toggle.
+        if (!props.ariaLabel) {
+          const ariaLabelText = typeof props.label === 'string' ? props.label : '';
+          const ariaCheckedText = newProps.checked ? props.onText : props.offText;
+          const ariaSeparator = ariaLabelText && ariaCheckedText ? ': ' : '';
+          newProps.ariaLabel = ariaLabelText + ariaSeparator + (ariaCheckedText ? ariaCheckedText : '');
+        }
+
         return newProps;
       }
     });
 
-    let label: string = typeof props.label === 'string' ? props.label : 'No label';
-    label += !!props.defaultChecked ? ': On' : ': Off';
-
     this.state = {
-      ariaLabel: props.ariaLabel ? props.ariaLabel : label,
       checked: !!props.defaultChecked,
       text: !!props.defaultChecked ? props.onText : props.offText,
       onChange: this._noop,
@@ -36,15 +41,12 @@ export class ToggleState extends BaseState<IToggleProps, IToggleViewProps, ITogg
   };
 
   private _onClick = (ev: React.MouseEvent<HTMLElement>) => {
-    const { label, disabled, onChange } = this.props;
+    const { disabled, onChange } = this.props;
     const { checked } = this.state;
 
     if (!disabled) {
-      let ariaLabel: string = typeof label === 'string' ? label : 'No label';
-      ariaLabel += !checked ? ': On' : ': Off';
-
       // Only update the state if the user hasn't provided it.
-      this.setState({ ariaLabel: ariaLabel, checked: !checked });
+      this.setState({ checked: !checked });
 
       if (onChange) {
         onChange(ev, !checked);

--- a/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
+++ b/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`ToggleView renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
+      aria-label="Label: Off"
       className=
           ms-Toggle-background
           {

--- a/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
+++ b/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ToggleView renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
-      aria-label="Label: Off"
+      aria-label="Label"
       className=
           ms-Toggle-background
           {

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -67,6 +67,11 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
     const { checked } = this.state;
     const stateText = checked ? onText : offText;
     const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
+
+    let composedAriaLabel = ariaLabel ? ariaLabel : badAriaLabel ? badAriaLabel : label;
+    const ariaLabelChecked = checked ? ': On' : ': Off';
+    composedAriaLabel += ariaLabelChecked ? ariaLabelChecked : '';
+
     const toggleNativeProps = getNativeProps(this.props, inputProperties, ['defaultChecked']);
     const classNames = getClassNames(styles!, {
       theme: theme!,
@@ -99,7 +104,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
                 ref={this._toggleButton}
                 aria-disabled={disabled}
                 aria-checked={checked}
-                aria-label={ariaLabel ? ariaLabel : badAriaLabel}
+                aria-label={composedAriaLabel}
                 data-is-focusable={true}
                 onChange={this._noop}
                 onClick={this._onClick}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -68,7 +68,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
     const stateText = checked ? onText : offText;
     const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
 
-    let composedAriaLabel = ariaLabel ? ariaLabel : badAriaLabel ? badAriaLabel : label;
+    let composedAriaLabel = badAriaLabel ? badAriaLabel : label;
     const ariaLabelChecked = checked ? ': On' : ': Off';
     composedAriaLabel += ariaLabelChecked ? ariaLabelChecked : '';
 
@@ -104,7 +104,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
                 ref={this._toggleButton}
                 aria-disabled={disabled}
                 aria-checked={checked}
-                aria-label={composedAriaLabel}
+                aria-label={ariaLabel ? ariaLabel : composedAriaLabel}
                 data-is-focusable={true}
                 onChange={this._noop}
                 onClick={this._onClick}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -65,12 +65,13 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
       inlineLabel
     } = this.props;
     const { checked } = this.state;
-    const stateText = checked ? onText : offText;
-    const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
 
-    let composedAriaLabel = badAriaLabel ? badAriaLabel : label;
-    const ariaLabelChecked = checked ? ': On' : ': Off';
-    composedAriaLabel += ariaLabelChecked ? ariaLabelChecked : '';
+    const stateText = checked ? onText : offText;
+
+    const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
+    const ariaLabelText = badAriaLabel ? badAriaLabel : label;
+    const ariaSeparator = ariaLabelText && stateText ? ': ' : '';
+    const composedAriaLabel = ariaLabelText + ariaSeparator + (stateText ? stateText : '');
 
     const toggleNativeProps = getNativeProps(this.props, inputProperties, ['defaultChecked']);
     const classNames = getClassNames(styles!, {

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.deprecated.test.tsx
@@ -25,7 +25,7 @@ describe('Toggle', () => {
         .first()
         .getDOMNode()
         .getAttribute('aria-label')
-    ).toEqual('offLabel: Off');
+    ).toEqual('offLabel');
   });
 
   it('renders aria-label based on onAriaLabel when Toggle is ON', () => {
@@ -44,7 +44,7 @@ describe('Toggle', () => {
         .first()
         .getDOMNode()
         .getAttribute('aria-label')
-    ).toEqual('offLabel: Off');
+    ).toEqual('offLabel');
 
     component
       .find('button')
@@ -59,6 +59,6 @@ describe('Toggle', () => {
         .first()
         .getDOMNode()
         .getAttribute('aria-label')
-    ).toEqual('onLabel: On');
+    ).toEqual('onLabel');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.deprecated.test.tsx
@@ -25,7 +25,7 @@ describe('Toggle', () => {
         .first()
         .getDOMNode()
         .getAttribute('aria-label')
-    ).toEqual('offLabel');
+    ).toEqual('offLabel: Off');
   });
 
   it('renders aria-label based on onAriaLabel when Toggle is ON', () => {
@@ -44,7 +44,7 @@ describe('Toggle', () => {
         .first()
         .getDOMNode()
         .getAttribute('aria-label')
-    ).toEqual('offLabel');
+    ).toEqual('offLabel: Off');
 
     component
       .find('button')
@@ -59,6 +59,6 @@ describe('Toggle', () => {
         .first()
         .getDOMNode()
         .getAttribute('aria-label')
-    ).toEqual('onLabel');
+    ).toEqual('onLabel: On');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
+      aria-label="undefined: Off"
       className=
           ms-Toggle-background
           {
@@ -152,6 +153,7 @@ exports[`Toggle renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
+      aria-label="Label: Off"
       className=
           ms-Toggle-background
           {
@@ -281,6 +283,7 @@ exports[`Toggle renders toggle correctly with inline label 1`] = `
   >
     <button
       aria-checked={false}
+      aria-label="Label: Off"
       className=
           ms-Toggle-background
           {
@@ -409,6 +412,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
   >
     <button
       aria-checked={false}
+      aria-label="Label: Off"
       className=
           ms-Toggle-background
           {

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
-      aria-label="undefined: Off"
+      aria-label="undefined"
       className=
           ms-Toggle-background
           {
@@ -153,7 +153,7 @@ exports[`Toggle renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
-      aria-label="Label: Off"
+      aria-label="Label"
       className=
           ms-Toggle-background
           {
@@ -283,7 +283,7 @@ exports[`Toggle renders toggle correctly with inline label 1`] = `
   >
     <button
       aria-checked={false}
-      aria-label="Label: Off"
+      aria-label="Label"
       className=
           ms-Toggle-background
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -968,6 +968,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={false}
+          aria-label="Hide alpha slider: Off"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -968,7 +968,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={false}
-          aria-label="Hide alpha slider: Off"
+          aria-label="Hide alpha slider"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -399,7 +399,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={true}
-        aria-label="Allow freeform: On"
+        aria-label="Allow freeform"
         checked={true}
         className=
             ms-Toggle-background
@@ -531,7 +531,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
-        aria-label="Auto-complete: Off"
+        aria-label="Auto-complete"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -399,6 +399,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={true}
+        aria-label="Allow freeform: On"
         checked={true}
         className=
             ms-Toggle-background
@@ -530,6 +531,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
+        aria-label="Auto-complete: Off"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -93,6 +93,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
+          aria-label="Enable compact mode: Off"
           checked={false}
           className=
               ms-Toggle-background
@@ -260,6 +261,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
+          aria-label="Enable modal selection: Off"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -93,7 +93,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
-          aria-label="Enable compact mode: Off"
+          aria-label="Enable compact mode: Normal"
           checked={false}
           className=
               ms-Toggle-background
@@ -261,7 +261,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
-          aria-label="Enable modal selection: Off"
+          aria-label="Enable modal selection: Normal"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -66,6 +66,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
       >
         <button
           aria-checked={true}
+          aria-label="Enable column reorder: On"
           checked={true}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -66,7 +66,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
       >
         <button
           aria-checked={true}
-          aria-label="Enable column reorder: On"
+          aria-label="Enable column reorder: Enabled"
           checked={true}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -186,7 +186,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
       >
         <button
           aria-checked={false}
-          aria-label="Compact mode: Off"
+          aria-label="Compact mode"
           checked={false}
           className=
               ms-Toggle-background
@@ -317,7 +317,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
       >
         <button
           aria-checked={false}
-          aria-label="Show index of first item in view when unmounting: Off"
+          aria-label="Show index of first item in view when unmounting"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -186,6 +186,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
       >
         <button
           aria-checked={false}
+          aria-label="Compact mode: Off"
           checked={false}
           className=
               ms-Toggle-background
@@ -316,6 +317,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
       >
         <button
           aria-checked={false}
+          aria-label="Show index of first item in view when unmounting: Off"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -116,7 +116,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
     >
       <button
         aria-checked={false}
-        aria-label="Controlled component: Off"
+        aria-label="Controlled component"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -116,6 +116,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
     >
       <button
         aria-checked={false}
+        aria-label="Controlled component: Off"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -367,6 +367,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
         >
           <button
             aria-checked={false}
+            aria-label="Focus Trap Zone: Off"
             checked={false}
             className=
                 ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -367,6 +367,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
         >
           <button
             aria-checked={false}
+            aria-label="Focus Trap Zone: Off"
             checked={false}
             className=
                 ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -368,6 +368,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           >
             <button
               aria-checked={false}
+              aria-label="Focus Trap Zone: Off"
               checked={false}
               className=
                   ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -171,6 +171,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       >
         <button
           aria-checked={false}
+          aria-label="Focus Trap Zone: Off"
           className=
               ms-Toggle-background
               {
@@ -450,6 +451,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         >
           <button
             aria-checked={false}
+            aria-label="Focus Trap Zone: Off"
             className=
                 ms-Toggle-background
                 {
@@ -729,6 +731,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           >
             <button
               aria-checked={false}
+              aria-label="Focus Trap Zone: Off"
               className=
                   ms-Toggle-background
                   {
@@ -1009,6 +1012,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           >
             <button
               aria-checked={false}
+              aria-label="Focus Trap Zone: Off"
               className=
                   ms-Toggle-background
                   {
@@ -1290,6 +1294,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         >
           <button
             aria-checked={false}
+            aria-label="Focus Trap Zone: Off"
             className=
                 ms-Toggle-background
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -941,6 +941,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             <button
               aria-checked={false}
               aria-describedby="ktp-layer-id ktp-a-1"
+              aria-label="undefined: Off"
               className=
                   ms-Toggle-background
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -941,7 +941,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             <button
               aria-checked={false}
               aria-describedby="ktp-layer-id ktp-a-1"
-              aria-label="undefined: Off"
+              aria-label="undefinedNo"
               className=
                   ms-Toggle-background
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -951,6 +951,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-label="undefined: On"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -951,7 +951,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-label="undefined: On"
+        aria-label="undefinedEnabled"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -55,7 +55,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-label="Show host: On"
+        aria-label="Show host"
         checked={true}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -55,6 +55,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-label="Show host: On"
         checked={true}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -506,7 +506,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       >
         <button
           aria-checked={false}
-          aria-label="Delay Suggestion Results: Off"
+          aria-label="Delay Suggestion Results"
           className=
               ms-Toggle-background
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -506,6 +506,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       >
         <button
           aria-checked={false}
+          aria-label="Delay Suggestion Results: Off"
           className=
               ms-Toggle-background
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -54,7 +54,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
     >
       <button
         aria-checked={false}
-        aria-label="Toggle to load content: Off"
+        aria-label="Toggle to load content: Shimmer"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -54,6 +54,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
     >
       <button
         aria-checked={false}
+        aria-label="Toggle to load content: Off"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -40,7 +40,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
-        aria-label="undefined: Off"
+        aria-label="undefinedToggle to load content"
         checked={false}
         className=
             ms-Toggle-background
@@ -376,7 +376,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
-        aria-label="undefined: Off"
+        aria-label="undefinedToggle to load content"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -40,6 +40,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
+        aria-label="undefined: Off"
         checked={false}
         className=
             ms-Toggle-background
@@ -375,6 +376,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
+        aria-label="undefined: Off"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -61,6 +61,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-label="Enabled and checked: On"
         className=
             ms-Toggle-background
             {
@@ -232,6 +233,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
+        aria-label="Enabled and unchecked: Off"
         className=
             ms-Toggle-background
             {
@@ -401,6 +403,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
+        aria-label="Disabled and checked: On"
         className=
             ms-Toggle-background
             {
@@ -567,6 +570,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={false}
         aria-disabled={true}
+        aria-label="Disabled and unchecked: Off"
         className=
             ms-Toggle-background
             {
@@ -730,6 +734,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-label="With inline label: On"
         className=
             ms-Toggle-background
             {
@@ -908,6 +913,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
+        aria-label="Disabled with inline label: On"
         className=
             ms-Toggle-background
             {
@@ -1074,6 +1080,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-label="With inline label and without onText and offText: On"
         className=
             ms-Toggle-background
             {
@@ -1214,6 +1221,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
+        aria-label="Disabled with inline label and without onText and offText: On"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -1080,7 +1080,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-label="With inline label and without onText and offText: On"
+        aria-label="With inline label and without onText and offText"
         className=
             ms-Toggle-background
             {
@@ -1221,7 +1221,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
-        aria-label="Disabled with inline label and without onText and offText: On"
+        aria-label="Disabled with inline label and without onText and offText"
         className=
             ms-Toggle-background
             {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7134
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The `aria-label` for `Toggle` was not defined in some cases. This didn't have a user impact from an accessibility standpoint as labels were associated with `For` and `Id` attributes, however, per accessibility standards the elements must have a value for that attribute.

This PR makes it so that the `aria-label` for `Toggle` components is always set and updates the tests that checked for this behavior. In addition to this, the `aria-label` now also shows if the `Toggle` is `checked` or not at any given time as it wasn't conveyed before, which was a hole we had from an accessibility standpoint.

The changes have been applied to the `Toggle` components that exist both in the `office-ui-fabric-react` package and in the `experiments` package.

Below are some screenshots of before and after the change:

__Before change - No aria-label present:__

![image](https://user-images.githubusercontent.com/7798177/53267764-11521900-3699-11e9-94e3-5ed145a3d575.png)


__After change - With aria-label present:__

![image](https://user-images.githubusercontent.com/7798177/53267920-7c035480-3699-11e9-88b0-30c76514fe5d.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8087)