### PR TITLE
Combo box option on blur add current pending value

### DIFF
--- a/common/changes/office-ui-fabric-react/comboBoxOption-onBlur-add-currentPendingValue_2019-03-11-17-43.json
+++ b/common/changes/office-ui-fabric-react/comboBoxOption-onBlur-add-currentPendingValue_2019-03-11-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "For multiSelectComboBox, if allowFreeForm is true, currentPendingValue should get added to option and be selected onBlur",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "hatrived@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -559,4 +559,108 @@ describe.only('ComboBox', () => {
     expect(calloutAfterClose).toBeDefined();
     expect(calloutAfterClose.classList.contains('ms-ComboBox-callout')).toBeTruthy();
   });
+
+  // Adds currentPendingValue to options and makes it selected onBlur
+  // if allowFreeFrom is true for multiselect with default selected values
+  it('adds currentPendingValue to options and selects if multiSelected with default values', () => {
+    const componentRef = React.createRef<any>();
+    const comboBoxOption: IComboBoxOption = {
+      key: 'ManuallyEnteredValue',
+      text: 'ManuallyEnteredValue'
+    };
+    wrapper = mount(
+      <ComboBox
+        multiSelect
+        options={DEFAULT_OPTIONS}
+        defaultSelectedKey={['1', '2', '3']}
+        allowFreeform={true}
+        componentRef={componentRef}
+      />
+    );
+    const inputElement: InputElementWrapper = wrapper.find('.ms-ComboBox input');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS], [0, 1, 2]);
+    inputElement.simulate('focus');
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], [0, 1, 2]);
+    inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], [0, 1, 2]);
+    inputElement.simulate('blur');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [0, 1, 2, 3]);
+  });
+
+  // Adds currentPendingValue to options and makes it selected onBlur
+  // if allowFreeForm is true for multiSelect with no default value selected
+  it('adds currentPendingValue to options and selects for multiSelect with no default value', () => {
+    const componentRef = React.createRef<any>();
+    const comboBoxOption: IComboBoxOption = {
+      key: 'ManuallyEnteredValue',
+      text: 'ManuallyEnteredValue'
+    };
+    wrapper = mount(<ComboBox multiSelect options={DEFAULT_OPTIONS} allowFreeform={true} componentRef={componentRef} />);
+    const inputElement: InputElementWrapper = wrapper.find('.ms-ComboBox input');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('focus');
+    expect((componentRef.current as ComboBox).state.focused).toEqual(true);
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('blur');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+
+    // this should toggle the checkbox
+    inputElement.simulate('focus');
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    inputElement.simulate('blur');
+    _verifyStateVariables(
+      componentRef,
+      false,
+      [
+        ...DEFAULT_OPTIONS,
+        {
+          ...comboBoxOption,
+          selected: false
+        }
+      ],
+      []
+    );
+  });
+
+  // adds currentPendingValue to options and makes it selected onBlur
+  // if allowFreeForm is true for singleSelect
+  it('adds currentPendingValue to options and selects for singleSelect', () => {
+    const componentRef = React.createRef<any>();
+    const comboBoxOption: IComboBoxOption = {
+      key: 'ManuallyEnteredValue',
+      text: 'ManuallyEnteredValue'
+    };
+    wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} allowFreeform={true} componentRef={componentRef} />);
+    const inputElement: InputElementWrapper = wrapper.find('.ms-ComboBox input');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('focus');
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('blur');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+
+    // this should toggle the checkbox
+    inputElement.simulate('focus');
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
+    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    inputElement.simulate('blur');
+    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+  });
+
+  function _verifyStateVariables(
+    componentRef: React.RefObject<any>,
+    isFocused: boolean,
+    currentOptions: IComboBoxOption[],
+    selectedIndices?: number[]
+  ): void {
+    expect((componentRef.current as ComboBox).state.focused).toEqual(isFocused);
+    expect((componentRef.current as ComboBox).state.selectedIndices).toEqual(selectedIndices);
+    expect((componentRef.current as ComboBox).state.currentOptions).toEqual(currentOptions);
+  }
 });

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -341,15 +341,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     this._classNames = this.props.getClassNames
       ? this.props.getClassNames(theme!, !!isOpen, !!disabled, !!required, !!focused, !!allowFreeform, !!hasErrorMessage, className)
       : getClassNames(
-        getStyles(theme!, customStyles),
-        className!,
-        !!isOpen,
-        !!disabled,
-        !!required,
-        !!focused,
-        !!allowFreeform,
-        !!hasErrorMessage
-      );
+          getStyles(theme!, customStyles),
+          className!,
+          !!isOpen,
+          !!disabled,
+          !!required,
+          !!focused,
+          !!allowFreeform,
+          !!hasErrorMessage
+        );
 
     return (
       <div {...divProps} ref={this._root} className={this._classNames.container}>
@@ -426,10 +426,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
               options: this.state.currentOptions.map((item, index) => ({ ...item, index: index }))
             },
             this._onRenderContainer
