### PR TITLE
ChoiceGroup: Adding defaultSelectedKey to 'ChoiceGroup with Icons' example so that aria-selected property is set

### DIFF
--- a/common/changes/office-ui-fabric-react/choiceGroupA11yBug9_2019-02-25-21-50.json
+++ b/common/changes/office-ui-fabric-react/choiceGroupA11yBug9_2019-02-25-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: Adding defaultSelectedKey to 'ChoiceGroup with Icons' example so that aria-selected property is set.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx
@@ -7,6 +7,7 @@ export class ChoiceGroupIconExample extends React.Component<any, any> {
     return (
       <ChoiceGroup
         label="Pick one icon"
+        defaultSelectedKey="day"
         options={[
           {
             key: 'day',

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -93,7 +93,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
 
         >
           <input
-            checked={false}
+            checked={true}
             className=
                 ms-ChoiceField-input
                 {
@@ -118,9 +118,11 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
           <label
             className=
                 ms-ChoiceField-field
+                is-checked
                 ms-ChoiceField--icon
                 {
                   align-items: center;
+                  border-color: #0078d4;
                   border: 2px solid transparent;
                   box-sizing: content-box;
                   cursor: pointer;
@@ -142,28 +144,28 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   vertical-align: top;
                 }
                 &:hover {
-                  border-color: #c8c8c8;
+                  border-color: #005a9e;
                 }
                 &:hover .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:hover:before {
-                  border-color: #333333;
+                  border-color: #005a9e;
                   opacity: 1;
                 }
                 &:focus {
-                  border-color: #c8c8c8;
+                  border-color: #005a9e;
                 }
                 &:focus .ms-ChoiceFieldLabel {
                   color: #000000;
                 }
                 &:focus:before {
-                  border-color: #333333;
+                  border-color: #005a9e;
                   opacity: 1;
                 }
                 &:before {
                   background-color: #ffffff;
-                  border-color: #666666;
+                  border-color: #0078d4;
                   border-radius: 50%;
                   border-style: solid;
                   border-width: 1px;
@@ -173,7 +175,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   font-weight: normal;
                   height: 20px;
                   left: auto;
-                  opacity: 0;
+                  opacity: 1;
                   position: absolute;
                   right: 3px;
                   top: 3px;
@@ -182,18 +184,28 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  border-color: Highlight;
+                }
                 &:after {
+                  border-color: #0078d4;
                   border-radius: 50%;
+                  border-style: solid;
+                  border-width: 5px;
                   box-sizing: border-box;
                   content: "";
-                  height: 0px;
-                  left: 10px;
+                  height: 10px;
+                  left: auto;
                   position: absolute;
-                  right: 0px;
+                  right: 8px;
+                  top: 8px;
                   transition-duration: 200ms;
                   transition-property: border-width;
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                  width: 0px;
+                  width: 10px;
+                }
+                @media screen and (-ms-high-contrast: active){&:after {
+                  border-color: Highlight;
                 }
             htmlFor="ChoiceGroup0-day"
           >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6844
- [x] Include a change request file using `$ npm run change`

#### Description of changes

A selected state was not defined for the `ChoiceGroup with Icons` example, which causes the first change of state to not be read by `Narrator`. This PR gives a `defaultSelectedKey` to the example so that a selected state is defined and this issue is avoided.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8112)