### PR TITLE
CommandBar: Adding aria-label to Sort, Grid View and Information Buttons in examples

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBarA11yBug3_2019-03-01-17-14.json
+++ b/common/changes/office-ui-fabric-react/commandBarA11yBug3_2019-03-01-17-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Adding aria-label to Grid View and Information Buttons in examples.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "makotom@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -110,6 +110,7 @@ export class CommandBarBasicExample extends React.Component<{}, {}> {
       {
         key: 'sort',
         name: 'Sort',
+        ariaLabel: 'Sort',
         iconProps: {
           iconName: 'SortLines'
         },
@@ -118,6 +119,7 @@ export class CommandBarBasicExample extends React.Component<{}, {}> {
       {
         key: 'tile',
         name: 'Grid view',
+        ariaLabel: 'Grid view',
         iconProps: {
           iconName: 'Tiles'
         },
@@ -127,6 +129,7 @@ export class CommandBarBasicExample extends React.Component<{}, {}> {
       {
         key: 'info',
         name: 'Info',
+        ariaLabel: 'Info',
         iconProps: {
           iconName: 'Info'
         },

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
@@ -136,6 +136,7 @@ export class CommandBarButtonAsExample extends React.Component<{}, {}> {
       {
         key: 'sort',
         name: 'Sort',
+        ariaLabel: 'Sort',
         iconProps: {
           iconName: 'SortLines'
         },
@@ -144,6 +145,7 @@ export class CommandBarButtonAsExample extends React.Component<{}, {}> {
       {
         key: 'tile',
         name: 'Grid view',
+        ariaLabel: 'Grid view',
         iconProps: {
           iconName: 'Tiles'
         },
@@ -153,6 +155,7 @@ export class CommandBarButtonAsExample extends React.Component<{}, {}> {
       {
         key: 'info',
         name: 'Info',
+        ariaLabel: 'Info',
         iconProps: {
           iconName: 'Info'
         },

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
@@ -183,6 +183,7 @@ export class IndividualCommandBarButtonAsExample extends React.Component<IIndivi
       {
         key: 'sort',
         name: 'Sort',
+        ariaLabel: 'Sort',
         iconProps: {
           iconName: 'SortLines'
         },
@@ -191,6 +192,7 @@ export class IndividualCommandBarButtonAsExample extends React.Component<IIndivi
       {
         key: 'tile',
         name: 'Grid view',
+        ariaLabel: 'Grid view',
         iconProps: {
           iconName: 'Tiles'
         },
@@ -200,6 +202,7 @@ export class IndividualCommandBarButtonAsExample extends React.Component<IIndivi
       {
         key: 'info',
         name: 'Info',
+        ariaLabel: 'Info',
         iconProps: {
           iconName: 'Info'
         },

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/data.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/data.ts
@@ -83,6 +83,7 @@ export const farItems = [
   {
     key: 'sort',
     name: 'Sort',
+    ariaLabel: 'Sort',
     iconProps: {
       iconName: 'SortLines'
     },
@@ -91,6 +92,7 @@ export const farItems = [
   {
     key: 'tile',
     name: 'Grid view',
+    ariaLabel: 'Grid view',
     iconProps: {
       iconName: 'Tiles'
     },
@@ -100,6 +102,7 @@ export const farItems = [
   {
     key: 'info',
     name: 'Info',
+    ariaLabel: 'Info',
     iconProps: {
       iconName: 'Info'
     },

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -875,6 +875,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   }
             >
               <button
+                aria-label="Sort"
                 className=
                     ms-Button
                     ms-Button--commandBar
@@ -1043,6 +1044,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onMouseLeave={[Function]}
               >
                 <button
+                  aria-label="Grid view"
                   className=
                       ms-Button
                       ms-Button--commandBar
@@ -1188,6 +1190,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                 onMouseLeave={[Function]}
               >
                 <button
+                  aria-label="Info"
                   className=
                       ms-Button
                       ms-Button--commandBar

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -879,6 +879,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                   }
             >
               <button
+                aria-label="Sort"
                 className=
                     ms-Button
                     ms-Button--commandBar
@@ -1048,6 +1049,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 onMouseLeave={[Function]}
               >
                 <button
+                  aria-label="Grid view"
                   className=
                       ms-Button
                       ms-Button--commandBar
@@ -1193,6 +1195,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 onMouseLeave={[Function]}
               >
                 <button
+                  aria-label="Info"
                   className=
                       ms-Button
                       ms-Button--commandBar

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -876,6 +876,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                 }
           >
             <button
+              aria-label="Sort"
               className=
                   ms-Button
                   ms-Button--commandBar
@@ -1044,6 +1045,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
               onMouseLeave={[Function]}
             >
               <button
+                aria-label="Grid view"
                 className=
                     ms-Button
                     ms-Button--commandBar
@@ -1189,6 +1191,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
               onMouseLeave={[Function]}
             >
               <button
+                aria-label="Info"
                 className=
                     ms-Button
                     ms-Button--commandBar
@@ -2658,6 +2661,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                 }
           >
             <button
+              aria-label="Sort"
               className=
                   ms-Button
                   ms-Button--commandBar
@@ -2826,6 +2830,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
               onMouseLeave={[Function]}
             >
               <button
+                aria-label="Grid view"
                 className=
                     ms-Button
                     ms-Button--commandBar
@@ -2971,6 +2976,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
               onMouseLeave={[Function]}
             >
               <button
+                aria-label="Info"
                 className=
                     ms-Button
                     ms-Button--commandBar


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Bug 3 in #6390
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The Keros pass requires all `Buttons` to have discernible text. This PR adds `aria-label` to those `Buttons` that were identified to be missing this discernible text in the `CommandBar` component.
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8163)