### PR TITLE
Fix invalid mergeAriaAttributeValues output when multiple ID references supplied

### DIFF
--- a/common/changes/@uifabric/utilities/keco-space-delimit-aria-attrs_2019-02-25-22-13.json
+++ b/common/changes/@uifabric/utilities/keco-space-delimit-aria-attrs_2019-02-25-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "ARIA: mergeAriaAttributeValues should produce space-delimited output by default",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "keco@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/keco-space-delimit-aria-attrs_2019-02-25-22-13.json
+++ b/common/changes/office-ui-fabric-react/keco-space-delimit-aria-attrs_2019-02-25-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ARIA: Update calls to mergeAriaAttributeValues to no longer explicitly supply output element id padding.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -385,7 +385,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 readOnly={disabled || !allowFreeform}
                 aria-labelledby={label && id + '-label'}
                 aria-label={ariaLabel && !label ? ariaLabel : undefined}
-                aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, ' ', keytipAttributes['aria-describedby'])}
+                aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}
                 aria-activedescendant={this._getAriaActiveDescentValue()}
                 aria-disabled={disabled}
                 aria-owns={isOpen ? id + '-list' : undefined}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -186,7 +186,7 @@ export class SpinButton extends BaseComponent<ISpinButtonProps, ISpinButtonState
                 aria-valuetext={ariaValueText ? ariaValueText : isNaN(Number(value)) ? value : undefined}
                 aria-valuemin={min}
                 aria-valuemax={max}
-                aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, ' ', keytipAttributes['aria-describedby'])}
+                aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}
                 onBlur={this._onBlur}
                 ref={this._input}
                 onFocus={this._onFocus}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -124,7 +124,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     </div>
   </button>
   <button
-    aria-describedby="id__4 ktp-layer-id ktp-1-b"
+    aria-describedby="id__4  ktp-layer-id ktp-1-b"
     aria-labelledby="id__3"
     className=
         ms-Button

--- a/packages/utilities/src/aria.test.ts
+++ b/packages/utilities/src/aria.test.ts
@@ -69,7 +69,7 @@ describe('aria utils tests', () => {
         cases: [
           {
             args: ['arg1', 'arg2'],
-            expected: 'arg1arg2'
+            expected: 'arg1 arg2'
           },
           {
             args: ['arg1', undefined],
@@ -84,7 +84,7 @@ describe('aria utils tests', () => {
             expected: 'arg1'
           },
           {
-            args: ['', 'arg1 ', 'arg2 '],
+            args: ['', 'arg1', 'arg2 '],
             expected: 'arg1 arg2'
           }
         ]

--- a/packages/utilities/src/aria.test.ts
+++ b/packages/utilities/src/aria.test.ts
@@ -86,6 +86,14 @@ describe('aria utils tests', () => {
           {
             args: ['', 'arg1', 'arg2 '],
             expected: 'arg1 arg2'
+          },
+          {
+            args: ['', ''],
+            expected: undefined
+          },
+          {
+            args: [' ', ' '],
+            expected: undefined
           }
         ]
       }

--- a/packages/utilities/src/aria.ts
+++ b/packages/utilities/src/aria.ts
@@ -2,14 +2,12 @@
  * ARIA helper to concatenate attributes, returning undefined if all attributes
  * are undefined. (Empty strings are not a valid ARIA attribute value.)
  *
- * NOTE: This function will NOT insert whitespace between provided attributes.
- *
  * @param ariaAttributes - ARIA attributes to merge
  */
 export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined)[]): string | undefined {
   const mergedAttribute = ariaAttributes
     .filter((arg: string | undefined) => arg !== undefined && arg !== null)
-    .join('')
+    .join(' ')
     .trim();
   return mergedAttribute === '' ? undefined : mergedAttribute;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

## The Problem

Reviewing #8057 brought to my attention that `mergeAriaAttributeValues` is producing invalid values for `aria-describedby` when it receives _multiple input values_ unless the consumer knows to supply the space padding themselves.

Currently, the helper is concatenating the values without a space which screen reader technology does not understand.

**Example:** The output `elementId1elementId2` should be `elementId1 elementId2` where each string refers to the ID attribute of an element in the DOM.

I believe that the helper should space-delimit the output _by default_ to minimize the risk of introducing ARIA bugs and/or regressions. Currently, the helper is only used for `aria-describedby` values within OUFR.

I'm unaware of an a11y scenario where we would want the output values concatenated without a space.

## Repro

[This Codepen illustrates the problem](https://codepen.io/kevintcoughlin/pen/KJLGbr) with Narrator enabled as you focus the two buttons. One of the buttons has its `aria-describedby` value space-delimited while the other does not. Narrator only reads the space-delimited values.

**Narrator Output**

```shell
Is read by narrator, button,
Description One Description Two, 
Is not read by Narrator, button,
```

[MDN states](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute#Value) that `aria-describedby` and similar attributes must have the value of:

>a space-separated list of element IDs

This "space-separated list of element IDs" is referred to as a "ID reference list" in the [W3 ARIA spec](https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-describedby).

#### Focus areas to test

- Tests should pass
- Components which use this helper and supply multiple values such as with `KeyTip` should now be correctly read by the screen-reader.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8113)