### PR TITLE
BaseButton does not call onAfterMenuDismiss when persistMenu is true

### DIFF
--- a/common/changes/office-ui-fabric-react/ddlbrena-btnPersistMenuCallDismiss_2019-03-05-07-23.json
+++ b/common/changes/office-ui-fabric-react/ddlbrena-btnPersistMenuCallDismiss_2019-03-05-07-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BaseButton does not call onAfterMenuDismiss when persistMenu is true",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "ddlbrena@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -440,6 +440,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   private _dismissMenu = (): void => {
     let menuProps = null;
     if (this.props.persistMenu && this.state.menuProps) {
+      // Create a new object to trigger componentDidUpdate
       menuProps = { ...this.state.menuProps, hidden: true };
     }
     this.setState({ menuProps: menuProps });

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -225,8 +225,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     // If Button's menu was closed, run onAfterMenuDismiss. If the menu is being persisted
     // this condition is tested by checking on a change on the menuProps hidden value.
     if (this.props.onAfterMenuDismiss && prevState.menuProps) {
-      if (!this.state.menuProps || (this.props.persistMenu && this.props.persistMenu &&
-        !prevState.menuProps.hidden && this.state.menuProps.hidden)) {
+      if (!this.state.menuProps || (this.props.persistMenu && !prevState.menuProps.hidden && this.state.menuProps.hidden)) {
         this.props.onAfterMenuDismiss();
       }
     }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -37,10 +37,11 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   }
 
   private get _isExpanded(): boolean {
+    const { menuProps } = this.state;
     if (this.props.persistMenu) {
-      return !this.state.menuProps!.hidden;
+      return !!menuProps && !menuProps.hidden;
     }
-    return !!this.state.menuProps;
+    return !!menuProps;
   }
 
   public static defaultProps: Partial<IBaseButtonProps> = {
@@ -107,29 +108,29 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     this._classNames = getClassNames
       ? getClassNames(
-          theme!,
-          className!,
-          variantClassName!,
-          iconProps && iconProps.className,
-          menuIconProps && menuIconProps.className,
-          isPrimaryButtonDisabled!,
-          checked!,
-          this._isMenuExpanded(),
-          this.props.split,
-          !!allowDisabledFocus
-        )
+        theme!,
+        className!,
+        variantClassName!,
+        iconProps && iconProps.className,
+        menuIconProps && menuIconProps.className,
+        isPrimaryButtonDisabled!,
+        checked!,
+        this._isMenuExpanded(),
+        this.props.split,
+        !!allowDisabledFocus
+      )
       : getBaseButtonClassNames(
-          theme!,
-          styles!,
-          className!,
-          variantClassName!,
-          iconProps && iconProps.className,
-          menuIconProps && menuIconProps.className,
-          isPrimaryButtonDisabled!,
-          checked!,
-          this._isMenuExpanded(),
-          this.props.split
-        );
+        theme!,
+        styles!,
+        className!,
+        variantClassName!,
+        iconProps && iconProps.className,
+        menuIconProps && menuIconProps.className,
+        isPrimaryButtonDisabled!,
+        checked!,
+        this._isMenuExpanded(),
+        this.props.split
+      );
 
     const { _ariaDescriptionId, _labelId, _descriptionId } = this;
     // Anchor tag cannot be disabled hence in disabled state rendering
