### PR TITLE
FocusTrapZone: Fix zero tabbable element scenarios

### DIFF
--- a/common/changes/office-ui-fabric-react/jg-fix-ftz-no-tabbable_2019-03-12-04-48.json
+++ b/common/changes/office-ui-fabric-react/jg-fix-ftz-no-tabbable_2019-03-12-04-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusTrapZone: Fix for zones that have zero tabbable elements.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -67,7 +67,7 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
       },
       tabIndex: 0,
       'aria-hidden': true,
-      'data-is-visible': 'true'
+      'data-is-visible': true
     } as React.HTMLAttributes<HTMLDivElement>;
 
     return (

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -60,10 +60,15 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
     const { className, ariaLabelledBy } = this.props;
     const divProps = getNativeProps(this.props, divProperties);
 
-    const bumperStyle: React.CSSProperties = {
-      pointerEvents: 'none',
-      position: 'fixed' // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them
-    };
+    const bumperProps = {
+      style: {
+        pointerEvents: 'none',
+        position: 'fixed' // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them
+      },
+      tabIndex: 0,
+      'aria-hidden': true,
+      'data-is-visible': 'true'
+    } as React.HTMLAttributes<HTMLDivElement>;
 
     return (
       <div
@@ -75,9 +80,9 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
         onFocus={this._onRootFocus}
         onBlur={this._onRootBlur}
       >
-        <div ref={this._firstBumper} onFocus={this._onFirstBumperFocus} style={bumperStyle} tabIndex={0} aria-hidden={true} />
+        <div {...bumperProps} ref={this._firstBumper} onFocus={this._onFirstBumperFocus} />
         {this.props.children}
-        <div ref={this._lastBumper} onFocus={this._onLastBumperFocus} style={bumperStyle} tabIndex={0} aria-hidden={true} />
+        <div {...bumperProps} ref={this._lastBumper} onFocus={this._onLastBumperFocus} />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
           >
             <div
               aria-hidden={true}
-              data-is-visible="true"
+              data-is-visible={true}
               onFocus={[Function]}
               style={
                 Object {
@@ -171,7 +171,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
-              data-is-visible="true"
+              data-is-visible={true}
               onFocus={[Function]}
               style={
                 Object {
@@ -330,7 +330,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
           >
             <div
               aria-hidden={true}
-              data-is-visible="true"
+              data-is-visible={true}
               onFocus={[Function]}
               style={
                 Object {
@@ -356,7 +356,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
-              data-is-visible="true"
+              data-is-visible={true}
               onFocus={[Function]}
               style={
                 Object {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -143,6 +143,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
           >
             <div
               aria-hidden={true}
+              data-is-visible="true"
               onFocus={[Function]}
               style={
                 Object {
@@ -170,6 +171,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
+              data-is-visible="true"
               onFocus={[Function]}
               style={
                 Object {
@@ -328,6 +330,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
           >
             <div
               aria-hidden={true}
+              data-is-visible="true"
               onFocus={[Function]}
               style={
                 Object {
@@ -353,6 +356,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
             </div>
             <div
               aria-hidden={true}
+              data-is-visible="true"
               onFocus={[Function]}
               style={
                 Object {

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`Modal renders Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
-            data-is-visible="true"
+            data-is-visible={true}
             onFocus={[Function]}
             style={
               Object {
@@ -159,7 +159,7 @@ exports[`Modal renders Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
-            data-is-visible="true"
+            data-is-visible={true}
             onFocus={[Function]}
             style={
               Object {
@@ -291,7 +291,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
-            data-is-visible="true"
+            data-is-visible={true}
             onFocus={[Function]}
             style={
               Object {
@@ -314,7 +314,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
-            data-is-visible="true"
+            data-is-visible={true}
             onFocus={[Function]}
             style={
               Object {

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`Modal renders Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-visible="true"
             onFocus={[Function]}
             style={
               Object {
@@ -158,6 +159,7 @@ exports[`Modal renders Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-visible="true"
             onFocus={[Function]}
             style={
               Object {
@@ -289,6 +291,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-visible="true"
             onFocus={[Function]}
             style={
               Object {
@@ -311,6 +314,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-visible="true"
             onFocus={[Function]}
             style={
               Object {

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`Panel renders Panel correctly 1`] = `
         >
           <div
             aria-hidden={true}
-            data-is-visible="true"
+            data-is-visible={true}
             onFocus={[Function]}
             style={
               Object {
@@ -409,7 +409,7 @@ exports[`Panel renders Panel correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
-            data-is-visible="true"
+            data-is-visible={true}
             onFocus={[Function]}
             style={
               Object {

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -160,6 +160,7 @@ exports[`Panel renders Panel correctly 1`] = `
         >
           <div
             aria-hidden={true}
+            data-is-visible="true"
             onFocus={[Function]}
             style={
               Object {
@@ -408,6 +409,7 @@ exports[`Panel renders Panel correctly 1`] = `
           </div>
           <div
             aria-hidden={true}
+            data-is-visible="true"
             onFocus={[Function]}
             style={
               Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -2114,7 +2114,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                               >
                                 <div
                                   aria-hidden={true}
-                                  data-is-visible="true"
+                                  data-is-visible={true}
                                   onFocus={[Function]}
                                   style={
                                     Object {
@@ -2351,7 +2351,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                 </div>
                                 <div
                                   aria-hidden={true}
-                                  data-is-visible="true"
+                                  data-is-visible={true}
                                   onFocus={[Function]}
                                   style={
                                     Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -2114,6 +2114,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                               >
                                 <div
                                   aria-hidden={true}
+                                  data-is-visible="true"
                                   onFocus={[Function]}
                                   style={
                                     Object {
@@ -2350,6 +2351,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                 </div>
                                 <div
                                   aria-hidden={true}
+                                  data-is-visible="true"
                                   onFocus={[Function]}
                                   style={
                                     Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -245,6 +245,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
           >
             <div
               aria-hidden={true}
+              data-is-visible="true"
               onFocus={[Function]}
               style={
                 Object {
@@ -493,6 +494,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
             </div>
             <div
               aria-hidden={true}
+              data-is-visible="true"
               onFocus={[Function]}
               style={
                 Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -245,7 +245,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
           >
             <div
               aria-hidden={true}
-              data-is-visible="true"
+              data-is-visible={true}
               onFocus={[Function]}
               style={
                 Object {
@@ -494,7 +494,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
             </div>
             <div
               aria-hidden={true}
-              data-is-visible="true"
+              data-is-visible={true}
               onFocus={[Function]}
               style={
                 Object {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The last commit of #8216 actually broke one scenario: FocusTrapZone with 0 tabbable elements. This is because using `position: fixed` causes `isElementVisible` utility to fail since `offsetParent` is always `null` for the bumpers. This PR fixes zero tabbable scenarios by adding the `data-is-visible` attribute to the bumpers.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8274)