### PR TITLE
Fabric Website Github FeedbackList: Iterate Github issues collection directly to avoid possible undefined value

### DIFF
--- a/common/changes/@uifabric/example-app-base/keco-feedbacklist-robust_2019-03-12-20-06.json
+++ b/common/changes/@uifabric/example-app-base/keco-feedbacklist-robust_2019-03-12-20-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "FeedbackList: Iterate Github issues collection directly to avoid total_count disparity",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "keco@microsoft.com"
+}

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.tsx
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.tsx
@@ -46,22 +46,22 @@ export class FeedbackList extends React.Component<IFeedbackListProps, IFeedbackL
   }
 
   public async getIssues(url: string): Promise<IListItem[]> {
-    let issueList: IListItem[] = [];
-
     const response = await fetch(url);
     const responseText = await response.text();
 
     const myObj = JSON.parse(responseText);
-    for (let i = 0; i < myObj.total_count; i++) {
-      let dateCreated = new Date(myObj.items[i].created_at);
-      let openedOn = relativeDates(dateCreated, new Date());
-      issueList.push({
-        issueTitle: myObj.items[i].title,
-        issueNum: myObj.items[i].number,
+    const { items = [] } = myObj;
+
+    return items.map((item: { created_at: string; title: string; number: number }) => {
+      const dateCreated = new Date(item.created_at);
+      const openedOn = relativeDates(dateCreated, new Date());
+
+      return {
+        issueTitle: item.title,
+        issueNum: item.number,
         issueCreated: openedOn
-      });
-    }
-    return issueList;
+      };
+    });
   }
 
   public render(): JSX.Element | null {

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.tsx
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.tsx
@@ -52,6 +52,8 @@ export class FeedbackList extends React.Component<IFeedbackListProps, IFeedbackL
     const myObj = JSON.parse(responseText);
     const { items = [] } = myObj;
 
+    // Intentionally render the first 30 issues until pagination support is added for
+    // https://github.com/OfficeDev/office-ui-fabric-react/issues/8284
     return items.map((item: { created_at: string; title: string; number: number }) => {
       const dateCreated = new Date(item.created_at);
       const openedOn = relativeDates(dateCreated, new Date());


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8276
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`FeedbackList` was using the API response value of `total_count` as its iterator max which doesn't necessarily map to the length of the collection being iterated over. Because of this, index lookup would sometimes return `undefined` which would result in a runtime exception.

The fix is to simply iterate over the issues collection for the response directly.

#### Focus areas to test

- CI should pass
- Build should pass
- Github issues widget should render properly on Fabric Website

**ChoiceGroup page example**:

![image](https://user-images.githubusercontent.com/706967/54232525-105a1d80-44c8-11e9-86f6-8dd4834c163b.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8280)