### PR TITLE
Fix selector in a mergeStyleSets example

### DIFF
--- a/common/changes/@uifabric/merge-styles/pr-8214_2019-03-07-13-23.json
+++ b/common/changes/@uifabric/merge-styles/pr-8214_2019-03-07-13-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Fix selector in a mergeStyleSets Readme example",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "ivdijan@microsoft.com"
+}

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -300,7 +300,7 @@ mergeStyleSets({
     classNames.child,
     {
       selectors: {
-        `.${classNames.root}:hover &`: {
+        [`.${classNames.root}:hover &`]: {
           background: 'green'
         }
       }


### PR DESCRIPTION
Fix selector in "Referencing child elements within the mergeStyleSets scope" example

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8214)