### PR TITLE
DetailsList: Remove redundant casts

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-rm-unneeded-dl-casts_2019-02-25-21-42.json
+++ b/common/changes/office-ui-fabric-react/keco-rm-unneeded-dl-casts_2019-02-25-21-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Remove redundant casts and local declaration",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -350,7 +350,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
         selection={selection}
         selectionMode={checkboxVisibility !== CheckboxVisibility.hidden ? selectionMode : SelectionMode.none}
         dragDropEvents={dragDropEvents}
-        dragDropHelper={dragDropHelper as DragDropHelper}
+        dragDropHelper={dragDropHelper}
         eventsToRegister={rowElementEventMap}
         listProps={additionalListProps}
         onGroupExpandStateChanged={this._onGroupExpandStateChanged}
@@ -484,7 +484,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
 
   private _onRenderListCell = (nestingDepth: number): ((item: any, itemIndex: number) => React.ReactNode) => {
     return (item: any, itemIndex: number): React.ReactNode => {
-      return this._onRenderCell(nestingDepth, item, itemIndex as number);
+      return this._onRenderCell(nestingDepth, item, itemIndex);
     };
   };
 
@@ -517,7 +517,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       item: item,
       itemIndex: index,
       compact: compact,
-      columns: columns as IColumn[],
+      columns: columns,
       groupNestingDepth: nestingDepth,
       selectionMode: selectionMode,
       selection: selection,
@@ -855,7 +855,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   }
 
   private _getColumnOverride(key: string): IColumn {
-    return (this._columnOverrides[key] = this._columnOverrides[key] || ({} as IColumn));
+    return (this._columnOverrides[key] = this._columnOverrides[key] || {});
   }
 
   /**
@@ -1024,9 +1024,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
         }
       : undefined;
 
-    const groupProps = detailsGroupProps as IGroupRenderProps;
     return {
-      ...groupProps,
+      ...detailsGroupProps,
       onRenderFooter,
       onRenderHeader
     };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Removes redundant casts in `DetailsList.base`. The only emitted JS change is related to a redundant local variable initialization, see https://github.com/OfficeDev/office-ui-fabric-react/pull/8110/files#diff-39279b6555df6a42c15227ace56e979dL1027.

#### Focus areas to test

- Existing tests should pass
- Existing build should run


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8110)