### PR TITLE
Use selected item keys on wrapped selected items

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-selected-item-keying_2019-03-11-16-03.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-selected-item-keying_2019-03-11-16-03.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Key wrapped selectedItem children when they are keyed",
-      "type": "patch"
+      "comment": "SelectedPeopleList: Key wrapped selectedItem children when they are keyed",
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-selected-item-keying_2019-03-11-16-03.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-selected-item-keying_2019-03-11-16-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Key wrapped selectedItem children when they are keyed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7824,6 +7824,8 @@ interface IExtendedPersonaProps extends IPersonaProps {
   // (undocumented)
   isValid: boolean;
   // (undocumented)
+  key?: React.Key;
+  // (undocumented)
   shouldBlockSelection?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -5,7 +5,6 @@ import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 
 import { SelectedPeopleList, IExtendedPersonaProps } from './SelectedPeopleList';
-import { FloatingPeoplePicker } from '../../FloatingPicker';
 
 describe('SelectedPeopleList', () => {
   describe('Element keying behavior', () => {

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -1,0 +1,92 @@
+/* tslint:disable:no-unused-variable */
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+/* tslint:enable:no-unused-variable */
+import * as renderer from 'react-test-renderer';
+
+import { SelectedPeopleList, IExtendedPersonaProps } from './SelectedPeopleList';
+import { FloatingPeoplePicker } from '../../FloatingPicker';
+
+describe('SelectedPeopleList', () => {
+  describe('Element keying behavior', () => {
+    it('renders keyed personas when there is no context menu', () => {
+      const r = renderer.create(<SelectedPeopleList />);
+      expect(r.root.instance).toBeInstanceOf(SelectedPeopleList);
+      const picker: SelectedPeopleList = r.root.instance;
+      picker.addItems([
+        {
+          key: 'person-A',
+          text: 'Person A',
+          isValid: true
+        },
+        {
+          key: 'person-B',
+          text: 'Person B',
+          isValid: true
+        }
+      ]);
+
+      const result = picker.render();
+      expect(result).toBeInstanceOf(Array);
+      expect(result[0].key).toBe('person-A');
+      expect(result[1].key).toBe('person-B');
+    });
+
+    it('renders keyed personas when there is a context menu', () => {
+      const r = renderer.create(<SelectedPeopleList removeMenuItemText="REMOVE" />);
+      expect(r.root.instance).toBeInstanceOf(SelectedPeopleList);
+      const picker: SelectedPeopleList = r.root.instance;
+      picker.addItems([
+        {
+          key: 'person-A',
+          text: 'Person A',
+          isValid: true
+        },
+        {
+          key: 'person-B',
+          text: 'Person B',
+          isValid: true
+        }
+      ]);
+
+      const result = picker.render();
+      expect(result).toBeInstanceOf(Array);
+      expect(result[0].key).toBe('person-A');
+      expect(result[1].key).toBe('person-B');
+    });
+
+    it('renders keyed personas when items are being edited', () => {
+      const getEditingItemText = (i: IExtendedPersonaProps) => i.text || 'lmao oops';
+      const ref = React.createRef<SelectedPeopleList>();
+
+      // editingitem has unlisted constraints on being mounted on an actual DOM.
+      // so we can't render it with `renderer` and expect the internal state of the EditingItem to be
+      // initialized
+      const root = document.createElement('div');
+      ReactDOM.render(<SelectedPeopleList ref={ref} editMenuItemText="REMOVE" getEditingItemText={getEditingItemText} />, root);
+      expect(ref.current).not.toBeNull();
+      const picker = ref.current;
+      if (picker === null) {
+        throw new Error('already checked ref instance was not null');
+      }
+      picker.addItems([
+        {
+          key: 'person-A',
+          text: 'Person A',
+          isValid: true,
+          isEditing: true
+        },
+        {
+          key: 'person-B',
+          text: 'Person B',
+          isValid: true
+        }
+      ]);
+
+      const result = picker.render();
+      expect(result).toBeInstanceOf(Array);
+      expect(result[0].key).toBe('person-A');
+      expect(result[1].key).toBe('person-B');
+    });
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -12,7 +12,7 @@ import { IBaseFloatingPickerProps } from '../../../FloatingPicker';
 import { EditingItem } from './Items/EditingItem';
 
 export interface IExtendedPersonaProps extends IPersonaProps {
-  key?: string;
+  key?: React.Key;
   isValid: boolean;
   blockRecipientRemoval?: boolean;
   shouldBlockSelection?: boolean;
@@ -74,7 +74,8 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
       index,
       key: item.key ? item.key : index,
       selected: this.selection.isIndexSelected(index),
-      onRemoveItem: () => this.removeItem(item),
+      // TODO removeItem is incorrectly typed. Remove this cast in the fix.
+      onRemoveItem: () => this.removeItem(item as any),
       onItemChange: this.onItemChange,
       removeButtonAriaLabel: removeButtonAriaLabel,
       onCopyItem: (itemToCopy: IExtendedPersonaProps) => this.copyItems([itemToCopy]),

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -75,7 +75,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
       key: item.key ? item.key : index,
       selected: this.selection.isIndexSelected(index),
       // TODO removeItem is incorrectly typed. Remove this cast in the fix.
-      onRemoveItem: () => this.removeItem(item as any),
+      onRemoveItem: () => this.removeItem(item),
       onItemChange: this.onItemChange,
       removeButtonAriaLabel: removeButtonAriaLabel,
       onCopyItem: (itemToCopy: IExtendedPersonaProps) => this.copyItems([itemToCopy]),

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -94,9 +94,9 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
         />
       );
     } else {
-      // This cast is here because we are guraranteed that onRenderItem is set
+      // This cast is here because we are guaranteed that onRenderItem is set
       // from static defaultProps
-      // TODO move this component to composition with required onRenderItem to remove
+      // TODO: Move this component to composition with required onRenderItem to remove
       // this cast.
       const onRenderItem = this.props.onRenderItem as (props: ISelectedPeopleItemProps) => JSX.Element;
       const renderedItem = onRenderItem(props);

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -74,7 +74,6 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
       index,
       key: item.key ? item.key : index,
       selected: this.selection.isIndexSelected(index),
-      // TODO removeItem is incorrectly typed. Remove this cast in the fix.
       onRemoveItem: () => this.removeItem(item),
       onItemChange: this.onItemChange,
       removeButtonAriaLabel: removeButtonAriaLabel,

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -12,6 +12,7 @@ import { IBaseFloatingPickerProps } from '../../../FloatingPicker';
 import { EditingItem } from './Items/EditingItem';
 
 export interface IExtendedPersonaProps extends IPersonaProps {
+  key?: string;
   isValid: boolean;
   blockRecipientRemoval?: boolean;
   shouldBlockSelection?: boolean;
@@ -61,12 +62,13 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
   protected renderItems = (): JSX.Element[] => {
     const { items } = this.state;
     // tslint:disable-next-line:no-any
-    return items.map((item: any, index: number) => this._renderItem(item, index));
+    return items.map((item: IExtendedPersonaProps, index: number) => this._renderItem(item, index));
   };
 
   // tslint:disable-next-line:no-any
-  private _renderItem(item: any, index: number): JSX.Element {
+  private _renderItem(item: IExtendedPersonaProps, index: number): JSX.Element {
     const { removeButtonAriaLabel } = this.props;
+    const expandGroup = this.props.onExpandGroup;
     const props = {
       item,
       index,
@@ -76,7 +78,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
       onItemChange: this.onItemChange,
       removeButtonAriaLabel: removeButtonAriaLabel,
       onCopyItem: (itemToCopy: IExtendedPersonaProps) => this.copyItems([itemToCopy]),
-      onExpandItem: this.props.onExpandGroup ? () => (this.props.onExpandGroup as (item: IExtendedPersonaProps) => void)(item) : undefined,
+      onExpandItem: expandGroup ? () => expandGroup(item) : undefined,
       menuItems: this._createMenuItems(item)
     };
 
@@ -92,10 +94,15 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
         />
       );
     } else {
+      // This cast is here because we are guraranteed that onRenderItem is set
+      // from static defaultProps
+      // TODO move this component to composition with required onRenderItem to remove
+      // this cast.
       const onRenderItem = this.props.onRenderItem as (props: ISelectedPeopleItemProps) => JSX.Element;
       const renderedItem = onRenderItem(props);
       return hasContextMenu ? (
         <SelectedItemWithContextMenu
+          key={props.key}
           renderedItem={renderedItem}
           beginEditing={this._beginEditing}
           menuItems={this._createMenuItems(props.item)}


### PR DESCRIPTION
#### Pull request checklist

- ~~[ ] Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Selected items throw a key error if they are rendered with context menus (since the context menu wrapper does not have a key set on it).

This PR uses the key of the wrapped item on the wrapper to avoid this problem.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8258)