### PR TITLE
GroupedList: Provide default getGroupHeight implementation to avoid infinite scroll handlers

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-default-getGroupHeight_2019-02-27-00-36.json
+++ b/common/changes/office-ui-fabric-react/keco-default-getGroupHeight_2019-02-27-00-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupedList: Provide default getGroupHeight implementation to avoid infinite scroll handlers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -6881,7 +6881,7 @@ interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps
   dragDropEvents?: IDragDropEvents;
   enableShimmer?: boolean;
   enterModalSelectionOnTouch?: boolean;
-  getGroupHeight?: (group: IGroup, groupIndex: number) => number;
+  getGroupHeight?: IGroupedListProps['getGroupHeight'];
   getKey?: (item: any, index?: number) => string;
   getRowAriaDescribedBy?: (item: any) => string;
   getRowAriaLabel?: (item: any) => string;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -3,7 +3,7 @@ import { DetailsListBase } from './DetailsList.base';
 import { ISelection, SelectionMode, ISelectionZoneProps } from '../../utilities/selection/index';
 import { IRefObject, IBaseProps, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IDragDropEvents, IDragDropContext } from './../../utilities/dragdrop/index';
-import { IGroup, IGroupRenderProps, IGroupDividerProps } from '../GroupedList/index';
+import { IGroup, IGroupRenderProps, IGroupDividerProps, IGroupedListProps } from '../GroupedList/index';
 import { IDetailsRowProps, IDetailsRowBaseProps } from '../DetailsList/DetailsRow';
 import { IDetailsHeaderProps, IDetailsHeaderBaseProps } from './DetailsHeader';
 import { IDetailsFooterProps, IDetailsFooterBaseProps } from './DetailsFooter.types';
@@ -268,15 +268,9 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   columnReorderOptions?: IColumnReorderOptions;
 
   /**
-   * Optional function which will be called to estimate the height (in pixels) of the given group.
-   *
-   * By default, scrolling through a large virtualized GroupedList will often "jump" due to the order
-   * in which heights are calculated. For more details, see https://github.com/OfficeDev/office-ui-fabric-react/issues/5094
-   *
-   * Pass this prop to ensure the list uses the computed height rather than cached DOM measurements,
-   * avoiding the scroll jumping issue.
+   * Optional function to override default group height calculation used by list virtualization.
    */
