### PR TITLE
Shimmer: add feature enabling easy customization of colors when placed in elements with themed background

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,7 +90,7 @@ FolderCover/ @ThomasMichon
 FocusTrapZone/ @JasonGore
 FocusZone/ @JasonGore
 GroupedList/  @aditima @KevinTCoughlin
-HoverCard/   @atneik @Jahnp
+HoverCard/   @atneik @Jahnp @Vitalius1
 Icon/ @dzearing
 Image/ @dzearing
 Label/ @cliffkoh
@@ -115,6 +115,7 @@ ProgressIndicator/ @aneeshak
 Rating/ @jdhuntington
 ResizeGroup/ @micahgodbolt
 SearchBox/ @ecraig12345
+Shimmer/ @Vitalius1 @atneik
 Signals/ @ThomasMichon
 Slider/ @aneeshak
 SpinButton/ @aneeshack4
@@ -154,7 +155,7 @@ DocumentCard/docs/ @yiminwu @mikewheaton
 # FocusTrapZone/docs/
 # FocusZone/docs/
 GroupedList/docs/  @aditima @KevinTCoughlin
-HoverCard/docs/   @atneik @Jahnp
+HoverCard/docs/   @atneik @Jahnp @Vitalius1
 # Icon/docs/
 # Image/docs/
 # Label/docs/
@@ -176,6 +177,7 @@ pickers/docs/  @joschect
 # Rating/docs/
 ResizeGroup/docs/  @micahgodbolt
 # SearchBox/docs/
+Shimmer/docs/ @Vitalius1 @atneik
 # Slider/docs/
 # SpinButton/docs/
 # Spinner/docs/

