### PR TITLE
Update style return type

### DIFF
--- a/common/changes/@uifabric/charting/update-style-return-type_2019-03-05-02-11.json
+++ b/common/changes/@uifabric/charting/update-style-return-type_2019-03-05-02-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Add type annotations based on update to \"styled\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "jdh@microsoft.com"
+}

--- a/common/changes/@uifabric/dashboard/update-style-return-type_2019-03-05-02-11.json
+++ b/common/changes/@uifabric/dashboard/update-style-return-type_2019-03-05-02-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Add type annotations based on update to \"styled\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "jdh@microsoft.com"
+}

--- a/common/changes/@uifabric/date-time/update-style-return-type_2019-03-05-02-11.json
+++ b/common/changes/@uifabric/date-time/update-style-return-type_2019-03-05-02-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "Add type annotations based on update to \"styled\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "jdh@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/update-style-return-type_2019-03-05-02-11.json
+++ b/common/changes/@uifabric/experiments/update-style-return-type_2019-03-05-02-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add type annotations based on update to \"styled\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jdh@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/update-style-return-type_2019-03-05-02-11.json
+++ b/common/changes/@uifabric/utilities/update-style-return-type_2019-03-05-02-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Modify return type of styled (function to React.StatelessComponent)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "jdh@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/update-style-return-type_2019-03-05-02-11.json
+++ b/common/changes/office-ui-fabric-react/update-style-return-type_2019-03-05-02-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Update version of 'styled', add type annotations to usages of 'styled'.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com"
+}

--- a/packages/charting/src/components/DonutChart/DonutChart.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.tsx
@@ -4,4 +4,7 @@ import { DonutChartBase } from './DonutChart.base';
 import { getStyles } from './DonutChart.styles';
 
 // Create a DonutChart variant which uses these default styles and this styled subcomponent.
-export const DonutChart = styled<IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles>(DonutChartBase, getStyles);
+export const DonutChart: React.StatelessComponent<IDonutChartProps> = styled<IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles>(
+  DonutChartBase,
+  getStyles
+);

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -4,7 +4,8 @@ import { HorizontalBarChartBase } from './HorizontalBarChart.base';
 import { getHorizontalBarChartStyles } from './HorizontalBarChart.styles';
 
 // Create a HorizontalBarChart variant which uses these default styles and this styled subcomponent.
-export const HorizontalBarChart = styled<IHorizontalBarChartProps, IHorizontalBarChartStyleProps, IHorizontalBarChartStyles>(
-  HorizontalBarChartBase,
-  getHorizontalBarChartStyles
-);
+export const HorizontalBarChart: React.StatelessComponent<IHorizontalBarChartProps> = styled<
+  IHorizontalBarChartProps,
+  IHorizontalBarChartStyleProps,
+  IHorizontalBarChartStyles
+>(HorizontalBarChartBase, getHorizontalBarChartStyles);

--- a/packages/charting/src/components/Legends/Legends.tsx
+++ b/packages/charting/src/components/Legends/Legends.tsx
@@ -3,4 +3,7 @@ import { ILegendsProps, ILegendStyleProps, ILegendsStyles } from './Legends.type
 import { LegendsBase } from './Legends.base';
 import { getStyles } from './Legends.styles';
 
-export const Legends = styled<ILegendsProps, ILegendStyleProps, ILegendsStyles>(LegendsBase, getStyles);
+export const Legends: React.StatelessComponent<ILegendsProps> = styled<ILegendsProps, ILegendStyleProps, ILegendsStyles>(
+  LegendsBase,
+  getStyles
+);

--- a/packages/charting/src/components/LineChart/LineChart.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.tsx
@@ -4,4 +4,7 @@ import { LineChartBase } from './LineChart.base';
 import { getStyles } from './LineChart.styles';
 
 // Create a LineChart variant which uses these default styles and this styled subcomponent.
-export const LineChart = styled<ILineChartProps, ILineChartStyleProps, ILineChartStyles>(LineChartBase, getStyles);
+export const LineChart: React.StatelessComponent<ILineChartProps> = styled<ILineChartProps, ILineChartStyleProps, ILineChartStyles>(
+  LineChartBase,
+  getStyles
+);

--- a/packages/charting/src/components/PieChart/PieChart.tsx
+++ b/packages/charting/src/components/PieChart/PieChart.tsx
@@ -4,4 +4,7 @@ import { PieChartBase } from './PieChart.base';
 import { getStyles } from './PieChart.styles';
 
 // Create a PieChart variant which uses these default styles and this styled subcomponent.
-export const PieChart = styled<IPieChartProps, IPieChartStyleProps, IPieChartStyles>(PieChartBase, getStyles);
+export const PieChart: React.StatelessComponent<IPieChartProps> = styled<IPieChartProps, IPieChartStyleProps, IPieChartStyles>(
+  PieChartBase,
+  getStyles
+);

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.tsx
@@ -4,7 +4,8 @@ import { MultiStackedBarChartBase } from './MultiStackedBarChart.base';
 import { getMultiStackedBarChartStyles } from './MultiStackedBarChart.styles';
 
 // Create a MultiStackedBarChart variant which uses these default styles and this styled subcomponent.
-export const MultiStackedBarChart = styled<IMultiStackedBarChartProps, IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>(
-  MultiStackedBarChartBase,
-  getMultiStackedBarChartStyles
-);
+export const MultiStackedBarChart: React.StatelessComponent<IMultiStackedBarChartProps> = styled<
+  IMultiStackedBarChartProps,
+  IMultiStackedBarChartStyleProps,
+  IMultiStackedBarChartStyles
+>(MultiStackedBarChartBase, getMultiStackedBarChartStyles);

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.tsx
@@ -4,7 +4,8 @@ import { StackedBarChartBase } from './StackedBarChart.base';
 import { getStyles } from './StackedBarChart.styles';
 
 // Create a StackedBarChart variant which uses these default styles and this styled subcomponent.
-export const StackedBarChart = styled<IStackedBarChartProps, IStackedBarChartStyleProps, IStackedBarChartStyles>(
-  StackedBarChartBase,
-  getStyles
-);
+export const StackedBarChart: React.StatelessComponent<IStackedBarChartProps> = styled<
+  IStackedBarChartProps,
+  IStackedBarChartStyleProps,
+  IStackedBarChartStyles
+>(StackedBarChartBase, getStyles);

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -4,7 +4,8 @@ import { VerticalBarChartBase } from './VerticalBarChart.base';
 import { getStyles } from './VerticalBarChart.styles';
 
 // Create a VerticalBarChart variant which uses these default styles and this styled subcomponent.
-export const VerticalBarChart = styled<IVerticalBarChartProps, IVerticalBarChartStyleProps, IVerticalBarChartStyles>(
-  VerticalBarChartBase,
-  getStyles
-);
+export const VerticalBarChart: React.StatelessComponent<IVerticalBarChartProps> = styled<
+  IVerticalBarChartProps,
+  IVerticalBarChartStyleProps,
+  IVerticalBarChartStyles
+>(VerticalBarChartBase, getStyles);

--- a/packages/dashboard/src/components/DashboardGridLayout/AddCardPanel/AddCardPanel.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/AddCardPanel/AddCardPanel.tsx
@@ -4,4 +4,8 @@ import { AddCardPanelBase } from './AddCardPanelBase';
 import { getStyles } from './AddCardPanel.styles';
 
 // Create a AddCardPanel variant which uses these default styles and this styled subcomponent.
-export const AddCardPanel = styled<IAddCardPanelProps, IAddCardPanelStyleProps, IAddCardPanelStyles>(AddCardPanelBase, getStyles);
+export const AddCardPanel: React.StatelessComponent<IAddCardPanelProps> = styled<
+  IAddCardPanelProps,
+  IAddCardPanelStyleProps,
+  IAddCardPanelStyles
+>(AddCardPanelBase, getStyles);

--- a/packages/dashboard/src/components/Recommendation/Recommendation.tsx
+++ b/packages/dashboard/src/components/Recommendation/Recommendation.tsx
@@ -4,7 +4,8 @@ import { RecommendationBannerBase } from './RecommendationBanner.base';
 import { getRecommendationBannerStyles } from './Recommendation.styles';
 
 // Create a RecommendationBanner variant which uses these default styles and this styled subcomponent.
-export const Recommendation = styled<IRecommendationProps, IRecommendationStyleProps, IRecommendationStyles>(
-  RecommendationBannerBase,
-  getRecommendationBannerStyles
-);
+export const Recommendation: React.StatelessComponent<IRecommendationProps> = styled<
+  IRecommendationProps,
+  IRecommendationStyleProps,
+  IRecommendationStyles
+>(RecommendationBannerBase, getRecommendationBannerStyles);

--- a/packages/dashboard/src/components/Section/EditSections.tsx
+++ b/packages/dashboard/src/components/Section/EditSections.tsx
@@ -3,7 +3,7 @@ import { getStyles } from './EditSections.styles';
 import { IEditSectionsProps, IEditSectionsStyles } from './Section.types';
 import { EditSectionsBase } from './EditSections.base';
 
