### PR TITLE
DetailsRowFields: Inherit from React.Component instead of BaseComponent

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-detailsrowfields-basecomponent_2019-03-04-20-12.json
+++ b/common/changes/office-ui-fabric-react/keco-detailsrowfields-basecomponent_2019-03-04-20-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsRowFields: Inherit from React.Component instead of BaseComponent\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IColumn } from './DetailsList.types';
-import { BaseComponent, css } from '../../Utilities';
+import { css } from '../../Utilities';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 
@@ -14,7 +14,7 @@ const getCellText = (item: any, column: IColumn): string => {
   return value;
 };
 
-export class DetailsRowFields extends BaseComponent<IDetailsRowFieldsProps> {
+export class DetailsRowFields extends React.Component<IDetailsRowFieldsProps> {
   public render(): JSX.Element {
     const {
       columns,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -1,16 +1,8 @@
 import { IColumn } from './DetailsList.types';
 import { IDetailsRowStyles, ICellStyleProps } from './DetailsRow.types';
-import { IBaseProps, IRefObject } from '../../Utilities';
 import { IDetailsListProps } from './DetailsList';
 
-export interface IDetailsRowFields {}
-
-export interface IDetailsRowFieldsProps extends Pick<IDetailsListProps, 'onRenderItemColumn'>, IBaseProps<IDetailsRowFields> {
-  /**
-   * Ref of component
-   */
-  componentRef?: IRefObject<IDetailsRowFields>;
-
+export interface IDetailsRowFieldsProps extends Pick<IDetailsListProps, 'onRenderItemColumn'> {
   /**
    * Data source for this component
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Currently, `DetailsRowFields` is spending a non-zero amount of time in its constructor due to the inheritance from `BaseComponent`. However, `DetailsRowFields` does not utilize anything from `BaseComponent`, so it should be removed in favor of `React.Component` or similar.

@dzearing @JasonGore and other reviewers, a few questions:

I marked this as `patch` since the public API was not marked as changed. 

- Should this be `minor` instead?
- Are the interface changes I made backwards-compatible?

#### Profiler Screengrabs

Below are screengrabs of the profiler's "Bottom-Up" call-stack captured on reload of http://localhost:4322/#/tests/detailslistbasicexample.

**Before**

![image](https://user-images.githubusercontent.com/706967/53761755-2427d300-3e7b-11e9-9fde-c2cc57afc47d.png)

**After**

![image](https://user-images.githubusercontent.com/706967/53761759-2722c380-3e7b-11e9-9335-610e93b54a8b.png)


#### Focus areas to test

- CI tests should pass
- CI API check should pass without changes
- *Lists should render as they do currently

Related to the effort started in #8169.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8184)