### PR TITLE
List: Add unit tests for default and optional behaviors

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-list-tests_2019-03-08-22-26.json
+++ b/common/changes/office-ui-fabric-react/keco-list-tests_2019-03-08-22-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Add unit tests for default and optional behaviors\"",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/keco-list-tests_2019-03-08-22-26.json
+++ b/common/changes/office-ui-fabric-react/keco-list-tests_2019-03-08-22-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "List: Add unit tests for default and optional behaviors\"",
+      "comment": "List: Add unit tests for default and optional behaviors",
       "type": "none"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/List/List.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.test.tsx
@@ -3,20 +3,22 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { List } from './List';
+import { IPage, IListProps } from './List.types';
 
-// Populate mock data for testing
-function mockData(count: number): any {
-  const data = [];
-  let _data = {};
+type IMockItem = { key: number; name: string; value: number };
+
+function mockData(count: number = 0): IMockItem[] {
+  const data: IMockItem[] = [];
+  let item: IMockItem;
 
   for (let i = 0; i < count; i++) {
-    _data = {
+    item = {
       key: i,
       name: 'Item ' + i,
       value: i
     };
 
-    data.push(_data);
+    data.push(item);
   }
 
   return data;
@@ -26,16 +28,132 @@ describe('List', () => {
   it('renders List correctly', () => {
     List.prototype.componentDidMount = jest.fn();
 
-    const component = renderer.create(
-      // tslint:disable-next-line:jsx-no-lambda
-      <List items={[]} onRenderCell={() => null} />
-    );
+    const onRenderCell = () => null;
+    const component = renderer.create(<List items={[]} onRenderCell={onRenderCell} />);
     const tree = component.toJSON();
+
     expect(tree).toMatchSnapshot();
   });
 
   it('can complete rendering', done => {
     const wrapper = mount(<List items={mockData(50)} />);
-    wrapper.setProps({ items: mockData(100), onPagesUpdated: (pages: any) => done() });
+
+    wrapper.setProps({ items: mockData(100), onPagesUpdated: (pages: IPage[]) => done() });
+  });
+
+  describe('by default', () => {
+    it('renders 1 page containing 10 rows', done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), onPagesUpdated: (pages: IPage[]) => done() });
+
+      const rows = wrapper.find('.ms-List-cell');
+
+      expect(rows).toHaveLength(10);
+    });
+
+    it("sets each row's key equal to the row's index value", done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), onPagesUpdated: (pages: IPage[]) => done() });
+
+      const firstRow = wrapper.find('.ms-List-cell').first();
+
+      expect(firstRow.key()).toEqual('0');
+    });
+
+    it("sets the root element's role to 'list'", done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), onPagesUpdated: (pages: IPage[]) => done() });
+
+      const listRoot = wrapper.find(List);
+
+      expect(listRoot.getDOMNode().getAttribute('role')).toEqual('list');
+    });
+
+    it("sets the row elements' role to 'listitem'", done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), onPagesUpdated: (pages: IPage[]) => done() });
+
+      const firstRow = wrapper.find('.ms-List-cell').first();
+
+      expect(firstRow.getDOMNode().getAttribute('role')).toEqual('listitem');
+    });
+  });
+
+  describe('if provided', () => {
+    it('invokes optional onRenderCell prop per item render', done => {
+      const onRenderCellMock = jest.fn();
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), onRenderCell: onRenderCellMock, onPagesUpdated: (pages: IPage[]) => done() });
+
+      expect(onRenderCellMock).toHaveBeenCalledTimes(10);
+    });
+
+    it('respects optional startIndex prop during row rendering', done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(10), startIndex: 5, onPagesUpdated: (pages: IPage[]) => done() });
+
+      const rows = wrapper.find('.ms-List-cell');
+
+      expect(rows).toHaveLength(5);
+    });
+
+    it('respects optional renderCount prop as row rendering limit', done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), renderCount: 5, onPagesUpdated: (pages: IPage[]) => done() });
+
+      const rows = wrapper.find('.ms-List-cell');
+
+      expect(rows).toHaveLength(5);
+    });
+
+    it("sets optional className to List's root", done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+
+      wrapper.setProps({ items: mockData(100), className: 'foo', onPagesUpdated: (pages: IPage[]) => done() });
+
+      const listRoot = wrapper.find(List);
+
+      expect(listRoot.getDOMNode().className).toContain('foo');
+    });
+
+    it('renders the return value of optional onRenderCell prop per row', done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+      const onRenderCell = (item: any, index: number, isScrolling: boolean) => <div className="foo">{item.name}</div>;
+
+      wrapper.setProps({ items: mockData(100), onRenderCell, onPagesUpdated: (pages: IPage[]) => done() });
+
+      const rows = wrapper.find('.foo');
+
+      expect(rows).toHaveLength(10);
+    });
+
+    it('sets the return value of optional getKey prop as React key per row', done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+      const getKey = (item: any, index: number) => `foo-${item.key}`;
+
+      wrapper.setProps({ items: mockData(100), getKey, onPagesUpdated: (pages: IPage[]) => done() });
+
+      const firstRow = wrapper.find('.ms-List-cell').first();
+
+      expect(firstRow.key()).toEqual('foo-0');
+    });
+
+    it('renders all rows if optional onShouldVirtualize prop returns false', done => {
+      const wrapper = mount(<List items={mockData(100)} />);
+      const onShouldVirtualize = (props: IListProps) => false;
+
+      wrapper.setProps({ items: mockData(100), onShouldVirtualize, onPagesUpdated: (pages: IPage[]) => done() });
+
+      const rows = wrapper.find('.ms-List-cell');
+
+      expect(rows).toHaveLength(100);
+    });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

In my recent dealings with `List` I realized the component lacks unit test coverage for _default_ and _optional_ behaviors. This PR is one such PR that aims to address that. Also adds some typings.

The manual `setProps` in addition to mounting the component seems to be required for virtualized rendering to kick-in. Not yet sure why, but once solved can be addressed separately if not part of this PR.

#### Focus areas to test

- CI should pass


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8249)