### PR TITLE
SpinButton: Stateful example should restrict input value to range.

### DIFF
--- a/common/changes/office-ui-fabric-react/spinbutton_stateful_2019-03-05-22-56.json
+++ b/common/changes/office-ui-fabric-react/spinbutton_stateful_2019-03-05-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SpinButton: Stateful example should restrict input value to range.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
@@ -9,11 +9,13 @@ export class SpinButtonStatefulExample extends React.Component<any, any> {
     return (
       <div style={{ width: '400px' }}>
         <SpinButton
-          label="SpinButton with custom implementation:"
+          label={'SpinButton with custom implementation:'}
+          min={0}
+          max={100}
           value={'7' + suffix}
           onValidate={(value: string) => {
             value = this._removeSuffix(value, suffix);
-            if (value.trim().length === 0 || isNaN(+value)) {
+            if (Number(value) > 100 || Number(value) < 0 || value.trim().length === 0 || isNaN(+value)) {
               return '0' + suffix;
             }
 

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Stateful.Example.tsx
@@ -23,11 +23,19 @@ export class SpinButtonStatefulExample extends React.Component<any, any> {
           }}
           onIncrement={(value: string) => {
             value = this._removeSuffix(value, suffix);
-            return String(+value + 2) + suffix;
+            if (Number(value) + 2 > 100) {
+              return String(+value) + suffix;
+            } else {
+              return String(+value + 2) + suffix;
+            }
           }}
           onDecrement={(value: string) => {
             value = this._removeSuffix(value, suffix);
-            return String(+value - 2) + suffix;
+            if (Number(value) - 2 < 0) {
+              return String(+value) + suffix;
+            } else {
+              return String(+value - 2) + suffix;
+            }
           }}
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7217
- [x] Include a change request file using `$ npm run change`

#### Description of changes
User should not be allowed to enter the values in 'Spin Button with custom implementation' edit box out of the defined range i.e.'0-100'. Bug 3 of [SpinButton A11y Pass](https://github.com/OfficeDev/office-ui-fabric-react/issues/7217).

#### Focus areas to test
Test by inputting values outside the 0-100 range in this Stateful example's input.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8202)