### PR TITLE
Suggestions Component bug fix: Slice suggestions based on selected suggestion        

### DIFF
--- a/common/changes/office-ui-fabric-react/SuggestionsFix_2019-03-14-00-00.json
+++ b/common/changes/office-ui-fabric-react/SuggestionsFix_2019-03-14-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix for  scrolling functionality in Suggestions component.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pratik661@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -321,8 +321,12 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
       }
     );
 
+    const selectedIndex = suggestions.findIndex(suggestion => suggestion.selected);
     if (resultsMaximumNumber) {
-      suggestions = suggestions.slice(0, resultsMaximumNumber);
+      suggestions =
+        selectedIndex >= resultsMaximumNumber
+          ? suggestions.slice(selectedIndex - resultsMaximumNumber + 1, selectedIndex + 1)
+          : suggestions.slice(0, resultsMaximumNumber);
     }
 
     if (suggestions.length === 0) {

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -321,7 +321,15 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
       }
     );
 
-    const selectedIndex = suggestions.findIndex(suggestion => suggestion.selected);
+    let selectedIndex = -1;
+    suggestions.some((element, index) => {
+      if (element.selected) {
+        selectedIndex = index;
+        return true;
+      }
+      return false;
+    });
+
     if (resultsMaximumNumber) {
       suggestions =
         selectedIndex >= resultsMaximumNumber


### PR DESCRIPTION
**Bug:**
User can not scroll down list of suggestions with keyboard.

**How to replicate:**
suggestions param: list of N SuggestionsItem where N is more than the resultsMaximumNumber param. 
When scrolling down the list of suggestions, if the selection index goes beyond resultsMaximumNumber, the selected item will not be visible. (See screenshots)

This can cause accesibility issues because the user can not access all the options using just the keyboard.

Selection is on index 0
![image](https://user-images.githubusercontent.com/2469361/54208590-98cdc380-44b2-11e9-9327-c084bb693434.png)

Selection is on index 4.
![image](https://user-images.githubusercontent.com/2469361/54208639-ab47fd00-44b2-11e9-89e3-ac139cd37c84.png)
The suggestions to display are sliced based on index 0 and resultsMaximumNumber, rather than the selected suggestion index

With the fix, the suggestions to display are sliced based on the current selected index:
![image](https://user-images.githubusercontent.com/2469361/54208739-dd595f00-44b2-11e9-9669-abc71c85c1ed.png)

This visually creates the impression of scrolling.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8282
- [x] Include a change request file using `$ npm run change`

#### Description of changes

(give an overview)

When displaying SuggestionItems, this component slices the list of suggestions based between index 0 and resultsMaximumNumber.

I modified this logic to
1. find the selected index
2. slice the suggestions array so that the selected suggestion will always be displayed. 

#### Focus areas to test

(optional)
