### PR TITLE
DetailsList: dragDropEvents props cannot be updated

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2019-02-23-00-58.json
+++ b/common/changes/office-ui-fabric-react/master_2019-02-23-00-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: dragDropEvents props updates not respected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aditima@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -204,7 +204,16 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   }
 
   public componentWillReceiveProps(newProps: IDetailsListProps): void {
-    const { checkboxVisibility, items, setKey, selectionMode = this._selection.mode, columns, viewport, compact } = this.props;
+    const {
+      checkboxVisibility,
+      items,
+      setKey,
+      selectionMode = this._selection.mode,
+      columns,
+      viewport,
+      compact,
+      dragDropEvents
+    } = this.props;
     const { isAllGroupsCollapsed = undefined } = this.props.groupProps || {};
 
     const shouldResetSelection = newProps.setKey !== setKey || newProps.setKey === undefined;
@@ -246,6 +255,17 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
         isCollapsed: newProps.groupProps.isAllGroupsCollapsed,
         isSomeGroupExpanded: !newProps.groupProps.isAllGroupsCollapsed
       });
+    }
+
+    if (newProps.dragDropEvents !== dragDropEvents) {
+      this._dragDropHelper && this._dragDropHelper.dispose();
+      this._dragDropHelper = newProps.dragDropEvents
+        ? new DragDropHelper({
+            selection: this._selection,
+            minimumPixelsForDrag: newProps.minimumPixelsForDrag
+          })
+        : undefined;
+      shouldForceUpdates = true;
     }
 
     if (shouldForceUpdates) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -254,9 +254,11 @@ describe('DetailsList', () => {
     };
 
     const container = document.createElement('div');
+    const items = mockData(5);
+    const columns = mockData(5, true);
 
     ReactDOM.render(
-      <DetailsListBase columns={mockData(5, true)} skipViewportMeasures={true} items={mockData(5)} dragDropEvents={_dragDropEvents} />,
+      <DetailsListBase columns={columns} skipViewportMeasures={true} items={items} dragDropEvents={_dragDropEvents} />,
       container
     );
 
@@ -270,7 +272,7 @@ describe('DetailsList', () => {
     expect(_dragDropEvents2.onDragStart).toHaveBeenCalledTimes(0);
 
     ReactDOM.render(
-      <DetailsListBase columns={mockData(5, true)} skipViewportMeasures={true} items={mockData(5)} dragDropEvents={_dragDropEvents} />,
+      <DetailsListBase columns={columns} skipViewportMeasures={true} items={items} dragDropEvents={_dragDropEvents} />,
       container
     );
 
@@ -283,7 +285,7 @@ describe('DetailsList', () => {
     expect(_dragDropEvents2.onDragStart).toHaveBeenCalledTimes(0);
 
     ReactDOM.render(
-      <DetailsListBase columns={mockData(5, true)} skipViewportMeasures={true} items={mockData(5)} dragDropEvents={_dragDropEvents2} />,
+      <DetailsListBase columns={columns} skipViewportMeasures={true} items={items} dragDropEvents={_dragDropEvents2} />,
       container
     );
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7503
- [X] Include a change request file using `$ npm run change`

#### Description of changes
DetailsListBase passes the dragDropHelper to DetailsRow that actually manages the event subscriptions. So anytime the dragDrop props change, we need to force render DetailsRow so that the event subscriptions are recreated.

#### Focus areas to test
Added unit test that fails without the fix, and passes after the fix


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8097)