-          )
-        }
+          )}
         {errorMessage && <div className={this._classNames.errorMessage}>{errorMessage}</div>}
-      </div >
+      </div>
     );
   }
 
@@ -544,8 +543,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           currentPendingValue !== null && currentPendingValue !== undefined
             ? currentPendingValue
             : this._indexWithinBounds(currentOptions, index)
-              ? currentOptions[index].text
-              : ''
+            ? currentOptions[index].text
+            : ''
         );
       } else {
         for (let idx = 0; selectedIndices && idx < selectedIndices.length; idx++) {
@@ -572,8 +571,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           currentPendingValue !== null && currentPendingValue !== undefined
             ? currentPendingValue
             : this._indexWithinBounds(currentOptions, index)
-              ? currentOptions[index].text
-              : ''
+            ? currentOptions[index].text
+            : ''
         );
       } else {
         // If we are not allowing freeform and have a
@@ -972,7 +971,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     if (this.state.focused) {
       this.setState({ focused: false });
-      if (!this.props.multiSelect) {
+      if (!this.props.multiSelect || this.props.allowFreeform) {
         this._submitPendingValue(event);
       }
     }
@@ -1021,7 +1020,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             (this._autofill.current &&
               this._autofill.current.isValueSelected &&
               currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-              pendingOptionText.length)) ||
+                pendingOptionText.length)) ||
             (this._autofill.current &&
               this._autofill.current.inputElement &&
               this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
@@ -1218,24 +1217,24 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           }
         </CommandButton>
       ) : (
-          <Checkbox
-            id={id + '-list' + item.index}
-            ariaLabel={this._getPreviewText(item)}
-            key={item.key}
-            data-index={item.index}
-            styles={checkboxStyles}
-            className={'ms-ComboBox-option'}
-            data-is-focusable={true}
-            onChange={this._onItemClick(item)}
-            label={item.text}
-            role="option"
-            aria-selected={isSelected ? 'true' : 'false'}
-            checked={isSelected}
-            title={title}
-          >
-            {onRenderOption(item, this._onRenderOptionContent)}
-          </Checkbox>
-        );
+        <Checkbox
+          id={id + '-list' + item.index}
+          ariaLabel={this._getPreviewText(item)}
+          key={item.key}
+          data-index={item.index}
+          styles={checkboxStyles}
+          className={'ms-ComboBox-option'}
+          data-is-focusable={true}
+          onChange={this._onItemClick(item)}
+          label={item.text}
+          role="option"
+          aria-selected={isSelected ? 'true' : 'false'}
+          checked={isSelected}
+          title={title}
+        >
+          {onRenderOption(item, this._onRenderOptionContent)}
+        </Checkbox>
+      );
     };
 
     return (
@@ -1294,10 +1293,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       ? currentPendingValueValidIndexOnHover
       : currentPendingValueValidIndex >= 0 ||
         (includeCurrentPendingValue && (currentPendingValue !== null && currentPendingValue !== undefined))
-        ? currentPendingValueValidIndex
-        : this.props.multiSelect
-          ? 0
-          : this._getFirstSelectedIndex();
+      ? currentPendingValueValidIndex
+      : this.props.multiSelect
+      ? 0
+      : this._getFirstSelectedIndex();
   }
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
For multiselect comboBox, if allowFreeForm is true, currentPendingValue is not added to options or gets selected when user click outside comboBox.
[Video](https://microsoft-my.sharepoint.com/:v:/p/hatrived/Eap5oTVLy-1OhNwDdl5yTHoBY_xydUS7GWI477tSEFLohg?e=piQRRf)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8256)