### PR TITLE
Fix feedback styles

### DIFF
--- a/common/changes/@uifabric/example-app-base/jahnp-fix-feedback-link-styles_2019-02-26-19-44.json
+++ b/common/changes/@uifabric/example-app-base/jahnp-fix-feedback-link-styles_2019-02-26-19-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Feedback button: Increase styles specificity to override MWF conflicts.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "pejahn@microsoft.com"
+}

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.scss
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.scss
@@ -15,7 +15,10 @@
   }
 
   // Temporary workaround for https://github.com/OfficeDev/office-ui-fabric-react/issues/6782.
-  a.FeedbackList-button {
+  a:link.FeedbackList-button,
+  a:hover.FeedbackList-button,
+  a:focus.FeedbackList-button,
+  a:visited.FeedbackList-button {
     color: $ms-color-white;
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6782
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Turns out that the overrides in #6960 weren't high-priority enough to actually override the styles coming from UHF. This results in the feedback buttons *still* having an awful foreground color:
![image](https://user-images.githubusercontent.com/307118/53443997-e0882180-39c1-11e9-930e-8f124d74528a.png)

This PR matches and increases the specificity required to override UHF the UHF styles. They should look correct now:
![image](https://user-images.githubusercontent.com/307118/53444059-0b727580-39c2-11e9-8217-fee4c6d2fa2b.png)

#### Focus areas to test

N/A

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8122)