@@ -221,9 +222,13 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   }
 
   public componentDidUpdate(prevProps: IBaseButtonProps, prevState: IBaseButtonState) {
-    // If Button's menu was closed, run onAfterMenuDismiss
-    if (this.props.onAfterMenuDismiss && prevState.menuProps && !this.state.menuProps) {
-      this.props.onAfterMenuDismiss();
+    // If Button's menu was closed, run onAfterMenuDismiss. If the menu is being persisted
+    // this condition is tested by checking on a change on the menuProps hidden value.
+    if (this.props.onAfterMenuDismiss && prevState.menuProps) {
+      if (!this.state.menuProps || (this.props.persistMenu && this.props.persistMenu &&
+        !prevState.menuProps.hidden && this.state.menuProps.hidden)) {
+        this.props.onAfterMenuDismiss();
+      }
     }
   }
 
@@ -435,8 +440,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   private _dismissMenu = (): void => {
     let menuProps = null;
     if (this.props.persistMenu && this.state.menuProps) {
-      menuProps = this.state.menuProps;
-      menuProps.hidden = true;
+      menuProps = { ...this.state.menuProps, hidden: true };
     }
     this.setState({ menuProps: menuProps });
   };

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -1,19 +1,58 @@
 import * as React from 'react';
 import { DefaultButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { IContextualMenuProps, ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { Label } from 'office-ui-fabric-react/lib/Label';
+import { css, classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { getStyles, IButtonBasicExampleStyleProps, IButtonBasicExampleStyles } from './Button.Basic.Example.styles';
 
 export class ButtonContextualMenuExample extends React.Component<IButtonProps, {}> {
   public render(): JSX.Element {
     const { disabled, checked } = this.props;
 
+    const getClassNames = classNamesFunction<IButtonBasicExampleStyleProps, IButtonBasicExampleStyles>();
+    const classNames = getClassNames(getStyles, {});
+
     return (
-      <div className="ms-ContextualMenuButtonsExample">
+      <div className={css(classNames.twoup)}>
         <div>
+          <Label>Non persisted menu</Label>
           <DefaultButton
             data-automation-id="test"
             disabled={disabled}
             allowDisabledFocus={true}
             checked={checked}
+            iconProps={{ iconName: 'Add' }}
+            menuAs={this._getMenu}
+            text="New"
+            // tslint:disable-next-line:jsx-no-lambda
+            onMenuClick={ev => {
+              console.log(ev);
+            }}
+            menuProps={{
+              items: [
+                {
+                  key: 'emailMessage',
+                  text: 'Email message',
+                  iconProps: { iconName: 'Mail' }
+                },
+                {
+                  key: 'calendarEvent',
+                  text: 'Calendar event',
+                  iconProps: { iconName: 'Calendar' }
+                }
+              ],
+              directionalHintFixed: true
+            }}
+          />
+        </div>
+        <div>
+          <Label>Persisted menu</Label>
+          <DefaultButton
+            data-automation-id="test"
+            disabled={disabled}
+            allowDisabledFocus={true}
+            checked={checked}
+            persistMenu={true}
             iconProps={{ iconName: 'Add' }}
             menuAs={this._getMenu}
             text="New"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
@@ -2,9 +2,46 @@
 
 exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 1`] = `
 <div
-  className="ms-ContextualMenuButtonsExample"
+  className=
+      ms-BasicButtonsTwoUp
+      {
+        display: flex;
+      }
+      & > * {
+        flex-grow: 1;
+      }
+      & .ms-Label {
+        margin-bottom: 10px;
+      }
 >
   <div>
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Non persisted menu
+    </label>
     <button
       aria-expanded={false}
       aria-haspopup={true}
@@ -175,6 +212,721 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
         >
           
         </i>
+      </div>
+    </button>
+  </div>
+  <div>
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Persisted menu
+    </label>
+    <button
+      aria-expanded={false}
+      aria-haspopup={true}
+      aria-owns="id__3-menu"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
+      data-automation-id="test"
+      data-is-focusable={true}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="button"
+    >
+      <div
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+      >
+        <i
+          className=
+              ms-Button-icon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 16px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
+          data-icon-name="Add"
+          role="presentation"
+        >
+          
+        </i>
+        <div
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
+        >
+          <div
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
+            id="id__3"
+          >
+            New
+          </div>
+        </div>
+        <i
+          className=
+              ms-Button-menuIcon
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
+                flex-shrink: 0;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                height: 16px;
+                line-height: 16px;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+                speak: none;
+                text-align: center;
+                vertical-align: middle;
+              }
+          data-icon-name="ChevronDown"
+          role="presentation"
+        >
+          
+        </i>
+        <span
+          className="ms-layer"
+        >
+          <div
+            className=
+                ms-Fabric
+                ms-Layer-content
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #333333;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  visibility: visible;
+                }
+                & button {
+                  font-family: inherit;
+                }
+                & input {
+                  font-family: inherit;
+                }
+                & textarea {
+                  font-family: inherit;
+                }
+                button {
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  overflow: visible;
+                }
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onDrag={[Function]}
+            onDragEnd={[Function]}
+            onDragEnter={[Function]}
+            onDragExit={[Function]}
+            onDragLeave={[Function]}
+            onDragOver={[Function]}
+            onDragStart={[Function]}
+            onDrop={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseMove={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+            onSubmit={[Function]}
+          >
+            <div
+              className=
+                  ms-Callout-container
+                  {
+                    position: relative;
+                  }
+              style={
+                Object {
+                  "visibility": "hidden",
+                }
+              }
+            >
+              <div
+                className=
+                    ms-Callout
+                    ms-ContextualMenu-Callout
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-color: #eaeaea;
+                      border-style: solid;
+                      border-width: 1px;
+                      box-shadow: 0 0 5px 0px rgba(0,0,0,0.4);
+                      box-sizing: border-box;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      outline: transparent;
+                      position: absolute;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                      border-style: solid;
+                      border-width: 1px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0px;
+                    }
+                hidden={true}
+                onScroll={[Function]}
+                style={
+                  Object {
+                    "filter": "opacity(0)",
+                    "opacity": 0,
+                  }
+                }
+                tabIndex={-1}
+              >
+                <div
+                  className=
+                      ms-Callout-main
+                      {
+                        background-color: #ffffff;
+                        overflow-x: hidden;
+                        overflow-y: auto;
+                        position: relative;
+                      }
+                  onKeyDown={[Function]}
+                  onScroll={[Function]}
+                  style={
+                    Object {
+                      "maxHeight": 750,
+                      "outline": "none",
+                      "overflowY": undefined,
+                    }
+                  }
+                >
+                  <div
+                    aria-labelledby="id__3"
+                    className=
+                        ms-ContextualMenu-container
+                        &:focus {
+                          outline: 0px;
+                        }
+                    id="id__3-menu"
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    role="menu"
+                    tabIndex={-1}
+                  >
+                    <div
+                      className=
+                          ms-FocusZone
+                          ms-ContextualMenu
+                          is-open
+                          ms-BaseButton-menuhost
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: #ffffff;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            min-width: 180px;
+                          }
+                      data-focuszone-id="FocusZone7"
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseDownCapture={[Function]}
+                      role="presentation"
+                    >
+                      <ul
+                        className=
+                            ms-ContextualMenu-list
+                            is-open
+                            {
+                              list-style-type: none;
+                              margin-bottom: 0;
+                              margin-left: 0;
+                              margin-right: 0;
+                              margin-top: 0;
+                              padding-bottom: 0;
+                              padding-left: 0;
+                              padding-right: 0;
+                              padding-top: 0;
+                            }
+                        onKeyDown={[Function]}
+                        onKeyUp={[Function]}
+                        role="menu"
+                      >
+                        <li
+                          className=
+                              ms-ContextualMenu-item
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                box-sizing: border-box;
+                                color: #333333;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                position: relative;
+                              }
+                          role="presentation"
+                        >
+                          <button
+                            aria-disabled={false}
+                            aria-posinset={1}
+                            aria-setsize={2}
+                            className=
+                                ms-ContextualMenu-link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  border: none;
+                                  color: #333333;
+                                  cursor: pointer;
+                                  display: block;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 32px;
+                                  line-height: 32px;
+                                  outline: transparent;
+                                  padding-bottom: 0;
+                                  padding-left: 4px;
+                                  padding-right: 8px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  text-align: left;
+                                  width: 100%;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #666666;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                &:active {
+                                  background-color: #eaeaea;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:hover {
+                                  background: inherit;
+                                }
+                            onClick={[Function]}
+                            onKeyDown={null}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            role="menuitem"
+                          >
+                            <div
+                              className=
+                                  ms-ContextualMenu-linkContent
+                                  {
+                                    align-items: center;
+                                    display: flex;
+                                    height: inherit;
+                                    max-width: 100%;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <i
+                                className=
+                                    ms-ContextualMenu-icon
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      color: #0078d4;
+                                      display: inline-block;
+                                      flex-shrink: 0;
+                                      font-family: "FabricMDL2Icons";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      max-height: 32px;
+                                      min-height: 1px;
+                                      speak: none;
+                                      vertical-align: middle;
+                                      width: 14px;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){& {
+                                      color: inherit;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){$root:hover & {
+                                      color: HighlightText;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){$root:focus & {
+                                      color: HighlightText;
+                                    }
+                                data-icon-name="Mail"
+                                role="presentation"
+                              >
+                                
+                              </i>
+                              <span
+                                className=
+                                    ms-ContextualMenu-itemText
+                                    {
+                                      display: inline-block;
+                                      flex-grow: 1;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      overflow: hidden;
+                                      text-overflow: ellipsis;
+                                      vertical-align: middle;
+                                      white-space: nowrap;
+                                    }
+                              >
+                                Email message
+                              </span>
+                            </div>
+                          </button>
+                        </li>
+                        <li
+                          className=
+                              ms-ContextualMenu-item
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                box-sizing: border-box;
+                                color: #333333;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                position: relative;
+                              }
+                          role="presentation"
+                        >
+                          <button
+                            aria-disabled={false}
+                            aria-posinset={2}
+                            aria-setsize={2}
+                            className=
+                                ms-ContextualMenu-link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  border: none;
+                                  color: #333333;
+                                  cursor: pointer;
+                                  display: block;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 14px;
+                                  font-weight: 400;
+                                  height: 32px;
+                                  line-height: 32px;
+                                  outline: transparent;
+                                  padding-bottom: 0;
+                                  padding-left: 4px;
+                                  padding-right: 8px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  text-align: left;
+                                  width: 100%;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #666666;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                &:active {
+                                  background-color: #eaeaea;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  background-color: #f4f4f4;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus, .ms-Fabric--isFocusVisible &:focus:hover {
+                                  -ms-high-contrast-adjust: none;
+                                  background-color: Highlight;
+                                  border-color: Highlight;
+                                  color: HighlightText;
+                                }
+                                .ms-Fabric--isFocusVisible &:hover {
+                                  background: inherit;
+                                }
+                            onClick={[Function]}
+                            onKeyDown={null}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            role="menuitem"
+                          >
+                            <div
+                              className=
+                                  ms-ContextualMenu-linkContent
+                                  {
+                                    align-items: center;
+                                    display: flex;
+                                    height: inherit;
+                                    max-width: 100%;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <i
+                                className=
+                                    ms-ContextualMenu-icon
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      color: #0078d4;
+                                      display: inline-block;
+                                      flex-shrink: 0;
+                                      font-family: "FabricMDL2Icons";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      max-height: 32px;
+                                      min-height: 1px;
+                                      speak: none;
+                                      vertical-align: middle;
+                                      width: 14px;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){& {
+                                      color: inherit;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){$root:hover & {
+                                      color: HighlightText;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){$root:focus & {
+                                      color: HighlightText;
+                                    }
+                                data-icon-name="Calendar"
+                                role="presentation"
+                              >
+                                
+                              </i>
+                              <span
+                                className=
+                                    ms-ContextualMenu-itemText
+                                    {
+                                      display: inline-block;
+                                      flex-grow: 1;
+                                      margin-bottom: 0;
+                                      margin-left: 4px;
+                                      margin-right: 4px;
+                                      margin-top: 0;
+                                      overflow: hidden;
+                                      text-overflow: ellipsis;
+                                      vertical-align: middle;
+                                      white-space: nowrap;
+                                    }
+                              >
+                                Calendar event
+                              </span>
+                            </div>
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
       </div>
     </button>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-458:hover + .headerDividerBar-459 {
+      & .headerDivider-461:hover + .headerDividerBar-462 {
         display: inline;
       }
 >


### PR DESCRIPTION
BaseButton does not call onAfterMenuDismiss when persistMenu is true

Problem: onAfterMenuDismiss is called in componentDidUpdate by checking menuProps going from set to unset. This does not work when in persistMenu mode since menuPRops are always set.

Fix: Update componentDidUpdate to check for persistMenu and menuProps.hidden props to figure out when to call onAfterMenuDismiss as well.

Verification: Added unit test. Also updated example page with button with context menu in persistMenu mode.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8191)