### PR TITLE
Revert "List: Remove usage of string refs for List pages"

### DIFF
--- a/common/changes/office-ui-fabric-react/revert-7704-keco-list-ref_2019-03-07-17-14.json
+++ b/common/changes/office-ui-fabric-react/revert-7704-keco-list-ref_2019-03-07-17-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Revert remove usage of string refs for List pages #7704",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -93,7 +93,6 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
 
   private _root = React.createRef<HTMLDivElement>();
   private _surface = React.createRef<HTMLDivElement>();
-  private _pageRefs: { [pageKey: string]: React.RefObject<HTMLDivElement> };
 
   private _estimatedPageHeight: number;
   private _totalEstimates: number;
@@ -161,7 +160,6 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
       leading: false
     });
 
-    this._pageRefs = {};
     this._cachedPageHeights = {};
     this._estimatedPageHeight = 0;
     this._focusedIndex = -1;
@@ -406,14 +404,12 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
 
     const { onRenderPage = this._onRenderPage } = this.props;
 
-    this._pageRefs[page.key] = this._pageRefs[page.key] || React.createRef();
-
     const pageElement = onRenderPage(
       {
         page: page,
         className: css('ms-List-page'),
         key: page.key,
-        ref: this._pageRefs[page.key],
+        ref: page.key,
         style: pageStyle,
         role: 'presentation'
       },
@@ -667,7 +663,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
    */
   private _measurePage(page: IPage): boolean {
     let hasChangedHeight = false;
-    const pageElement = this._pageRefs[page.key].current;
+    const pageElement = this.refs[page.key] as HTMLElement;
     const cachedHeight = this._cachedPageHeights[page.startIndex];
 
     // console.log('   * measure attempt', page.startIndex, cachedHeight);


### PR DESCRIPTION
Reverts OfficeDev/office-ui-fabric-react#7704

There's an edge-case with the call flow to `_measurePage` which results in `undefined` refs that we don't currently catch causing issues in production.

Reverting until that is figured out and guarded against.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8237)