### PR TITLE
Calendar: Change CalendarDay button role from 'button' to 'gridcell'

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2019-02-fixCalendarDayButtonRole_2019-02-25-20-13.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-02-fixCalendarDayButtonRole_2019-02-25-20-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Calendar: Change role of CalendarDay button from 'button' to 'gridcell'",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -318,7 +318,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                             ['ms-DatePicker-day--disabled ' + styles.dayIsDisabled]: !day.isInBounds,
                             ['ms-DatePicker-day--today ' + styles.dayIsToday]: day.isToday
                           })}
-                          role={'button'}
+                          role="gridcell"
                           onKeyDown={this._onDayKeyDown(day.originalDate, weekIndex, dayIndex)}
                           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
                           id={isNavigatedDate ? activeDescendantId : undefined}

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -225,7 +225,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -250,7 +250,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         id="DatePickerDay-active0"
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -274,7 +274,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -298,7 +298,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -322,7 +322,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -346,7 +346,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -372,7 +372,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -396,7 +396,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -420,7 +420,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -444,7 +444,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -468,7 +468,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -492,7 +492,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -516,7 +516,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -542,7 +542,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -566,7 +566,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -590,7 +590,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -614,7 +614,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -638,7 +638,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -662,7 +662,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -686,7 +686,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -712,7 +712,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -736,7 +736,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -760,7 +760,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -784,7 +784,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -808,7 +808,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -832,7 +832,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -856,7 +856,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -882,7 +882,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -906,7 +906,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -930,7 +930,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -954,7 +954,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -978,7 +978,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -1002,7 +1002,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -1026,7 +1026,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="button"
+                        role="gridcell"
                         type="button"
                       >
                         <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8103 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Changes button role from `button` to `gridcell` to fix breaking Keros rule `aria-allowed-attr`

See https://ej2.syncfusion.com/documentation/calendar/accessibility/

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8109)