### PR TITLE
DetailPanel: Enable use the currentL2Id on Panel load to load L2 page directly

### DIFF
--- a/common/changes/@uifabric/dashboard/ddx_2019-03-09-01-24.json
+++ b/common/changes/@uifabric/dashboard/ddx_2019-03-09-01-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "DetailPanel: Enable use the currentL2Id on Panel load to load L2 page directly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "timto@corp.microsoft.com"
+}

--- a/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
+++ b/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
@@ -55,7 +55,7 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
     let snapshotUpdated = false;
     const snapshot = {} as IMainBodySnapshot;
 
-    if (this.props.currentL2Id !== prevProps.currentL2Id) {
+    if (this.props.currentL2Id !== this.state.currentL2Id) {
       // L2Id is changed
       snapshot.nextL2Id = this.props.currentL2Id;
       snapshotUpdated = true;
@@ -124,6 +124,7 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
       const { onGetL2Content, onGetL2ActionBar, mainActionBar } = this.props;
       if (snapshot.nextL2Id && onGetL2Content) {
         // Set loading animation
+        this.setState({ currentL2Id: snapshot.nextL2Id });
         this._setLoadingAnimation(LoadingTheme.OnL2ContentLoad);
         Promise.resolve(onGetL2Content(snapshot.nextL2Id))
           .then((element: JSX.Element) => {

--- a/packages/dashboard/src/components/DetailPanel/Examples/DetailPanel.L2Content.Example.tsx
+++ b/packages/dashboard/src/components/DetailPanel/Examples/DetailPanel.L2Content.Example.tsx
@@ -20,7 +20,7 @@ export interface IDetailPanelL2ContentExampleStates {
 export class DetailPanelL2ContentExample extends React.PureComponent<{}, IDetailPanelL2ContentExampleStates> {
   constructor(props: {}) {
     super(props);
-    this.state = { show: false, currentL2Id: undefined };
+    this.state = { show: false, currentL2Id: 'dog' };
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

DetailPanel: Enable use the currentL2Id on Panel load to load L2 page directly

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8251)