--- a/apps/vr-tests/src/stories/Shimmer.stories.tsx
+++ b/apps/vr-tests/src/stories/Shimmer.stories.tsx
@@ -82,20 +82,20 @@ storiesOf('Shimmer', module)
       <Shimmer
         width={300}
         shimmerColors={{
-          shimmerMain: '#71afe5',
+          shimmer: '#71afe5',
           shimmerWave: '#2b88d8'
         }}
         customElementsGroup={
           <div style={{ display: 'flex' }}>
             <ShimmerElementsGroup
-              surroundingColor={'#0078D4'}
+              spaceColor={'#0078D4'}
               shimmerElements={[
                 { type: ElemType.circle, height: 40 },
                 { type: ElemType.gap, width: 16, height: 40 }
               ]}
             />
             <ShimmerElementsGroup
-              surroundingColor={'#0078D4'}
+              spaceColor={'#0078D4'}
               flexWrap={true}
               width="100%"
               shimmerElements={[

--- a/apps/vr-tests/src/stories/Shimmer.stories.tsx
+++ b/apps/vr-tests/src/stories/Shimmer.stories.tsx
@@ -8,6 +8,19 @@ import {
   ShimmerElementType as ElemType,
   ShimmerElementsGroup
 } from 'office-ui-fabric-react';
+import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+
+const wrapperClassName = mergeStyles({
+  width: 400,
+  height: 100,
+  margin: '10px 0',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: '#0078D4',
+  outline: `1px solid #333333`,
+  outlineOffset: '-10px'
+});
 
 storiesOf('Shimmer', module)
   .addDecorator(story => (
@@ -63,6 +76,38 @@ storiesOf('Shimmer', module)
       }
       width={300}
     />
+  ))
+  .addStory('Custom elements on themed background', () => (
+    <div className={wrapperClassName}>
+      <Shimmer
+        width={300}
+        shimmerColors={{
+          shimmerMain: '#71afe5',
+          shimmerWave: '#2b88d8'
+        }}
+        customElementsGroup={
+          <div style={{ display: 'flex' }}>
+            <ShimmerElementsGroup
+              surroundingColor={'#0078D4'}
+              shimmerElements={[
+                { type: ElemType.circle, height: 40 },
+                { type: ElemType.gap, width: 16, height: 40 }
+              ]}
+            />
+            <ShimmerElementsGroup
+              surroundingColor={'#0078D4'}
+              flexWrap={true}
+              width="100%"
+              shimmerElements={[
+                { type: ElemType.line, width: '100%', height: 10, verticalAlign: 'bottom' },
+                { type: ElemType.line, width: '90%', height: 8 },
+                { type: ElemType.gap, width: '10%', height: 20 }
+              ]}
+            />
+          </div>
+        }
+      />
+    </div>
   ))
   .addStory('Data not loaded', () => (
     <Shimmer isDataLoaded={false} ariaLabel={'Loading content'}>

--- a/apps/vr-tests/src/stories/Shimmer.stories.tsx
+++ b/apps/vr-tests/src/stories/Shimmer.stories.tsx
@@ -88,14 +88,14 @@ storiesOf('Shimmer', module)
         customElementsGroup={
           <div style={{ display: 'flex' }}>
             <ShimmerElementsGroup
-              spaceColor={'#0078D4'}
+              backgroundColor={'#0078D4'}
               shimmerElements={[
                 { type: ElemType.circle, height: 40 },
                 { type: ElemType.gap, width: 16, height: 40 }
               ]}
             />
             <ShimmerElementsGroup
-              spaceColor={'#0078D4'}
+              backgroundColor={'#0078D4'}
               flexWrap={true}
               width="100%"
               shimmerElements={[

--- a/common/changes/office-ui-fabric-react/v-vibr-ShimmerWhite_2019-03-08-02-01.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ShimmerWhite_2019-03-08-02-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Shimmer: adds new props `shimmerColors` to Shimmer and `surroundingColor` to ShimmerElementsGroup to allow easy customization of Shimmer colors when placed on elements with background colors other than white.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/v-vibr-ShimmerWhite_2019-03-08-02-01.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ShimmerWhite_2019-03-08-02-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Shimmer: adds new props `shimmerColors` to Shimmer and `spaceColor` to ShimmerElementsGroup to allow easy customization of Shimmer colors when placed on elements with background colors other than white.",
+      "comment": "Shimmer: adds new props `shimmerColors` to Shimmer and `backgroundColor` to ShimmerElementsGroup to allow easy customization of Shimmer colors when placed on elements with background colors other than white.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/v-vibr-ShimmerWhite_2019-03-08-02-01.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-ShimmerWhite_2019-03-08-02-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Shimmer: adds new props `shimmerColors` to Shimmer and `surroundingColor` to ShimmerElementsGroup to allow easy customization of Shimmer colors when placed on elements with background colors other than white.",
+      "comment": "Shimmer: adds new props `shimmerColors` to Shimmer and `spaceColor` to ShimmerElementsGroup to allow easy customization of Shimmer colors when placed on elements with background colors other than white.",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -2584,7 +2584,7 @@ interface IChoiceGroupStyles {
   root?: IStyle;
 }
 
-// @public (undocumented)
+// @public
 interface ICircle extends IShimmerElement {
   height?: number;
 }
@@ -8016,7 +8016,7 @@ interface IFontStyles {
   xxLarge: IRawStyle;
 }
 
-// @public (undocumented)
+// @public
 interface IGap extends IShimmerElement {
   height?: number;
   width?: number | string;
@@ -8600,7 +8600,7 @@ interface ILayerStyles {
   root?: IStyle;
 }
 
-// @public (undocumented)
+// @public
 interface ILine extends IShimmerElement {
   height?: number;
   width?: number | string;
@@ -10335,6 +10335,13 @@ interface IShimmerCircleStyles {
 }
 
 // @public
+interface IShimmerColors {
+  shimmerMain?: string;
+  shimmerWave?: string;
+  surroundingSpace?: string;
+}
+
+// @public
 interface IShimmerElement {
   height?: number;
   type: ShimmerElementType;
@@ -10353,21 +10360,19 @@ interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTMLElement
   rowHeight?: number;
   shimmerElements?: IShimmerElement[];
   styles?: IStyleFunctionOrObject<IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>;
+  surroundingColor?: string;
   theme?: ITheme;
   width?: string;
 }
 
-// @public (undocumented)
+// @public
 interface IShimmerElementsGroupStyleProps {
-  // (undocumented)
   flexWrap?: boolean;
-  // (undocumented)
   theme: ITheme;
 }
 
-// @public (undocumented)
+// @public
 interface IShimmerElementsGroupStyles {
-  // (undocumented)
   root?: IStyle;
 }
 
@@ -10422,6 +10427,7 @@ interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
   componentRef?: IRefObject<IShimmer>;
   customElementsGroup?: React.ReactNode;
   isDataLoaded?: boolean;
+  shimmerColors?: IShimmerColors;
   shimmerElements?: IShimmerElement[];
   styles?: IStyleFunctionOrObject<IShimmerStyleProps, IShimmerStyles>;
   theme?: ITheme;
@@ -10433,27 +10439,21 @@ interface IShimmerState {
   contentLoaded?: boolean;
 }
 
-// @public (undocumented)
+// @public
 interface IShimmerStyleProps {
-  // (undocumented)
   className?: string;
-  // (undocumented)
   isDataLoaded?: boolean;
-  // (undocumented)
+  shimmerMainColor?: string;
+  shimmerWaveColor?: string;
   theme: ITheme;
-  // (undocumented)
   transitionAnimationInterval?: number;
 }
 
-// @public (undocumented)
+// @public
 interface IShimmerStyles {
-  // (undocumented)
   dataWrapper?: IStyle;
-  // (undocumented)
   root?: IStyle;
-  // (undocumented)
   screenReaderText?: IStyle;
-  // (undocumented)
   shimmerWrapper?: IStyle;
 }
 
@@ -12301,7 +12301,7 @@ class ShimmeredDetailsListBase extends BaseComponent<IShimmeredDetailsListProps,
   render(): JSX.Element;
 }
 
-// @public (undocumented)
+// @public
 enum ShimmerElementsDefaultHeights {
   circle = 24,
   gap = 16,
@@ -12317,7 +12317,7 @@ class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGroupProps,
   render(): JSX.Element;
 }
 
-// @public (undocumented)
+// @public
 enum ShimmerElementType {
   circle = 2,
   gap = 3,

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10355,11 +10355,11 @@ interface IShimmerElementsGroup {
 
 // @public
 interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTMLElement> {
+  backgroundColor?: string;
   componentRef?: IRefObject<IShimmerElementsGroup>;
   flexWrap?: boolean;
   rowHeight?: number;
   shimmerElements?: IShimmerElement[];
-  spaceColor?: string;
   styles?: IStyleFunctionOrObject<IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>;
   theme?: ITheme;
   width?: string;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10336,9 +10336,9 @@ interface IShimmerCircleStyles {
 
 // @public
 interface IShimmerColors {
-  shimmerMain?: string;
+  background?: string;
+  shimmer?: string;
   shimmerWave?: string;
-  surroundingSpace?: string;
 }
 
 // @public
@@ -10359,8 +10359,8 @@ interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTMLElement
   flexWrap?: boolean;
   rowHeight?: number;
   shimmerElements?: IShimmerElement[];
+  spaceColor?: string;
   styles?: IStyleFunctionOrObject<IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>;
-  surroundingColor?: string;
   theme?: ITheme;
   width?: string;
 }
@@ -10443,7 +10443,7 @@ interface IShimmerState {
 interface IShimmerStyleProps {
   className?: string;
   isDataLoaded?: boolean;
-  shimmerMainColor?: string;
+  shimmerColor?: string;
   shimmerWaveColor?: string;
   theme: ITheme;
   transitionAnimationInterval?: number;

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -72,7 +72,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
       isDataLoaded,
       className,
       transitionAnimationInterval: TRANSITION_ANIMATION_INTERVAL,
-      shimmerMainColor: shimmerColors && shimmerColors.shimmerMain,
+      shimmerColor: shimmerColors && shimmerColors.shimmer,
       shimmerWaveColor: shimmerColors && shimmerColors.shimmerWave
     });
 
@@ -85,7 +85,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
             {customElementsGroup ? (
               customElementsGroup
             ) : (
-              <ShimmerElementsGroup shimmerElements={shimmerElements} surroundingColor={shimmerColors && shimmerColors.surroundingSpace} />
+              <ShimmerElementsGroup shimmerElements={shimmerElements} spaceColor={shimmerColors && shimmerColors.background} />
             )}
           </div>
         )}

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -85,7 +85,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
             {customElementsGroup ? (
               customElementsGroup
             ) : (
-              <ShimmerElementsGroup shimmerElements={shimmerElements} spaceColor={shimmerColors && shimmerColors.background} />
+              <ShimmerElementsGroup shimmerElements={shimmerElements} backgroundColor={shimmerColors && shimmerColors.background} />
             )}
           </div>
         )}

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -52,7 +52,18 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
   }
 
   public render(): JSX.Element {
-    const { styles, shimmerElements, children, isDataLoaded, width, className, customElementsGroup, theme, ariaLabel } = this.props;
+    const {
+      styles,
+      shimmerElements,
+      children,
+      isDataLoaded,
+      width,
+      className,
+      customElementsGroup,
+      theme,
+      ariaLabel,
+      shimmerColors
+    } = this.props;
 
     const { contentLoaded } = this.state;
 
@@ -60,7 +71,9 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
       theme: theme!,
       isDataLoaded,
       className,
-      transitionAnimationInterval: TRANSITION_ANIMATION_INTERVAL
+      transitionAnimationInterval: TRANSITION_ANIMATION_INTERVAL,
+      shimmerMainColor: shimmerColors && shimmerColors.shimmerMain,
+      shimmerWaveColor: shimmerColors && shimmerColors.shimmerWave
     });
 
     const divProps = getNativeProps(this.props, divProperties);
@@ -69,7 +82,11 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
       <div {...divProps} className={this._classNames.root}>
         {!contentLoaded && (
           <div style={{ width: width ? width : '100%' }} className={this._classNames.shimmerWrapper}>
-            {customElementsGroup ? customElementsGroup : <ShimmerElementsGroup shimmerElements={shimmerElements} />}
+            {customElementsGroup ? (
+              customElementsGroup
+            ) : (
+              <ShimmerElementsGroup shimmerElements={shimmerElements} surroundingColor={shimmerColors && shimmerColors.surroundingSpace} />
+            )}
           </div>
         )}
         {children && <div className={this._classNames.dataWrapper}>{children}</div>}

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.doc.tsx
@@ -8,12 +8,16 @@ import { ShimmerStatus } from './Shimmer.checklist';
 import { IDocPageProps } from '../../common/DocPage.types';
 
 const ShimmerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Basic.Example.tsx') as string;
+const ShimmerBasicExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Shimmer/Shimmer.Basic.Example.Codepen.txt') as string;
 
 const ShimmerCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.CustomElements.Example.tsx') as string;
+const ShimmerCustomExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Shimmer/Shimmer.CustomElements.Example.Codepen.txt') as string;
 
 const ShimmerStylingExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx') as string;
+const ShimmerStylingExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Shimmer/Shimmer.Styling.Example.Codepen.txt') as string;
 
 const ShimmerLoadDataExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.LoadData.Example.tsx') as string;
+const ShimmerLoadDataExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Shimmer/Shimmer.LoadData.Example.Codepen.txt') as string;
 
 const ShimmerApplicationExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx') as string;
 const ShimmerApplicationExampleCodepen = require('!raw-loader!office-ui-fabric-react/lib/codepen/components/Shimmer/Shimmer.Application.Example.Codepen.txt') as string;
@@ -26,16 +30,19 @@ export const ShimmerPageProps: IDocPageProps = {
     {
       title: 'Shimmer with basic elements using the ~shimmerElements~ prop',
       code: ShimmerBasicExampleCode,
+      codepenJS: ShimmerBasicExampleCodepen,
       view: <ShimmerBasicExample />
     },
     {
       title: 'Shimmer with custom elements using the ~customElementsGroup~ prop',
       code: ShimmerCustomExampleCode,
+      codepenJS: ShimmerCustomExampleCodepen,
       view: <ShimmerCustomElementsExample />
     },
     {
       title: 'Shimmer swapping with the content it replaces',
       code: ShimmerLoadDataExampleCode,
+      codepenJS: ShimmerLoadDataExampleCodepen,
       view: <ShimmerLoadDataExample />
     },
     {
@@ -47,6 +54,7 @@ export const ShimmerPageProps: IDocPageProps = {
     {
       title: 'Shimmer styles customizations',
       code: ShimmerStylingExampleCode,
+      codepenJS: ShimmerStylingExampleCodepen,
       view: <ShimmerStylingExample />
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.doc.tsx
@@ -24,12 +24,12 @@ export const ShimmerPageProps: IDocPageProps = {
   componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Shimmer',
   examples: [
     {
-      title: "Shimmer with basic elements using the 'shimmerElements' prop",
+      title: 'Shimmer with basic elements using the ~shimmerElements~ prop',
       code: ShimmerBasicExampleCode,
       view: <ShimmerBasicExample />
     },
     {
-      title: "Shimmer with custom elements using the 'customElementsGroup' prop",
+      title: 'Shimmer with custom elements using the ~customElementsGroup~ prop',
       code: ShimmerCustomExampleCode,
       view: <ShimmerCustomElementsExample />
     },
@@ -45,7 +45,7 @@ export const ShimmerPageProps: IDocPageProps = {
       view: <ShimmerApplicationExample />
     },
     {
-      title: "Style override of shimmering wave using 'styles' prop",
+      title: 'Shimmer styles customizations',
       code: ShimmerStylingExampleCode,
       view: <ShimmerStylingExample />
     }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -29,7 +29,7 @@ const shimmerAnimationRTL: string = keyframes({
 });
 
 export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
-  const { isDataLoaded, className, theme, transitionAnimationInterval, shimmerMainColor, shimmerWaveColor } = props;
+  const { isDataLoaded, className, theme, transitionAnimationInterval, shimmerColor, shimmerWaveColor } = props;
 
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
@@ -49,12 +49,12 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
     shimmerWrapper: [
       classNames.shimmerWrapper,
       {
-        background: `${shimmerMainColor || palette.neutralLighter}
+        background: `${shimmerColor || palette.neutralLighter}
                     linear-gradient(
                       to right,
-                      ${shimmerMainColor || palette.neutralLighter} 0%,
+                      ${shimmerColor || palette.neutralLighter} 0%,
                       ${shimmerWaveColor || palette.neutralLight} 50%,
-                      ${shimmerMainColor || palette.neutralLighter} 100%)
+                      ${shimmerColor || palette.neutralLighter} 100%)
                     0 0 / 90% 100%
                     no-repeat`,
         animationDuration: '2s',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -29,7 +29,7 @@ const shimmerAnimationRTL: string = keyframes({
 });
 
 export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
-  const { isDataLoaded, className, theme, transitionAnimationInterval } = props;
+  const { isDataLoaded, className, theme, transitionAnimationInterval, shimmerMainColor, shimmerWaveColor } = props;
 
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
@@ -49,12 +49,12 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
     shimmerWrapper: [
       classNames.shimmerWrapper,
       {
-        background: `${palette.neutralLighter}
+        background: `${shimmerMainColor || palette.neutralLighter}
                     linear-gradient(
                       to right,
-                      ${palette.neutralLighter} 0%,
-                      ${palette.neutralLight} 50%,
-                      ${palette.neutralLighter} 100%)
+                      ${shimmerMainColor || palette.neutralLighter} 0%,
+                      ${shimmerWaveColor || palette.neutralLight} 50%,
+                      ${shimmerMainColor || palette.neutralLighter} 100%)
                     0 0 / 90% 100%
                     no-repeat`,
         animationDuration: '2s',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
@@ -55,6 +55,11 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
    * Theme provided by High-Order Component.
    */
   theme?: ITheme;
+
+  /**
+   * Defines an object with possible colors to pass for Shimmer customization used on different backgrounds.
+   */
+  shimmerColors?: IShimmerColors;
 }
 
 /**
@@ -62,24 +67,25 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
  */
 export interface IShimmerElement {
   /**
+   * Represents the possible type of the shimmer elements: Gap, Circle, Line.
    * Required for every element you intend to use.
    */
   type: ShimmerElementType;
 
   /**
-   * The height of the element (ICircle, ILine, IGap) in pixels.
+   * Sets the height of the element (ICircle, ILine, IGap) in pixels.
    * Read more details for each specific element.
    */
   height?: number;
 
   /**
-   * The width value of the element (ILine, IGap) in pixels.
+   * Sets the width value of the element (ILine, IGap) in pixels.
    * Read more details for each specific element.
    */
   width?: number | string;
 
   /**
-   * The vertical alignemt of the element (ICircle, ILine).
+   * Sets vertical alignment of the element (ICircle, ILine).
    * @defaultvalue center
    */
   verticalAlign?: 'top' | 'center' | 'bottom';
@@ -127,6 +133,8 @@ export interface IShimmerStyleProps {
   className?: string;
   theme: ITheme;
   transitionAnimationInterval?: number;
+  shimmerMainColor?: string;
+  shimmerWaveColor?: string;
 }
 
 export interface IShimmerStyles {
@@ -168,4 +176,27 @@ export enum ShimmerElementsDefaultHeights {
    * Default height of the circle element when not provided by user: 24px
    */
   circle = 24
+}
+
+/**
+ * Interface describing the possible color customizations of Shimmer.
+ */
+export interface IShimmerColors {
+  /**
+   * Defines the main background color which is the color you see when the wave is not animating.
+   * @defaultvalue theme.palette.neutralLight
+   */
+  shimmerMain?: string;
+
+  /**
+   * Defines the tip color of the shimmer wave which gradually gets from and to `shimmerMain` color.
+   * @defaultvalue theme.palette.neutralLighter
+   */
+  shimmerWave?: string;
+
+  /**
+   * Defines the background color of the space in between and around shimmer elements (borders, gaps and rounded corners).
+   * @defaultvalue theme.palette.white
+   */
+  surroundingSpace?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
@@ -154,9 +154,9 @@ export interface IShimmerStyleProps {
   transitionAnimationInterval?: number;
 
   /** Color to be used as the main background color of Shimmer when not animating. */
-  shimmerMainColor?: string;
+  shimmerColor?: string;
 
-  /** Tip color of the shimmer wave which gradually gets from and to `shimmerMainColor`. */
+  /** Tip color of the shimmer wave which gradually gets from and to `shimmerColor`. */
   shimmerWaveColor?: string;
 }
 
@@ -225,10 +225,10 @@ export interface IShimmerColors {
    * Defines the main background color which is the color you see when the wave is not animating.
    * @defaultvalue theme.palette.neutralLight
    */
-  shimmerMain?: string;
+  shimmer?: string;
 
   /**
-   * Defines the tip color of the shimmer wave which gradually gets from and to `shimmerMain` color.
+   * Defines the tip color of the shimmer wave which gradually gets from and to `shimmer` color.
    * @defaultvalue theme.palette.neutralLighter
    */
   shimmerWave?: string;
@@ -237,5 +237,5 @@ export interface IShimmerColors {
    * Defines the background color of the space in between and around shimmer elements (borders, gaps and rounded corners).
    * @defaultvalue theme.palette.white
    */
-  surroundingSpace?: string;
+  background?: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
@@ -63,7 +63,7 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
 }
 
 /**
- * Shimmer Elements Interface
+ * Shimmer Elements Interface representing all common properties between Gap, Circle and Line.
  */
 export interface IShimmerElement {
   /**
@@ -91,6 +91,9 @@ export interface IShimmerElement {
   verticalAlign?: 'top' | 'center' | 'bottom';
 }
 
+/**
+ * Line element interface
+ */
 export interface ILine extends IShimmerElement {
   /**
    * Sets the height of the shimmer line in pixels.
@@ -105,6 +108,9 @@ export interface ILine extends IShimmerElement {
   width?: number | string;
 }
 
+/**
+ * Circle element interface
+ */
 export interface ICircle extends IShimmerElement {
   /**
    * Sets the height of the shimmer circle in pixels.
@@ -114,6 +120,9 @@ export interface ICircle extends IShimmerElement {
   height?: number;
 }
 
+/**
+ * Gap element interface
+ */
 export interface IGap extends IShimmerElement {
   /**
    * Sets the height of the shimmer gap in pixels.
@@ -128,22 +137,49 @@ export interface IGap extends IShimmerElement {
   width?: number | string;
 }
 
+/**
+ * Defines props needed to construct styles. This represents the simplified set of immutable things which control the class names.
+ */
 export interface IShimmerStyleProps {
+  /** Boolean flag to trigger fadeIn/fadeOut transition animation when content is loaded. */
   isDataLoaded?: boolean;
+
+  /** Optional CSS class name for the component attached to the root stylable area. */
   className?: string;
+
+  /** Theme provided by High-Order Component. */
   theme: ITheme;
+
+  /** Interval in milliseconds for the adeIn/fadeOut transition animation. */
   transitionAnimationInterval?: number;
+
+  /** Color to be used as the main background color of Shimmer when not animating. */
   shimmerMainColor?: string;
+
+  /** Tip color of the shimmer wave which gradually gets from and to `shimmerMainColor`. */
   shimmerWaveColor?: string;
 }
 
+/**
+ * Represents the stylable areas of the control.
+ */
 export interface IShimmerStyles {
+  /** Refers to the root wrapper element. */
   root?: IStyle;
+
+  /** Refers to wrapper element of the shimmer animation only. */
   shimmerWrapper?: IStyle;
+
+  /** Refers to wrapper element of the children only. */
   dataWrapper?: IStyle;
+
+  /** Styles for the hidden helper element to aid with screen readers. */
   screenReaderText?: IStyle;
 }
 
+/**
+ * Describes the possible types for shimmer elements used.
+ */
 export enum ShimmerElementType {
   /**
    * Line element type
@@ -161,6 +197,9 @@ export enum ShimmerElementType {
   gap = 3
 }
 
+/**
+ * Describes the default heights for shimmer elements when omitted in implementation.
+ */
 export enum ShimmerElementsDefaultHeights {
   /**
    * Default height of the line element when not provided by user: 16px

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -48,11 +48,11 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
           const { type, ...filteredElem } = elem;
           switch (elem.type) {
             case ShimmerElementType.circle:
-              return <ShimmerCircle key={index} {...filteredElem} styles={this._getBorderStyles(elem, rowHeight)} />;
+              return <ShimmerCircle key={index} {...filteredElem} styles={this._getStyles(elem, rowHeight)} />;
             case ShimmerElementType.gap:
-              return <ShimmerGap key={index} {...filteredElem} styles={this._getBorderStyles(elem, rowHeight)} />;
+              return <ShimmerGap key={index} {...filteredElem} styles={this._getStyles(elem, rowHeight)} />;
             case ShimmerElementType.line:
-              return <ShimmerLine key={index} {...filteredElem} styles={this._getBorderStyles(elem, rowHeight)} />;
+              return <ShimmerLine key={index} {...filteredElem} styles={this._getStyles(elem, rowHeight)} />;
           }
         }
       )
@@ -63,31 +63,55 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
     return renderedElements;
   };
 
-  private _getBorderStyles = (elem: IShimmerElement, rowHeight?: number): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
+  private _getStyles = (elem: IShimmerElement, rowHeight?: number): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
+    const { surroundingColor } = this.props;
+    const { verticalAlign, type } = elem;
     const elemHeight: number | undefined = elem.height;
     const dif: number = rowHeight && elemHeight ? rowHeight - elemHeight : 0;
 
     let borderStyle: IRawStyle | undefined;
 
-    if (!elem.verticalAlign || elem.verticalAlign === 'center') {
+    if (!verticalAlign || verticalAlign === 'center') {
       borderStyle = {
         borderBottomWidth: `${dif ? Math.floor(dif / 2) : 0}px`,
         borderTopWidth: `${dif ? Math.ceil(dif / 2) : 0}px`
       };
-    } else if (elem.verticalAlign && elem.verticalAlign === 'top') {
+    } else if (verticalAlign && verticalAlign === 'top') {
       borderStyle = {
         borderBottomWidth: `${dif ? dif : 0}px`,
         borderTopWidth: `0px`
       };
-    } else if (elem.verticalAlign && elem.verticalAlign === 'bottom') {
+    } else if (verticalAlign && verticalAlign === 'bottom') {
       borderStyle = {
         borderBottomWidth: `0px`,
         borderTopWidth: `${dif ? dif : 0}px`
       };
     }
 
+    if (surroundingColor) {
+      switch (type) {
+        case ShimmerElementType.circle:
+          return {
+            root: { ...borderStyle, borderColor: surroundingColor },
+            svg: { fill: surroundingColor }
+          };
+        case ShimmerElementType.gap:
+          return {
+            root: { ...borderStyle, borderColor: surroundingColor, backgroundColor: surroundingColor }
+          };
+        case ShimmerElementType.line:
+          return {
+            root: { ...borderStyle, borderColor: surroundingColor },
+            topLeftCorner: { fill: surroundingColor },
+            topRightCorner: { fill: surroundingColor },
+            bottomLeftCorner: { fill: surroundingColor },
+            bottomRightCorner: { fill: surroundingColor }
+          };
+      }
+    }
+
     return {
-      root: [{ ...borderStyle }]
+      root: { ...borderStyle }
     };
   };
 

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -64,7 +64,7 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
   };
 
   private _getStyles = (elem: IShimmerElement, rowHeight?: number): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
-    const { spaceColor } = this.props;
+    const { backgroundColor } = this.props;
     const { verticalAlign, type } = elem;
     const elemHeight: number | undefined = elem.height;
     const dif: number = rowHeight && elemHeight ? rowHeight - elemHeight : 0;
@@ -88,24 +88,24 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
       };
     }
 
-    if (spaceColor) {
+    if (backgroundColor) {
       switch (type) {
         case ShimmerElementType.circle:
           return {
-            root: { ...borderStyle, borderColor: spaceColor },
-            svg: { fill: spaceColor }
+            root: { ...borderStyle, borderColor: backgroundColor },
+            svg: { fill: backgroundColor }
           };
         case ShimmerElementType.gap:
           return {
-            root: { ...borderStyle, borderColor: spaceColor, backgroundColor: spaceColor }
+            root: { ...borderStyle, borderColor: backgroundColor, backgroundColor: backgroundColor }
           };
         case ShimmerElementType.line:
           return {
-            root: { ...borderStyle, borderColor: spaceColor },
-            topLeftCorner: { fill: spaceColor },
-            topRightCorner: { fill: spaceColor },
-            bottomLeftCorner: { fill: spaceColor },
-            bottomRightCorner: { fill: spaceColor }
+            root: { ...borderStyle, borderColor: backgroundColor },
+            topLeftCorner: { fill: backgroundColor },
+            topRightCorner: { fill: backgroundColor },
+            bottomLeftCorner: { fill: backgroundColor },
+            bottomRightCorner: { fill: backgroundColor }
           };
       }
     }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -64,7 +64,7 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
   };
 
   private _getStyles = (elem: IShimmerElement, rowHeight?: number): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
-    const { surroundingColor } = this.props;
+    const { spaceColor } = this.props;
     const { verticalAlign, type } = elem;
     const elemHeight: number | undefined = elem.height;
     const dif: number = rowHeight && elemHeight ? rowHeight - elemHeight : 0;
@@ -88,24 +88,24 @@ export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGrou
       };
     }
 
-    if (surroundingColor) {
+    if (spaceColor) {
       switch (type) {
         case ShimmerElementType.circle:
           return {
-            root: { ...borderStyle, borderColor: surroundingColor },
-            svg: { fill: surroundingColor }
+            root: { ...borderStyle, borderColor: spaceColor },
+            svg: { fill: spaceColor }
           };
         case ShimmerElementType.gap:
           return {
-            root: { ...borderStyle, borderColor: surroundingColor, backgroundColor: surroundingColor }
+            root: { ...borderStyle, borderColor: spaceColor, backgroundColor: spaceColor }
           };
         case ShimmerElementType.line:
           return {
-            root: { ...borderStyle, borderColor: surroundingColor },
-            topLeftCorner: { fill: surroundingColor },
-            topRightCorner: { fill: surroundingColor },
-            bottomLeftCorner: { fill: surroundingColor },
-            bottomRightCorner: { fill: surroundingColor }
+            root: { ...borderStyle, borderColor: spaceColor },
+            topLeftCorner: { fill: spaceColor },
+            topRightCorner: { fill: spaceColor },
+            bottomLeftCorner: { fill: spaceColor },
+            bottomRightCorner: { fill: spaceColor }
           };
       }
     }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
@@ -53,11 +53,25 @@ export interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTML
   styles?: IStyleFunctionOrObject<IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>;
 }
 
+/**
+ * Props needed to construct styles.
+ */
 export interface IShimmerElementsGroupStyleProps {
+  /**
+   * Boolean flag to notify whether the root element needs to flex wrap.
+   */
   flexWrap?: boolean;
+
+  /** Theme provided by High-Order Component. */
   theme: ITheme;
 }
 
+/**
+ * Represents the stylable areas of the control.
+ */
 export interface IShimmerElementsGroupStyles {
+  /**
+   * Represents the wrapper root element holding all elements inside.
+   */
   root?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
@@ -45,7 +45,7 @@ export interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTML
    * Defines the background color of the space in between and around shimmer elements.
    * @defaultvalue theme.palette.white
    */
-  spaceColor?: string;
+  backgroundColor?: string;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
@@ -42,6 +42,12 @@ export interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTML
   theme?: ITheme;
 
   /**
+   * Defines the background color of the space in between and around shimmer elements.
+   * @defaultvalue theme.palette.white
+   */
+  surroundingColor?: string;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles>;

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.types.ts
@@ -45,7 +45,7 @@ export interface IShimmerElementsGroupProps extends React.AllHTMLAttributes<HTML
    * Defines the background color of the space in between and around shimmer elements.
    * @defaultvalue theme.palette.white
    */
-  surroundingColor?: string;
+  spaceColor?: string;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.CustomElements.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.CustomElements.Example.tsx
@@ -1,7 +1,7 @@
 // @codepen
 
 import * as React from 'react';
-import { Shimmer, ShimmerElementsGroup, ShimmerElementType as ElemType } from 'office-ui-fabric-react/lib/Shimmer';
+import { Shimmer, ShimmerElementsGroup, ShimmerElementType } from 'office-ui-fabric-react/lib/Shimmer';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
@@ -37,14 +37,17 @@ export class ShimmerCustomElementsExample extends React.Component<{}, {}> {
         style={{ display: 'flex' }}
       >
         <ShimmerElementsGroup
-          shimmerElements={[{ type: ElemType.line, width: 40, height: 40 }, { type: ElemType.gap, width: 10, height: 40 }]}
+          shimmerElements={[
+            { type: ShimmerElementType.line, width: 40, height: 40 },
+            { type: ShimmerElementType.gap, width: 10, height: 40 }
+          ]}
         />
         <ShimmerElementsGroup
           flexWrap={true}
           shimmerElements={[
-            { type: ElemType.line, width: 300, height: 10 },
-            { type: ElemType.line, width: 200, height: 10 },
-            { type: ElemType.gap, width: 100, height: 20 }
+            { type: ShimmerElementType.line, width: 300, height: 10 },
+            { type: ShimmerElementType.line, width: 200, height: 10 },
+            { type: ShimmerElementType.gap, width: 100, height: 20 }
           ]}
         />
       </div>
@@ -57,13 +60,15 @@ export class ShimmerCustomElementsExample extends React.Component<{}, {}> {
         // tslint:disable-next-line:jsx-ban-props
         style={{ display: 'flex' }}
       >
-        <ShimmerElementsGroup shimmerElements={[{ type: ElemType.circle, height: 40 }, { type: ElemType.gap, width: 10, height: 40 }]} />
+        <ShimmerElementsGroup
+          shimmerElements={[{ type: ShimmerElementType.circle, height: 40 }, { type: ShimmerElementType.gap, width: 10, height: 40 }]}
+        />
         <ShimmerElementsGroup
           flexWrap={true}
           shimmerElements={[
-            { type: ElemType.line, width: 400, height: 10 },
-            { type: ElemType.gap, width: 100, height: 20 },
-            { type: ElemType.line, width: 500, height: 10 }
+            { type: ShimmerElementType.line, width: 400, height: 10 },
+            { type: ShimmerElementType.gap, width: 100, height: 20 },
+            { type: ShimmerElementType.line, width: 500, height: 10 }
           ]}
         />
       </div>
@@ -78,31 +83,36 @@ export class ShimmerCustomElementsExample extends React.Component<{}, {}> {
       >
         <ShimmerElementsGroup
           width={'90px'}
-          shimmerElements={[{ type: ElemType.line, height: 80, width: 80 }, { type: ElemType.gap, width: 10, height: 80 }]}
+          shimmerElements={[
+            { type: ShimmerElementType.line, height: 80, width: 80 },
+            { type: ShimmerElementType.gap, width: 10, height: 80 }
+          ]}
         />
         <div
           // tslint:disable-next-line:jsx-ban-props
           style={{ display: 'flex', flexWrap: 'wrap', width: '100%' }}
         >
-          <ShimmerElementsGroup shimmerElements={[{ type: ElemType.circle, height: 40 }, { type: ElemType.gap, width: 10, height: 40 }]} />
+          <ShimmerElementsGroup
+            shimmerElements={[{ type: ShimmerElementType.circle, height: 40 }, { type: ShimmerElementType.gap, width: 10, height: 40 }]}
+          />
           <ShimmerElementsGroup
             flexWrap={true}
             width={'calc(100% - 50px)'}
             shimmerElements={[
-              { type: ElemType.line, width: '90%', height: 10 },
-              { type: ElemType.gap, width: '10%', height: 20 },
-              { type: ElemType.line, width: '100%', height: 10 }
+              { type: ShimmerElementType.line, width: '90%', height: 10 },
+              { type: ShimmerElementType.gap, width: '10%', height: 20 },
+              { type: ShimmerElementType.line, width: '100%', height: 10 }
             ]}
           />
           <ShimmerElementsGroup
             flexWrap={true}
             width={'100%'}
             shimmerElements={[
-              { type: ElemType.line, width: '80%', height: 10, verticalAlign: 'bottom' },
-              { type: ElemType.gap, width: '20%', height: 20 },
-              { type: ElemType.line, width: '40%', height: 10, verticalAlign: 'bottom' },
-              { type: ElemType.gap, width: '2%', height: 20 },
-              { type: ElemType.line, width: '58%', height: 10, verticalAlign: 'bottom' }
+              { type: ShimmerElementType.line, width: '80%', height: 10, verticalAlign: 'bottom' },
+              { type: ShimmerElementType.gap, width: '20%', height: 20 },
+              { type: ShimmerElementType.line, width: '40%', height: 10, verticalAlign: 'bottom' },
+              { type: ShimmerElementType.gap, width: '2%', height: 20 },
+              { type: ShimmerElementType.line, width: '58%', height: 10, verticalAlign: 'bottom' }
             ]}
           />
         </div>

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.LoadData.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.LoadData.Example.tsx
@@ -1,7 +1,7 @@
 // @codepen
 
 import * as React from 'react';
-import { Shimmer, ShimmerElementsGroup, ShimmerElementType as ElemType } from 'office-ui-fabric-react/lib/Shimmer';
+import { Shimmer, ShimmerElementsGroup, ShimmerElementType } from 'office-ui-fabric-react/lib/Shimmer';
 import { Persona, PersonaSize, PersonaPresence, IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
@@ -88,14 +88,16 @@ export class ShimmerLoadDataExample extends React.Component<{}, IShimmerLoadData
   private _getCustomElements = (): JSX.Element => {
     return (
       <div style={{ display: 'flex' }}>
-        <ShimmerElementsGroup shimmerElements={[{ type: ElemType.circle, height: 40 }, { type: ElemType.gap, width: 16, height: 40 }]} />
+        <ShimmerElementsGroup
+          shimmerElements={[{ type: ShimmerElementType.circle, height: 40 }, { type: ShimmerElementType.gap, width: 16, height: 40 }]}
+        />
         <ShimmerElementsGroup
           flexWrap={true}
           width="100%"
           shimmerElements={[
-            { type: ElemType.line, width: '100%', height: 10, verticalAlign: 'bottom' },
-            { type: ElemType.line, width: '90%', height: 8 },
-            { type: ElemType.gap, width: '10%', height: 20 }
+            { type: ShimmerElementType.line, width: '100%', height: 10, verticalAlign: 'bottom' },
+            { type: ShimmerElementType.line, width: '90%', height: 8 },
+            { type: ShimmerElementType.gap, width: '10%', height: 20 }
           ]}
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
@@ -50,6 +50,9 @@ const classNames = mergeStyleSets({
     background: customThemeForShimmer.palette.white, // using the palette color to match the gaps and borders of the shimmer.
     outline: `1px solid ${customThemeForShimmer.palette.neutralPrimary}`,
     outlineOffset: '-10px'
+  },
+  indent: {
+    paddingLeft: 18
   }
 });
 
@@ -64,9 +67,9 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
         <div>
           <b>1.</b> The recommended way by using the <b>shimmerColors</b> prop which in turn has 2 sub-scenarios:
         </div>
-        <div>
-          &emsp;<b>a. </b>
-          When using <b>shimmerElements</b> prop to build the placeholder you can pass all 3 possible colors to <b>shimmerColors</b> prop.
+        <div className={classNames.indent}>
+          <b>a. </b>When using <b>shimmerElements</b> prop to build the placeholder you can pass all 3 possible colors to{' '}
+          <b>shimmerColors</b> prop.
         </div>
         <div className={classNames.themedBackgroundWrapper}>
           <Shimmer
@@ -88,8 +91,8 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
             ]}
           />
         </div>
-        <div>
-          &emsp;<b>b.</b> When using <b>customElementsGroup</b> prop to build the placeholder:
+        <div className={classNames.indent}>
+          <b>b. </b>When using <b>customElementsGroup</b> prop to build the placeholder:
         </div>
         <div className={classNames.themedBackgroundWrapper2}>
           <Shimmer
@@ -102,7 +105,7 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
           />
         </div>
         <div>
-          <b>2.</b> Another way of doing it by using <b>Customizer</b> component wrapper.
+          <b>2. </b>Another way of doing it by using <b>Customizer</b> component wrapper.
         </div>
         <Customizer settings={{ theme: { ...customThemeForShimmer } }}>
           <div className={classNames.themedBackgroundWrapper2}>
@@ -110,7 +113,7 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
           </div>
         </Customizer>
         <div>
-          <b>3.</b> Style overrides of shimmering wave using <b>styles</b> prop.
+          <b>3. </b>Style overrides of shimmering wave using <b>styles</b> prop.
         </div>
         <div className={classNames.wrapper}>
           <Shimmer width="75%" styles={this._getShimmerStyles} />

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
@@ -74,9 +74,9 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
         <div className={classNames.themedBackgroundWrapper}>
           <Shimmer
             shimmerColors={{
-              shimmerMain: customThemeForShimmer.palette.themeTertiary,
+              shimmer: customThemeForShimmer.palette.themeTertiary,
               shimmerWave: customThemeForShimmer.palette.themeSecondary,
-              surroundingSpace: customThemeForShimmer.palette.white // to match the background color of the containing div
+              background: customThemeForShimmer.palette.white // to match the background color of the containing div
             }}
             shimmerElements={[
               { type: ShimmerElementType.circle, height: 24 },
@@ -99,7 +99,7 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
             customElementsGroup={this._getCustomElements(customThemeForShimmer.palette.white)}
             width={300}
             shimmerColors={{
-              shimmerMain: customThemeForShimmer.palette.themeTertiary,
+              shimmer: customThemeForShimmer.palette.themeTertiary,
               shimmerWave: customThemeForShimmer.palette.themeSecondary
             }}
           />
@@ -127,15 +127,15 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
   }
 
   // Passing a color to match the background color of the containing div.
-  private _getCustomElements = (surroundingColor?: string) => {
+  private _getCustomElements = (spaceColor?: string) => {
     return (
       <div style={{ display: 'flex' }}>
         <ShimmerElementsGroup
-          surroundingColor={surroundingColor}
+          spaceColor={spaceColor}
           shimmerElements={[{ type: ShimmerElementType.circle, height: 40 }, { type: ShimmerElementType.gap, width: 16, height: 40 }]}
         />
         <ShimmerElementsGroup
-          surroundingColor={surroundingColor}
+          spaceColor={spaceColor}
           flexWrap={true}
           width="100%"
           shimmerElements={[

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
@@ -127,15 +127,15 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
   }
 
   // Passing a color to match the background color of the containing div.
-  private _getCustomElements = (spaceColor?: string) => {
+  private _getCustomElements = (backgroundColor?: string) => {
     return (
       <div style={{ display: 'flex' }}>
         <ShimmerElementsGroup
-          spaceColor={spaceColor}
+          backgroundColor={backgroundColor}
           shimmerElements={[{ type: ShimmerElementType.circle, height: 40 }, { type: ShimmerElementType.gap, width: 16, height: 40 }]}
         />
         <ShimmerElementsGroup
-          spaceColor={spaceColor}
+          backgroundColor={backgroundColor}
           flexWrap={true}
           width="100%"
           shimmerElements={[

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
@@ -1,30 +1,149 @@
 // @codepen
 
 import * as React from 'react';
-import { Shimmer, IShimmerStyleProps, IShimmerStyles } from 'office-ui-fabric-react/lib/Shimmer';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { Shimmer, IShimmerStyleProps, IShimmerStyles, ShimmerElementsGroup, ShimmerElementType } from 'office-ui-fabric-react/lib/Shimmer';
+import { mergeStyleSets, ITheme, createTheme } from 'office-ui-fabric-react/lib/Styling';
+import { Customizer } from 'office-ui-fabric-react/lib/Utilities';
 
-const wrapperClass = mergeStyles({
-  padding: 2,
-  selectors: {
-    '& > *': {
-      margin: '10px 0'
+// Custom theme passed to Customizer
+const customThemeForShimmer: ITheme = createTheme({
+  palette: {
+    // palette slot used in Shimmer for main background
+    neutralLight: '#bdd4ed',
+    // palette slot used in Shimmer for tip of the moving wave
+    neutralLighter: '#7AAFE7',
+    // palette slot used in Shimmer for all the space around the shimmering elements
+    white: '#0078D4'
+  }
+});
+
+const classNames = mergeStyleSets({
+  wrapper: {
+    selectors: {
+      '& > *': {
+        margin: '10px 0'
+      }
     }
+  },
+  themedBackgroundWrapper: {
+    padding: 20,
+    margin: '10px 0',
+    height: 100,
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'stretch',
+    background: customThemeForShimmer.palette.white, // using the palette color to match the gaps and borders of the shimmer.
+    selectors: {
+      '& > :first-child': {
+        flexGrow: 1
+      }
+    }
+  },
+  themedBackgroundWrapper2: {
+    width: 400,
+    height: 100,
+    margin: '10px 0',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: customThemeForShimmer.palette.white, // using the palette color to match the gaps and borders of the shimmer.
+    outline: `1px solid ${customThemeForShimmer.palette.neutralPrimary}`,
+    outlineOffset: '-10px'
   }
 });
 
 export class ShimmerStylingExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
-      <div className={wrapperClass}>
-        <Shimmer width="75%" styles={this._getShimmerStyles} />
-        <Shimmer width="75%" styles={this._getShimmerStyles} />
-        <Shimmer width="75%" styles={this._getShimmerStyles} />
-        <Shimmer width="75%" styles={this._getShimmerStyles} />
-        <Shimmer width="75%" styles={this._getShimmerStyles} />
-      </div>
+      <React.Fragment>
+        <div>
+          Style overrides of shimmering wave and space around in cases where Shimmer is placed on backgrounds different than the main
+          background of the app. There are several scenarios that can be considered bellow:
+        </div>
+        <div>
+          <b>1.</b> The recommended way by using the <b>shimmerColors</b> prop which in turn has 2 sub-scenarios:
+        </div>
+        <div>
+          &emsp;<b>a. </b>
+          When using <b>shimmerElements</b> prop to build the placeholder you can pass all 3 possible colors to <b>shimmerColors</b> prop.
+        </div>
+        <div className={classNames.themedBackgroundWrapper}>
+          <Shimmer
+            shimmerColors={{
+              shimmerMain: customThemeForShimmer.palette.themeTertiary,
+              shimmerWave: customThemeForShimmer.palette.themeSecondary,
+              surroundingSpace: customThemeForShimmer.palette.white // to match the background color of the containing div
+            }}
+            shimmerElements={[
+              { type: ShimmerElementType.circle, height: 24 },
+              { type: ShimmerElementType.gap, width: '2%' },
+              { type: ShimmerElementType.line, height: 16, width: '20%' },
+              { type: ShimmerElementType.gap, width: '5%' },
+              { type: ShimmerElementType.line, height: 16, width: '20%' },
+              { type: ShimmerElementType.gap, width: '10%' },
+              { type: ShimmerElementType.line, height: 16, width: '15%' },
+              { type: ShimmerElementType.gap, width: '10%' },
+              { type: ShimmerElementType.line, height: 16 }
+            ]}
+          />
+        </div>
+        <div>
+          &emsp;<b>b.</b> When using <b>customElementsGroup</b> prop to build the placeholder:
+        </div>
+        <div className={classNames.themedBackgroundWrapper2}>
+          <Shimmer
+            customElementsGroup={this._getCustomElements(customThemeForShimmer.palette.white)}
+            width={300}
+            shimmerColors={{
+              shimmerMain: customThemeForShimmer.palette.themeTertiary,
+              shimmerWave: customThemeForShimmer.palette.themeSecondary
+            }}
+          />
+        </div>
+        <div>
+          <b>2.</b> Another way of doing it by using <b>Customizer</b> component wrapper.
+        </div>
+        <Customizer settings={{ theme: { ...customThemeForShimmer } }}>
+          <div className={classNames.themedBackgroundWrapper2}>
+            <Shimmer customElementsGroup={this._getCustomElements()} width={300} />
+          </div>
+        </Customizer>
+        <div>
+          <b>3.</b> Style overrides of shimmering wave using <b>styles</b> prop.
+        </div>
+        <div className={classNames.wrapper}>
+          <Shimmer width="75%" styles={this._getShimmerStyles} />
+          <Shimmer width="75%" styles={this._getShimmerStyles} />
+          <Shimmer width="75%" styles={this._getShimmerStyles} />
+          <Shimmer width="75%" styles={this._getShimmerStyles} />
+          <Shimmer width="75%" styles={this._getShimmerStyles} />
+        </div>
+      </React.Fragment>
     );
   }
+
+  // Passing a color to match the background color of the containing div.
+  private _getCustomElements = (surroundingColor?: string) => {
+    return (
+      <div style={{ display: 'flex' }}>
+        <ShimmerElementsGroup
+          surroundingColor={surroundingColor}
+          shimmerElements={[{ type: ShimmerElementType.circle, height: 40 }, { type: ShimmerElementType.gap, width: 16, height: 40 }]}
+        />
+        <ShimmerElementsGroup
+          surroundingColor={surroundingColor}
+          flexWrap={true}
+          width="100%"
+          shimmerElements={[
+            { type: ShimmerElementType.line, width: '100%', height: 10, verticalAlign: 'bottom' },
+            { type: ShimmerElementType.line, width: '90%', height: 8 },
+            { type: ShimmerElementType.gap, width: '10%', height: 20 }
+          ]}
+        />
+      </div>
+    );
+  };
 
   private _getShimmerStyles = (props: IShimmerStyleProps): IShimmerStyles => {
     return {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -1,861 +1,2383 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders Shimmer.Styling.Example.tsx correctly 1`] = `
-<div
-  className=
+Array [
+  <div>
+    Style overrides of shimmering wave and space around in cases where Shimmer is placed on backgrounds different than the main background of the app. There are several scenarios that can be considered bellow:
+  </div>,
+  <div>
+    <b>
+      1.
+    </b>
+     The recommended way by using the 
+    <b>
+      shimmerColors
+    </b>
+     prop which in turn has 2 sub-scenarios:
+  </div>,
+  <div
+    className=
 
-      {
-        padding-bottom: 2px;
-        padding-left: 2px;
-        padding-right: 2px;
-        padding-top: 2px;
-      }
-      & > * {
-        margin-bottom: 10px;
-        margin-left: 0;
-        margin-right: 0;
-        margin-top: 10px;
-      }
->
+        {
+          padding-left: 18px;
+        }
+  >
+    <b>
+      a. 
+    </b>
+    When using 
+    <b>
+      shimmerElements
+    </b>
+     prop to build the placeholder you can pass all 3 possible colors to
+     
+    <b>
+      shimmerColors
+    </b>
+     prop.
+  </div>,
   <div
     className=
-        ms-Shimmer-container
+
         {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          position: relative;
+          align-items: center;
+          background: #0078D4;
+          box-sizing: border-box;
+          display: flex;
+          height: 100px;
+          justify-content: stretch;
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          padding-bottom: 20px;
+          padding-left: 20px;
+          padding-right: 20px;
+          padding-top: 20px;
         }
-    width="75%"
+        & > :first-child {
+          flex-grow: 1;
+        }
   >
     <div
       className=
-          ms-Shimmer-shimmerWrapper
+          ms-Shimmer-container
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background-color: #deecf9;
-            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-            background: #f4f4f4
-                              linear-gradient(
-                                to right,
-                                #f4f4f4 0%,
-                                #eaeaea 50%,
-                                #f4f4f4 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
-            transition: opacity 200ms;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            background: WindowText
-                                  linear-gradient(
-                                    to right,
-                                    transparent 0%,
-                                    Window 50%,
-                                    transparent 100%)
-                                  0 0 / 90% 100%
-                                  no-repeat;
-          }
-      style={
-        Object {
-          "width": "75%",
-        }
-      }
     >
       <div
         className=
-            ms-ShimmerElementsGroup-root
+            ms-Shimmer-shimmerWrapper
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              display: flex;
-              flex-wrap: nowrap;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background: #71afe5
+                                linear-gradient(
+                                  to right,
+                                  #71afe5 0%,
+                                  #2b88d8 50%,
+                                  #71afe5 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
             }
         style={
           Object {
-            "width": "auto",
+            "width": "100%",
           }
         }
       >
         <div
           className=
-              ms-ShimmerLine-root
+              ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                border-bottom-style: solid;
-                border-color: #ffffff;
-                border-top-style: solid;
-                border-width: 0px;
-                box-sizing: content-box;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 16px;
-                position: relative;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                border-color: Window;
-              }
-              @media screen and (-ms-high-contrast: active){& > * {
-                fill: Window;
               }
           style={
             Object {
-              "minWidth": "auto",
-              "width": "100%",
+              "width": "auto",
             }
           }
         >
-          <svg
+          <div
             className=
-                ms-ShimmerLine-topLeftCorner
+                ms-ShimmerCircle-root
                 {
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                  top: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 0px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 24px;
+                  min-width: 24px;
+                  width: 24px;
                 }
-            height="2"
-            width="2"
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
           >
-            <path
-              d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-            />
-          </svg>
-          <svg
+            <svg
+              className=
+                  ms-ShimmerCircle-svg
+                  {
+                    display: block;
+                    fill: #0078D4;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    fill: Window;
+                  }
+              height={24}
+              viewBox="0 0 10 10"
+              width={24}
+            >
+              <path
+                d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
+              />
+            </svg>
+          </div>
+          <div
             className=
-                ms-ShimmerLine-topRightCorner
+                ms-ShimmerGap-root
                 {
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
-                  top: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078D4;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-            />
-          </svg>
-          <svg
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "2%",
+              }
+            }
+          />
+          <div
             className=
-                ms-ShimmerLine-bottomRightCorner
+                ms-ShimmerLine-root
                 {
-                  bottom: 0;
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
                 }
-            height="2"
-            width="2"
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "20%",
+              }
+            }
           >
-            <path
-              d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-            />
-          </svg>
-          <svg
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+          <div
             className=
-                ms-ShimmerLine-bottomLeftCorner
+                ms-ShimmerGap-root
                 {
-                  bottom: 0;
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078D4;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
                 }
-            height="2"
-            width="2"
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "5%",
+              }
+            }
+          />
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "20%",
+              }
+            }
           >
-            <path
-              d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-            />
-          </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+          <div
+            className=
+                ms-ShimmerGap-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078D4;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "10%",
+              }
+            }
+          />
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "15%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+          <div
+            className=
+                ms-ShimmerGap-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078D4;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: Window;
+                  border-color: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "10%",
+              }
+            }
+          />
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-bottom-width: 4px;
+                  border-color: #0078D4;
+                  border-top-style: solid;
+                  border-top-width: 4px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #0078D4;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     className=
-        ms-Shimmer-container
+
         {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          position: relative;
+          padding-left: 18px;
         }
-    width="75%"
+  >
+    <b>
+      b. 
+    </b>
+    When using 
+    <b>
+      customElementsGroup
+    </b>
+     prop to build the placeholder:
+  </div>,
+  <div
+    className=
+
+        {
+          align-items: center;
+          background: #0078D4;
+          display: flex;
+          height: 100px;
+          justify-content: center;
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline-offset: -10px;
+          outline: 1px solid #333333;
+          width: 400px;
+        }
   >
     <div
       className=
-          ms-Shimmer-shimmerWrapper
+          ms-Shimmer-container
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background-color: #deecf9;
-            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-            background: #f4f4f4
-                              linear-gradient(
-                                to right,
-                                #f4f4f4 0%,
-                                #eaeaea 50%,
-                                #f4f4f4 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
-            transition: opacity 200ms;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            background: WindowText
-                                  linear-gradient(
-                                    to right,
-                                    transparent 0%,
-                                    Window 50%,
-                                    transparent 100%)
-                                  0 0 / 90% 100%
-                                  no-repeat;
-          }
-      style={
-        Object {
-          "width": "75%",
-        }
-      }
+      width={300}
     >
       <div
         className=
-            ms-ShimmerElementsGroup-root
+            ms-Shimmer-shimmerWrapper
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              display: flex;
-              flex-wrap: nowrap;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background: #71afe5
+                                linear-gradient(
+                                  to right,
+                                  #71afe5 0%,
+                                  #2b88d8 50%,
+                                  #71afe5 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
             }
         style={
           Object {
-            "width": "auto",
+            "width": 300,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            style={
+              Object {
+                "width": "auto",
+              }
+            }
+          >
+            <div
+              className=
+                  ms-ShimmerCircle-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    min-width: 40px;
+                    width: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+            >
+              <svg
+                className=
+                    ms-ShimmerCircle-svg
+                    {
+                      display: block;
+                      fill: #0078D4;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      fill: Window;
+                    }
+                height={40}
+                viewBox="0 0 10 10"
+                width={40}
+              >
+                <path
+                  d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
+                />
+              </svg>
+            </div>
+            <div
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #0078D4;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "16px",
+                  "width": 16,
+                }
+              }
+            />
+          </div>
+          <div
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: wrap;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 10px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "auto",
+                  "width": "100%",
+                }
+              }
+            >
+              <svg
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+                />
+              </svg>
+            </div>
+            <div
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-bottom-style: solid;
+                    border-bottom-width: 6px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 6px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 8px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "auto",
+                  "width": "90%",
+                }
+              }
+            >
+              <svg
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+                />
+              </svg>
+            </div>
+            <div
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #0078D4;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "auto",
+                  "width": "10%",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <b>
+      2. 
+    </b>
+    Another way of doing it by using 
+    <b>
+      Customizer
+    </b>
+     component wrapper.
+  </div>,
+  <div
+    className=
+
+        {
+          align-items: center;
+          background: #0078D4;
+          display: flex;
+          height: 100px;
+          justify-content: center;
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          outline-offset: -10px;
+          outline: 1px solid #333333;
+          width: 400px;
+        }
+  >
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+      width={300}
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background: #7AAFE7
+                                linear-gradient(
+                                  to right,
+                                  #7AAFE7 0%,
+                                  #bdd4ed 50%,
+                                  #7AAFE7 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+        style={
+          Object {
+            "width": 300,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: nowrap;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            style={
+              Object {
+                "width": "auto",
+              }
+            }
+          >
+            <div
+              className=
+                  ms-ShimmerCircle-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                    min-width: 40px;
+                    width: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+            >
+              <svg
+                className=
+                    ms-ShimmerCircle-svg
+                    {
+                      display: block;
+                      fill: #0078D4;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      fill: Window;
+                    }
+                height={40}
+                viewBox="0 0 10 10"
+                width={40}
+              >
+                <path
+                  d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
+                />
+              </svg>
+            </div>
+            <div
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #0078D4;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 40px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "16px",
+                  "width": 16,
+                }
+              }
+            />
+          </div>
+          <div
+            className=
+                ms-ShimmerElementsGroup-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  display: flex;
+                  flex-wrap: wrap;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 10px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 10px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "auto",
+                  "width": "100%",
+                }
+              }
+            >
+              <svg
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+                />
+              </svg>
+            </div>
+            <div
+              className=
+                  ms-ShimmerLine-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border-bottom-style: solid;
+                    border-bottom-width: 6px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 6px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 8px;
+                    position: relative;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: Window;
+                  }
+                  @media screen and (-ms-high-contrast: active){& > * {
+                    fill: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "auto",
+                  "width": "90%",
+                }
+              }
+            >
+              <svg
+                className=
+                    ms-ShimmerLine-topLeftCorner
+                    {
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-topRightCorner
+                    {
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                      top: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomRightCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      position: absolute;
+                      right: 0;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+                />
+              </svg>
+              <svg
+                className=
+                    ms-ShimmerLine-bottomLeftCorner
+                    {
+                      bottom: 0;
+                      fill: #0078D4;
+                      left: 0;
+                      position: absolute;
+                    }
+                height="2"
+                width="2"
+              >
+                <path
+                  d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+                />
+              </svg>
+            </div>
+            <div
+              className=
+                  ms-ShimmerGap-root
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #0078D4;
+                    border-bottom-style: solid;
+                    border-bottom-width: 0px;
+                    border-color: #0078D4;
+                    border-top-style: solid;
+                    border-top-width: 0px;
+                    box-sizing: content-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 20px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background-color: Window;
+                    border-color: Window;
+                  }
+              style={
+                Object {
+                  "minWidth": "auto",
+                  "width": "10%",
+                }
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div>
+    <b>
+      3. 
+    </b>
+    Style overrides of shimmering wave using 
+    <b>
+      styles
+    </b>
+     prop.
+  </div>,
+  <div
+    className=
+
+        & > * {
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+        }
+  >
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+      width="75%"
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background-color: #deecf9;
+              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+              background: #f4f4f4
+                                linear-gradient(
+                                  to right,
+                                  #f4f4f4 0%,
+                                  #eaeaea 50%,
+                                  #f4f4f4 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+        style={
+          Object {
+            "width": "75%",
           }
         }
       >
         <div
           className=
-              ms-ShimmerLine-root
+              ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                border-bottom-style: solid;
-                border-color: #ffffff;
-                border-top-style: solid;
-                border-width: 0px;
-                box-sizing: content-box;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 16px;
-                position: relative;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                border-color: Window;
-              }
-              @media screen and (-ms-high-contrast: active){& > * {
-                fill: Window;
               }
           style={
             Object {
-              "minWidth": "auto",
-              "width": "100%",
+              "width": "auto",
             }
           }
         >
-          <svg
+          <div
             className=
-                ms-ShimmerLine-topLeftCorner
+                ms-ShimmerLine-root
                 {
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                  top: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-topRightCorner
-                {
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
-                  top: 0;
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomRightCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
                 }
-            height="2"
-            width="2"
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
           >
-            <path
-              d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomLeftCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-            />
-          </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className=
-        ms-Shimmer-container
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          position: relative;
-        }
-    width="75%"
-  >
     <div
       className=
-          ms-Shimmer-shimmerWrapper
+          ms-Shimmer-container
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background-color: #deecf9;
-            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-            background: #f4f4f4
-                              linear-gradient(
-                                to right,
-                                #f4f4f4 0%,
-                                #eaeaea 50%,
-                                #f4f4f4 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
-            transition: opacity 200ms;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            background: WindowText
-                                  linear-gradient(
-                                    to right,
-                                    transparent 0%,
-                                    Window 50%,
-                                    transparent 100%)
-                                  0 0 / 90% 100%
-                                  no-repeat;
-          }
-      style={
-        Object {
-          "width": "75%",
-        }
-      }
+      width="75%"
     >
       <div
         className=
-            ms-ShimmerElementsGroup-root
+            ms-Shimmer-shimmerWrapper
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              display: flex;
-              flex-wrap: nowrap;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background-color: #deecf9;
+              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+              background: #f4f4f4
+                                linear-gradient(
+                                  to right,
+                                  #f4f4f4 0%,
+                                  #eaeaea 50%,
+                                  #f4f4f4 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
             }
         style={
           Object {
-            "width": "auto",
+            "width": "75%",
           }
         }
       >
         <div
           className=
-              ms-ShimmerLine-root
+              ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                border-bottom-style: solid;
-                border-color: #ffffff;
-                border-top-style: solid;
-                border-width: 0px;
-                box-sizing: content-box;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 16px;
-                position: relative;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                border-color: Window;
-              }
-              @media screen and (-ms-high-contrast: active){& > * {
-                fill: Window;
               }
           style={
             Object {
-              "minWidth": "auto",
-              "width": "100%",
+              "width": "auto",
             }
           }
         >
-          <svg
+          <div
             className=
-                ms-ShimmerLine-topLeftCorner
+                ms-ShimmerLine-root
                 {
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                  top: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-topRightCorner
-                {
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
-                  top: 0;
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomRightCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
                 }
-            height="2"
-            width="2"
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
           >
-            <path
-              d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomLeftCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-            />
-          </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className=
-        ms-Shimmer-container
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          position: relative;
-        }
-    width="75%"
-  >
     <div
       className=
-          ms-Shimmer-shimmerWrapper
+          ms-Shimmer-container
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background-color: #deecf9;
-            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-            background: #f4f4f4
-                              linear-gradient(
-                                to right,
-                                #f4f4f4 0%,
-                                #eaeaea 50%,
-                                #f4f4f4 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
-            transition: opacity 200ms;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            background: WindowText
-                                  linear-gradient(
-                                    to right,
-                                    transparent 0%,
-                                    Window 50%,
-                                    transparent 100%)
-                                  0 0 / 90% 100%
-                                  no-repeat;
-          }
-      style={
-        Object {
-          "width": "75%",
-        }
-      }
+      width="75%"
     >
       <div
         className=
-            ms-ShimmerElementsGroup-root
+            ms-Shimmer-shimmerWrapper
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              display: flex;
-              flex-wrap: nowrap;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background-color: #deecf9;
+              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+              background: #f4f4f4
+                                linear-gradient(
+                                  to right,
+                                  #f4f4f4 0%,
+                                  #eaeaea 50%,
+                                  #f4f4f4 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
             }
         style={
           Object {
-            "width": "auto",
+            "width": "75%",
           }
         }
       >
         <div
           className=
-              ms-ShimmerLine-root
+              ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                border-bottom-style: solid;
-                border-color: #ffffff;
-                border-top-style: solid;
-                border-width: 0px;
-                box-sizing: content-box;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 16px;
-                position: relative;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                border-color: Window;
-              }
-              @media screen and (-ms-high-contrast: active){& > * {
-                fill: Window;
               }
           style={
             Object {
-              "minWidth": "auto",
-              "width": "100%",
+              "width": "auto",
             }
           }
         >
-          <svg
+          <div
             className=
-                ms-ShimmerLine-topLeftCorner
+                ms-ShimmerLine-root
                 {
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                  top: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-topRightCorner
-                {
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
-                  top: 0;
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomRightCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
                 }
-            height="2"
-            width="2"
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
           >
-            <path
-              d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomLeftCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-            />
-          </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className=
-        ms-Shimmer-container
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          position: relative;
-        }
-    width="75%"
-  >
     <div
       className=
-          ms-Shimmer-shimmerWrapper
+          ms-Shimmer-container
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background-color: #deecf9;
-            background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-            background: #f4f4f4
-                              linear-gradient(
-                                to right,
-                                #f4f4f4 0%,
-                                #eaeaea 50%,
-                                #f4f4f4 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
-            transition: opacity 200ms;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            background: WindowText
-                                  linear-gradient(
-                                    to right,
-                                    transparent 0%,
-                                    Window 50%,
-                                    transparent 100%)
-                                  0 0 / 90% 100%
-                                  no-repeat;
-          }
-      style={
-        Object {
-          "width": "75%",
-        }
-      }
+      width="75%"
     >
       <div
         className=
-            ms-ShimmerElementsGroup-root
+            ms-Shimmer-shimmerWrapper
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              align-items: center;
-              display: flex;
-              flex-wrap: nowrap;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background-color: #deecf9;
+              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+              background: #f4f4f4
+                                linear-gradient(
+                                  to right,
+                                  #f4f4f4 0%,
+                                  #eaeaea 50%,
+                                  #f4f4f4 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
             }
         style={
           Object {
-            "width": "auto",
+            "width": "75%",
           }
         }
       >
         <div
           className=
-              ms-ShimmerLine-root
+              ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                border-bottom-style: solid;
-                border-color: #ffffff;
-                border-top-style: solid;
-                border-width: 0px;
-                box-sizing: content-box;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 16px;
-                position: relative;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                border-color: Window;
-              }
-              @media screen and (-ms-high-contrast: active){& > * {
-                fill: Window;
               }
           style={
             Object {
-              "minWidth": "auto",
-              "width": "100%",
+              "width": "auto",
             }
           }
         >
-          <svg
+          <div
             className=
-                ms-ShimmerLine-topLeftCorner
+                ms-ShimmerLine-root
                 {
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                  top: 0;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-topRightCorner
-                {
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
-                  top: 0;
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
                 }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomRightCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  position: absolute;
-                  right: 0;
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
                 }
-            height="2"
-            width="2"
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
           >
-            <path
-              d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-            />
-          </svg>
-          <svg
-            className=
-                ms-ShimmerLine-bottomLeftCorner
-                {
-                  bottom: 0;
-                  fill: #ffffff;
-                  left: 0;
-                  position: absolute;
-                }
-            height="2"
-            width="2"
-          >
-            <path
-              d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-            />
-          </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+      width="75%"
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              animation-direction: normal;
+              animation-duration: 2s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
+              animation-timing-function: ease-in-out;
+              background-color: #deecf9;
+              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+              background: #f4f4f4
+                                linear-gradient(
+                                  to right,
+                                  #f4f4f4 0%,
+                                  #eaeaea 50%,
+                                  #f4f4f4 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+              transition: opacity 200ms;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+        style={
+          Object {
+            "width": "75%",
+          }
+        }
+      >
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+              }
+          style={
+            Object {
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8161 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
1. Add new prop `shimmerColors` to `Shimmer` component and new prop `surroundingColor` to `ShimmerElementsGroup` sub-component to allow easy customization of the shimmer colors when it's used in elements which have deviated from the overall app background color and use a different `palette` slot than `white`. (see screenshot below)
2. Added more examples to demo the new props with detailed information on when and how to use the new feature. (see screenshot below)
3. Added a new screener test to reflect the new addition.
4. Cleaned up the documentation of all interfaces related to `Shimmer` by adding the missing descriptions.
5. Added the `codepen` tab to all Shimmer examples.
6. Updated the `CODEOWNERS` for Shimmer and HoverCard.

![screen shot 2019-03-07 at 4 17 02 pm](https://user-images.githubusercontent.com/29514833/54003681-d8d62480-4107-11e9-9234-99ba3c89f4cb.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8243)