### PR TITLE
Add types to BaseSelectedItemsList + fix incorrect typing in removeItem

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-removeItem-Typing_2019-03-11-19-10.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-removeItem-Typing_2019-03-11-19-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix typing on BaseSelectedItemList.removeItem",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -411,7 +411,7 @@ class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BasePicker<T
 }
 
 // @public (undocumented)
-class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> extends BaseComponent<P, IBaseSelectedItemsListState>, implements IBaseSelectedItemsList<T> {
+class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> extends BaseComponent<P, IBaseSelectedItemsListState<T>>, implements IBaseSelectedItemsList<T> {
   constructor(basePickerProps: P);
   // (undocumented)
   addItems: (items: T[]) => void;
@@ -438,7 +438,7 @@ class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> extends
   // (undocumented)
   protected onSelectionChanged: () => void;
   // (undocumented)
-  removeItem: (item: ISelectedItemProps<T>) => void;
+  removeItem: (item: T) => void;
   // (undocumented)
   removeItemAt: (index: number) => void;
   // (undocumented)
@@ -2010,9 +2010,9 @@ interface IBaseSelectedItemsListProps<T> extends React.ClassAttributes<any> {
 }
 
 // @public (undocumented)
-interface IBaseSelectedItemsListState {
+interface IBaseSelectedItemsListState<T = any> {
   // (undocumented)
-  items?: any;
+  items: T[];
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -4,12 +4,12 @@ import { Selection } from '../../Selection';
 
 import { IBaseSelectedItemsList, IBaseSelectedItemsListProps, ISelectedItemProps } from './BaseSelectedItemsList.types';
 
-export interface IBaseSelectedItemsListState {
+export interface IBaseSelectedItemsListState<T = any> {
   // tslint:disable-next-line:no-any
-  items?: any;
+  items: T[];
 }
 
-export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> extends BaseComponent<P, IBaseSelectedItemsListState>
+export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> extends BaseComponent<P, IBaseSelectedItemsListState<T>>
   implements IBaseSelectedItemsList<T> {
   protected root: HTMLElement;
   protected selection: Selection;
@@ -65,7 +65,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     }
   };
 
-  public removeItem = (item: ISelectedItemProps<T>): void => {
+  public removeItem = (item: T): void => {
     const { items } = this.state;
     const index: number = items.indexOf(item);
 
@@ -142,7 +142,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     const newItems = newProps.selectedItems;
 
     if (newItems) {
-      this.setState({ items: newProps.selectedItems });
+      this.setState({ items: newItems });
     }
 
     if (newProps.selection) {

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.tsx
@@ -138,7 +138,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
         key: 'Remove',
         text: this.props.removeMenuItemText,
         onClick: (ev: React.MouseEvent<HTMLElement>, menuItem: IContextualMenuItem) => {
-          this.removeItem(menuItem.data as ISelectedItemProps<IExtendedPersonaProps>);
+          this.removeItem(menuItem.data as IExtendedPersonaProps);
         },
         data: item
       });


### PR DESCRIPTION
#### Pull request checklist

- [ ] ~~Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Removes some uses of 'any' from BaseSelectedItemList.

It looks like removeItem was incorrectly typed against its current usage -- it's expecting an ISelectedItemProps<T>, when in reality all callsites are just passing it a value of <T>.

The reason this error was introduced was in part because MenuItem's data is not parameterized on the data type, so all reference sites require a type assertion.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8260)