### PR TITLE
Announce column header for Day in Calendar

### DIFF
--- a/common/changes/office-ui-fabric-react/datepicker_2019-02-25-22-59.json
+++ b/common/changes/office-ui-fabric-react/datepicker_2019-02-25-22-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Announce column header for Day in Calendar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -226,7 +226,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 {strings.shortDays.map((val, index) => (
                   <th
                     className={css('ms-DatePicker-weekday', styles.weekday)}
-                    role="gridcell"
+                    role="columnheader"
                     scope="col"
                     key={index}
                     title={strings.days[(index + firstDayOfWeek) % DAYS_IN_WEEK]}

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Sunday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Sunday"
                     >
@@ -132,7 +132,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Monday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Monday"
                     >
@@ -141,7 +141,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Tuesday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Tuesday"
                     >
@@ -150,7 +150,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Wednesday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Wednesday"
                     >
@@ -159,7 +159,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Thursday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Thursday"
                     >
@@ -168,7 +168,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Friday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Friday"
                     >
@@ -177,7 +177,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                     <th
                       aria-label="Saturday"
                       className="ms-DatePicker-weekday"
-                      role="gridcell"
+                      role="columnheader"
                       scope="col"
                       title="Saturday"
                     >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8078 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Change role of the week day in Calendar from gridcell to columnheader so that the days get announced when their respective columns are in focus.  

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8114)