### PR TITLE
Dropdown: onRenderTitle typing should be IRenderFunction<IDropdownOption[]> only

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-dropdown-onRenderTitle-type_2019-03-12-00-03.json
+++ b/common/changes/office-ui-fabric-react/keco-dropdown-onRenderTitle-type_2019-03-12-00-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Type onRenderTitle as Array<IDropdownOption> only",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7670,7 +7670,7 @@ interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDi
   onDismiss?: () => void;
   onRenderCaretDown?: IRenderFunction<IDropdownProps>;
   onRenderPlaceHolder?: IRenderFunction<IDropdownProps>;
-  onRenderTitle?: IRenderFunction<IDropdownOption | IDropdownOption[]>;
+  onRenderTitle?: IRenderFunction<IDropdownOption[]>;
   options: IDropdownOption[];
   // @deprecated
   placeHolder?: string;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -401,10 +401,10 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
   }
 
   /** Render text in dropdown input */
-  private _onRenderTitle = (item: IDropdownOption[]): JSX.Element => {
+  private _onRenderTitle = (items: IDropdownOption[]): JSX.Element => {
     const { multiSelectDelimiter = ', ' } = this.props;
 
-    const displayTxt = item.map(i => i.text).join(multiSelectDelimiter);
+    const displayTxt = items.map(i => i.text).join(multiSelectDelimiter);
     return <span>{displayTxt}</span>;
   };
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -50,7 +50,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   /**
    * Optional custom renderer for selected option displayed in input
    */
-  onRenderTitle?: IRenderFunction<IDropdownOption | IDropdownOption[]>;
+  onRenderTitle?: IRenderFunction<IDropdownOption[]>;
 
   /**
    * Optional custom renderer for chevron icon


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8263
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This fixes the typing of `Dropdown`'s `onRenderTitle` to be `IRenderFunction<IDropdownOption[]>` instead of a union of `IRenderFunction<IDropdownOption | IDropdownOption[]>` introduced in https://github.com/OfficeDev/office-ui-fabric-react/pull/2386.

I believe this fix can be classified as a "bug fix" even though it is modifying the public API signature. This is because based on my grepping ([Github search](https://github.com/OfficeDev/office-ui-fabric-react/search?q=onRenderTitle&unscoped_q=onRenderTitle)), the `Dropdown` never passes a non-Array value to `onRenderTitle` since the above linked refactor.

I've checked OneDrive / SharePoint usage of `onRenderTitle` and all call-sites expect `IDropdownOption[]`.

I've also renamed `item` to `items` in the base implementation of `onRenderTitle` for clarity.

#### Focus areas to test

- CI should pass
- Tests should pass
- Dropdowns should function as they did previously

cc: @yenchanghsieh

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8270)