### PR TITLE
Modal: Fix insertFirst prop naming

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-ModalFixInsertFirstProp_2019-02-27-00-53.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-ModalFixInsertFirstProp_2019-02-27-00-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Modal: Fix missed naming updated from Modeless PR",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -155,7 +155,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
       ...this.props.layerProps,
       onLayerDidMount: layerProps && layerProps.onLayerDidMount ? layerProps.onLayerDidMount : onLayerDidMount,
       className: layerClassName,
-      insertAsHostFirstChild: isModeless
+      insertFirst: isModeless
     };
 
     // @temp tuatology - Will adjust this to be a panel at certain breakpoints


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
After merging https://github.com/OfficeDev/office-ui-fabric-react/pull/8065 I noticed that I missed renaming the insertFirst prop in for the Layer during Modal creation

#### Focus areas to test
Verified that the Modal is now correctly passing down the insertFirst prop when isModeless


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8127)