### PR TITLE
TagItem: Adding white-space CSS prop which is required for text-overflow: ellipsis.

### DIFF
--- a/common/changes/office-ui-fabric-react/tagitem_2019-02-27-19-42.json
+++ b/common/changes/office-ui-fabric-react/tagitem_2019-02-27-19-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TagItem: Adding white-space CSS prop which is required for text-overflow\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/tagitem_2019-02-27-19-42.json
+++ b/common/changes/office-ui-fabric-react/tagitem_2019-02-27-19-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "TagItem: Adding white-space CSS prop which is required for text-overflow\"",
+      "comment": "TagItemSuggestion: adds `white-space: nowrap` CSS declaration which is required for `text-overflow: ellipsis` to work.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItemSuggestion.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItemSuggestion.styles.ts
@@ -17,7 +17,8 @@ export function getStyles(props: ITagItemSuggestionStyleProps): ITagItemSuggesti
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         maxWidth: '60vw',
-        padding: '6px 12px 7px'
+        padding: '6px 12px 7px',
+        whiteSpace: 'nowrap'
       },
       className
     ]


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8030 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

According to the [CSS documentation](https://www.w3schools.com/cssref/css3_pr_text-overflow.asp), our `text-overflow: ellipsis` setting in TagItemSuggestions's styles is missing a required white-space setting. Added it so that long name tags don't overflow into a second line while also being trimmed by the ellipsis.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8141)