### PR TITLE
Clean up dependencies

### DIFF
--- a/common/changes/@uifabric/dashboard/example-dev-dep_2019-02-25-20-22.json
+++ b/common/changes/@uifabric/dashboard/example-dev-dep_2019-02-25-20-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/dashboard",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "xbtsw.chen@gmail.com"
+}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -2,18 +2,14 @@
   "name": "@uifabric/dashboard",
   "version": "0.50.0",
   "dependencies": {
-    "@microsoft/load-themed-styles": "^1.7.13",
     "@uifabric/charting": "^0.28.7",
-    "@uifabric/example-app-base": ">=6.11.7 <7.0.0",
     "@uifabric/experiments": ">=6.59.2 <7.0.0",
     "@uifabric/fluent-theme": ">=0.15.1 <1.0.0",
     "@uifabric/set-version": ">=1.1.3 <2.0.0",
     "auto-fontsize": "^1.0.18",
-    "css-loader": "^0.28.7",
     "office-ui-fabric-react": ">=6.143.1 <7.0.0",
     "react-grid-layout-fabric": "^0.16.6",
     "react-resizable": "^1.7.5",
-    "style-loader": "^0.21.0",
     "tslib": "^1.7.1"
   },
   "main": "lib-commonjs/index.js",
@@ -32,6 +28,7 @@
     "update-snapshots": "node ../../scripts/just.js jest -u"
   },
   "devDependencies": {
+    "@microsoft/load-themed-styles": "^1.7.13",
     "@types/enzyme": "3.1.13",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/jest": "23.0.0",
@@ -39,16 +36,19 @@
     "@types/react-dom": "16.0.5",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.13.0",
+    "@uifabric/example-app-base": ">=6.11.7 <7.0.0",
     "@uifabric/jest-serializer-merge-styles": ">=6.0.7 <7.0.0",
     "@uifabric/prettier-rules": ">=1.0.0 <2.0.0",
     "@uifabric/tslint-rules": ">=1.0.0 <2.0.0",
+    "css-loader": "^0.28.7",
     "enzyme": "^3.4.1",
     "enzyme-adapter-react-16": "^1.2.0",
     "react": ">=16.3.2-0 <17.0.0",
     "react-draggable": "^3.0.5",
     "react-dom": ">=16.3.2-0 <17.0.0",
     "react-test-renderer": "^16.3.0",
-    "stickyfilljs": "^2.1.0"
+    "stickyfilljs": "^2.1.0",
+    "style-loader": "^0.21.0"
   },
   "peerDependencies": {
     "react": ">=16.3.2-0 <17.0.0",


### PR DESCRIPTION
Especially highlight.js released a new version which is broken.

https://github.com/highlightjs/highlight.js/issues/1984

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8108)