### PR TITLE
Fix tslint-rules and prettier-rules config and publishing

### DIFF
--- a/common/changes/@uifabric/prettier-rules/tslint_2019-03-06-00-19.json
+++ b/common/changes/@uifabric/prettier-rules/tslint_2019-03-06-00-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/prettier-rules",
+      "comment": "Update package description",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/prettier-rules",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/tslint-rules/tslint_2019-03-06-00-19.json
+++ b/common/changes/@uifabric/tslint-rules/tslint_2019-03-06-00-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/tslint-rules",
+      "comment": "Make tslint-react a non-dev dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/tslint-rules",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/prettier-rules/package.json
+++ b/packages/prettier-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/prettier-rules",
   "version": "1.0.0",
-  "description": "Shared Prettier rules",
+  "description": "Shared Prettier rules for UI Fabric projects",
   "main": "prettier.config.js",
   "scripts": {
     "clean": "",

--- a/packages/tslint-rules/package.json
+++ b/packages/tslint-rules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/tslint-rules",
   "version": "1.0.0",
-  "description": "Shared tslint rules",
+  "description": "Shared TSLint rules for UI Fabric projects",
   "main": "tslint.json",
   "scripts": {
     "clean": "",
@@ -11,7 +11,7 @@
   "disabledTasks": [
     "verify-api-extractor"
   ],
-  "devDependencies": {
+  "dependencies": {
     "tslint-react": "^3.2.0"
   }
 }

--- a/rush.json
+++ b/rush.json
@@ -408,12 +408,12 @@
     {
       "packageName": "@uifabric/tslint-rules",
       "projectFolder": "packages/tslint-rules",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@uifabric/prettier-rules",
       "projectFolder": "packages/prettier-rules",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@uifabric/theme-samples",


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

While working on making a new repo for the dashboard project (which depends on `@uifabric/tslint-rules`), I noticed that tslint-rules had `tslint-react` as a devDependency when it should have been a regular dependency. 

Also updated rush.json so that changes to tslint-rules and prettier-rules are published--this is relevant for dashboard and will become more important as we start adding other repos with builds similar to Fabric's build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8205)