### PR TITLE
Adding pre-copy.json creation step and template when using create-package

### DIFF
--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -68,6 +68,7 @@ const steps = [
   { template: 'WebpackServeConfig', output: 'webpack.serve.config.js' },
   { template: 'VsCodeLaunch', output: path.join('.vscode', 'launch.json') },
   { template: 'Tests', output: path.join('config', 'tests.js') },
+  { template: 'PreCopy', output: path.join('config', 'pre-copy.json') },
   { template: 'Tests', output: path.join('src', 'common', 'tests.js') },
   { template: 'IndexTs', output: path.join('src', 'index.ts') },
   { template: 'Version', output: path.join('src', 'version.ts') },

--- a/scripts/templates/create-package/EmptyPreCopy.mustache
+++ b/scripts/templates/create-package/EmptyPreCopy.mustache
@@ -1,0 +1,11 @@
+{
+  "copyTo": {
+    "dist": [
+      "./index.html",
+      "./node_modules/react/umd/react.development.js",
+      "./node_modules/react/umd/react.production.min.js",
+      "./node_modules/react-dom/umd/react-dom.development.js",
+      "./node_modules/react-dom/umd/react-dom.production.min.js"
+    ]
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The `create-package` script was outputting packages that were giving an error when using `npm start` on them because it was missing the creation of `pre-copy.json` under the new package's config folder, which meant that `index.html` was not being copied to the `dist` folder when building the package.

This PR fixes this by creating `EmptyPreCopy.mustache`, a template file for the `pre-copy.json` file, under `scripts/templates/create-package` and by adding the step to use this template in `create-package.js`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8229)