### PR TITLE
Styling: adding theme.js as a sideEffect.

### DIFF
--- a/common/changes/@uifabric/styling/fix-sideeffect_2019-03-05-16-35.json
+++ b/common/changes/@uifabric/styling/fix-sideeffect_2019-03-05-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Adding theme.js to sideEffects list to prevent webpack from treeshaking it out.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -11,7 +11,8 @@
   "module": "lib/index.js",
   "sideEffects": [
     "lib/version.js",
-    "lib/styles/DefaultFontStyles.js"
+    "lib/styles/DefaultFontStyles.js",
+    "lib/styles/theme.js"
   ],
   "typings": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8193
- [X] Include a change request file using `$ npm run change`

#### Description of changes

theme.js registers a default theme. This is done in file scope and is not imported or referenced by any code, hence webpack treeshakes it out.

Adding file to sideEffects list in package.json.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8194)