### PR TITLE
Facepile: Adding role="option" on the personas' listitems.

### DIFF
--- a/common/changes/office-ui-fabric-react/facepile_2019-02-26-00-30.json
+++ b/common/changes/office-ui-fabric-react/facepile_2019-02-26-00-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Make the list items of personas used in rendering Facepile have role=\"option\" which is required because the <ul> encompassing these has a role=\"listbox\". Caught in a Keros FastPass.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -87,7 +87,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     return personas.map((persona: IFacepilePersona, index: number) => {
       const personaControl: JSX.Element = singlePersona ? this._getPersonaControl(persona) : this._getPersonaCoinControl(persona);
       return (
-        <li key={`${singlePersona ? 'persona' : 'personaCoin'}-${index}`} className={this._classNames.member}>
+        <li role="option" key={`${singlePersona ? 'persona' : 'personaCoin'}-${index}`} className={this._classNames.member}>
           {persona.onClick
             ? this._getElementWithOnClickEvent(personaControl, persona, index)
             : this._getElementWithoutOnClickEvent(personaControl, persona, index)}

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
               margin-right: 2px;
               margin-top: 2px;
             }
+        role="option"
       >
         <div
           className=
@@ -172,6 +173,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
               margin-right: 2px;
               margin-top: 2px;
             }
+        role="option"
       >
         <div
           className=
@@ -295,6 +297,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
               margin-right: 2px;
               margin-top: 2px;
             }
+        role="option"
       >
         <button
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -74,6 +74,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <div
             className=
@@ -197,6 +198,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <div
             className=
@@ -320,6 +322,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <button
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -74,6 +74,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <div
             className=
@@ -197,6 +198,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <div
             className=
@@ -320,6 +322,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <button
             className=
@@ -471,6 +474,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <div
             className=
@@ -567,6 +571,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 margin-right: 2px;
                 margin-top: 2px;
               }
+          role="option"
         >
           <div
             className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8048 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Make the list items of personas used in rendering Facepile have role="option" which is required because the <ul> encompassing these has a role="listbox". Caught in a Keros FastPass.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8117)