### PR TITLE
onEnter is not available for TextField anymore

### DIFF
--- a/common/changes/office-ui-fabric-react/patch-1_2019-03-12-20-26.json
+++ b/common/changes/office-ui-fabric-react/patch-1_2019-03-12-20-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "daisrawi@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/docs/TextFieldDos.md
+++ b/packages/office-ui-fabric-react/src/components/TextField/docs/TextFieldDos.md
@@ -3,7 +3,7 @@
 - Provide concise helper text that specifies what content is expected to be entered.
 - Provide all appropriate states for the control (static, hover, focus, engaged, unavailable, error).
 - When part of a form, provide clear designations for which fields are required vs. optional.
-- Provide all appropriate methods for submitting provided data (onEnter or a dedicated ‘Submit’ button).
+- Provide all appropriate methods for submitting provided data (e.g. dedicated ‘Submit’ button).
 - Provide all appropriate methods of clearing provided data (‘X’ or something similar).
 - Allow for selection, copy and paste of field data.
 - Whenever possible, format TextField relative to the expected entry (4-digit PIN, 10-digit phone number (3 separate fields), etc).


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Documentation suggests there is a onEnter event for TextField. This is not true per current documentation.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8277)