### PR TITLE
List, DetailsList, & GroupedList: Add items array immutability and SCU documentation

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-list-mutable-data_2019-03-05-22-15.json
+++ b/common/changes/office-ui-fabric-react/keco-list-mutable-data_2019-03-05-22-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "List & DetailsList: Add documentation covering item immutability and shouldComponentUpdate",
+      "comment": "List, DetailsList, & GroupedList: Add documentation covering item immutability and shouldComponentUpdate",
       "type": "none"
     }
   ],

--- a/common/changes/office-ui-fabric-react/keco-list-mutable-data_2019-03-05-22-15.json
+++ b/common/changes/office-ui-fabric-react/keco-list-mutable-data_2019-03-05-22-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List & DetailsList: Add documentation covering item immutability and shouldComponentUpdate",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/docs/DetailsListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/docs/DetailsListOverview.md
@@ -9,3 +9,17 @@ DetailsList is classically used to display files, but is also used to render cus
 Add the `data-is-scrollable="true"` attribute to your scrollable element containing the DetailsList.
 
 By default, the List used within DetailsList will use the `BODY` element as the scrollable element. If you contain the List within a scrollable `DIV` using `overflow: auto` or `scroll`, the List needs to listen for scroll events on that element instead. On initialization, the List will traverse up the DOM looking for the first element with the `data-is-scrollable` attribute to know when element to listen to for knowing when to re-evaulate the visible window.
+
+## My List is not re-rendering when I mutate its items! What should I do?
+
+To determine if the List within DetailsList should re-render its contents, the component performs a referential equality check within its `shouldComponentUpdate` method.
+This is done to minimize the performance overhead associating with re-rendering the virtualized List pages, as recommended by the [React documentation](https://reactjs.org/docs/optimizing-performance.html#the-power-of-not-mutating-data).
+
+As a result of this implementation, the inner List will not determine it should re-render if the array values are mutated.
+To avoid this problem, we recommend re-creating the items array backing the DetailsList by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
+
+```tsx
+<DetailsList items={[...items, ...newItems]} />
+```
+
+By re-creating the items array without mutating the values, the inner List will correctly determine its contents have changed and that it should re-render the new values.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/docs/DetailsListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/docs/DetailsListOverview.md
@@ -19,7 +19,19 @@ As a result of this implementation, the inner List will not determine it should 
 To avoid this problem, we recommend re-creating the items array backing the DetailsList by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
 
 ```tsx
-<DetailsList items={[...items, ...newItems]} />
+public appendItems(): void {
+  const { items } = this.state;
+
+  this.setState({
+    items: [...items, ...['Foo', 'Bar']]
+  })
+}
+
+public render(): JSX.Element {
+  const { items } = this.state;
+
+  return <DetailsList items={items} />;
+}
 ```
 
 By re-creating the items array without mutating the values, the inner List will correctly determine its contents have changed and that it should re-render the new values.

--- a/packages/office-ui-fabric-react/src/components/GroupedList/docs/GroupedListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/docs/GroupedListOverview.md
@@ -1,1 +1,15 @@
 Allows you to render a set of items as multiple lists with various grouping properties.
+
+## My List is not re-rendering when I mutate its items! What should I do?
+
+To determine if the List within GroupedList should re-render its contents, the component performs a referential equality check within its `shouldComponentUpdate` method.
+This is done to minimize the performance overhead associating with re-rendering the virtualized List pages, as recommended by the [React documentation](https://reactjs.org/docs/optimizing-performance.html#the-power-of-not-mutating-data).
+
+As a result of this implementation, the inner List will not determine it should re-render if the array values are mutated.
+To avoid this problem, we recommend re-creating the items array backing the GroupedList by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
+
+```tsx
+<GroupedList items={[...items, ...newItems]} />
+```
+
+By re-creating the items array without mutating the values, the inner List will correctly determine its contents have changed and that it should re-render the new values.

--- a/packages/office-ui-fabric-react/src/components/GroupedList/docs/GroupedListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/docs/GroupedListOverview.md
@@ -9,7 +9,19 @@ As a result of this implementation, the inner List will not determine it should 
 To avoid this problem, we recommend re-creating the items array backing the GroupedList by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
 
 ```tsx
-<GroupedList items={[...items, ...newItems]} />
+public appendItems(): void {
+  const { items } = this.state;
+
+  this.setState({
+    items: [...items, ...['Foo', 'Bar']]
+  })
+}
+
+public render(): JSX.Element {
+  const { items } = this.state;
+
+  return <GroupedList items={items} />;
+}
 ```
 
 By re-creating the items array without mutating the values, the inner List will correctly determine its contents have changed and that it should re-render the new values.

--- a/packages/office-ui-fabric-react/src/components/List/docs/ListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/List/docs/ListOverview.md
@@ -11,3 +11,17 @@ Note: although `onRenderCell` is an optional member of `IListProps`, if you do n
 Add the `data-is-scrollable="true"` attribute to your scrollable element containing the List.
 
 By default, List will use the `BODY` element as the scrollable element. If you contain the List within a scrollable `DIV` using `overflow: auto` or `scroll`, the List needs to listen for scroll events on that element instead. On initialization, the List will traverse up the DOM looking for the first element with the `data-is-scrollable` attribute to know when element to listen to for knowing when to re-evaulate the visible window.
+
+## My List is not re-rendering when I mutate its items! What should I do?
+
+To determine if the List should re-render its contents, the component performs a referential equality check within its `shouldComponentUpdate` method.
+This is done to minimize the performance overhead associating with re-rendering the virtualized List pages, as recommended by the [React documentation](https://reactjs.org/docs/optimizing-performance.html#the-power-of-not-mutating-data).
+
+As a result of this implementation, the List will not determine it should re-render if the array values are mutated.
+To avoid this problem, we recommend re-creating the items array backing the List by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
+
+```tsx
+<List items={[...items, ...newItems]} />
+```
+
+By re-creating the items array without mutating the values, the List will correctly determine its contents have changed and that it should re-render the new values.

--- a/packages/office-ui-fabric-react/src/components/List/docs/ListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/List/docs/ListOverview.md
@@ -21,7 +21,19 @@ As a result of this implementation, the List will not determine it should re-ren
 To avoid this problem, we recommend re-creating the items array backing the List by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
 
 ```tsx
-<List items={[...items, ...newItems]} />
+public appendItems(): void {
+  const { items } = this.state;
+
+  this.setState({
+    items: [...items, ...[{ name: 'Foo' }, { name: 'Bar' }]]
+  })
+}
+
+public render(): JSX.Element {
+  const { items } = this.state;
+
+  return <List items={items} />;
+}
 ```
 
 By re-creating the items array without mutating the values, the List will correctly determine its contents have changed and that it should re-render the new values.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7684 #8131
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds documentation to the `List` & `DetailsList` pages covering the common scenario folks run into which is that they mutate the underlying `items` array values rather than re-create the array. By mutating the values directly, the List's SCU returns `false` and so the List is not re-rendered.

This documentation recommends recreating the `items` array when its values are modified via an `Array.prototype` helper such as `.concat` or ES6 syntax `[ ...items, ...newItems ]` as recommended per the React documentation (also linked).

#### Focus areas to test

None.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8201)