### PR TITLE
ChoiceGroup: Fixing Narrator focus on ChoiceGroupOptions

### DIFF
--- a/common/changes/office-ui-fabric-react/choiceGroupA11yBug5_2019-02-27-00-33.json
+++ b/common/changes/office-ui-fabric-react/choiceGroupA11yBug5_2019-02-27-00-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ChoiceGroup: Fixing Narrator focus on ChoiceGroupOptions.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -245,12 +245,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       {
         position: 'absolute',
         opacity: 0,
-        top: 8
-      },
-      (hasIcon || hasImage) && {
         top: 0,
         right: 0,
-        opacity: 0,
         width: '100%',
         height: '100%',
         margin: 0

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -35,9 +35,16 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         className=
             ms-ChoiceField-input
             {
+              height: 100%;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
               opacity: 0;
               position: absolute;
-              top: 8px;
+              right: 0px;
+              top: 0px;
+              width: 100%;
             }
         onBlur={[Function]}
         onChange={[Function]}
@@ -163,9 +170,16 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         className=
             ms-ChoiceField-input
             {
+              height: 100%;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
               opacity: 0;
               position: absolute;
-              top: 8px;
+              right: 0px;
+              top: 0px;
+              width: 100%;
             }
         onBlur={[Function]}
         onChange={[Function]}
@@ -292,9 +306,16 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         className=
             ms-ChoiceField-input
             {
+              height: 100%;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
               opacity: 0;
               position: absolute;
-              top: 8px;
+              right: 0px;
+              top: 0px;
+              width: 100%;
             }
         onBlur={[Function]}
         onChange={[Function]}
@@ -411,9 +432,16 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         className=
             ms-ChoiceField-input
             {
+              height: 100%;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
               opacity: 0;
               position: absolute;
-              top: 8px;
+              right: 0px;
+              top: 0px;
+              width: 100%;
             }
         disabled={true}
         onBlur={[Function]}
@@ -517,9 +545,16 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         className=
             ms-ChoiceField-input
             {
+              height: 100%;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
               opacity: 0;
               position: absolute;
-              top: 8px;
+              right: 0px;
+              top: 0px;
+              width: 100%;
             }
         disabled={true}
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -93,9 +93,16 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             className=
                 ms-ChoiceField-input
                 {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
                   opacity: 0;
                   position: absolute;
-                  top: 8px;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
                 }
             data-automation-id="auto1"
             id="ChoiceGroup0-1"
@@ -207,9 +214,16 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             className=
                 ms-ChoiceField-input
                 {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
                   opacity: 0;
                   position: absolute;
-                  top: 8px;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
                 }
             id="ChoiceGroup0-2"
             name="ChoiceGroup0"
@@ -320,9 +334,16 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             className=
                 ms-ChoiceField-input
                 {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
                   opacity: 0;
                   position: absolute;
-                  top: 8px;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
                 }
             id="ChoiceGroup0-3"
             name="ChoiceGroup0"
@@ -462,9 +483,16 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             className=
                 ms-ChoiceField-input
                 {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
                   opacity: 0;
                   position: absolute;
-                  top: 8px;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
                 }
             data-automation-id="auto1"
             id="ChoiceGroup0-1"
@@ -576,9 +604,16 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             className=
                 ms-ChoiceField-input
                 {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
                   opacity: 0;
                   position: absolute;
-                  top: 8px;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
                 }
             id="ChoiceGroup0-2"
             name="ChoiceGroup0"
@@ -689,9 +724,16 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             className=
                 ms-ChoiceField-input
                 {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
                   opacity: 0;
                   position: absolute;
-                  top: 8px;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
                 }
             id="ChoiceGroup0-3"
             name="ChoiceGroup0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -94,9 +94,16 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               data-automation-id="auto1"
               id="ChoiceGroup0-A"
@@ -208,9 +215,16 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               id="ChoiceGroup0-B"
               name="ChoiceGroup0"
@@ -333,9 +347,16 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               disabled={true}
               id="ChoiceGroup0-C"
@@ -444,9 +465,16 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               disabled={true}
               id="ChoiceGroup0-D"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -94,9 +94,16 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               id="ChoiceGroup0-A"
               name="ChoiceGroup0"
@@ -390,9 +397,16 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               id="ChoiceGroup0-B"
               name="ChoiceGroup0"
@@ -515,9 +529,16 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               disabled={true}
               id="ChoiceGroup0-C"
@@ -626,9 +647,16 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               id="ChoiceGroup0-D"
               name="ChoiceGroup0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -65,9 +65,16 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               data-automation-id="auto1"
               id="ChoiceGroup1-A"
@@ -179,9 +186,16 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               id="ChoiceGroup1-B"
               name="ChoiceGroup1"
@@ -304,9 +318,16 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               disabled={true}
               id="ChoiceGroup1-C"
@@ -415,9 +436,16 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               className=
                   ms-ChoiceField-input
                   {
+                    height: 100%;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                     opacity: 0;
                     position: absolute;
-                    top: 8px;
+                    right: 0px;
+                    top: 0px;
+                    width: 100%;
                   }
               disabled={true}
               id="ChoiceGroup1-D"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-437:hover + .headerDividerBar-438 {
+      & .headerDivider-436:hover + .headerDividerBar-437 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6844
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Narrator focus was not visible while navigating through the `ChoiceGroupOptions` radio buttons in `ChoiceGroups` without icons and images. This PR fixes the issue.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8126)