-export const EditSections: (props: IEditSectionsProps) => JSX.Element = styled<IEditSectionsProps, {}, IEditSectionsStyles>(
+export const EditSections: React.StatelessComponent<IEditSectionsProps> = styled<IEditSectionsProps, {}, IEditSectionsStyles>(
   EditSectionsBase,
   getStyles,
   undefined,

--- a/packages/dashboard/src/components/SubwayNav/SubwayNav.tsx
+++ b/packages/dashboard/src/components/SubwayNav/SubwayNav.tsx
@@ -3,7 +3,7 @@ import { SubwayNavBase } from './SubwayNavBase';
 import { getSubwayNavStyles } from './SubwayNav.styles';
 import { ISubwayNavProps, ISubwayNavStyles } from './SubwayNav.types';
 
-export const SubwayNav: (props: ISubwayNavProps) => JSX.Element = styled<ISubwayNavProps, {}, ISubwayNavStyles>(
+export const SubwayNav: React.StatelessComponent<ISubwayNavProps> = styled<ISubwayNavProps, {}, ISubwayNavStyles>(
   SubwayNavBase,
   getSubwayNavStyles,
   undefined

--- a/packages/dashboard/src/components/SubwayNav/SubwayNode.tsx
+++ b/packages/dashboard/src/components/SubwayNav/SubwayNode.tsx
@@ -3,7 +3,7 @@ import { SubwayNodeBase } from './SubwayNodeBase';
 import { getSubwayNodeStyles } from './SubwayNode.styles';
 import { ISubwayNavNodeProps, ISubwayNavNodeStyleProps, ISubwayNavNodeStyles } from './SubwayNode.types';
 
-export const SubwayNode: (props: ISubwayNavNodeProps) => JSX.Element = styled<
+export const SubwayNode: React.StatelessComponent<ISubwayNavNodeProps> = styled<
   ISubwayNavNodeProps,
   ISubwayNavNodeStyleProps,
   ISubwayNavNodeStyles

--- a/packages/dashboard/src/components/Wizard/FullParentWizard.tsx
+++ b/packages/dashboard/src/components/Wizard/FullParentWizard.tsx
@@ -3,7 +3,7 @@ import { FullParentWizardBase } from './FullParentWizard.Base';
 import { IFullParentWizardProps, IFullParentWizardStyleProps, IFullParentWizardStyles } from './FullParentWizard.types';
 import { getFullParentWizardStyles } from './FullParentWizard.styles';
 
-export const FullParentWizard: (props: IFullParentWizardProps) => JSX.Element = styled<
+export const FullParentWizard: React.StatelessComponent<IFullParentWizardProps> = styled<
   IFullParentWizardProps,
   IFullParentWizardStyleProps,
   IFullParentWizardStyles

--- a/packages/dashboard/src/components/Wizard/PanelWizard.Base.tsx
+++ b/packages/dashboard/src/components/Wizard/PanelWizard.Base.tsx
@@ -69,9 +69,8 @@ export class PanelWizardBase extends React.Component<IPanelWizardProps, {}> {
   };
 }
 
-export const PanelWizard: (props: IPanelWizardProps) => JSX.Element = styled<IPanelWizardProps, IPanelWizardStyleProps, IPanelWizardStyles>(
-  PanelWizardBase,
-  getPanelWizardStyles,
-  undefined,
-  { scope: 'PanelWizard' }
-);
+export const PanelWizard: React.StatelessComponent<IPanelWizardProps> = styled<
+  IPanelWizardProps,
+  IPanelWizardStyleProps,
+  IPanelWizardStyles
+>(PanelWizardBase, getPanelWizardStyles, undefined, { scope: 'PanelWizard' });

--- a/packages/dashboard/src/components/Wizard/PanelWizard.tsx
+++ b/packages/dashboard/src/components/Wizard/PanelWizard.tsx
@@ -3,9 +3,8 @@ import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { getPanelWizardStyles } from './PanelWizard.styles';
 import { PanelWizardBase } from './PanelWizard.Base';
 
-export const PanelWizard: (props: IPanelWizardProps) => JSX.Element = styled<IPanelWizardProps, IPanelWizardStyleProps, IPanelWizardStyles>(
-  PanelWizardBase,
-  getPanelWizardStyles,
-  undefined,
-  { scope: 'PanelWizard' }
-);
+export const PanelWizard: React.StatelessComponent<IPanelWizardProps> = styled<
+  IPanelWizardProps,
+  IPanelWizardStyleProps,
+  IPanelWizardStyles
+>(PanelWizardBase, getPanelWizardStyles, undefined, { scope: 'PanelWizard' });

--- a/packages/dashboard/src/components/Wizard/SetupWizard.tsx
+++ b/packages/dashboard/src/components/Wizard/SetupWizard.tsx
@@ -3,9 +3,8 @@ import { ISetupWizardProps, ISetupWizardStyles, ISetupWizardStyleProps } from '.
 import { getSetupWizardStyles } from './SetupWizard.styles';
 import { SetupWizardBase } from './SetupWizard.Base';
 
-export const SetupWizard: (props: ISetupWizardProps) => JSX.Element = styled<ISetupWizardProps, ISetupWizardStyleProps, ISetupWizardStyles>(
-  SetupWizardBase,
-  getSetupWizardStyles,
-  undefined,
-  { scope: 'SetupWizard' }
-);
+export const SetupWizard: React.StatelessComponent<ISetupWizardProps> = styled<
+  ISetupWizardProps,
+  ISetupWizardStyleProps,
+  ISetupWizardStyles
+>(SetupWizardBase, getSetupWizardStyles, undefined, { scope: 'SetupWizard' });

--- a/packages/dashboard/src/components/Wizard/Wizard.tsx
+++ b/packages/dashboard/src/components/Wizard/Wizard.tsx
@@ -3,7 +3,7 @@ import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { getWizardStyles } from './Wizard.styles';
 import { IWizardProps, IWizardStyleProps, IWizardStyles } from './Wizard.types';
 
-export const Wizard: (props: IWizardProps) => JSX.Element = styled<IWizardProps, IWizardStyleProps, IWizardStyles>(
+export const Wizard: React.StatelessComponent<IWizardProps> = styled<IWizardProps, IWizardStyleProps, IWizardStyles>(
   WizardBase,
   getWizardStyles,
   undefined,

--- a/packages/date-time/src/components/Calendar/Calendar.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.tsx
@@ -6,6 +6,11 @@ import { styles } from './Calendar.styles';
 /**
  * Calendar description
  */
-export const Calendar = styled<ICalendarProps, ICalendarStyleProps, ICalendarStyles>(CalendarBase, styles, undefined, {
-  scope: 'Calendar'
-});
+export const Calendar: React.StatelessComponent<ICalendarProps> = styled<ICalendarProps, ICalendarStyleProps, ICalendarStyles>(
+  CalendarBase,
+  styles,
+  undefined,
+  {
+    scope: 'Calendar'
+  }
+);

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.tsx
@@ -6,9 +6,8 @@ import { styled } from 'office-ui-fabric-react/lib/Utilities';
 /**
  * CalendarDay description
  */
-export const CalendarDay: (props: ICalendarDayProps) => JSX.Element = styled<ICalendarDayProps, ICalendarDayStyleProps, ICalendarDayStyles>(
-  CalendarDayBase,
-  styles,
-  undefined,
-  { scope: 'CalendarDay' }
-);
+export const CalendarDay: React.StatelessComponent<ICalendarDayProps> = styled<
+  ICalendarDayProps,
+  ICalendarDayStyleProps,
+  ICalendarDayStyles
+>(CalendarDayBase, styles, undefined, { scope: 'CalendarDay' });

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.tsx
@@ -6,7 +6,7 @@ import { styled } from 'office-ui-fabric-react/lib/Utilities';
 /**
  * CalendarMonth description
  */
-export const CalendarMonth: (props: ICalendarMonthProps) => JSX.Element = styled<
+export const CalendarMonth: React.StatelessComponent<ICalendarMonthProps> = styled<
   ICalendarMonthProps,
   ICalendarMonthStyleProps,
   ICalendarMonthStyles

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.tsx
@@ -6,7 +6,7 @@ import { CalendarYearBase } from './CalendarYear.base';
 /**
  * CalendarYear description
  */
-export const CalendarYear: (props: ICalendarYearProps) => JSX.Element = styled<
+export const CalendarYear: React.StatelessComponent<ICalendarYearProps> = styled<
   ICalendarYearProps,
   ICalendarYearStyleProps,
   ICalendarYearStyles

--- a/packages/experiments/src/components/Chiclet/Chiclet.tsx
+++ b/packages/experiments/src/components/Chiclet/Chiclet.tsx
@@ -3,6 +3,11 @@ import { IChicletProps, IChicletStyleProps, IChicletStyles } from './Chiclet.typ
 import { getStyles } from './Chiclet.styles';
 import { ChicletBase } from './Chiclet.base';
 
-export const Chiclet = styled<IChicletProps, IChicletStyleProps, IChicletStyles>(ChicletBase, getStyles, undefined, {
-  scope: 'Chiclet'
-});
+export const Chiclet: React.StatelessComponent<IChicletProps> = styled<IChicletProps, IChicletStyleProps, IChicletStyles>(
+  ChicletBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Chiclet'
+  }
+);

--- a/packages/experiments/src/components/Chiclet/ChicletCard.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletCard.tsx
@@ -3,6 +3,10 @@ import { IChicletCardProps, IChicletCardStyleProps, IChicletCardStyles } from '.
 import { getStyles } from './ChicletCard.styles';
 import { ChicletCardBase } from './ChicletCard.base';
 
-export const ChicletCard = styled<IChicletCardProps, IChicletCardStyleProps, IChicletCardStyles>(ChicletCardBase, getStyles, undefined, {
+export const ChicletCard: React.StatelessComponent<IChicletCardProps> = styled<
+  IChicletCardProps,
+  IChicletCardStyleProps,
+  IChicletCardStyles
+>(ChicletCardBase, getStyles, undefined, {
   scope: 'ChicletCard'
 });

--- a/packages/experiments/src/components/Pagination/Pagination.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.tsx
@@ -2,7 +2,8 @@ import { styled } from '../../Utilities';
 import { IPaginationProps, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
 import { getStyles } from './Pagination.styles';
 import { PaginationBase } from './Pagination.base';
-export const Pagination: (props: IPaginationProps) => JSX.Element = styled<IPaginationProps, IPaginationStyleProps, IPaginationStyles>(
+
+export const Pagination: React.StatelessComponent<IPaginationProps> = styled<IPaginationProps, IPaginationStyleProps, IPaginationStyles>(
   PaginationBase,
   getStyles,
   undefined,

--- a/packages/experiments/src/components/Separator/Separator.tsx
+++ b/packages/experiments/src/components/Separator/Separator.tsx
@@ -3,6 +3,11 @@ import { ISeparatorProps, ISeparatorStyleProps, ISeparatorStyles } from './Separ
 import { getStyles } from './Separator.styles';
 import { SeparatorBase } from './Separator.base';
 
-export const Separator = styled<ISeparatorProps, ISeparatorStyleProps, ISeparatorStyles>(SeparatorBase, getStyles, undefined, {
-  scope: 'Separator'
-});
+export const Separator: React.StatelessComponent<ISeparatorProps> = styled<ISeparatorProps, ISeparatorStyleProps, ISeparatorStyles>(
+  SeparatorBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Separator'
+  }
+);

--- a/packages/experiments/src/components/Shimmer/Shimmer.tsx
+++ b/packages/experiments/src/components/Shimmer/Shimmer.tsx
@@ -3,6 +3,11 @@ import { IShimmerProps, IShimmerStyleProps, IShimmerStyles } from './Shimmer.typ
 import { getStyles } from './Shimmer.styles';
 import { ShimmerBase } from './Shimmer.base';
 
-export const Shimmer = styled<IShimmerProps, IShimmerStyleProps, IShimmerStyles>(ShimmerBase, getStyles, undefined, {
-  scope: 'Shimmer'
-});
+export const Shimmer: React.StatelessComponent<IShimmerProps> = styled<IShimmerProps, IShimmerStyleProps, IShimmerStyles>(
+  ShimmerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Shimmer'
+  }
+);

--- a/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerCircle/ShimmerCircle.tsx
@@ -3,9 +3,8 @@ import { getStyles } from './ShimmerCircle.styles';
 import { IShimmerCircleProps, IShimmerCircleStyleProps, IShimmerCircleStyles } from './ShimmerCircle.types';
 import { ShimmerCircleBase } from './ShimmerCircle.base';
 
-export const ShimmerCircle = styled<IShimmerCircleProps, IShimmerCircleStyleProps, IShimmerCircleStyles>(
-  ShimmerCircleBase,
-  getStyles,
-  undefined,
-  { scope: 'ShimmerCircle' }
-);
+export const ShimmerCircle: React.StatelessComponent<IShimmerCircleProps> = styled<
+  IShimmerCircleProps,
+  IShimmerCircleStyleProps,
+  IShimmerCircleStyles
+>(ShimmerCircleBase, getStyles, undefined, { scope: 'ShimmerCircle' });

--- a/packages/experiments/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.tsx
@@ -3,9 +3,8 @@ import { IShimmerElementsGroupProps, IShimmerElementsGroupStyleProps, IShimmerEl
 import { ShimmerElementsGroupBase } from './ShimmerElementsGroup.base';
 import { getStyles } from './ShimmerElementsGroup.styles';
 
-export const ShimmerElementsGroup = styled<IShimmerElementsGroupProps, IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>(
-  ShimmerElementsGroupBase,
-  getStyles,
-  undefined,
-  { scope: 'ShimmerElementsGroup' }
-);
+export const ShimmerElementsGroup: React.StatelessComponent<IShimmerElementsGroupProps> = styled<
+  IShimmerElementsGroupProps,
+  IShimmerElementsGroupStyleProps,
+  IShimmerElementsGroupStyles
+>(ShimmerElementsGroupBase, getStyles, undefined, { scope: 'ShimmerElementsGroup' });

--- a/packages/experiments/src/components/Shimmer/ShimmerGap/ShimmerGap.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerGap/ShimmerGap.tsx
@@ -3,6 +3,11 @@ import { IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles } from './Sh
 import { ShimmerGapBase } from './ShimmerGap.base';
 import { getStyles } from './ShimmerGap.styles';
 
-export const ShimmerGap = styled<IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles>(ShimmerGapBase, getStyles, undefined, {
-  scope: 'ShimmerGap'
-});
+export const ShimmerGap: React.StatelessComponent<IShimmerGapProps> = styled<IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles>(
+  ShimmerGapBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'ShimmerGap'
+  }
+);

--- a/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.tsx
+++ b/packages/experiments/src/components/Shimmer/ShimmerLine/ShimmerLine.tsx
@@ -3,6 +3,10 @@ import { IShimmerLineProps, IShimmerLineStyleProps, IShimmerLineStyles } from '.
 import { ShimmerLineBase } from './ShimmerLine.base';
 import { getStyles } from './ShimmerLine.styles';
 
-export const ShimmerLine = styled<IShimmerLineProps, IShimmerLineStyleProps, IShimmerLineStyles>(ShimmerLineBase, getStyles, undefined, {
+export const ShimmerLine: React.StatelessComponent<IShimmerLineProps> = styled<
+  IShimmerLineProps,
+  IShimmerLineStyleProps,
+  IShimmerLineStyles
+>(ShimmerLineBase, getStyles, undefined, {
   scope: 'ShimmerLine'
 });

--- a/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.tsx
+++ b/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.tsx
@@ -3,4 +3,8 @@ import { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from '.
 import { ShimmerTileBase } from './ShimmerTile.base';
 import { getStyles } from './ShimmerTile.styles';
 
-export const ShimmerTile = styled<IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles>(ShimmerTileBase, getStyles);
+export const ShimmerTile: React.StatelessComponent<IShimmerTileProps> = styled<
+  IShimmerTileProps,
+  IShimmerTileStyleProps,
+  IShimmerTileStyles
+>(ShimmerTileBase, getStyles);

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -12440,7 +12440,7 @@ enum StickyPositionType {
 }
 
 // @public
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps): (props: TComponentProps) => JSX.Element;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps): React.StatelessComponent<TComponentProps>;
 
 // @public
 class Stylesheet {

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.ts
@@ -3,4 +3,4 @@ import { IAnnouncedProps, IAnnouncedStyles } from './Announced.types';
 import { AnnouncedBase } from './Announced.base';
 import { getStyles } from './Announced.styles';
 
-export const Announced = styled<IAnnouncedProps, {}, IAnnouncedStyles>(AnnouncedBase, getStyles);
+export const Announced: React.StatelessComponent<IAnnouncedProps> = styled<IAnnouncedProps, {}, IAnnouncedStyles>(AnnouncedBase, getStyles);

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.tsx
@@ -3,7 +3,7 @@ import { ICalloutProps, ICalloutContentStyles, ICalloutContentStyleProps } from 
 import { CalloutContentBase } from './CalloutContent.base';
 import { getStyles } from './CalloutContent.styles';
 
-export const CalloutContent: (props: ICalloutProps) => JSX.Element = styled<
+export const CalloutContent: React.StatelessComponent<ICalloutProps> = styled<
   ICalloutProps,
   ICalloutContentStyleProps,
   ICalloutContentStyles

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -3,6 +3,11 @@ import { ICheckProps, ICheckStyleProps, ICheckStyles } from './Check.types';
 import { CheckBase } from './Check.base';
 import { getStyles } from './Check.styles';
 
-export const Check = styled<ICheckProps, ICheckStyleProps, ICheckStyles>(CheckBase, getStyles, undefined, {
-  scope: 'Check'
-});
+export const Check: React.StatelessComponent<ICheckProps> = styled<ICheckProps, ICheckStyleProps, ICheckStyles>(
+  CheckBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Check'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.tsx
@@ -3,7 +3,7 @@ import { CheckboxBase } from './Checkbox.base';
 import { getStyles } from './Checkbox.styles';
 import { ICheckboxProps, ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
 
-export const Checkbox: (props: ICheckboxProps) => JSX.Element = styled<ICheckboxProps, ICheckboxStyleProps, ICheckboxStyles>(
+export const Checkbox: React.StatelessComponent<ICheckboxProps> = styled<ICheckboxProps, ICheckboxStyleProps, ICheckboxStyles>(
   CheckboxBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -3,9 +3,8 @@ import { ChoiceGroupBase } from './ChoiceGroup.base';
 import { IChoiceGroupProps, IChoiceGroupStyles, IChoiceGroupStyleProps } from './ChoiceGroup.types';
 import { getStyles } from './ChoiceGroup.styles';
 
-export const ChoiceGroup: (props: IChoiceGroupProps) => JSX.Element = styled<IChoiceGroupProps, IChoiceGroupStyleProps, IChoiceGroupStyles>(
-  ChoiceGroupBase,
-  getStyles,
-  undefined,
-  { scope: 'ChoiceGroup' }
-);
+export const ChoiceGroup: React.StatelessComponent<IChoiceGroupProps> = styled<
+  IChoiceGroupProps,
+  IChoiceGroupStyleProps,
+  IChoiceGroupStyles
+>(ChoiceGroupBase, getStyles, undefined, { scope: 'ChoiceGroup' });

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.tsx
@@ -3,7 +3,7 @@ import { ChoiceGroupOptionBase } from './ChoiceGroupOption.base';
 import { IChoiceGroupOptionProps, IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption.types';
 import { getStyles } from './ChoiceGroupOption.styles';
 
-export const ChoiceGroupOption: (props: IChoiceGroupOptionProps) => JSX.Element = styled<
+export const ChoiceGroupOption: React.StatelessComponent<IChoiceGroupOptionProps> = styled<
   IChoiceGroupOptionProps,
   IChoiceGroupOptionStyleProps,
   IChoiceGroupOptionStyles

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.ts
@@ -3,6 +3,11 @@ import { ICoachmarkProps, ICoachmarkStyleProps, ICoachmarkStyles } from './Coach
 import { getStyles } from './Coachmark.styles';
 import { CoachmarkBase } from './Coachmark.base';
 
-export const Coachmark = styled<ICoachmarkProps, ICoachmarkStyleProps, ICoachmarkStyles>(CoachmarkBase, getStyles, undefined, {
-  scope: 'Coachmark'
-});
+export const Coachmark: React.StatelessComponent<ICoachmarkProps> = styled<ICoachmarkProps, ICoachmarkStyleProps, ICoachmarkStyles>(
+  CoachmarkBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Coachmark'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.tsx
@@ -3,9 +3,8 @@ import { ColorPickerBase } from './ColorPicker.base';
 import { getStyles } from './ColorPicker.styles';
 import { IColorPickerProps, IColorPickerStyles, IColorPickerStyleProps } from './ColorPicker.types';
 
-export const ColorPicker: (props: IColorPickerProps) => JSX.Element = styled<IColorPickerProps, IColorPickerStyleProps, IColorPickerStyles>(
-  ColorPickerBase,
-  getStyles,
-  undefined,
-  { scope: 'ColorPicker' }
-);
+export const ColorPicker: React.StatelessComponent<IColorPickerProps> = styled<
+  IColorPickerProps,
+  IColorPickerStyleProps,
+  IColorPickerStyles
+>(ColorPickerBase, getStyles, undefined, { scope: 'ColorPicker' });

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.tsx
@@ -3,7 +3,7 @@ import { ColorRectangleBase } from './ColorRectangle.base';
 import { getStyles } from './ColorRectangle.styles';
 import { IColorRectangleProps, IColorRectangleStyles, IColorRectangleStyleProps } from './ColorRectangle.types';
 
-export const ColorRectangle: (props: IColorRectangleProps) => JSX.Element = styled<
+export const ColorRectangle: React.StatelessComponent<IColorRectangleProps> = styled<
   IColorRectangleProps,
   IColorRectangleStyleProps,
   IColorRectangleStyles

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.tsx
@@ -3,9 +3,8 @@ import { ColorSliderBase } from './ColorSlider.base';
 import { getStyles } from './ColorSlider.styles';
 import { IColorSliderProps, IColorSliderStyleProps, IColorSliderStyles } from './ColorSlider.types';
 
-export const ColorSlider: (props: IColorSliderProps) => JSX.Element = styled<IColorSliderProps, IColorSliderStyleProps, IColorSliderStyles>(
-  ColorSliderBase,
-  getStyles,
-  undefined,
-  { scope: 'ColorSlider' }
-);
+export const ColorSlider: React.StatelessComponent<IColorSliderProps> = styled<
+  IColorSliderProps,
+  IColorSliderStyleProps,
+  IColorSliderStyles
+>(ColorSliderBase, getStyles, undefined, { scope: 'ColorSlider' });

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -4,6 +4,11 @@ import { CommandBarBase } from './CommandBar.base';
 import { getStyles } from './CommandBar.styles';
 
 // Create a CommandBar variant which uses these default styles and this styled subcomponent.
-export const CommandBar = styled<ICommandBarProps, ICommandBarStyleProps, ICommandBarStyles>(CommandBarBase, getStyles, undefined, {
-  scope: 'CommandBar'
-});
+export const CommandBar: React.StatelessComponent<ICommandBarProps> = styled<ICommandBarProps, ICommandBarStyleProps, ICommandBarStyles>(
+  CommandBarBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'CommandBar'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -6,9 +6,8 @@ import { getStyles } from './ContextualMenu.styles';
 /**
  * ContextualMenu description
  */
-export const ContextualMenu = styled<IContextualMenuProps, IContextualMenuStyleProps, IContextualMenuStyles>(
-  ContextualMenuBase,
-  getStyles,
-  undefined,
-  { scope: 'ContextualMenu' }
-);
+export const ContextualMenu: React.StatelessComponent<IContextualMenuProps> = styled<
+  IContextualMenuProps,
+  IContextualMenuStyleProps,
+  IContextualMenuStyles
+>(ContextualMenuBase, getStyles, undefined, { scope: 'ContextualMenu' });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.ts
@@ -6,9 +6,8 @@ import { getItemStyles } from './ContextualMenu.classNames';
 /**
  * ContextualMenuItem description
  */
-export const ContextualMenuItem = styled<IContextualMenuItemProps, IContextualMenuItemStyleProps, IContextualMenuItemStyles>(
-  ContextualMenuItemBase,
-  getItemStyles,
-  undefined,
-  { scope: 'ContextualMenuItem' }
-);
+export const ContextualMenuItem: React.StatelessComponent<IContextualMenuItemProps> = styled<
+  IContextualMenuItemProps,
+  IContextualMenuItemStyleProps,
+  IContextualMenuItemStyles
+>(ContextualMenuItemBase, getItemStyles, undefined, { scope: 'ContextualMenuItem' });

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.tsx
@@ -6,6 +6,11 @@ import { styles } from './DatePicker.styles';
 /**
  * DatePicker description
  */
-export const DatePicker = styled<IDatePickerProps, IDatePickerStyleProps, IDatePickerStyles>(DatePickerBase, styles, undefined, {
-  scope: 'DatePicker'
-});
+export const DatePicker: React.StatelessComponent<IDatePickerProps> = styled<IDatePickerProps, IDatePickerStyleProps, IDatePickerStyles>(
+  DatePickerBase,
+  styles,
+  undefined,
+  {
+    scope: 'DatePicker'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.ts
@@ -5,9 +5,8 @@ import { getStyles } from './DetailsColumn.styles';
 
 export { IDetailsColumnProps };
 
-export const DetailsColumn = styled<IDetailsColumnProps, IDetailsColumnStyleProps, IDetailsColumnStyles>(
-  DetailsColumnBase,
-  getStyles,
-  undefined,
-  { scope: 'DetailsColumn' }
-);
+export const DetailsColumn: React.StatelessComponent<IDetailsColumnProps> = styled<
+  IDetailsColumnProps,
+  IDetailsColumnStyleProps,
+  IDetailsColumnStyles
+>(DetailsColumnBase, getStyles, undefined, { scope: 'DetailsColumn' });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.ts
@@ -5,9 +5,8 @@ import { getStyles } from './DetailsHeader.styles';
 
 export { IDetailsHeaderProps, IDetailsHeaderBaseProps };
 
-export const DetailsHeader = styled<IDetailsHeaderBaseProps, IDetailsHeaderStyleProps, IDetailsHeaderStyles>(
-  DetailsHeaderBase,
-  getStyles,
-  undefined,
-  { scope: 'DetailsHeader' }
-);
+export const DetailsHeader: React.StatelessComponent<IDetailsHeaderBaseProps> = styled<
+  IDetailsHeaderBaseProps,
+  IDetailsHeaderStyleProps,
+  IDetailsHeaderStyles
+>(DetailsHeaderBase, getStyles, undefined, { scope: 'DetailsHeader' });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.ts
@@ -5,6 +5,10 @@ import { getStyles } from './DetailsList.styles';
 
 export { IDetailsListProps };
 
-export const DetailsList = styled<IDetailsListProps, IDetailsListStyleProps, IDetailsListStyles>(DetailsListBase, getStyles, undefined, {
+export const DetailsList: React.StatelessComponent<IDetailsListProps> = styled<
+  IDetailsListProps,
+  IDetailsListStyleProps,
+  IDetailsListStyles
+>(DetailsListBase, getStyles, undefined, {
   scope: 'DetailsList'
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.ts
@@ -5,6 +5,10 @@ import { getStyles } from './DetailsRow.styles';
 
 export { IDetailsRowProps, IDetailsRowBaseProps };
 
-export const DetailsRow = styled<IDetailsRowBaseProps, IDetailsRowStyleProps, IDetailsRowStyles>(DetailsRowBase, getStyles, undefined, {
+export const DetailsRow: React.StatelessComponent<IDetailsRowBaseProps> = styled<
+  IDetailsRowBaseProps,
+  IDetailsRowStyleProps,
+  IDetailsRowStyles
+>(DetailsRowBase, getStyles, undefined, {
   scope: 'DetailsRow'
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.ts
@@ -3,9 +3,8 @@ import { ShimmeredDetailsListBase } from './ShimmeredDetailsList.base';
 import { getStyles } from './ShimmeredDetailsList.styles';
 import { IShimmeredDetailsListProps, IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles } from './ShimmeredDetailsList.types';
 
-export const ShimmeredDetailsList = styled<IShimmeredDetailsListProps, IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>(
-  ShimmeredDetailsListBase,
-  getStyles,
-  undefined,
-  { scope: 'ShimmeredDetailsList' }
-);
+export const ShimmeredDetailsList: React.StatelessComponent<IShimmeredDetailsListProps> = styled<
+  IShimmeredDetailsListProps,
+  IShimmeredDetailsListStyleProps,
+  IShimmeredDetailsListStyles
+>(ShimmeredDetailsListBase, getStyles, undefined, { scope: 'ShimmeredDetailsList' });

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.tsx
@@ -3,9 +3,8 @@ import { IDialogContentProps, IDialogContentStyleProps, IDialogContentStyles } f
 import { DialogContentBase } from './DialogContent.base';
 import { getStyles } from './DialogContent.styles';
 
-export const DialogContent = styled<IDialogContentProps, IDialogContentStyleProps, IDialogContentStyles>(
-  DialogContentBase,
-  getStyles,
-  undefined,
-  { scope: 'DialogContent' }
-);
+export const DialogContent: React.StatelessComponent<IDialogContentProps> = styled<
+  IDialogContentProps,
+  IDialogContentStyleProps,
+  IDialogContentStyles
+>(DialogContentBase, getStyles, undefined, { scope: 'DialogContent' });

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogFooter.tsx
@@ -3,9 +3,8 @@ import { IDialogFooterProps, IDialogFooterStyleProps, IDialogFooterStyles } from
 import { DialogFooterBase } from './DialogFooter.base';
 import { getStyles } from './DialogFooter.styles';
 
-export const DialogFooter = styled<IDialogFooterProps, IDialogFooterStyleProps, IDialogFooterStyles>(
-  DialogFooterBase,
-  getStyles,
-  undefined,
-  { scope: 'DialogFooter' }
-);
+export const DialogFooter: React.StatelessComponent<IDialogFooterProps> = styled<
+  IDialogFooterProps,
+  IDialogFooterStyleProps,
+  IDialogFooterStyles
+>(DialogFooterBase, getStyles, undefined, { scope: 'DialogFooter' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.ts
@@ -3,9 +3,8 @@ import { DocumentCardBase } from './DocumentCard.base';
 import { getStyles } from './DocumentCard.styles';
 import { IDocumentCardProps, IDocumentCardStyleProps, IDocumentCardStyles } from './DocumentCard.types';
 
-export const DocumentCard = styled<IDocumentCardProps, IDocumentCardStyleProps, IDocumentCardStyles>(
-  DocumentCardBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCard' }
-);
+export const DocumentCard: React.StatelessComponent<IDocumentCardProps> = styled<
+  IDocumentCardProps,
+  IDocumentCardStyleProps,
+  IDocumentCardStyles
+>(DocumentCardBase, getStyles, undefined, { scope: 'DocumentCard' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.ts
@@ -3,9 +3,8 @@ import { DocumentCardActionsBase } from './DocumentCardActions.base';
 import { getStyles } from './DocumentCardActions.styles';
 import { IDocumentCardActionsProps, IDocumentCardActionsStyleProps, IDocumentCardActionsStyles } from './DocumentCardActions.types';
 
-export const DocumentCardActions = styled<IDocumentCardActionsProps, IDocumentCardActionsStyleProps, IDocumentCardActionsStyles>(
-  DocumentCardActionsBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardActions' }
-);
+export const DocumentCardActions: React.StatelessComponent<IDocumentCardActionsProps> = styled<
+  IDocumentCardActionsProps,
+  IDocumentCardActionsStyleProps,
+  IDocumentCardActionsStyles
+>(DocumentCardActionsBase, getStyles, undefined, { scope: 'DocumentCardActions' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.ts
@@ -3,9 +3,8 @@ import { DocumentCardActivityBase } from './DocumentCardActivity.base';
 import { getStyles } from './DocumentCardActivity.styles';
 import { IDocumentCardActivityProps, IDocumentCardActivityStyleProps, IDocumentCardActivityStyles } from './DocumentCardActivity.types';
 
-export const DocumentCardActivity = styled<IDocumentCardActivityProps, IDocumentCardActivityStyleProps, IDocumentCardActivityStyles>(
-  DocumentCardActivityBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardActivity' }
-);
+export const DocumentCardActivity: React.StatelessComponent<IDocumentCardActivityProps> = styled<
+  IDocumentCardActivityProps,
+  IDocumentCardActivityStyleProps,
+  IDocumentCardActivityStyles
+>(DocumentCardActivityBase, getStyles, undefined, { scope: 'DocumentCardActivity' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardDetails.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardDetails.ts
@@ -3,9 +3,8 @@ import { DocumentCardDetailsBase } from './DocumentCardDetails.base';
 import { getStyles } from './DocumentCardDetails.styles';
 import { IDocumentCardDetailsProps, IDocumentCardDetailsStyleProps, IDocumentCardDetailsStyles } from './DocumentCardDetails.types';
 
-export const DocumentCardDetails = styled<IDocumentCardDetailsProps, IDocumentCardDetailsStyleProps, IDocumentCardDetailsStyles>(
-  DocumentCardDetailsBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardDetails' }
-);
+export const DocumentCardDetails: React.StatelessComponent<IDocumentCardDetailsProps> = styled<
+  IDocumentCardDetailsProps,
+  IDocumentCardDetailsStyleProps,
+  IDocumentCardDetailsStyles
+>(DocumentCardDetailsBase, getStyles, undefined, { scope: 'DocumentCardDetails' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardImage.ts
@@ -3,9 +3,8 @@ import { DocumentCardImageBase } from './DocumentCardImage.base';
 import { getStyles } from './DocumentCardImage.styles';
 import { IDocumentCardImageProps, IDocumentCardImageStyleProps, IDocumentCardImageStyles } from './DocumentCardImage.types';
 
-export const DocumentCardImage = styled<IDocumentCardImageProps, IDocumentCardImageStyleProps, IDocumentCardImageStyles>(
-  DocumentCardImageBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardImage' }
-);
+export const DocumentCardImage: React.StatelessComponent<IDocumentCardImageProps> = styled<
+  IDocumentCardImageProps,
+  IDocumentCardImageStyleProps,
+  IDocumentCardImageStyles
+>(DocumentCardImageBase, getStyles, undefined, { scope: 'DocumentCardImage' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.ts
@@ -3,9 +3,8 @@ import { DocumentCardLocationBase } from './DocumentCardLocation.base';
 import { getStyles } from './DocumentCardLocation.styles';
 import { IDocumentCardLocationProps, IDocumentCardLocationStyleProps, IDocumentCardLocationStyles } from './DocumentCardLocation.types';
 
-export const DocumentCardLocation = styled<IDocumentCardLocationProps, IDocumentCardLocationStyleProps, IDocumentCardLocationStyles>(
-  DocumentCardLocationBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardLocation' }
-);
+export const DocumentCardLocation: React.StatelessComponent<IDocumentCardLocationProps> = styled<
+  IDocumentCardLocationProps,
+  IDocumentCardLocationStyleProps,
+  IDocumentCardLocationStyles
+>(DocumentCardLocationBase, getStyles, undefined, { scope: 'DocumentCardLocation' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLogo.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLogo.ts
@@ -3,9 +3,8 @@ import { DocumentCardLogoBase } from './DocumentCardLogo.base';
 import { getStyles } from './DocumentCardLogo.styles';
 import { IDocumentCardLogoProps, IDocumentCardLogoStyleProps, IDocumentCardLogoStyles } from './DocumentCardLogo.types';
 
-export const DocumentCardLogo = styled<IDocumentCardLogoProps, IDocumentCardLogoStyleProps, IDocumentCardLogoStyles>(
-  DocumentCardLogoBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardLogo' }
-);
+export const DocumentCardLogo: React.StatelessComponent<IDocumentCardLogoProps> = styled<
+  IDocumentCardLogoProps,
+  IDocumentCardLogoStyleProps,
+  IDocumentCardLogoStyles
+>(DocumentCardLogoBase, getStyles, undefined, { scope: 'DocumentCardLogo' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.ts
@@ -3,9 +3,8 @@ import { DocumentCardPreviewBase } from './DocumentCardPreview.base';
 import { getStyles } from './DocumentCardPreview.styles';
 import { IDocumentCardPreviewProps, IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles } from './DocumentCardPreview.types';
 
-export const DocumentCardPreview = styled<IDocumentCardPreviewProps, IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>(
-  DocumentCardPreviewBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardPreview' }
-);
+export const DocumentCardPreview: React.StatelessComponent<IDocumentCardPreviewProps> = styled<
+  IDocumentCardPreviewProps,
+  IDocumentCardPreviewStyleProps,
+  IDocumentCardPreviewStyles
+>(DocumentCardPreviewBase, getStyles, undefined, { scope: 'DocumentCardPreview' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardStatus.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardStatus.ts
@@ -3,9 +3,8 @@ import { DocumentCardStatusBase } from './DocumentCardStatus.base';
 import { getStyles } from './DocumentCardStatus.styles';
 import { IDocumentCardStatusProps, IDocumentCardStatusStyleProps, IDocumentCardStatusStyles } from './DocumentCardStatus.types';
 
-export const DocumentCardStatus = styled<IDocumentCardStatusProps, IDocumentCardStatusStyleProps, IDocumentCardStatusStyles>(
-  DocumentCardStatusBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardStatus' }
-);
+export const DocumentCardStatus: React.StatelessComponent<IDocumentCardStatusProps> = styled<
+  IDocumentCardStatusProps,
+  IDocumentCardStatusStyleProps,
+  IDocumentCardStatusStyles
+>(DocumentCardStatusBase, getStyles, undefined, { scope: 'DocumentCardStatus' });

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardTitle.ts
@@ -3,9 +3,8 @@ import { DocumentCardTitleBase } from './DocumentCardTitle.base';
 import { getStyles } from './DocumentCardTitle.styles';
 import { IDocumentCardTitleProps, IDocumentCardTitleStyleProps, IDocumentCardTitleStyles } from './DocumentCardTitle.types';
 
-export const DocumentCardTitle = styled<IDocumentCardTitleProps, IDocumentCardTitleStyleProps, IDocumentCardTitleStyles>(
-  DocumentCardTitleBase,
-  getStyles,
-  undefined,
-  { scope: 'DocumentCardTitle' }
-);
+export const DocumentCardTitle: React.StatelessComponent<IDocumentCardTitleProps> = styled<
+  IDocumentCardTitleProps,
+  IDocumentCardTitleStyleProps,
+  IDocumentCardTitleStyles
+>(DocumentCardTitleBase, getStyles, undefined, { scope: 'DocumentCardTitle' });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.ts
@@ -3,6 +3,11 @@ import { DropdownBase } from './Dropdown.base';
 import { getStyles } from './Dropdown.styles';
 import { IDropdownProps, IDropdownStyleProps, IDropdownStyles } from './Dropdown.types';
 
-export const Dropdown = styled<IDropdownProps, IDropdownStyleProps, IDropdownStyles>(DropdownBase, getStyles, undefined, {
-  scope: 'Dropdown'
-});
+export const Dropdown: React.StatelessComponent<IDropdownProps> = styled<IDropdownProps, IDropdownStyleProps, IDropdownStyles>(
+  DropdownBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Dropdown'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.tsx
@@ -3,6 +3,11 @@ import { FabricBase } from './Fabric.base';
 import { getStyles } from './Fabric.styles';
 import { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric.types';
 
-export const Fabric = styled<IFabricProps, IFabricStyleProps, IFabricStyles>(FabricBase, getStyles, undefined, {
-  scope: 'Fabric'
-});
+export const Fabric: React.StatelessComponent<IFabricProps> = styled<IFabricProps, IFabricStyleProps, IFabricStyles>(
+  FabricBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Fabric'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.tsx
@@ -6,6 +6,11 @@ import { styles } from './Facepile.styles';
 /**
  * The Facepile shows a list of faces or initials in a horizontal lockup. Each circle represents a person.
  */
-export const Facepile = styled<IFacepileProps, IFacepileStyleProps, IFacepileStyles>(FacepileBase, styles, undefined, {
-  scope: 'Facepile'
-});
+export const Facepile: React.StatelessComponent<IFacepileProps> = styled<IFacepileProps, IFacepileStyleProps, IFacepileStyles>(
+  FacepileBase,
+  styles,
+  undefined,
+  {
+    scope: 'Facepile'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.ts
@@ -4,6 +4,10 @@ import { GroupFooterBase } from './GroupFooter.base';
 import { IGroupFooterProps, IGroupFooterStyles, IGroupFooterStyleProps } from './GroupFooter.types';
 export { IGroupFooterProps };
 
-export const GroupFooter = styled<IGroupFooterProps, IGroupFooterStyleProps, IGroupFooterStyles>(GroupFooterBase, getStyles, undefined, {
+export const GroupFooter: React.StatelessComponent<IGroupFooterProps> = styled<
+  IGroupFooterProps,
+  IGroupFooterStyleProps,
+  IGroupFooterStyles
+>(GroupFooterBase, getStyles, undefined, {
   scope: 'GroupFooter'
 });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.ts
@@ -4,6 +4,10 @@ import { GroupHeaderBase } from './GroupHeader.base';
 import { IGroupHeaderProps, IGroupHeaderStyles, IGroupHeaderStyleProps } from './GroupHeader.types';
 export { IGroupHeaderProps };
 
-export const GroupHeader = styled<IGroupHeaderProps, IGroupHeaderStyleProps, IGroupHeaderStyles>(GroupHeaderBase, getStyles, undefined, {
+export const GroupHeader: React.StatelessComponent<IGroupHeaderProps> = styled<
+  IGroupHeaderProps,
+  IGroupHeaderStyleProps,
+  IGroupHeaderStyles
+>(GroupHeaderBase, getStyles, undefined, {
   scope: 'GroupHeader'
 });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.ts
@@ -4,9 +4,8 @@ import { GroupShowAllBase } from './GroupShowAll.base';
 import { IGroupShowAllProps, IGroupShowAllStyleProps, IGroupShowAllStyles } from './GroupShowAll.types';
 export { IGroupShowAllProps };
 
-export const GroupShowAll = styled<IGroupShowAllProps, IGroupShowAllStyleProps, IGroupShowAllStyles>(
-  GroupShowAllBase,
-  getStyles,
-  undefined,
-  { scope: 'GroupShowAll' }
-);
+export const GroupShowAll: React.StatelessComponent<IGroupShowAllProps> = styled<
+  IGroupShowAllProps,
+  IGroupShowAllStyleProps,
+  IGroupShowAllStyles
+>(GroupShowAllBase, getStyles, undefined, { scope: 'GroupShowAll' });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.ts
@@ -4,6 +4,10 @@ import { GroupedListBase } from './GroupedList.base';
 import { IGroupedListProps, IGroupedListStyles, IGroupedListStyleProps } from './GroupedList.types';
 export { IGroupedListProps };
 
-export const GroupedList = styled<IGroupedListProps, IGroupedListStyleProps, IGroupedListStyles>(GroupedListBase, getStyles, undefined, {
+export const GroupedList: React.StatelessComponent<IGroupedListProps> = styled<
+  IGroupedListProps,
+  IGroupedListStyleProps,
+  IGroupedListStyles
+>(GroupedListBase, getStyles, undefined, {
   scope: 'GroupedList'
 });

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.ts
@@ -3,11 +3,10 @@ import { IExpandingCardProps, IExpandingCardStyles, IExpandingCardStyleProps } f
 import { getStyles } from './ExpandingCard.styles';
 import { ExpandingCardBase } from './ExpandingCard.base';
 
-export const ExpandingCard = styled<IExpandingCardProps, IExpandingCardStyleProps, IExpandingCardStyles>(
-  ExpandingCardBase,
-  getStyles,
-  undefined,
-  {
-    scope: 'ExpandingCard'
-  }
-);
+export const ExpandingCard: React.StatelessComponent<IExpandingCardProps> = styled<
+  IExpandingCardProps,
+  IExpandingCardStyleProps,
+  IExpandingCardStyles
+>(ExpandingCardBase, getStyles, undefined, {
+  scope: 'ExpandingCard'
+});

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.ts
@@ -3,6 +3,11 @@ import { IHoverCardProps, IHoverCardStyles, IHoverCardStyleProps } from './Hover
 import { getStyles } from './HoverCard.styles';
 import { HoverCardBase } from './HoverCard.base';
 
-export const HoverCard = styled<IHoverCardProps, IHoverCardStyleProps, IHoverCardStyles>(HoverCardBase, getStyles, undefined, {
-  scope: 'HoverCard'
-});
+export const HoverCard: React.StatelessComponent<IHoverCardProps> = styled<IHoverCardProps, IHoverCardStyleProps, IHoverCardStyles>(
+  HoverCardBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'HoverCard'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/HoverCard/PlainCard/PlainCard.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/PlainCard/PlainCard.ts
@@ -3,6 +3,11 @@ import { IPlainCardProps, IPlainCardStyles, IPlainCardStyleProps } from './Plain
 import { getStyles } from './PlainCard.styles';
 import { PlainCardBase } from './PlainCard.base';
 
-export const PlainCard = styled<IPlainCardProps, IPlainCardStyleProps, IPlainCardStyles>(PlainCardBase, getStyles, undefined, {
-  scope: 'PlainCard'
-});
+export const PlainCard: React.StatelessComponent<IPlainCardProps> = styled<IPlainCardProps, IPlainCardStyleProps, IPlainCardStyles>(
+  PlainCardBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'PlainCard'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -7,4 +7,6 @@ import { getStyles } from './Icon.styles';
  * Icons are used for rendering an individual's avatar, presence and details.
  * They are used within the PeoplePicker components.
  */
-export const Icon = styled<IIconProps, IIconStyleProps, IIconStyles>(IconBase, getStyles, undefined, { scope: 'Icon' });
+export const Icon: React.StatelessComponent<IIconProps> = styled<IIconProps, IIconStyleProps, IIconStyles>(IconBase, getStyles, undefined, {
+  scope: 'Icon'
+});

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -3,6 +3,11 @@ import { IImageProps, IImageStyleProps, IImageStyles } from './Image.types';
 import { ImageBase } from './Image.base';
 import { getStyles } from './Image.styles';
 
-export const Image = styled<IImageProps, IImageStyleProps, IImageStyles>(ImageBase, getStyles, undefined, {
-  scope: 'Image'
-});
+export const Image: React.StatelessComponent<IImageProps> = styled<IImageProps, IImageStyleProps, IImageStyles>(
+  ImageBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Image'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Keytip/KeytipContent.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/KeytipContent.tsx
@@ -3,6 +3,11 @@ import { IKeytipProps, IKeytipStyleProps, IKeytipStyles } from './Keytip.types';
 import { KeytipContentBase } from './KeytipContent.base';
 import { getStyles } from './Keytip.styles';
 
-export const KeytipContent = styled<IKeytipProps, IKeytipStyleProps, IKeytipStyles>(KeytipContentBase, getStyles, undefined, {
-  scope: 'KeytipContent'
-});
+export const KeytipContent: React.StatelessComponent<IKeytipProps> = styled<IKeytipProps, IKeytipStyleProps, IKeytipStyles>(
+  KeytipContentBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'KeytipContent'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.tsx
@@ -3,6 +3,10 @@ import { IKeytipLayerProps, IKeytipLayerStyleProps, IKeytipLayerStyles } from '.
 import { KeytipLayerBase } from './KeytipLayer.base';
 import { getStyles } from './KeytipLayer.styles';
 
-export const KeytipLayer = styled<IKeytipLayerProps, IKeytipLayerStyleProps, IKeytipLayerStyles>(KeytipLayerBase, getStyles, undefined, {
+export const KeytipLayer: React.StatelessComponent<IKeytipLayerProps> = styled<
+  IKeytipLayerProps,
+  IKeytipLayerStyleProps,
+  IKeytipLayerStyles
+>(KeytipLayerBase, getStyles, undefined, {
   scope: 'KeytipLayer'
 });

--- a/packages/office-ui-fabric-react/src/components/Label/Label.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.tsx
@@ -3,6 +3,11 @@ import { LabelBase } from './Label.base';
 import { getStyles } from './Label.styles';
 import { ILabelProps, ILabelStyleProps, ILabelStyles } from './Label.types';
 
-export const Label = styled<ILabelProps, ILabelStyleProps, ILabelStyles>(LabelBase, getStyles, undefined, {
-  scope: 'Label'
-});
+export const Label: React.StatelessComponent<ILabelProps> = styled<ILabelProps, ILabelStyleProps, ILabelStyles>(
+  LabelBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Label'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.tsx
@@ -3,7 +3,12 @@ import { ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer.types';
 import { LayerBase } from './Layer.base';
 import { getStyles } from './Layer.styles';
 
-export const Layer = styled<ILayerProps, ILayerStyleProps, ILayerStyles>(LayerBase, getStyles, undefined, {
-  scope: 'Layer',
-  fields: ['hostId', 'theme', 'styles']
-});
+export const Layer: React.StatelessComponent<ILayerProps> = styled<ILayerProps, ILayerStyleProps, ILayerStyles>(
+  LayerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Layer',
+    fields: ['hostId', 'theme', 'styles']
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.tsx
@@ -3,6 +3,6 @@ import { MarqueeSelectionBase } from './MarqueeSelection.base';
 import { getStyles } from './MarqueeSelection.styles';
 import { IMarqueeSelectionProps } from './MarqueeSelection.types';
 
-export const MarqueeSelection: (props: IMarqueeSelectionProps) => JSX.Element = styled(MarqueeSelectionBase, getStyles, undefined, {
+export const MarqueeSelection: React.StatelessComponent<IMarqueeSelectionProps> = styled(MarqueeSelectionBase, getStyles, undefined, {
   scope: 'MarqueeSelection'
 });

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.tsx
@@ -3,7 +3,7 @@ import { MessageBarBase } from './MessageBar.base';
 import { getStyles } from './MessageBar.styles';
 import { IMessageBarProps, IMessageBarStyleProps, IMessageBarStyles } from './MessageBar.types';
 
-export const MessageBar: (props: IMessageBarProps) => JSX.Element = styled<IMessageBarProps, IMessageBarStyleProps, IMessageBarStyles>(
+export const MessageBar: React.StatelessComponent<IMessageBarProps> = styled<IMessageBarProps, IMessageBarStyleProps, IMessageBarStyles>(
   MessageBarBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.ts
@@ -3,6 +3,11 @@ import { IModalProps, IModalStyleProps, IModalStyles } from './Modal.types';
 import { ModalBase } from './Modal.base';
 import { getStyles } from './Modal.styles';
 
-export const Modal = styled<IModalProps, IModalStyleProps, IModalStyles>(ModalBase, getStyles, undefined, {
-  scope: 'Modal'
-});
+export const Modal: React.StatelessComponent<IModalProps> = styled<IModalProps, IModalStyleProps, IModalStyles>(
+  ModalBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Modal'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.tsx
@@ -3,4 +3,6 @@ import { INavProps, INavStyleProps, INavStyles } from './Nav.types';
 import { NavBase } from './Nav.base';
 import { getStyles } from './Nav.styles';
 
-export const Nav = styled<INavProps, INavStyleProps, INavStyles>(NavBase, getStyles, undefined, { scope: 'Nav' });
+export const Nav: React.StatelessComponent<INavProps> = styled<INavProps, INavStyleProps, INavStyles>(NavBase, getStyles, undefined, {
+  scope: 'Nav'
+});

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.ts
@@ -3,6 +3,6 @@ import { OverflowSetBase } from './OverflowSet.base';
 import { getStyles } from './OverflowSet.styles';
 import { IOverflowSetProps } from './OverflowSet.types';
 
-export const OverflowSet: (props: IOverflowSetProps) => JSX.Element = styled(OverflowSetBase, getStyles, undefined, {
+export const OverflowSet: React.StatelessComponent<IOverflowSetProps> = styled(OverflowSetBase, getStyles, undefined, {
   scope: 'OverflowSet'
 });

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.tsx
@@ -3,6 +3,11 @@ import { IOverlayProps, IOverlayStyleProps, IOverlayStyles } from './Overlay.typ
 import { OverlayBase } from './Overlay.base';
 import { getStyles } from './Overlay.styles';
 
-export const Overlay = styled<IOverlayProps, IOverlayStyleProps, IOverlayStyles>(OverlayBase, getStyles, undefined, {
-  scope: 'Overlay'
-});
+export const Overlay: React.StatelessComponent<IOverlayProps> = styled<IOverlayProps, IOverlayStyleProps, IOverlayStyles>(
+  OverlayBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Overlay'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.ts
@@ -6,6 +6,11 @@ import { getStyles } from './Panel.styles';
 /**
  * Panel description
  */
-export const Panel = styled<IPanelProps, IPanelStyleProps, IPanelStyles>(PanelBase, getStyles, undefined, {
-  scope: 'Panel'
-});
+export const Panel: React.StatelessComponent<IPanelProps> = styled<IPanelProps, IPanelStyleProps, IPanelStyles>(
+  PanelBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Panel'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.tsx
@@ -7,6 +7,11 @@ import { getStyles } from './Persona.styles';
  * Personas are used for rendering an individual's avatar, presence and details.
  * They are used within the PeoplePicker components.
  */
-export const Persona = styled<IPersonaProps, IPersonaStyleProps, IPersonaStyles>(PersonaBase, getStyles, undefined, {
-  scope: 'Persona'
-});
+export const Persona: React.StatelessComponent<IPersonaProps> = styled<IPersonaProps, IPersonaStyleProps, IPersonaStyles>(
+  PersonaBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Persona'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.tsx
@@ -6,6 +6,10 @@ import { getStyles } from './PersonaCoin.styles';
 /**
  * PersonaCoin is used to render an individual's avatar and presence.
  */
-export const PersonaCoin = styled<IPersonaCoinProps, IPersonaCoinStyleProps, IPersonaCoinStyles>(PersonaCoinBase, getStyles, undefined, {
+export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps> = styled<
+  IPersonaCoinProps,
+  IPersonaCoinStyleProps,
+  IPersonaCoinStyles
+>(PersonaCoinBase, getStyles, undefined, {
   scope: 'PersonaCoin'
 });

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.tsx
@@ -6,9 +6,8 @@ import { getStyles } from './PersonaPresence.styles';
 /**
  * PersonaPresence is used to render an individual's presence.
  */
-export const PersonaPresence = styled<IPersonaPresenceProps, IPersonaPresenceStyleProps, IPersonaPresenceStyles>(
-  PersonaPresenceBase,
-  getStyles,
-  undefined,
-  { scope: 'PersonaPresence' }
-);
+export const PersonaPresence: React.StatelessComponent<IPersonaPresenceProps> = styled<
+  IPersonaPresenceProps,
+  IPersonaPresenceStyleProps,
+  IPersonaPresenceStyles
+>(PersonaPresenceBase, getStyles, undefined, { scope: 'PersonaPresence' });

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.tsx
@@ -8,6 +8,11 @@ import { getStyles } from './Pivot.styles';
  * distinct content categories. Pivots allow for navigation between two or more content
  * views and relies on text headers to articulate the different sections of content.
  */
-export const Pivot = styled<IPivotProps, IPivotStyleProps, IPivotStyles>(PivotBase, getStyles, undefined, {
-  scope: 'Pivot'
-});
+export const Pivot: React.StatelessComponent<IPivotProps> = styled<IPivotProps, IPivotStyleProps, IPivotStyles>(
+  PivotBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Pivot'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -6,9 +6,8 @@ import { getStyles } from './ProgressIndicator.styles';
 /**
  * ProgressIndicator description
  */
-export const ProgressIndicator = styled<IProgressIndicatorProps, IProgressIndicatorStyleProps, IProgressIndicatorStyles>(
-  ProgressIndicatorBase,
-  getStyles,
-  undefined,
-  { scope: 'ProgressIndicator' }
-);
+export const ProgressIndicator: React.StatelessComponent<IProgressIndicatorProps> = styled<
+  IProgressIndicatorProps,
+  IProgressIndicatorStyleProps,
+  IProgressIndicatorStyles
+>(ProgressIndicatorBase, getStyles, undefined, { scope: 'ProgressIndicator' });

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.tsx
@@ -3,7 +3,7 @@ import { IRatingProps, IRatingStyleProps, IRatingStyles } from './Rating.types';
 import { getStyles } from './Rating.styles';
 import { RatingBase } from './Rating.base';
 
-export const Rating: (props: IRatingProps) => JSX.Element = styled<IRatingProps, IRatingStyleProps, IRatingStyles>(
+export const Rating: React.StatelessComponent<IRatingProps> = styled<IRatingProps, IRatingStyleProps, IRatingStyles>(
   RatingBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.tsx
@@ -3,9 +3,8 @@ import { IScrollablePaneProps, IScrollablePaneStyleProps, IScrollablePaneStyles 
 import { ScrollablePaneBase } from './ScrollablePane.base';
 import { getStyles } from './ScrollablePane.styles';
 
-export const ScrollablePane = styled<IScrollablePaneProps, IScrollablePaneStyleProps, IScrollablePaneStyles>(
-  ScrollablePaneBase,
-  getStyles,
-  undefined,
-  { scope: 'ScrollablePane' }
-);
+export const ScrollablePane: React.StatelessComponent<IScrollablePaneProps> = styled<
+  IScrollablePaneProps,
+  IScrollablePaneStyleProps,
+  IScrollablePaneStyles
+>(ScrollablePaneBase, getStyles, undefined, { scope: 'ScrollablePane' });

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.tsx
@@ -3,7 +3,7 @@ import { SearchBoxBase } from './SearchBox.base';
 import { ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox.types';
 import { getStyles } from './SearchBox.styles';
 
-export const SearchBox: (props: ISearchBoxProps) => JSX.Element = styled<ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles>(
+export const SearchBox: React.StatelessComponent<ISearchBoxProps> = styled<ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles>(
   SearchBoxBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.tsx
@@ -3,6 +3,11 @@ import { IShimmerProps, IShimmerStyleProps, IShimmerStyles } from './Shimmer.typ
 import { getStyles } from './Shimmer.styles';
 import { ShimmerBase } from './Shimmer.base';
 
-export const Shimmer = styled<IShimmerProps, IShimmerStyleProps, IShimmerStyles>(ShimmerBase, getStyles, undefined, {
-  scope: 'Shimmer'
-});
+export const Shimmer: React.StatelessComponent<IShimmerProps> = styled<IShimmerProps, IShimmerStyleProps, IShimmerStyles>(
+  ShimmerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Shimmer'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.tsx
@@ -3,9 +3,8 @@ import { getStyles } from './ShimmerCircle.styles';
 import { IShimmerCircleProps, IShimmerCircleStyleProps, IShimmerCircleStyles } from './ShimmerCircle.types';
 import { ShimmerCircleBase } from './ShimmerCircle.base';
 
-export const ShimmerCircle = styled<IShimmerCircleProps, IShimmerCircleStyleProps, IShimmerCircleStyles>(
-  ShimmerCircleBase,
-  getStyles,
-  undefined,
-  { scope: 'ShimmerCircle' }
-);
+export const ShimmerCircle: React.StatelessComponent<IShimmerCircleProps> = styled<
+  IShimmerCircleProps,
+  IShimmerCircleStyleProps,
+  IShimmerCircleStyles
+>(ShimmerCircleBase, getStyles, undefined, { scope: 'ShimmerCircle' });

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.tsx
@@ -3,9 +3,8 @@ import { IShimmerElementsGroupProps, IShimmerElementsGroupStyleProps, IShimmerEl
 import { ShimmerElementsGroupBase } from './ShimmerElementsGroup.base';
 import { getStyles } from './ShimmerElementsGroup.styles';
 
-export const ShimmerElementsGroup = styled<IShimmerElementsGroupProps, IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>(
-  ShimmerElementsGroupBase,
-  getStyles,
-  undefined,
-  { scope: 'ShimmerElementsGroup' }
-);
+export const ShimmerElementsGroup: React.StatelessComponent<IShimmerElementsGroupProps> = styled<
+  IShimmerElementsGroupProps,
+  IShimmerElementsGroupStyleProps,
+  IShimmerElementsGroupStyles
+>(ShimmerElementsGroupBase, getStyles, undefined, { scope: 'ShimmerElementsGroup' });

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.tsx
@@ -3,6 +3,11 @@ import { IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles } from './Sh
 import { ShimmerGapBase } from './ShimmerGap.base';
 import { getStyles } from './ShimmerGap.styles';
 
-export const ShimmerGap = styled<IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles>(ShimmerGapBase, getStyles, undefined, {
-  scope: 'ShimmerGap'
-});
+export const ShimmerGap: React.StatelessComponent<IShimmerGapProps> = styled<IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles>(
+  ShimmerGapBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'ShimmerGap'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.tsx
@@ -3,6 +3,10 @@ import { IShimmerLineProps, IShimmerLineStyleProps, IShimmerLineStyles } from '.
 import { ShimmerLineBase } from './ShimmerLine.base';
 import { getStyles } from './ShimmerLine.styles';
 
-export const ShimmerLine = styled<IShimmerLineProps, IShimmerLineStyleProps, IShimmerLineStyles>(ShimmerLineBase, getStyles, undefined, {
+export const ShimmerLine: React.StatelessComponent<IShimmerLineProps> = styled<
+  IShimmerLineProps,
+  IShimmerLineStyleProps,
+  IShimmerLineStyles
+>(ShimmerLineBase, getStyles, undefined, {
   scope: 'ShimmerLine'
 });

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.tsx
@@ -5,6 +5,11 @@ import { ISliderProps, ISliderStyleProps, ISliderStyles } from './Slider.types';
 import { SliderBase } from './Slider.base';
 import { getStyles } from './Slider.styles';
 
-export const Slider = styled<ISliderProps, ISliderStyleProps, ISliderStyles>(SliderBase, getStyles, undefined, {
-  scope: 'Slider'
-});
+export const Slider: React.StatelessComponent<ISliderProps> = styled<ISliderProps, ISliderStyleProps, ISliderStyles>(
+  SliderBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Slider'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.tsx
@@ -3,7 +3,7 @@ import { SpinnerBase } from './Spinner.base';
 import { getStyles } from './Spinner.styles';
 import { ISpinnerProps, ISpinnerStyles, ISpinnerStyleProps } from './Spinner.types';
 
-export const Spinner: (props: ISpinnerProps) => JSX.Element = styled<ISpinnerProps, ISpinnerStyleProps, ISpinnerStyles>(
+export const Spinner: React.StatelessComponent<ISpinnerProps> = styled<ISpinnerProps, ISpinnerStyleProps, ISpinnerStyles>(
   SpinnerBase,
   getStyles,
   undefined,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.tsx
@@ -3,7 +3,7 @@ import { ColorPickerGridCellBase } from './ColorPickerGridCell.base';
 import { IColorPickerGridCellProps, IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
 import { getStyles } from './ColorPickerGridCell.styles';
 
-export const ColorPickerGridCell: (props: IColorPickerGridCellProps) => JSX.Element = styled<
+export const ColorPickerGridCell: React.StatelessComponent<IColorPickerGridCellProps> = styled<
   IColorPickerGridCellProps,
   IColorPickerGridCellStyleProps,
   IColorPickerGridCellStyles

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.tsx
@@ -3,7 +3,7 @@ import { SwatchColorPickerBase } from './SwatchColorPicker.base';
 import { ISwatchColorPickerProps, ISwatchColorPickerStyles, ISwatchColorPickerStyleProps } from './SwatchColorPicker.types';
 import { getStyles } from './SwatchColorPicker.styles';
 
-export const SwatchColorPicker: (props: ISwatchColorPickerProps) => JSX.Element = styled<
+export const SwatchColorPicker: React.StatelessComponent<ISwatchColorPickerProps> = styled<
   ISwatchColorPickerProps,
   ISwatchColorPickerStyleProps,
   ISwatchColorPickerStyles

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.ts
@@ -3,9 +3,8 @@ import { ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles 
 import { TeachingBubbleBase } from './TeachingBubble.base';
 import { getStyles } from './TeachingBubble.styles';
 
-export const TeachingBubble = styled<ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles>(
-  TeachingBubbleBase,
-  getStyles,
-  undefined,
-  { scope: 'TeachingBubble' }
-);
+export const TeachingBubble: React.StatelessComponent<ITeachingBubbleProps> = styled<
+  ITeachingBubbleProps,
+  ITeachingBubbleStyleProps,
+  ITeachingBubbleStyles
+>(TeachingBubbleBase, getStyles, undefined, { scope: 'TeachingBubble' });

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.ts
@@ -3,9 +3,8 @@ import { ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles 
 import { TeachingBubbleContentBase } from './TeachingBubbleContent.base';
 import { getStyles } from './TeachingBubble.styles';
 
-export const TeachingBubbleContent = styled<ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles>(
-  TeachingBubbleContentBase,
-  getStyles,
-  undefined,
-  { scope: 'TeachingBubbleContent' }
-);
+export const TeachingBubbleContent: React.StatelessComponent<ITeachingBubbleProps> = styled<
+  ITeachingBubbleProps,
+  ITeachingBubbleStyleProps,
+  ITeachingBubbleStyles
+>(TeachingBubbleContentBase, getStyles, undefined, { scope: 'TeachingBubbleContent' });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.ts
@@ -4,6 +4,11 @@ import { ITextFieldProps, ITextFieldStyles, ITextFieldStyleProps } from './TextF
 import { getStyles } from './TextField.styles';
 export { ITextField } from './TextField.types';
 
-export const TextField = styled<ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles>(TextFieldBase, getStyles, undefined, {
-  scope: 'TextField'
-});
+export const TextField: React.StatelessComponent<ITextFieldProps> = styled<ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles>(
+  TextFieldBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'TextField'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.tsx
@@ -3,6 +3,11 @@ import { TooltipBase } from './Tooltip.base';
 import { ITooltipProps, ITooltipStyleProps, ITooltipStyles } from './Tooltip.types';
 import { getStyles } from './Tooltip.styles';
 
-export const Tooltip = styled<ITooltipProps, ITooltipStyleProps, ITooltipStyles>(TooltipBase, getStyles, undefined, {
-  scope: 'Tooltip'
-});
+export const Tooltip: React.StatelessComponent<ITooltipProps> = styled<ITooltipProps, ITooltipStyleProps, ITooltipStyles>(
+  TooltipBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Tooltip'
+  }
+);

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.ts
@@ -3,6 +3,10 @@ import { TooltipHostBase } from './TooltipHost.base';
 import { ITooltipHostProps, ITooltipHostStyleProps, ITooltipHostStyles } from './TooltipHost.types';
 import { getStyles } from './TooltipHost.styles';
 
-export const TooltipHost = styled<ITooltipHostProps, ITooltipHostStyleProps, ITooltipHostStyles>(TooltipHostBase, getStyles, undefined, {
+export const TooltipHost: React.StatelessComponent<ITooltipHostProps> = styled<
+  ITooltipHostProps,
+  ITooltipHostStyleProps,
+  ITooltipHostStyles
+>(TooltipHostBase, getStyles, undefined, {
   scope: 'TooltipHost'
 });

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.tsx
@@ -3,4 +3,4 @@ import { GridBase } from './Grid.base';
 import { IGridProps, IGridStyleProps, IGridStyles } from './Grid.types';
 import { getStyles } from './Grid.styles';
 
-export const Grid: (props: IGridProps) => JSX.Element = styled<IGridProps, IGridStyleProps, IGridStyles>(GridBase, getStyles);
+export const Grid: React.StatelessComponent<IGridProps> = styled<IGridProps, IGridStyleProps, IGridStyles>(GridBase, getStyles);

--- a/packages/utilities/etc/utilities.api.ts
+++ b/packages/utilities/etc/utilities.api.ts
@@ -657,7 +657,7 @@ export function shallowCompare<TA, TB>(a: TA, b: TB): boolean;
 export function shouldWrapFocus(element: HTMLElement, noWrapDataAttribute: 'data-no-vertical-wrap' | 'data-no-horizontal-wrap'): boolean;
 
 // @public
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps): (props: TComponentProps) => JSX.Element;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps): React.StatelessComponent<TComponentProps>;
 
 // @public
 export function toMatrix<T>(items: T[], columnCount: number): T[][];

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -47,7 +47,7 @@ export function styled<
   baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>,
   getProps?: (props: TComponentProps) => Partial<TComponentProps>,
   customizable?: ICustomizableProps
-): (props: TComponentProps) => JSX.Element {
+): React.StatelessComponent<TComponentProps> {
   customizable = customizable || { scope: '', fields: undefined };
 
   const { scope, fields = DefaultFields } = customizable;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7874, Fixes #8177
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Update return type of the `styled` HOC from the utils package. Now typed as `React.StatelessComponent` instead of in-place lambda.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8189)