### PR TITLE
Panel: do not render an empty div in navigation section when nothing provided

### DIFF
--- a/apps/vr-tests/src/stories/Panel.stories.tsx
+++ b/apps/vr-tests/src/stories/Panel.stories.tsx
@@ -63,6 +63,9 @@ storiesOf('Panel', module)
   ))
   .addStory('Custom anchored left', () => (
     <Panel {...defaultProps} type={PanelType.customNear} headerText="Custom left" customWidth="320px" />
+  ))
+  .addStory('With no navigation', () => (
+    <Panel {...defaultProps} type={PanelType.smallFixedFar} headerText="No navigation" hasCloseButton={false} />
   ));
 
 storiesOf('Panel', module)

--- a/common/changes/office-ui-fabric-react/v-vibr-PanelFixNaviagation_2019-03-09-03-04.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-PanelFixNaviagation_2019-03-09-03-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: fixes regression when no custom navigation renderer provided and `hasCloseButton` prop is set to false there should not be an empty div rendered occupying the space.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -238,6 +238,9 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   }
 
   private _onRenderNavigation = (props: IPanelProps): JSX.Element | null => {
+    if (!this.props.onRenderNavigationContent && !this.props.onRenderNavigation && !this.props.hasCloseButton) {
+      return null;
+    }
     const { onRenderNavigationContent = this._onRenderNavigationContent } = this.props;
     return <div className={this._classNames.navigation}>{onRenderNavigationContent(props, this._onRenderNavigationContent)}</div>;
   };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fix a regression introduced by #7956 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

#7956 introduced a new feature to be able to provide some custom navigation elements and still keep the styling and the close button... but moved the wrapping `div` element with the className `navigation` outside the conditional checking if it has the close button. This brings to rendering an empty div with 44px height when no navigation renderers are given and `hasCloseButton` prop is set to `false`. Not having a screener test for this scenario enabled this to get slipped into master. The issue surfaced in Sharepoint where they render an `iframe` with its own close button like in the screenshot below.

![image001](https://user-images.githubusercontent.com/29514833/54065469-48b2e080-41d6-11e9-9d2e-b78439b3f1f7.png)


Unless @betrue-final-final considers that we actually want the new behavior of leaving the empty space occupy the navigation section this PR should fix it and also adds a screener story to prevent future regressions.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8252)