### PR TITLE
SpinButton: Mark label as optional since it has default prop value

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-spinbutton-label-opt_2019-03-12-20-40.json
+++ b/common/changes/office-ui-fabric-react/keco-spinbutton-label-opt_2019-03-12-20-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SpinButton: label prop should be marked as optional",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10577,7 +10577,7 @@ interface ISpinButtonProps {
   incrementButtonAriaLabel?: string;
   incrementButtonIcon?: IIconProps;
   keytipProps?: IKeytipProps;
-  label: string;
+  label?: string;
   // (undocumented)
   labelPosition?: Position;
   max?: number;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -89,7 +89,7 @@ export interface ISpinButtonProps {
   /**
    * Descriptive label for the SpinButton.
    */
-  label: string;
+  label?: string;
 
   /**
    * @defaultvalue Left


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8278
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As described in the above linked issue, `SpinButton`'s `label` prop can be marked as _optional_ because it has a `defaultProps` value of empty string i.e. `""`. Therefore, it is not required that a user pass-in a value for `label`. See:

https://github.com/OfficeDev/office-ui-fabric-react/blob/b1268e9483baebde1af06e1df18797b3d1417bde/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx#L59

I stepped thru both providing and not providing a value for `label`. I found that when not provided, label properly defaults to `""`.

---

Note that usages of `label` within `SpinButton` properly conditionally render to handle the absence of a `label` value.

https://github.com/OfficeDev/office-ui-fabric-react/blob/b1268e9483baebde1af06e1df18797b3d1417bde/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx#L158

https://github.com/OfficeDev/office-ui-fabric-react/blob/b1268e9483baebde1af06e1df18797b3d1417bde/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx#L184

https://github.com/OfficeDev/office-ui-fabric-react/blob/b1268e9483baebde1af06e1df18797b3d1417bde/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx#L234

#### Focus areas to test

- CI should pass
- Users should be able to use both `ISpinButtonProps` and `<SpinButton/>` without having to provide a value for `label`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8283)