### PR TITLE
Add absolute position example to Tooltip documentation

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2019-03-updateTooltipDocumentation_2019-03-05-17-35.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-03-updateTooltipDocumentation_2019-03-05-17-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: Add absolute position example to documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
@@ -7,6 +7,7 @@ import { TooltipDisplayExample } from './examples/Tooltip.Display.Example';
 import { TooltipInteractiveExample } from './examples/Tooltip.Interactive.Example';
 import { TooltipOverflowExample } from './examples/Tooltip.Overflow.Example';
 import { TooltipNoScrollExample } from './examples/Tooltip.NoScroll.Example';
+import { TooltipAbsolutePositionExample } from './examples/Tooltip.Absolute.Position.Example';
 import { TooltipStatus } from './Tooltip.checklist';
 
 const TooltipBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx') as string;
@@ -16,6 +17,7 @@ const TooltipCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src
 const TooltipInteractiveExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx') as string;
 const TooltipOverflowExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Overflow.Example.tsx') as string;
 const TooltipNoScrollExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx') as string;
+const TooltipAbsolutePositionExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Absolute.Position.Example.tsx') as string;
 
 export const TooltipPageProps: IDocPageProps = {
   title: 'Tooltip',
@@ -53,6 +55,11 @@ export const TooltipPageProps: IDocPageProps = {
       title: 'Tooltip without scroll (improves performance)',
       code: TooltipNoScrollExampleCode,
       view: <TooltipNoScrollExample />
+    },
+    {
+      title: 'Tooltip with position absolute',
+      code: TooltipAbsolutePositionExampleCode,
+      view: <TooltipAbsolutePositionExample />
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Absolute.Position.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Absolute.Position.Example.tsx
@@ -1,0 +1,44 @@
+// @codepen
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { getId } from 'office-ui-fabric-react/lib/Utilities';
+
+export class TooltipAbsolutePositionExample extends React.Component<any, any> {
+  // Use getId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  private _hostId: string = getId('tooltipHost');
+  private _buttonId: string = getId('targetButton');
+
+  public render(): JSX.Element {
+    console.log(this._buttonId);
+    return (
+      <div
+        style={{
+          minHeight: 50
+        }}
+      >
+        <TooltipHost
+          content="This is the tooltip"
+          id={this._hostId}
+          calloutProps={{
+            gapSpace: 0,
+            target: `#${this._buttonId}`
+          }}
+        >
+          <DefaultButton
+            id={this._buttonId}
+            aria-labelledby={this._hostId}
+            style={{
+              position: 'absolute',
+              top: 50,
+              left: 200
+            }}
+          >
+            Hover Over Me
+          </DefaultButton>
+        </TooltipHost>
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Absolute.Position.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Absolute.Position.Example.tsx.shot
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Tooltip.Absolute.Position.Example.tsx correctly 1`] = `
+<div
+  style={
+    Object {
+      "minHeight": 50,
+    }
+  }
+>
+  <div
+    className=
+        ms-TooltipHost
+        {
+          display: inline;
+        }
+    onBlurCapture={[Function]}
+    onFocusCapture={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <button
+      aria-labelledby="tooltipHost0"
+      className=
+          ms-Button
+          ms-Button--default
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #f4f4f4;
+            border-radius: 0px;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+            color: #333333;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #eaeaea;
+            color: #212121;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:active {
+            background-color: #c8c8c8;
+            color: #212121;
+          }
+      data-is-focusable={true}
+      id="targetButton1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      style={
+        Object {
+          "left": 200,
+          "position": "absolute",
+          "top": 50,
+        }
+      }
+      type="button"
+    >
+      <div
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+      >
+        <div
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
+        >
+          <div
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
+            id="id__2"
+          >
+            Hover Over Me
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8149 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds a absolute position example to Tooltip

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8196)