-  getGroupHeight?: (group: IGroup, groupIndex: number) => number;
+  getGroupHeight?: IGroupedListProps['getGroupHeight'];
 
   /**
    * Rerender DetailsRow only when props changed. Might cause regression when depending on external updates.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -5,14 +5,21 @@ import { Link } from 'office-ui-fabric-react/lib/Link';
 import { DetailsList, IGroup, IGroupDividerProps } from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, createGroups, IExampleItem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 import { getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { DEFAULT_ROW_HEIGHTS } from '../DetailsRow.styles';
+
+const { rowHeight: ROW_HEIGHT } = DEFAULT_ROW_HEIGHTS;
+const GROUP_HEADER_AND_FOOTER_SPACING: number = 8;
+const GROUP_HEADER_AND_FOOTER_BORDER_WIDTH: number = 1;
+const GROUP_HEADER_HEIGHT: number = 95;
+const GROUP_FOOTER_HEIGHT: number = GROUP_HEADER_AND_FOOTER_SPACING * 4 + GROUP_HEADER_AND_FOOTER_BORDER_WIDTH * 2;
 
 const theme = getTheme();
 const classNames = mergeStyleSets({
   headerAndFooter: {
-    borderTop: '1px solid ' + theme.palette.neutralQuaternary,
-    borderBottom: '1px solid ' + theme.palette.neutralQuaternary,
-    padding: '8px',
-    margin: '8px 0',
+    borderTop: `${GROUP_HEADER_AND_FOOTER_BORDER_WIDTH}px solid ${theme.palette.neutralQuaternary}`,
+    borderBottom: `${GROUP_HEADER_AND_FOOTER_BORDER_WIDTH}px solid ${theme.palette.neutralQuaternary}`,
+    padding: GROUP_HEADER_AND_FOOTER_SPACING,
+    margin: `${GROUP_HEADER_AND_FOOTER_SPACING}px 0`,
     background: theme.palette.neutralLighterAlt,
     // Overlay the sizer bars
     position: 'relative',
@@ -55,6 +62,7 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
           onRenderHeader: this._onRenderGroupHeader,
           onRenderFooter: this._onRenderGroupFooter
         }}
+        getGroupHeight={this._getGroupHeight}
         ariaLabelForSelectionColumn="Toggle selection"
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
       />
@@ -83,6 +91,14 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
         <em>{`Custom footer for ${props.group!.name}`}</em>
       </div>
     );
+  };
+
+  private _getGroupTotalRowHeight = (group: IGroup): number => {
+    return group.isCollapsed ? 0 : ROW_HEIGHT * group.count;
+  };
+
+  private _getGroupHeight = (group: IGroup, _groupIndex: number): number => {
+    return GROUP_HEADER_HEIGHT + GROUP_FOOTER_HEIGHT + this._getGroupTotalRowHeight(group);
   };
 
   private _onToggleSelectGroup(props: IGroupDividerProps): () => void {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
@@ -3,9 +3,6 @@
 import * as React from 'react';
 import { DetailsList, IColumn, IGroup } from 'office-ui-fabric-react/lib/DetailsList';
 
-const GROUP_HEADER_HEIGHT = 40;
-const GROUP_ITEM_HEIGHT = 43;
-
 interface IDetailsListGroupedLargeExampleItem {
   key: string;
   name: string;
@@ -51,14 +48,9 @@ export class DetailsListGroupedLargeExample extends React.Component<{}, {}> {
         items={this._items}
         groups={this._groups}
         columns={this._columns}
-        getGroupHeight={this._getGroupHeight}
         ariaLabelForSelectAllCheckbox="Toggle selection for all items"
         ariaLabelForSelectionColumn="Toggle selection"
       />
     );
   }
-
-  private _getGroupHeight = (group: IGroup) => {
-    return GROUP_HEADER_HEIGHT + (group.isCollapsed ? 0 : GROUP_ITEM_HEIGHT * group.count);
-  };
 }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -196,13 +196,13 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     return 1;
   }
 
-  private _getGroupItemLimit = (group: IGroup): number => {
+  private _getDefaultGroupItemLimit = (group: IGroup): number => {
     return group.count;
   };
 
-  private _getGroupRenderCount = (group: IGroup): number => {
+  private _getGroupItemLimit = (group: IGroup): number => {
     const { groupProps } = this.props;
-    const getGroupItemLimit = groupProps && groupProps.getGroupItemLimit ? groupProps.getGroupItemLimit : this._getGroupItemLimit;
+    const getGroupItemLimit = groupProps && groupProps.getGroupItemLimit ? groupProps.getGroupItemLimit : this._getDefaultGroupItemLimit;
 
     return getGroupItemLimit(group);
   };
@@ -210,7 +210,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
   private _getGroupHeight = (group: IGroup): number => {
     const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
 
-    return rowHeight + (group.isCollapsed ? 0 : rowHeight * this._getGroupRenderCount(group));
+    return rowHeight + (group.isCollapsed ? 0 : rowHeight * this._getGroupItemLimit(group));
   };
 
   private _getPageHeight: IListProps['getPageHeight'] = (itemIndex: number) => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { BaseComponent, IRectangle, assign, classNamesFunction, IClassNames } from '../../Utilities';
 import { IGroupedList, IGroupedListProps, IGroup, IGroupedListStyleProps, IGroupedListStyles } from './GroupedList.types';
 import { GroupedListSection } from './GroupedListSection';
-import { List, ScrollToMode } from '../../List';
+import { List, ScrollToMode, IListProps } from '../../List';
 import { SelectionMode } from '../../utilities/selection/index';
+import { DEFAULT_ROW_HEIGHTS } from '../DetailsList/DetailsRow.styles';
 
 const getClassNames = classNamesFunction<IGroupedListStyleProps, IGroupedListStyles>();
+const { rowHeight: ROW_HEIGHT, compactRowHeight: COMPACT_ROW_HEIGHT } = DEFAULT_ROW_HEIGHTS;
 
 export interface IGroupedListState {
   lastWidth?: number;
@@ -71,7 +73,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
   }
 
   public render(): JSX.Element {
-    const { className, usePageCache, onShouldVirtualize, getGroupHeight, theme, styles, compact } = this.props;
+    const { className, usePageCache, onShouldVirtualize, theme, styles, compact } = this.props;
     const { groups } = this.state;
     this._classNames = getClassNames(styles, {
       theme: theme!,
@@ -90,7 +92,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
             items={groups}
             onRenderCell={this._renderGroup}
             getItemCountForPage={this._returnOne}
-            getPageHeight={getGroupHeight && this._getPageHeight(getGroupHeight)}
+            getPageHeight={this._getPageHeight}
             getPageSpecification={this._getPageSpecification}
             usePageCache={usePageCache}
             onShouldVirtualize={onShouldVirtualize}
@@ -194,11 +196,29 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     return 1;
   }
 
-  private _getPageHeight = (getGroupHeight: (group?: IGroup, groupIndex?: number) => number) => (itemIndex: number) => {
-    const { groups } = this.state;
+  private _getGroupItemLimit = (group: IGroup): number => {
+    return group.count;
+  };
 
+  private _getGroupRenderCount = (group: IGroup): number => {
+    const { groupProps } = this.props;
+    const getGroupItemLimit = groupProps && groupProps.getGroupItemLimit ? groupProps.getGroupItemLimit : this._getGroupItemLimit;
+
+    return getGroupItemLimit(group);
+  };
+
+  private _getGroupHeight = (group: IGroup): number => {
+    const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
+
+    return rowHeight + (group.isCollapsed ? 0 : rowHeight * this._getGroupRenderCount(group));
+  };
+
+  private _getPageHeight: IListProps['getPageHeight'] = (itemIndex: number) => {
+    const { groups } = this.state;
+    const { getGroupHeight = this._getGroupHeight } = this.props;
     const pageGroup = groups && groups[itemIndex];
-    return getGroupHeight(pageGroup, itemIndex);
+
+    return getGroupHeight(pageGroup!, itemIndex);
   };
 
   private _getGroupKey(group: IGroup | undefined, index: number): string {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -218,7 +218,11 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     const { getGroupHeight = this._getGroupHeight } = this.props;
     const pageGroup = groups && groups[itemIndex];
 
-    return getGroupHeight(pageGroup!, itemIndex);
+    if (pageGroup) {
+      return getGroupHeight(pageGroup, itemIndex);
+    } else {
+      return 0;
+    }
   };
 
   private _getGroupKey(group: IGroup | undefined, index: number): string {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -104,13 +104,7 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
   onShouldVirtualize?: (props: IListProps) => boolean;
 
   /**
-   * Optional function which will be called to estimate the height (in pixels) of the given group.
-   *
-   * By default, scrolling through a large virtualized GroupedList will often "jump" due to the order
-   * in which heights are calculated. For more details, see https://github.com/OfficeDev/office-ui-fabric-react/issues/5094
-   *
-   * Pass this prop to ensure the list uses the computed height rather than cached DOM measurements,
-   * avoiding the scroll jumping issue.
+   * Optional function to override default group height calculation used by list virtualization.
    */
   getGroupHeight?: (group: IGroup, groupIndex: number) => number;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5400 #6953 #5094
