### PR TITLE
Prevent webpack output to stderr in non-error cases

### DIFF
--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -142,8 +142,10 @@ module.exports = {
         plugins: [
           // TODO: will investigate why this doesn't work on mac
           // new WebpackNotifierPlugin(),
-          new ForkTsCheckerWebpackPlugin(),
-          ...(process.env.TRAVIS ? [] : [new webpack.ProgressPlugin()])
+          new ForkTsCheckerWebpackPlugin()
+          // This sends output to stderr for some reason, which makes rush build say
+          // "succeeded with warnings" when there were no real warnings
+          // ...(process.env.TRAVIS ? [] : [new webpack.ProgressPlugin()])
         ]
       },
       customConfig


### PR DESCRIPTION
The [ProgressPlugin](https://webpack.js.org/plugins/progress-plugin/) in the webpack config was sending a bunch of diagnostic output to stderr for some reason (instead of stdout), which caused `rush build` to say projects "succeeded with warnings" when there were no actual warnings. This is obnoxious and misleading.

Currently I have the ProgressPlugin line commented out, but if we *must* have a ProgressPlugin, we could make a custom handler which does the exact same as the original ([implementation here](https://github.com/webpack/webpack/blob/0293c3a5ee6e41d04f4c5e1fb0607fdb7a0b38a8/lib/ProgressPlugin.js#L19-L61)) except sends the output to `process.stdout` not `process.stderr`.

(I also opened an [issue with webpack](https://github.com/webpack/webpack/issues/8871) to find out whether they'd be open to adding an option to make the plugin's default handler use stdout.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8208)