### PR TITLE
Autofill: Fix korean input by removing special case.

### DIFF
--- a/common/changes/office-ui-fabric-react/joschect-fix-korean_2019-03-06-19-43.json
+++ b/common/changes/office-ui-fabric-react/joschect-fix-korean_2019-03-06-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Autofill: Fix korean ime entry by removing special case",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -150,13 +150,10 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
   private _onCompositionEnd = (ev: React.CompositionEvent<HTMLInputElement>) => {
     const inputValue = this._getCurrentInputValue();
     this._tryEnableAutofill(inputValue, this.value, false, true);
-    // Korean characters typing issue has been addressed in React 16.5
-    // TODO: revert back below lines when we upgrade to React 16.5
-    // Find out at https://github.com/facebook/react/pull/12563/commits/06524c6c542c571705c0fd7df61ac48f3d5ce244
-    const isKorean = (ev.nativeEvent as any).locale === 'ko';
+
     // Due to timing, this needs to be async, otherwise no text will be selected.
     this._async.setTimeout(() => {
-      const updatedInputValue = isKorean ? this.value : inputValue;
+      const updatedInputValue = inputValue;
       this._updateValue(updatedInputValue);
     }, 0);
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #8082 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

In react 15 there was a bug where Korean ime inputs were not handled correctly but now that fabric is on react 16 we no longer need the special case fix for that and so it should be removed.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8219)