- [x] Include a change request file using `$ npm run change`

#### Description of changes

### The Bug

Currently, there is a bug that users of either `GroupedList` or the "Grouped" `DetailsList` will encounter unless they know to supply the _optional_ prop `getGroupHeight` (added in #5204). In the worst case, the bug results in an infinite loop of scroll handlers which continuously shift your scroll position. This leads to **poor usability** and **page performance**.

The bug most often occurs when a user scrolls quickly from one region of the list to another. The easiest repro being when you drag the scrollbar from **top** to **bottom**. See the screengrabs below for examples.

### The Patch

To patch this bug, I propose we provide a _default implementation_ of `getGroupHeight` within `GroupedList` as it is non-obvious that a developer should provide it. Developers with existing implementations will continue to override ours and can provide their own for more complex scenarios such as groups with custom header / footer rows.

In the future, supplementing the virtualization logic with [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) will provide a more performant and less error-prone implementation particularly for developers rendering custom groups.

### Breakdown of work

- https://github.com/OfficeDev/office-ui-fabric-react/commit/3bde15a511af880ff1b101bd6c6863ee9739bd9c Provides a default implementation for `getGroupHeight` in `GroupedList`.
- https://github.com/OfficeDev/office-ui-fabric-react/commit/cb2aa30456b4c600fbf5c1333583193c50d7cfb8 Removes `getGroupHeight` from `DetailsList.Grouped.Large.Example.tsx` as it matches the default implementation.
- https://github.com/OfficeDev/office-ui-fabric-react/commit/aa0fed8c084dc0f7d2565bdf1814a18c3a2c5ce0 Adds `getGroupHeight` to `DetailsList.CustomGroupHeaders.Example.tsx` as it deviates from default behavior.
- https://github.com/OfficeDev/office-ui-fabric-react/commit/6a0beef2d6f37222b1fe7b1705b3283ac91d0d50 Uses a look-up type to keep `getGroupHeight` in-sync across various prop typings 

### Screengrabs

**Note:** In the screengrabs below, pay close attention to the scrollbar once scrolled.

**Before (Basic Grouped DetailsList)**

![grouped_list_infinite_loop_before](https://user-images.githubusercontent.com/706967/53456397-273a4380-39e3-11e9-80e0-68db5d91d571.gif)

**After (Basic Grouped DetailsList)**

![grouped_list_infinite_loop_after](https://user-images.githubusercontent.com/706967/53456412-33260580-39e3-11e9-8975-614ccfe093bc.gif)

#### Focus areas to test

- Check-out this branch or visit the deploy link
- Navigate to a "Grouped" DetailsList or GroupedList example
- Scroll using the mouse pointer
- Compare with production examples / `master`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8125)