### PR TITLE
CommandBar: Fixing aria-label in examples so that it doesn't repeat information

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBarA11yBug1_2019-02-28-22-16.json
+++ b/common/changes/office-ui-fabric-react/commandBarA11yBug1_2019-02-28-22-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Fixing aria-label in examples so that it doesn't repeat information.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "makotom@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -27,7 +27,7 @@ export class CommandBarBasicExample extends React.Component<{}, {}> {
         iconProps: {
           iconName: 'Add'
         },
-        ariaLabel: 'New. Use left and right arrow keys to navigate',
+        ariaLabel: 'New',
         subMenuProps: {
           items: [
             {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
@@ -53,7 +53,7 @@ export class CommandBarButtonAsExample extends React.Component<{}, {}> {
         iconProps: {
           iconName: 'Add'
         },
-        ariaLabel: 'New. Use left and right arrow keys to navigate',
+        ariaLabel: 'New',
         subMenuProps: {
           items: [
             {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
@@ -99,7 +99,7 @@ export class IndividualCommandBarButtonAsExample extends React.Component<IIndivi
         iconProps: {
           iconName: 'Add'
         },
-        ariaLabel: 'New. Use left and right arrow keys to navigate',
+        ariaLabel: 'New',
         subMenuProps: {
           items: [
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
               <button
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-label="New. Use left and right arrow keys to navigate"
+                aria-label="New"
                 aria-owns={null}
                 className=
                     ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
               <button
                 aria-expanded={false}
                 aria-haspopup={true}
-                aria-label="New. Use left and right arrow keys to navigate"
+                aria-label="New"
                 aria-owns={null}
                 className=
                     ms-Button

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -67,7 +67,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
             <button
               aria-expanded={false}
               aria-haspopup={true}
-              aria-label="New. Use left and right arrow keys to navigate"
+              aria-label="New"
               aria-owns={null}
               className=
                   ms-Button
@@ -1388,7 +1388,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
             <button
               aria-expanded={false}
               aria-haspopup={true}
-              aria-label="New. Use left and right arrow keys to navigate"
+              aria-label="New"
               aria-owns={null}
               className=
                   ms-Button


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6390
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The aria-label of both the `CommandBar` and the `CommandBar items` had some repeated information inside of it that was being read twice by screen readers. This PR removes the repetition from the `CommandBar items` so that this doesn't happen anymore.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8155)