### PR TITLE
updating getFileTypeIconProps to make reference to correct sharepoint  list icon

### DIFF
--- a/common/changes/@uifabric/file-type-icons/master_2019-02-28-21-55.json
+++ b/common/changes/@uifabric/file-type-icons/master_2019-02-28-21-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "fix mapping for OneNote notebook filetype icon",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/master_2019-03-01-17-06.json
+++ b/common/changes/@uifabric/file-type-icons/master_2019-03-01-17-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "updating getFileTypeIconProps to make reference to correct sharepoint… ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -4,6 +4,8 @@
  * Always use getFileTypeIconProps to get the most up-to-date icon at the right pixel density.
  */
 export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
+  photo360: {},
+  video360: {},
   accdb: { extensions: ['accdb', 'mdb'] },
   archive: {
     extensions: ['7z', 'ace', 'arc', 'arj', 'dmg', 'gz', 'iso', 'lzh', 'pkg', 'rar', 'sit', 'tgz', 'tar', 'z']

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -4,8 +4,6 @@
  * Always use getFileTypeIconProps to get the most up-to-date icon at the right pixel density.
  */
 export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
-  photo360: {},
-  video360: {},
   accdb: { extensions: ['accdb', 'mdb'] },
   archive: {
     extensions: ['7z', 'ace', 'arc', 'arj', 'dmg', 'gz', 'iso', 'lzh', 'pkg', 'rar', 'sit', 'tgz', 'tar', 'z']

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -7,7 +7,7 @@ const GENERIC_FILE = 'genericfile';
 const FOLDER = 'folder';
 const SHARED_FOLDER = 'sharedfolder';
 const DOCSET_FOLDER = 'docset';
-const LIST_ITEM = 'listitem';
+const LIST_ITEM = 'splist';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 
 export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 64 | 96;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Fixes an issue with sharepoint list item filetype icon

#### Description of changes

updated the method that handles special "non-file" items

#### Focus areas to test

doclibs that render files


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8162)