### PR TITLE
Fluent-theme: clean the fluent styles so no hard coded colors are used

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-buttons_2019-02-23-01-08.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-buttons_2019-02-23-01-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Cleans up the `fluent-theme` styles of hard coded values for colors. Replaces the `borderRadius` and `boxShadow` styles with values from theme.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/fluent-buttons_2019-02-23-01-08.json
+++ b/common/changes/@uifabric/styling/fluent-buttons_2019-02-23-01-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "IEffects: changes types of the `elevation` and `roundedCorner2` properties to `string` to allow a more flexible way to provide values.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "v-vibr@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fluent-buttons_2019-02-23-04-00.json
+++ b/common/changes/office-ui-fabric-react/fluent-buttons_2019-02-23-04-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updating the API file resulted in the updates to the @uifabric/styling package which is exported form OUFR.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -8,6 +8,7 @@ export const FluentTheme: ITheme = createTheme({
     neutralPrimary: NeutralColors.gray160,
     neutralPrimaryAlt: NeutralColors.gray150,
     neutralSecondary: NeutralColors.gray130,
+    neutralSecondaryAlt: NeutralColors.gray110,
     neutralTertiary: NeutralColors.gray90,
     neutralTertiaryAlt: NeutralColors.gray60,
     neutralQuaternary: NeutralColors.gray50,

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,5 +1,7 @@
 import { createTheme, ITheme } from '@uifabric/styling';
 import { NeutralColors, SharedColors } from './FluentColors';
+import { Depths } from './FluentDepths';
+import { FontSizes } from './FluentType';
 
 export const FluentTheme: ITheme = createTheme({
   palette: {
@@ -20,6 +22,26 @@ export const FluentTheme: ITheme = createTheme({
     // Shared Colors
     red: SharedColors.red10,
     redDark: SharedColors.red20
+  },
+  effects: {
+    roundedCorner2: '2px',
+    elevation4: Depths.depth4,
+    elevation8: Depths.depth8,
+    elevation16: Depths.depth16,
+    elevation64: Depths.depth64
+  },
+  fonts: {
+    tiny: { fontSize: FontSizes.size10 },
+    xSmall: { fontSize: FontSizes.size12 },
+    small: { fontSize: FontSizes.size14 },
+    smallPlus: { fontSize: FontSizes.size16 },
+    medium: { fontSize: FontSizes.size18 },
+    mediumPlus: { fontSize: FontSizes.size20 },
+    large: { fontSize: FontSizes.size24 },
+    xLarge: { fontSize: FontSizes.size28 },
+    xxLarge: { fontSize: FontSizes.size32 },
+    superLarge: { fontSize: FontSizes.size42 },
+    mega: { fontSize: FontSizes.size68 }
   }
 });
 

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,5 +1,5 @@
 import { createTheme, ITheme } from '@uifabric/styling';
-import { NeutralColors } from './FluentColors';
+import { NeutralColors, SharedColors } from './FluentColors';
 
 export const FluentTheme: ITheme = createTheme({
   palette: {
@@ -15,7 +15,10 @@ export const FluentTheme: ITheme = createTheme({
     neutralLight: NeutralColors.gray30,
     neutralLighter: NeutralColors.gray20,
     neutralLighterAlt: NeutralColors.gray10,
-    white: NeutralColors.white
+    white: NeutralColors.white,
+    // Shared Colors
+    red: SharedColors.red10,
+    redDark: SharedColors.red20
   }
 });
 

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,7 +1,6 @@
 import { createTheme, ITheme } from '@uifabric/styling';
 import { NeutralColors, SharedColors } from './FluentColors';
 import { Depths } from './FluentDepths';
-import { FontSizes } from './FluentType';
 
 export const FluentTheme: ITheme = createTheme({
   palette: {
@@ -29,19 +28,6 @@ export const FluentTheme: ITheme = createTheme({
     elevation8: Depths.depth8,
     elevation16: Depths.depth16,
     elevation64: Depths.depth64
-  },
-  fonts: {
-    tiny: { fontSize: FontSizes.size10 },
-    xSmall: { fontSize: FontSizes.size12 },
-    small: { fontSize: FontSizes.size14 },
-    smallPlus: { fontSize: FontSizes.size16 },
-    medium: { fontSize: FontSizes.size18 },
-    mediumPlus: { fontSize: FontSizes.size20 },
-    large: { fontSize: FontSizes.size24 },
-    xLarge: { fontSize: FontSizes.size28 },
-    xxLarge: { fontSize: FontSizes.size32 },
-    superLarge: { fontSize: FontSizes.size42 },
-    mega: { fontSize: FontSizes.size68 }
   }
 });
 

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -4,7 +4,6 @@ import { Depths } from './FluentDepths';
 
 export const FluentTheme: ITheme = createTheme({
   palette: {
-    black: NeutralColors.black,
     neutralDark: NeutralColors.gray190,
     neutralPrimary: NeutralColors.gray160,
     neutralPrimaryAlt: NeutralColors.gray150,
@@ -17,7 +16,6 @@ export const FluentTheme: ITheme = createTheme({
     neutralLight: NeutralColors.gray30,
     neutralLighter: NeutralColors.gray20,
     neutralLighterAlt: NeutralColors.gray10,
-    white: NeutralColors.white,
     // Shared Colors
     red: SharedColors.red10,
     redDark: SharedColors.red20

--- a/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
@@ -1,13 +1,18 @@
 import { IBasePickerStyleProps, IBasePickerStyles } from 'office-ui-fabric-react/lib/Pickers';
-import { fluentBorderRadius } from './styleConstants';
 
 export const BasePickerStyles = (props: IBasePickerStyleProps): Partial<IBasePickerStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
+  }
+  const { effects } = theme;
+
   return {
     text: {
-      borderRadius: fluentBorderRadius
+      borderRadius: effects.roundedCorner2
     },
     input: {
-      borderRadius: fluentBorderRadius
+      borderRadius: effects.roundedCorner2
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -1,19 +1,24 @@
 import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react/lib/Callout';
 import { Depths } from '../FluentDepths';
-import { fluentBorderRadius } from './styleConstants';
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
+  }
+  const { effects } = theme;
+
   return {
     root: {
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       borderWidth: 0,
       boxShadow: Depths.depth16
     },
     beakCurtain: {
-      borderRadius: fluentBorderRadius
+      borderRadius: effects.roundedCorner2
     },
     calloutMain: {
-      borderRadius: fluentBorderRadius
+      borderRadius: effects.roundedCorner2
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -2,9 +2,6 @@ import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabr
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   const { theme } = props;
-  if (!theme) {
-    throw new Error('Theme is undefined or null.');
-  }
   const { effects } = theme;
 
   return {

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -1,5 +1,4 @@
 import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react/lib/Callout';
-import { Depths } from '../FluentDepths';
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   const { theme } = props;
@@ -12,7 +11,7 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<
     root: {
       borderRadius: effects.roundedCorner2,
       borderWidth: 0,
-      boxShadow: Depths.depth16
+      boxShadow: effects.elevation16
     },
     beakCurtain: {
       borderRadius: effects.roundedCorner2

--- a/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
@@ -1,14 +1,13 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from 'office-ui-fabric-react/lib/Checkbox';
-import { fluentBorderRadius } from './styleConstants';
 
 export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxStyles> => {
   const { disabled, checked, theme } = props;
-  const { semanticColors, palette } = theme;
+  const { semanticColors, palette, effects } = theme;
 
   return {
     checkbox: [
       {
-        borderRadius: fluentBorderRadius,
+        borderRadius: effects.roundedCorner2,
         borderColor: palette.neutralPrimary
       },
       !disabled &&

--- a/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
@@ -1,6 +1,5 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from 'office-ui-fabric-react/lib/Checkbox';
 import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors } from '../FluentColors';
 
 export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxStyles> => {
   const { disabled, checked, theme } = props;
@@ -33,7 +32,7 @@ export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxSty
         !checked && {
           selectors: {
             ':hover .ms-Checkbox-text': { color: palette.neutralDark },
-            ':hover .ms-Checkbox-checkmark': { color: NeutralColors.gray120 } // color not in the palette or semanticColors
+            ':hover .ms-Checkbox-checkmark': { color: palette.neutralSecondary }
           }
         },
         checked && {

--- a/packages/fluent-theme/src/fluent/styles/ChoiceGroupOption.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ChoiceGroupOption.styles.ts
@@ -1,5 +1,4 @@
 import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from 'office-ui-fabric-react/lib/ChoiceGroup';
-import { NeutralColors } from '../FluentColors';
 
 export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Partial<IChoiceGroupOptionStyles> => {
   const { checked, disabled, theme, hasIcon, hasImage } = props;
@@ -53,7 +52,7 @@ export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Pa
                       top: 5,
                       width: 10,
                       height: 10,
-                      backgroundColor: NeutralColors.gray120 // color not in the palette or semanticColors
+                      backgroundColor: palette.neutralSecondary
                     },
                   checked && {
                     borderColor: palette.themeDark

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -6,10 +6,7 @@ import {
   IColorSliderStyleProps,
   IColorSliderStyles
 } from 'office-ui-fabric-react/lib/ColorPicker';
-
-import { NeutralColors } from '../FluentColors';
 import { Depths } from '../FluentDepths';
-import { fluentBorderRadius } from './styleConstants';
 
 export const ColorPickerStyles = (props: IColorPickerStyleProps): Partial<IColorPickerStyles> => {
   return {
@@ -44,28 +41,31 @@ export const ColorPickerStyles = (props: IColorPickerStyleProps): Partial<IColor
 
 export const ColorRectangleStyles = (props: IColorRectangleStyleProps): Partial<IColorRectangleStyles> => {
   const { theme } = props;
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     root: {
       border: `1px solid ${palette.neutralLighter}`,
-      borderRadius: fluentBorderRadius
+      borderRadius: effects.roundedCorner2
     },
     thumb: {
-      borderColor: NeutralColors.gray80,
+      borderColor: palette.neutralTertiary,
       boxShadow: Depths.depth8
     }
   };
 };
 
 export const ColorSliderStyles = (props: IColorSliderStyleProps): Partial<IColorSliderStyles> => {
+  const { theme } = props;
+  const { palette, effects } = theme;
+
   return {
     root: {
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       marginBottom: 8
     },
     sliderThumb: {
-      borderColor: NeutralColors.gray80,
+      borderColor: palette.neutralTertiary,
       boxShadow: Depths.depth8
     }
   };

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -6,7 +6,6 @@ import {
   IColorSliderStyleProps,
   IColorSliderStyles
 } from 'office-ui-fabric-react/lib/ColorPicker';
-import { Depths } from '../FluentDepths';
 
 export const ColorPickerStyles = (props: IColorPickerStyleProps): Partial<IColorPickerStyles> => {
   return {
@@ -50,7 +49,7 @@ export const ColorRectangleStyles = (props: IColorRectangleStyleProps): Partial<
     },
     thumb: {
       borderColor: palette.neutralTertiary,
-      boxShadow: Depths.depth8
+      boxShadow: effects.elevation8
     }
   };
 };
@@ -66,7 +65,7 @@ export const ColorSliderStyles = (props: IColorSliderStyleProps): Partial<IColor
     },
     sliderThumb: {
       borderColor: palette.neutralTertiary,
-      boxShadow: Depths.depth8
+      boxShadow: effects.elevation8
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
@@ -1,5 +1,4 @@
 import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from 'office-ui-fabric-react/lib/SwatchColorPicker';
-import { NeutralColors } from '../FluentColors';
 import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
 export const ColorPickerGridCellStyles = (props: IColorPickerGridCellStyleProps): Partial<IColorPickerGridCellStyles> => {
@@ -26,7 +25,7 @@ export const ColorPickerGridCellStyles = (props: IColorPickerGridCellStyleProps)
       },
       isWhite &&
         !selected && {
-          backgroundColor: NeutralColors.gray80
+          backgroundColor: palette.neutralTertiary
         },
       !selected && {
         selectors: {

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -1,6 +1,6 @@
 import { fluentBorderRadius } from './styleConstants';
 import { Depths } from '../FluentDepths';
-import { NeutralColors, SharedColors } from '../FluentColors';
+import { NeutralColors } from '../FluentColors';
 import { IComboBoxStyles, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
 
 export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> => {
@@ -25,7 +25,7 @@ export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> 
       }
     },
     rootError: {
-      borderColor: SharedColors.red10 // current structure of ComboBox does not allow to change the hover/focus color when has error
+      borderColor: palette.red // current structure of ComboBox does not allow to change the hover/focus color when has error
     },
     callout: {
       borderRadius: fluentBorderRadius,

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -1,4 +1,3 @@
-import { Depths } from '../FluentDepths';
 import { IComboBoxStyles, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
 
 export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> => {
@@ -28,7 +27,7 @@ export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> 
     callout: {
       borderRadius: effects.roundedCorner2,
       border: 'none',
-      boxShadow: Depths.depth8,
+      boxShadow: effects.elevation8,
       selectors: {
         '.ms-Callout-main': { borderRadius: effects.roundedCorner2 }
       }

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -1,62 +1,70 @@
 import { fluentBorderRadius } from './styleConstants';
 import { Depths } from '../FluentDepths';
 import { NeutralColors, SharedColors } from '../FluentColors';
-import { IComboBoxStyles } from 'office-ui-fabric-react/lib/ComboBox';
+import { IComboBoxStyles, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
 
-export const ComboBoxStyles: Partial<IComboBoxStyles> = {
-  root: {
-    borderRadius: fluentBorderRadius, // the bound input box
-    borderColor: NeutralColors.gray80,
-    paddingLeft: 8
-  },
-  rootHovered: {
-    borderColor: NeutralColors.gray160,
-    selectors: {
-      '.ms-ComboBox-Input': {
-        color: NeutralColors.gray190
-      }
-    }
-  },
-  rootError: {
-    borderColor: SharedColors.red10 // current structure of ComboBox does not allow to change the hover/focus color when has error
-  },
-  callout: {
-    borderRadius: fluentBorderRadius,
-    border: 'none',
-    boxShadow: Depths.depth8,
-    selectors: {
-      '.ms-Callout-main': { borderRadius: fluentBorderRadius }
-    }
-  },
-  header: {
-    padding: '0 8px'
-  },
-  optionsContainer: {
-    selectors: {
-      '.ms-ComboBox-option': {
-        paddingLeft: 8,
-        paddingRight: 8,
-        selectors: {
-          ':hover:active': {
-            backgroundColor: NeutralColors.gray30
-          }
-        }
-      },
-      '.is-checked': {
-        backgroundColor: 'transparent',
-        selectors: {
-          ':hover': {
-            backgroundColor: NeutralColors.gray20
-          }
-        }
-      },
-      '.ms-Checkbox': {
-        selectors: {
-          ':hover': {
-            backgroundColor: NeutralColors.gray20
-          }
-        }
-      }
-    }
+export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { palette } = theme;
+
+  return {
+    root: {
+      borderRadius: fluentBorderRadius, // the bound input box
+      borderColor: NeutralColors.gray80,
+      paddingLeft: 8
+    },
+    rootHovered: {
+      borderColor: palette.neutralPrimary,
+      selectors: {
+        '.ms-ComboBox-Input': {
+          color: palette.neutralDark
+        }
+      }
+    },
+    rootError: {
+      borderColor: SharedColors.red10 // current structure of ComboBox does not allow to change the hover/focus color when has error
+    },
+    callout: {
+      borderRadius: fluentBorderRadius,
+      border: 'none',
+      boxShadow: Depths.depth8,
+      selectors: {
+        '.ms-Callout-main': { borderRadius: fluentBorderRadius }
+      }
+    },
+    header: {
+      padding: '0 8px'
+    },
+    optionsContainer: {
+      selectors: {
+        '.ms-ComboBox-option': {
+          paddingLeft: 8,
+          paddingRight: 8,
+          selectors: {
+            ':hover:active': {
+              backgroundColor: palette.neutralLight
+            }
+          }
+        },
+        '.is-checked': {
+          backgroundColor: 'transparent',
+          selectors: {
+            ':hover': {
+              backgroundColor: palette.neutralLighter
+            }
+          }
+        },
+        '.ms-Checkbox': {
+          selectors: {
+            ':hover': {
+              backgroundColor: palette.neutralLighter
+            }
+          }
+        }
+      }
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -1,6 +1,4 @@
-import { fluentBorderRadius } from './styleConstants';
 import { Depths } from '../FluentDepths';
-import { NeutralColors } from '../FluentColors';
 import { IComboBoxStyles, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
 
 export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> => {
@@ -8,12 +6,12 @@ export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> 
   if (!theme) {
     throw new Error('Theme is undefined or null.');
   }
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     root: {
-      borderRadius: fluentBorderRadius, // the bound input box
-      borderColor: NeutralColors.gray80,
+      borderRadius: effects.roundedCorner2, // the bound input box
+      borderColor: palette.neutralTertiary,
       paddingLeft: 8
     },
     rootHovered: {
@@ -28,11 +26,11 @@ export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> 
       borderColor: palette.red // current structure of ComboBox does not allow to change the hover/focus color when has error
     },
     callout: {
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       border: 'none',
       boxShadow: Depths.depth8,
       selectors: {
-        '.ms-Callout-main': { borderRadius: fluentBorderRadius }
+        '.ms-Callout-main': { borderRadius: effects.roundedCorner2 }
       }
     },
     header: {

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -10,11 +10,9 @@ export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> 
   return {
     root: {
       borderRadius: effects.roundedCorner2, // the bound input box
-      borderColor: palette.neutralTertiary,
       paddingLeft: 8
     },
     rootHovered: {
-      borderColor: palette.neutralPrimary,
       selectors: {
         '.ms-ComboBox-Input': {
           color: palette.neutralDark

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -1,9 +1,6 @@
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
-// TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
-//        this 'any' once we upgrade to TS3.1+
-// tslint:disable-next-line:no-any
 export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;
   if (!theme) {

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -1,12 +1,18 @@
-import FluentTheme from '../FluentTheme';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
 // TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
 //        this 'any' once we upgrade to TS3.1+
 // tslint:disable-next-line:no-any
-export const CommandBarButtonStyles: Partial<IButtonStyles> = {
-  root: {
-    ...getFocusStyle(FluentTheme, 2)
+export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+
+  return {
+    root: {
+      ...getFocusStyle(theme, 2)
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -1,4 +1,3 @@
-import { fluentBorderRadius } from './styleConstants';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
@@ -7,14 +6,14 @@ export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles
   if (!theme) {
     throw new Error('Theme is undefined or null.');
   }
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     root: {
       ...getFocusStyle(theme, 2),
       backgroundColor: palette.white,
       border: `1px solid ${palette.neutralSecondaryAlt}`,
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       padding: '16px 12px',
 
       // Primary styles require targeting a selector for now.

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -1,5 +1,4 @@
 import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors } from '../FluentColors';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
@@ -14,7 +13,7 @@ export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles
     root: {
       ...getFocusStyle(theme, 2),
       backgroundColor: palette.white,
-      border: `1px solid ${NeutralColors.gray110}`,
+      border: `1px solid ${palette.neutralSecondaryAlt}`,
       borderRadius: fluentBorderRadius,
       padding: '16px 12px',
 

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -1,55 +1,62 @@
 import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors, CommunicationColors } from '../FluentColors';
-import FluentTheme from '../FluentTheme';
+import { NeutralColors } from '../FluentColors';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
-export const CompoundButtonStyles: Partial<IButtonStyles> = {
-  root: {
-    ...getFocusStyle(FluentTheme, 2),
-    backgroundColor: NeutralColors.white,
-    border: `1px solid ${NeutralColors.gray110}`,
-    borderRadius: fluentBorderRadius,
-    padding: '16px 12px',
-
-    // Primary styles require targeting a selector for now.
-    // @todo: These selectors override the focus style above. Need to fix this.
-    selectors: {
-      '&.ms-Button--compoundPrimary': {
-        backgroundColor: CommunicationColors.primary,
-        borderColor: CommunicationColors.primary
-      }
-    }
-  },
-  rootPressed: {
-    backgroundColor: NeutralColors.gray40,
-
-    // Primary styles require targeting a selector for now.
-    selectors: {
-      '&.ms-Button--compoundPrimary:active': {
-        backgroundColor: CommunicationColors.shade20
-      }
-    }
-  },
-  rootChecked: {
-    backgroundColor: NeutralColors.gray40,
-
-    // Primary styles require targeting a selector for now.
-    selectors: {
-      '&.ms-Button--compoundPrimary': {
-        backgroundColor: CommunicationColors.shade20,
-        borderColor: CommunicationColors.shade20
-      }
-    }
-  },
-  rootDisabled: {
-    borderColor: NeutralColors.gray20,
-
-    selectors: {
-      '&.ms-Button--compoundPrimary': {
-        backgroundColor: NeutralColors.gray20,
-        borderColor: NeutralColors.gray20
-      }
-    }
+export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { palette } = theme;
+
+  return {
+    root: {
+      ...getFocusStyle(theme, 2),
+      backgroundColor: palette.white,
+      border: `1px solid ${NeutralColors.gray110}`,
+      borderRadius: fluentBorderRadius,
+      padding: '16px 12px',
+
+      // Primary styles require targeting a selector for now.
+      // @todo: These selectors override the focus style above. Need to fix this.
+      selectors: {
+        '&.ms-Button--compoundPrimary': {
+          backgroundColor: palette.themePrimary,
+          borderColor: palette.themePrimary
+        }
+      }
+    },
+    rootPressed: {
+      backgroundColor: palette.neutralQuaternaryAlt,
+
+      // Primary styles require targeting a selector for now.
+      selectors: {
+        '&.ms-Button--compoundPrimary:active': {
+          backgroundColor: palette.themeDark
+        }
+      }
+    },
+    rootChecked: {
+      backgroundColor: palette.neutralQuaternaryAlt,
+
+      // Primary styles require targeting a selector for now.
+      selectors: {
+        '&.ms-Button--compoundPrimary': {
+          backgroundColor: palette.themeDark,
+          borderColor: palette.themeDark
+        }
+      }
+    },
+    rootDisabled: {
+      borderColor: palette.neutralLighter,
+
+      selectors: {
+        '&.ms-Button--compoundPrimary': {
+          backgroundColor: palette.neutralLighter,
+          borderColor: palette.neutralLighter
+        }
+      }
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
@@ -6,7 +6,6 @@ import {
 } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 import { MinimumScreenSelector } from './styleConstants';
-import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';
 
 export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<IContextualMenuStyles> => {
@@ -32,7 +31,7 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
         root: {
           border: 'none',
           borderRadius: effects.roundedCorner2,
-          boxShadow: Depths.depth8,
+          boxShadow: effects.elevation8,
           selectors: {
             ['.ms-Callout-main']: { borderRadius: effects.roundedCorner2 }
           }

--- a/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
@@ -5,13 +5,13 @@ import {
   IContextualMenuItemStyles
 } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
-import { fluentBorderRadius, MinimumScreenSelector } from './styleConstants';
+import { MinimumScreenSelector } from './styleConstants';
 import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';
 
 export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<IContextualMenuStyles> => {
   const { theme } = props;
-  const { palette } = theme;
+  const { palette, effects } = theme;
   const CONTEXTUAL_MENU_ITEM_HEIGHT = 36;
 
   const iconStyles = {
@@ -31,13 +31,13 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
       callout: {
         root: {
           border: 'none',
-          borderRadius: fluentBorderRadius,
+          borderRadius: effects.roundedCorner2,
           boxShadow: Depths.depth8,
           selectors: {
-            ['.ms-Callout-main']: { borderRadius: fluentBorderRadius }
+            ['.ms-Callout-main']: { borderRadius: effects.roundedCorner2 }
           }
         },
-        beakCurtain: { borderRadius: fluentBorderRadius }
+        beakCurtain: { borderRadius: effects.roundedCorner2 }
       },
       menuItem: (itemStyleProps: IContextualMenuItemStyleProps): Partial<IContextualMenuItemStyles> => {
         const { disabled, expanded, primaryDisabled, checked } = itemStyleProps;

--- a/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
@@ -2,9 +2,6 @@ import { IDatePickerStyleProps, IDatePickerStyles } from 'office-ui-fabric-react
 
 export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
   const { theme } = props;
-  if (!theme) {
-    throw new Error('Theme is undefined or null.');
-  }
   const { effects } = theme;
 
   return {

--- a/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
@@ -1,5 +1,4 @@
 import { IDatePickerStyleProps, IDatePickerStyles } from 'office-ui-fabric-react/lib/DatePicker';
-import { Depths } from '../FluentDepths';
 
 export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
   const { theme } = props;
@@ -12,7 +11,7 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
     callout: {
       border: 'none',
       borderRadius: effects.roundedCorner2,
-      boxShadow: Depths.depth8,
+      boxShadow: effects.elevation8,
       selectors: {
         '.ms-Callout-main': { borderRadius: effects.roundedCorner2 }
       }

--- a/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
@@ -1,15 +1,20 @@
 import { IDatePickerStyleProps, IDatePickerStyles } from 'office-ui-fabric-react/lib/DatePicker';
-import { fluentBorderRadius } from './styleConstants';
 import { Depths } from '../FluentDepths';
 
 export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
+  }
+  const { effects } = theme;
+
   return {
     callout: {
       border: 'none',
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       boxShadow: Depths.depth8,
       selectors: {
-        '.ms-Callout-main': { borderRadius: fluentBorderRadius }
+        '.ms-Callout-main': { borderRadius: effects.roundedCorner2 }
       }
     }
   };

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,66 +1,73 @@
 import { fluentBorderRadius } from './styleConstants';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import FluentTheme from '../FluentTheme';
-import { NeutralColors, CommunicationColors } from '../FluentColors';
-import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { NeutralColors } from '../FluentColors';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
 // TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
 //        this 'any' once we upgrade to TS3.1+
 // tslint:disable-next-line:no-any
-export const DefaultButtonStyles: Partial<IButtonStyles> = {
-  root: {
-    borderRadius: fluentBorderRadius,
-    backgroundColor: NeutralColors.white,
-    border: `1px solid ${NeutralColors.gray110}`,
-    ...getFocusStyle(FluentTheme, 1)
-  },
-  rootHovered: {
-    backgroundColor: NeutralColors.gray20,
-    selectors: {
-      '.ms-Button--primary': {
-        backgroundColor: CommunicationColors.shade10
-      }
-    }
-  },
-  rootPressed: {
-    backgroundColor: NeutralColors.gray30
-  },
-  rootChecked: {
-    backgroundColor: NeutralColors.gray30
-  },
-  rootDisabled: {
-    backgroundColor: NeutralColors.gray20,
-    borderColor: NeutralColors.gray20
-  },
-  splitButtonMenuButton: {
-    background: 'transparent',
-    borderTopRightRadius: fluentBorderRadius,
-    borderBottomRightRadius: fluentBorderRadius,
-    border: `1px solid ${NeutralColors.gray110}`,
-    borderLeft: 'none'
-  },
-  splitButtonContainer: {
-    selectors: {
-      '.ms-Button--default': {
-        borderRight: 'none',
-        borderTopRightRadius: '0',
-        borderBottomRightRadius: '0'
-      },
-      '.ms-Button--primary': {
-        border: 'none',
-        backgroundColor: CommunicationColors.primary
-      },
-      '.ms-Button--primary + .ms-Button': {
-        backgroundColor: CommunicationColors.primary,
-        border: 'none'
-      },
-      '.ms-Button.is-disabled': {
-        backgroundColor: NeutralColors.gray20
-      },
-      '.ms-Button.is-disabled + .ms-Button': {
-        backgroundColor: NeutralColors.gray20,
-        border: 'none'
-      }
-    }
+export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { palette } = theme;
+
+  return {
+    root: {
+      borderRadius: fluentBorderRadius,
+      backgroundColor: palette.white,
+      border: `1px solid ${NeutralColors.gray110}`,
+      ...getFocusStyle(theme, 1)
+    },
+    rootHovered: {
+      backgroundColor: palette.neutralLighter,
+      selectors: {
+        '.ms-Button--primary': {
+          backgroundColor: palette.themeDarkAlt
+        }
+      }
+    },
+    rootPressed: {
+      backgroundColor: palette.neutralLight
+    },
+    rootChecked: {
+      backgroundColor: palette.neutralLight
+    },
+    rootDisabled: {
+      backgroundColor: palette.neutralLighter,
+      borderColor: palette.neutralLighter
+    },
+    splitButtonMenuButton: {
+      background: 'transparent',
+      borderTopRightRadius: fluentBorderRadius,
+      borderBottomRightRadius: fluentBorderRadius,
+      border: `1px solid ${NeutralColors.gray110}`,
+      borderLeft: 'none'
+    },
+    splitButtonContainer: {
+      selectors: {
+        '.ms-Button--default': {
+          borderRight: 'none',
+          borderTopRightRadius: '0',
+          borderBottomRightRadius: '0'
+        },
+        '.ms-Button--primary': {
+          border: 'none',
+          backgroundColor: palette.themePrimary
+        },
+        '.ms-Button--primary + .ms-Button': {
+          backgroundColor: palette.themePrimary,
+          border: 'none'
+        },
+        '.ms-Button.is-disabled': {
+          backgroundColor: palette.neutralLighter
+        },
+        '.ms-Button.is-disabled + .ms-Button': {
+          backgroundColor: palette.neutralLighter,
+          border: 'none'
+        }
+      }
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,11 +1,7 @@
 import { fluentBorderRadius } from './styleConstants';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import { NeutralColors } from '../FluentColors';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
-// TODO: "any" is used here to get around "is using xxx but cannot be named" TS error. Should be able to remove
-//        this 'any' once we upgrade to TS3.1+
-// tslint:disable-next-line:no-any
 export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;
   if (!theme) {
@@ -17,7 +13,7 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
     root: {
       borderRadius: fluentBorderRadius,
       backgroundColor: palette.white,
-      border: `1px solid ${NeutralColors.gray110}`,
+      border: `1px solid ${palette.neutralSecondaryAlt}`,
       ...getFocusStyle(theme, 1)
     },
     rootHovered: {
@@ -42,7 +38,7 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
       background: 'transparent',
       borderTopRightRadius: fluentBorderRadius,
       borderBottomRightRadius: fluentBorderRadius,
-      border: `1px solid ${NeutralColors.gray110}`,
+      border: `1px solid ${palette.neutralSecondaryAlt}`,
       borderLeft: 'none'
     },
     splitButtonContainer: {

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,4 +1,3 @@
-import { fluentBorderRadius } from './styleConstants';
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
@@ -7,11 +6,11 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
   if (!theme) {
     throw new Error('Theme is undefined or null.');
   }
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     root: {
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       backgroundColor: palette.white,
       border: `1px solid ${palette.neutralSecondaryAlt}`,
       ...getFocusStyle(theme, 1)
@@ -36,8 +35,8 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
     },
     splitButtonMenuButton: {
       background: 'transparent',
-      borderTopRightRadius: fluentBorderRadius,
-      borderBottomRightRadius: fluentBorderRadius,
+      borderTopRightRadius: effects.roundedCorner2,
+      borderBottomRightRadius: effects.roundedCorner2,
       border: `1px solid ${palette.neutralSecondaryAlt}`,
       borderLeft: 'none'
     },

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -53,17 +53,29 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
           borderBottomRightRadius: '0'
         },
         '.ms-Button--primary': {
+          borderTopRightRadius: '0',
+          borderBottomRightRadius: '0',
           border: 'none',
-          backgroundColor: palette.themePrimary
+          backgroundColor: palette.themePrimary,
+          selectors: {
+            ':hover': {
+              background: palette.themeDarkAlt
+            }
+          }
         },
         '.ms-Button--primary + .ms-Button': {
           backgroundColor: palette.themePrimary,
-          border: 'none'
+          border: 'none',
+          selectors: {
+            ':hover': {
+              background: palette.themeDarkAlt
+            }
+          }
         },
         '.ms-Button.is-disabled': {
           backgroundColor: palette.neutralLighter
         },
-        '.ms-Button.is-disabled + .ms-Button': {
+        '.ms-Button.is-disabled + .ms-Button.is-disabled': {
           backgroundColor: palette.neutralLighter,
           border: 'none'
         }

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -5,13 +5,11 @@ import {
   IDialogFooterStyles
 } from 'office-ui-fabric-react/lib/Dialog';
 import { FontWeights } from '@uifabric/styling';
-
 import { FontSizes } from '../FluentType';
-import { fluentBorderRadius } from './styleConstants';
 
 export const DialogContentStyles = (props: IDialogContentStyleProps): Partial<IDialogContentStyles> => {
   const { theme } = props;
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     title: {
@@ -28,7 +26,7 @@ export const DialogContentStyles = (props: IDialogContentStyleProps): Partial<ID
         },
         '.ms-Dialog-button:hover': {
           color: palette.neutralDark,
-          borderRadius: fluentBorderRadius
+          borderRadius: effects.roundedCorner2
         }
       }
     },

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -4,11 +4,9 @@ import { IStyle } from '@uifabric/styling';
 
 export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownStyles> => {
   const { disabled, hasError, isOpen, calloutRenderEdge, theme, isRenderingPlaceholder } = props;
-
   if (!theme) {
     throw new Error('theme is undefined or null in base Dropdown getStyles function.');
   }
-
   const { palette, effects } = theme;
   const ITEM_HEIGHT = '36px';
 

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -1,7 +1,5 @@
 import { IDropdownStyleProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
 import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
-import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors } from '../FluentColors';
 import { Depths } from '../FluentDepths';
 import { IStyle } from '@uifabric/styling';
 
@@ -12,18 +10,18 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     throw new Error('theme is undefined or null in base Dropdown getStyles function.');
   }
 
-  const { palette } = theme;
+  const { palette, effects } = theme;
   const ITEM_HEIGHT = '36px';
 
   const titleOpenBorderRadius =
     calloutRenderEdge === RectangleEdge.bottom
-      ? `${fluentBorderRadius} ${fluentBorderRadius} 0 0`
-      : `0 0 ${fluentBorderRadius} ${fluentBorderRadius}`;
+      ? `${effects.roundedCorner2} ${effects.roundedCorner2} 0 0`
+      : `0 0 ${effects.roundedCorner2} ${effects.roundedCorner2}`;
 
   const calloutOpenBorderRadius =
     calloutRenderEdge === RectangleEdge.bottom
-      ? `0 0 ${fluentBorderRadius} ${fluentBorderRadius}`
-      : `${fluentBorderRadius} ${fluentBorderRadius} 0 0`;
+      ? `0 0 ${effects.roundedCorner2} ${effects.roundedCorner2}`
+      : `${effects.roundedCorner2} ${effects.roundedCorner2} 0 0`;
 
   const commonItemStyles: IStyle = {
     minHeight: ITEM_HEIGHT,
@@ -100,8 +98,8 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     ],
     title: [
       {
-        borderColor: NeutralColors.gray80,
-        borderRadius: isOpen ? titleOpenBorderRadius : fluentBorderRadius,
+        borderColor: palette.neutralTertiary,
+        borderRadius: isOpen ? titleOpenBorderRadius : effects.roundedCorner2,
         padding: `0 28px 0 8px`
       },
       hasError && { borderColor: !isOpen ? palette.red : palette.redDark },

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -1,6 +1,5 @@
 import { IDropdownStyleProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
 import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
-import { Depths } from '../FluentDepths';
 import { IStyle } from '@uifabric/styling';
 
 export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownStyles> => {
@@ -118,7 +117,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     callout: {
       border: 'none',
       borderRadius: calloutOpenBorderRadius,
-      boxShadow: Depths.depth8,
+      boxShadow: effects.elevation8,
       selectors: {
         ['.ms-Callout-main']: { borderRadius: calloutOpenBorderRadius }
       }

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -95,7 +95,6 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     ],
     title: [
       {
-        borderColor: palette.neutralTertiary,
         borderRadius: isOpen ? titleOpenBorderRadius : effects.roundedCorner2,
         padding: `0 28px 0 8px`
       },

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -1,7 +1,7 @@
 import { IDropdownStyleProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
 import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
 import { fluentBorderRadius } from './styleConstants';
-import { SharedColors, NeutralColors } from '../FluentColors';
+import { NeutralColors } from '../FluentColors';
 import { Depths } from '../FluentDepths';
 import { IStyle } from '@uifabric/styling';
 
@@ -92,7 +92,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
 
           // Title has error states
           ['&:hover .ms-Dropdown-title--hasError, &:focus .ms-Dropdown-title--hasError, &:active .ms-Dropdown-title--hasError']: {
-            borderColor: SharedColors.red20,
+            borderColor: palette.redDark,
             color: isRenderingPlaceholder ? palette.neutralSecondary : palette.neutralPrimary
           }
         }
@@ -104,7 +104,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
         borderRadius: isOpen ? titleOpenBorderRadius : fluentBorderRadius,
         padding: `0 28px 0 8px`
       },
-      hasError && { borderColor: !isOpen ? SharedColors.red10 : SharedColors.red20 },
+      hasError && { borderColor: !isOpen ? palette.red : palette.redDark },
       isOpen && !hasError && { borderColor: palette.themePrimary },
       disabled && { color: palette.neutralTertiary }
     ],
@@ -116,7 +116,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
         color: palette.neutralTertiary
       }
     ],
-    errorMessage: { color: SharedColors.red20 },
+    errorMessage: { color: palette.redDark },
     callout: {
       border: 'none',
       borderRadius: calloutOpenBorderRadius,

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -5,21 +5,28 @@ import {
   IPlainCardStyles
 } from 'office-ui-fabric-react/lib/HoverCard';
 import { Depths } from '../FluentDepths';
-import { fluentBorderRadius } from './styleConstants';
 
-const commonCardStyles = {
-  border: 'none',
-  boxShadow: Depths.depth16,
-  borderRadius: fluentBorderRadius,
-  selectors: {
-    '.ms-Callout-main': { borderRadius: fluentBorderRadius }
+const commonCardStyles = (props: IExpandingCardStyleProps | IPlainCardStyleProps) => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { effects } = theme;
+
+  return {
+    border: 'none',
+    boxShadow: Depths.depth16,
+    borderRadius: effects.roundedCorner2,
+    selectors: {
+      '.ms-Callout-main': { borderRadius: effects.roundedCorner2 }
+    }
+  };
 };
 
 export const ExpandingCardStyles = (props: IExpandingCardStyleProps): Partial<IExpandingCardStyles> => {
   return {
     root: {
-      ...commonCardStyles,
+      ...commonCardStyles(props),
       width: 320
     },
     expandedCard: {
@@ -34,6 +41,6 @@ export const ExpandingCardStyles = (props: IExpandingCardStyleProps): Partial<IE
 
 export const PlainCardStyles = (props: IPlainCardStyleProps): Partial<IPlainCardStyles> => {
   return {
-    root: { ...commonCardStyles }
+    root: { ...commonCardStyles(props) }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -4,7 +4,6 @@ import {
   IPlainCardStyleProps,
   IPlainCardStyles
 } from 'office-ui-fabric-react/lib/HoverCard';
-import { Depths } from '../FluentDepths';
 
 const commonCardStyles = (props: IExpandingCardStyleProps | IPlainCardStyleProps) => {
   const { theme } = props;
@@ -15,7 +14,7 @@ const commonCardStyles = (props: IExpandingCardStyleProps | IPlainCardStyleProps
 
   return {
     border: 'none',
-    boxShadow: Depths.depth16,
+    boxShadow: effects.elevation16,
     borderRadius: effects.roundedCorner2,
     selectors: {
       '.ms-Callout-main': { borderRadius: effects.roundedCorner2 }

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -7,9 +7,6 @@ import {
 
 const commonCardStyles = (props: IExpandingCardStyleProps | IPlainCardStyleProps) => {
   const { theme } = props;
-  if (!theme) {
-    throw new Error('Theme is undefined or null.');
-  }
   const { effects } = theme;
 
   return {

--- a/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
@@ -1,25 +1,32 @@
-import { CommunicationColors, NeutralColors } from '../FluentColors';
-import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
-export const IconButtonStyles: Partial<IButtonStyles> = {
-  root: {
-    backgroundColor: NeutralColors.white,
-    color: CommunicationColors.primary
-  },
-  rootHovered: {
-    backgroundColor: NeutralColors.gray20,
-    color: CommunicationColors.shade10
-  },
-  rootPressed: {
-    backgroundColor: NeutralColors.gray30,
-    color: CommunicationColors.shade20
-  },
-  rootChecked: {
-    backgroundColor: NeutralColors.gray30,
-    color: CommunicationColors.shade20
-  },
-  rootDisabled: {
-    backgroundColor: NeutralColors.white,
-    color: NeutralColors.gray90
+export const IconButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { palette } = theme;
+
+  return {
+    root: {
+      backgroundColor: palette.white,
+      color: palette.themePrimary
+    },
+    rootHovered: {
+      backgroundColor: palette.neutralLighter,
+      color: palette.themeDarkAlt
+    },
+    rootPressed: {
+      backgroundColor: palette.neutralLight,
+      color: palette.themeDark
+    },
+    rootChecked: {
+      backgroundColor: palette.neutralLight,
+      color: palette.themeDark
+    },
+    rootDisabled: {
+      backgroundColor: palette.white,
+      color: palette.neutralTertiary
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
@@ -1,4 +1,3 @@
-import { Depths } from '../FluentDepths';
 import { IModalStyles, IModalProps } from 'office-ui-fabric-react/lib/Modal';
 
 export const ModalStyles = (props: IModalProps): Partial<IModalStyles> => {
@@ -10,7 +9,7 @@ export const ModalStyles = (props: IModalProps): Partial<IModalStyles> => {
 
   return {
     main: {
-      boxShadow: Depths.depth64,
+      boxShadow: effects.elevation64,
       borderRadius: effects.roundedCorner2
     }
   };

--- a/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
@@ -1,10 +1,17 @@
 import { Depths } from '../FluentDepths';
-import { fluentBorderRadius } from './styleConstants';
-import { IModalStyles } from 'office-ui-fabric-react/lib/Modal';
+import { IModalStyles, IModalProps } from 'office-ui-fabric-react/lib/Modal';
 
-export const ModalStyles: Partial<IModalStyles> = {
-  main: {
-    boxShadow: Depths.depth64,
-    borderRadius: fluentBorderRadius
+export const ModalStyles = (props: IModalProps): Partial<IModalStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { effects } = theme;
+
+  return {
+    main: {
+      boxShadow: Depths.depth64,
+      borderRadius: effects.roundedCorner2
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/Panel.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Panel.styles.ts
@@ -1,12 +1,14 @@
 import { IPanelStyleProps, IPanelStyles } from 'office-ui-fabric-react/lib/Panel';
-import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 export const PanelStyles = (props: IPanelStyleProps): Partial<IPanelStyles> => {
+  const { theme } = props;
+  const { effects } = theme;
+
   return {
     main: {
-      boxShadow: Depths.depth64
+      boxShadow: effects.elevation64
     },
     headerText: {
       fontSize: FontSizes.size20,

--- a/packages/fluent-theme/src/fluent/styles/Persona.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Persona.styles.ts
@@ -4,8 +4,6 @@ import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 export const PersonaStyles = (props: IPersonaStyleProps): Partial<IPersonaStyles> => {
   const size = sizeBoolean(props.size as PersonaSize);
-  const { theme } = props;
-  const { palette } = theme;
 
   return {
     primaryText: [
@@ -20,15 +18,8 @@ export const PersonaStyles = (props: IPersonaStyleProps): Partial<IPersonaStyles
         fontSize: FontSizes.size16
       }
     ],
-    secondaryText: {
-      color: palette.neutralSecondary
-    },
     tertiaryText: {
-      fontSize: FontSizes.size14,
-      color: palette.neutralSecondary
-    },
-    optionalText: {
-      color: palette.neutralSecondary
+      fontSize: FontSizes.size14
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/Persona.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Persona.styles.ts
@@ -1,10 +1,11 @@
 import { IPersonaStyleProps, IPersonaStyles, PersonaSize, sizeBoolean } from 'office-ui-fabric-react/lib/Persona';
 import { FontSizes } from '../FluentType';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { NeutralColors } from '../FluentColors';
 
 export const PersonaStyles = (props: IPersonaStyleProps): Partial<IPersonaStyles> => {
   const size = sizeBoolean(props.size as PersonaSize);
+  const { theme } = props;
+  const { palette } = theme;
 
   return {
     primaryText: [
@@ -20,14 +21,14 @@ export const PersonaStyles = (props: IPersonaStyleProps): Partial<IPersonaStyles
       }
     ],
     secondaryText: {
-      color: NeutralColors.gray120
+      color: palette.neutralSecondary
     },
     tertiaryText: {
       fontSize: FontSizes.size14,
-      color: NeutralColors.gray120
+      color: palette.neutralSecondary
     },
     optionalText: {
-      color: NeutralColors.gray120
+      color: palette.neutralSecondary
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
@@ -1,21 +1,28 @@
 import { fluentBorderRadius } from './styleConstants';
-import { CommunicationColors, NeutralColors } from '../FluentColors';
-import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
-export const PrimaryButtonStyles: Partial<IButtonStyles> = {
-  root: {
-    borderRadius: fluentBorderRadius,
-    border: 'none',
-    backgroundColor: CommunicationColors.primary,
-    color: NeutralColors.white
-  },
-  rootHovered: {
-    backgroundColor: CommunicationColors.shade10
-  },
-  rootPressed: {
-    backgroundColor: CommunicationColors.shade20
-  },
-  rootChecked: {
-    backgroundColor: CommunicationColors.shade20
+export const PrimaryButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
+  const { palette } = theme;
+
+  return {
+    root: {
+      borderRadius: fluentBorderRadius,
+      border: 'none',
+      backgroundColor: palette.themePrimary,
+      color: palette.white
+    },
+    rootHovered: {
+      backgroundColor: palette.themeDarkAlt
+    },
+    rootPressed: {
+      backgroundColor: palette.themeDark
+    },
+    rootChecked: {
+      backgroundColor: palette.themeDark
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
@@ -1,4 +1,3 @@
-import { fluentBorderRadius } from './styleConstants';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 
 export const PrimaryButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
@@ -6,11 +5,11 @@ export const PrimaryButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
   if (!theme) {
     throw new Error('Theme is undefined or null.');
   }
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     root: {
-      borderRadius: fluentBorderRadius,
+      borderRadius: effects.roundedCorner2,
       border: 'none',
       backgroundColor: palette.themePrimary,
       color: palette.white

--- a/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
@@ -2,7 +2,7 @@ import { IRatingStyleProps, IRatingStyles } from 'office-ui-fabric-react/lib/Rat
 
 export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> => {
   const { disabled, readOnly, theme } = props;
-  const { palette, semanticColors } = theme;
+  const { palette } = theme;
 
   return {
     root: [
@@ -18,30 +18,8 @@ export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> =
           }
         }
     ],
-    ratingStarBack: [
-      {
-        color: palette.neutralTertiary
-      },
-      disabled && {
-        color: semanticColors.disabledBodySubtext
-      }
-    ],
     ratingStarFront: {
       color: palette.neutralPrimary
-    },
-    ratingButton: [
-      !disabled &&
-        !readOnly && {
-          selectors: {
-            // This is part 2 of highlighting all stars up to the one the user is hovering over
-            '&:hover ~ .ms-Rating-button': {
-              selectors: {
-                '.ms-RatingStar-back': { color: palette.neutralTertiary },
-                '.ms-RatingStar-front': { color: palette.neutralTertiary }
-              }
-            }
-          }
-        }
-    ]
+    }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
@@ -1,5 +1,4 @@
 import { IRatingStyleProps, IRatingStyles } from 'office-ui-fabric-react/lib/Rating';
-import { NeutralColors } from '../FluentColors';
 
 export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> => {
   const { disabled, readOnly, theme } = props;
@@ -21,7 +20,7 @@ export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> =
     ],
     ratingStarBack: [
       {
-        color: NeutralColors.gray80
+        color: palette.neutralTertiary
       },
       disabled && {
         color: semanticColors.disabledBodySubtext
@@ -37,8 +36,8 @@ export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> =
             // This is part 2 of highlighting all stars up to the one the user is hovering over
             '&:hover ~ .ms-Rating-button': {
               selectors: {
-                '.ms-RatingStar-back': { color: NeutralColors.gray80 },
-                '.ms-RatingStar-front': { color: NeutralColors.gray80 }
+                '.ms-RatingStar-back': { color: palette.neutralTertiary },
+                '.ms-RatingStar-front': { color: palette.neutralTertiary }
               }
             }
           }

--- a/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
@@ -1,49 +1,58 @@
 import { fluentBorderRadius } from './styleConstants';
 import { NeutralColors } from '../FluentColors';
-import { ISpinButtonStyles } from 'office-ui-fabric-react/lib/SpinButton';
+import { ISpinButtonStyles, ISpinButtonProps } from 'office-ui-fabric-react/lib/SpinButton';
 
-const buttonStyles = {
-  color: NeutralColors.gray130,
-  width: 23,
-  selectors: {
-    ':hover': {
-      backgroundColor: NeutralColors.gray20,
-      color: NeutralColors.gray130
-    },
-    ':active': {
-      backgroundColor: NeutralColors.gray30,
-      color: NeutralColors.gray130
-    },
-    '.ms-Button-icon': {
-      fontSize: 8
-    }
+export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonStyles> => {
+  const SPIN_BUTTON_WIDTH = 23;
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
   }
-};
+  const { palette } = theme;
 
-export const SpinButtonStyles: Partial<ISpinButtonStyles> = {
-  spinButtonWrapper: {
-    borderRadius: fluentBorderRadius,
-    borderColor: NeutralColors.gray80
-  },
-  spinButtonWrapperHovered: {
-    borderColor: NeutralColors.gray160
-  },
-  input: {
-    padding: '0 8px',
-    width: 'calc(100% - 23px)', // -23px because buttons width changed
-    borderRadius: `${fluentBorderRadius} 0 0 ${fluentBorderRadius}`
-  },
-  arrowButtonsContainer: {
+  const buttonStyles = {
+    color: palette.neutralSecondary,
+    width: SPIN_BUTTON_WIDTH,
     selectors: {
-      // No direct style section available so need to target a global className
-      '.ms-DownButton': {
-        ...buttonStyles,
-        borderRadius: `0 0 ${fluentBorderRadius} 0`
+      ':hover': {
+        backgroundColor: palette.neutralLighter,
+        color: palette.neutralSecondary
       },
-      '.ms-UpButton': {
-        ...buttonStyles,
-        borderRadius: `0 ${fluentBorderRadius} 0 0`
+      ':active': {
+        backgroundColor: palette.neutralLight,
+        color: palette.neutralSecondary
+      },
+      '.ms-Button-icon': {
+        fontSize: 8 // following the redlines even though we don't have this size in our type ramp.
       }
     }
-  }
+  };
+
+  return {
+    spinButtonWrapper: {
+      borderRadius: fluentBorderRadius,
+      borderColor: NeutralColors.gray80
+    },
+    spinButtonWrapperHovered: {
+      borderColor: palette.neutralPrimary
+    },
+    input: {
+      padding: '0 8px',
+      width: `calc(100% - ${SPIN_BUTTON_WIDTH}px)`, // -23px because buttons width changed
+      borderRadius: `${fluentBorderRadius} 0 0 ${fluentBorderRadius}`
+    },
+    arrowButtonsContainer: {
+      selectors: {
+        // No direct style section available so need to target a global className
+        '.ms-DownButton': {
+          ...buttonStyles,
+          borderRadius: `0 0 ${fluentBorderRadius} 0`
+        },
+        '.ms-UpButton': {
+          ...buttonStyles,
+          borderRadius: `0 ${fluentBorderRadius} 0 0`
+        }
+      }
+    }
+  };
 };

--- a/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
@@ -1,5 +1,3 @@
-import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors } from '../FluentColors';
 import { ISpinButtonStyles, ISpinButtonProps } from 'office-ui-fabric-react/lib/SpinButton';
 
 export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonStyles> => {
@@ -8,7 +6,7 @@ export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonSt
   if (!theme) {
     throw new Error('Theme is undefined or null.');
   }
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   const buttonStyles = {
     color: palette.neutralSecondary,
@@ -30,8 +28,8 @@ export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonSt
 
   return {
     spinButtonWrapper: {
-      borderRadius: fluentBorderRadius,
-      borderColor: NeutralColors.gray80
+      borderRadius: effects.roundedCorner2,
+      borderColor: palette.neutralTertiary
     },
     spinButtonWrapperHovered: {
       borderColor: palette.neutralPrimary
@@ -39,18 +37,18 @@ export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonSt
     input: {
       padding: '0 8px',
       width: `calc(100% - ${SPIN_BUTTON_WIDTH}px)`, // -23px because buttons width changed
-      borderRadius: `${fluentBorderRadius} 0 0 ${fluentBorderRadius}`
+      borderRadius: `${effects.roundedCorner2} 0 0 ${effects.roundedCorner2}`
     },
     arrowButtonsContainer: {
       selectors: {
         // No direct style section available so need to target a global className
         '.ms-DownButton': {
           ...buttonStyles,
-          borderRadius: `0 0 ${fluentBorderRadius} 0`
+          borderRadius: `0 0 ${effects.roundedCorner2} 0`
         },
         '.ms-UpButton': {
           ...buttonStyles,
-          borderRadius: `0 ${fluentBorderRadius} 0 0`
+          borderRadius: `0 ${effects.roundedCorner2} 0 0`
         }
       }
     }

--- a/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
@@ -28,11 +28,7 @@ export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonSt
 
   return {
     spinButtonWrapper: {
-      borderRadius: effects.roundedCorner2,
-      borderColor: palette.neutralTertiary
-    },
-    spinButtonWrapperHovered: {
-      borderColor: palette.neutralPrimary
+      borderRadius: effects.roundedCorner2
     },
     input: {
       padding: '0 8px',

--- a/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
@@ -2,9 +2,6 @@ import { ITagItemStyleProps, ITagItemStyles } from 'office-ui-fabric-react/lib/P
 
 export const TagItemStyles = (props: ITagItemStyleProps): Partial<ITagItemStyles> => {
   const { theme } = props;
-  if (!theme) {
-    throw new Error('Theme is undefined or null.');
-  }
   const { effects } = theme;
 
   return {

--- a/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
@@ -1,14 +1,19 @@
 import { ITagItemStyleProps, ITagItemStyles } from 'office-ui-fabric-react/lib/Pickers';
-import { fluentBorderRadius } from './styleConstants';
 
 export const TagItemStyles = (props: ITagItemStyleProps): Partial<ITagItemStyles> => {
+  const { theme } = props;
+  if (!theme) {
+    throw new Error('Theme is undefined or null.');
+  }
+  const { effects } = theme;
+
   return {
     root: {
-      borderRadius: fluentBorderRadius
+      borderRadius: effects.roundedCorner2
     },
     close: {
       background: 'transparent',
-      borderRadius: `0 ${fluentBorderRadius} ${fluentBorderRadius} 0`
+      borderRadius: `0 ${effects.roundedCorner2} ${effects.roundedCorner2} 0`
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
@@ -1,14 +1,16 @@
-import { Depths } from '../FluentDepths';
 import { FontSizes } from '../FluentType';
 import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react/lib/TeachingBubble';
 
 export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
+  const { theme } = props;
+  const { effects } = theme;
+
   return {
     subComponentStyles: {
       callout: {
         root: {
-          boxShadow: Depths.depth16
+          boxShadow: effects.elevation16
         }
       }
     }

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -6,19 +6,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
 
   return {
     fieldGroup: [
-      {
-        borderRadius: effects.roundedCorner2
-      },
-      !focused &&
-        !disabled &&
-        !hasErrorMessage && {
-          borderColor: palette.neutralTertiary,
-          selectors: {
-            ':hover': {
-              borderColor: palette.neutralPrimary
-            }
-          }
-        },
+      { borderRadius: effects.roundedCorner2 },
       hasErrorMessage && [
         {
           borderColor: palette.red,
@@ -33,14 +21,18 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         }
       ]
     ],
-    field: {
-      color: palette.neutralDark,
-      padding: !multiline ? '0 8px' : '6px 8px',
-      selectors: {
-        '::placeholder': [disabled && { color: palette.neutralTertiary }],
-        ':-ms-input-placeholder': [disabled && { color: palette.neutralTertiary }]
+    field: [
+      !disabled && {
+        color: palette.neutralDark
+      },
+      {
+        padding: !multiline ? '0 8px' : '6px 8px',
+        selectors: {
+          '::placeholder': [disabled && { color: palette.neutralTertiary }],
+          ':-ms-input-placeholder': [disabled && { color: palette.neutralTertiary }]
+        }
       }
-    },
+    ],
     errorMessage: {
       color: palette.redDark
     }

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -1,20 +1,18 @@
 import { ITextFieldStyleProps, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
-import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors } from '../FluentColors';
 
 export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
   const { focused, disabled, hasErrorMessage, multiline, theme } = props;
-  const { palette } = theme;
+  const { palette, effects } = theme;
 
   return {
     fieldGroup: [
       {
-        borderRadius: fluentBorderRadius
+        borderRadius: effects.roundedCorner2
       },
       !focused &&
         !disabled &&
         !hasErrorMessage && {
-          borderColor: NeutralColors.gray80,
+          borderColor: palette.neutralTertiary,
           selectors: {
             ':hover': {
               borderColor: palette.neutralPrimary

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -1,6 +1,6 @@
 import { ITextFieldStyleProps, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
 import { fluentBorderRadius } from './styleConstants';
-import { NeutralColors, SharedColors } from '../FluentColors';
+import { NeutralColors } from '../FluentColors';
 
 export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
   const { focused, disabled, hasErrorMessage, multiline, theme } = props;
@@ -23,15 +23,15 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         },
       hasErrorMessage && [
         {
-          borderColor: SharedColors.red10,
+          borderColor: palette.red,
           selectors: {
             '&:focus, &:hover': {
-              borderColor: SharedColors.red20
+              borderColor: palette.redDark
             }
           }
         },
         focused && {
-          borderColor: SharedColors.red20
+          borderColor: palette.redDark
         }
       ]
     ],
@@ -44,7 +44,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
       }
     },
     errorMessage: {
-      color: SharedColors.red20
+      color: palette.redDark
     }
   };
 };

--- a/packages/fluent-theme/src/fluent/styles/Toggle.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Toggle.styles.ts
@@ -3,11 +3,6 @@ import { IToggleStyleProps, IToggleStyles } from 'office-ui-fabric-react/lib/Tog
 
 export const ToggleStyles = (props: IToggleStyleProps): Partial<IToggleStyles> => {
   const { disabled, checked, theme } = props;
-
-  if (!theme) {
-    throw new Error('Theme is undefined or null in Fluent theme Toggle getStyles function.');
-  }
-
   const { palette } = theme;
 
   return {

--- a/packages/fluent-theme/src/fluent/styles/styleConstants.ts
+++ b/packages/fluent-theme/src/fluent/styles/styleConstants.ts
@@ -1,5 +1,4 @@
 import { ScreenWidthMaxMedium, ScreenWidthMaxSmall, ScreenWidthMinMedium, getScreenSelector } from '@uifabric/styling';
 
-export const fluentBorderRadius = '2px';
 export const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMaxSmall);
 export const MediumScreenSelector = getScreenSelector(ScreenWidthMinMedium, ScreenWidthMaxMedium);

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7689,11 +7689,11 @@ interface IDropdownSubComponentStyles {
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
 // @internal
 interface IEffects {
-  elevation16: IRawStyle;
-  elevation4: IRawStyle;
-  elevation64: IRawStyle;
-  elevation8: IRawStyle;
-  roundedCorner2: number;
+  elevation16: string;
+  elevation4: string;
+  elevation64: string;
+  elevation8: string;
+  roundedCorner2: string;
 }
 
 // @public

--- a/packages/styling/etc/styling.api.ts
+++ b/packages/styling/etc/styling.api.ts
@@ -217,11 +217,11 @@ module IconFontSizes {
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
 // @internal
 interface IEffects {
-  elevation16: IRawStyle;
-  elevation4: IRawStyle;
-  elevation64: IRawStyle;
-  elevation8: IRawStyle;
-  roundedCorner2: number;
+  elevation16: string;
+  elevation4: string;
+  elevation64: string;
+  elevation8: string;
+  roundedCorner2: string;
 }
 
 // @public

--- a/packages/styling/src/interfaces/IEffects.ts
+++ b/packages/styling/src/interfaces/IEffects.ts
@@ -7,25 +7,25 @@ import { IRawStyle } from '@uifabric/merge-styles';
 export interface IEffects {
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
-   * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
+   * This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: cards, grid items
    */
   elevation4: string;
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
-   * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
+   * This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: menus, command surfaces
    */
   elevation8: string;
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
-   * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
+   * This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: search result dropdowns, hover cards, tooltips, help bubbles
    */
   elevation16: string;
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
-   * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
+   * This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: Panels, Dialogs
    */
   elevation64: string;

--- a/packages/styling/src/interfaces/IEffects.ts
+++ b/packages/styling/src/interfaces/IEffects.ts
@@ -10,28 +10,28 @@ export interface IEffects {
    * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: cards, grid items
    */
-  elevation4: IRawStyle;
+  elevation4: string;
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
    * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: menus, command surfaces
    */
-  elevation8: IRawStyle;
+  elevation8: string;
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
    * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: search result dropdowns, hover cards, tooltips, help bubbles
    */
-  elevation16: IRawStyle;
+  elevation16: string;
   /**
    * Used to provide a visual affordance that this element is elevated above the surface it rests on.
    * Usually a shadow. This is lower than elevations with a higher value, and higher than elevations with a lower value.
    * Used for: Panels, Dialogs
    */
-  elevation64: IRawStyle;
+  elevation64: string;
 
   /**
    * How much corners should be rounded, for use with border-radius.
    */
-  roundedCorner2: number;
+  roundedCorner2: string;
 }

--- a/packages/styling/src/styles/DefaultEffects.ts
+++ b/packages/styling/src/styles/DefaultEffects.ts
@@ -2,10 +2,10 @@ import { IEffects } from '../interfaces/index';
 
 export const DefaultEffects: IEffects = {
   // commented values are the defaults for Fluent
-  elevation4: { boxShadow: '0 0 5px 0 rgba(0,0,0,.4)' }, // '0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108)'
-  elevation8: { boxShadow: '0 0 5px 0 rgba(0,0,0,.4)' }, // '0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108)'
-  elevation16: { boxShadow: '0 0 5px 0 rgba(0,0,0,.4)' }, // '0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108)'
-  elevation64: { boxShadow: '0 0 5px 0 rgba(0,0,0,.4)' }, // '0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18)'
+  elevation4: '0 0 5px 0 rgba(0,0,0,.4)', // '0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108)'
+  elevation8: '0 0 5px 0 rgba(0,0,0,.4)', // '0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108)'
+  elevation16: '0 0 5px 0 rgba(0,0,0,.4)', // '0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108)'
+  elevation64: '0 0 5px 0 rgba(0,0,0,.4)', // '0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18)'
 
-  roundedCorner2: 0 // 2
+  roundedCorner2: '0px' // 2
 };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7983 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
1. Cleaning all the hard-coded fluent color values with the ones coming from the theme. This required bringing back the `neutralSecondaryAlt` from the deprecation status. All the colors swaps changes were approved by designers (@betrue-final-final ) and @phkuo might have to change the `ThemeGenerator` logic to take into account the `neutralSecondaryAlt` resurrection from death.
2. Make the buttons styles to be functions so that we can access the theme palette and not use the hard-coded colors which were blocking OWA team from testing the package (thanks to #7748). (@MLoughry FYI)
3. Clean up the use of hard-coded `boxShadow` and `borderRadius` values from FluentDepths and `styleConstants` with the ones passed through `theme.effects`
4. Adjust the types on `IEffects` properties to allow more flexibility for what to pass and making it easier to use in styles. (discussed with @phkuo )


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8098)