### PR TITLE
Find active element within iframe

### DIFF
--- a/common/changes/office-ui-fabric-react/active-element-in-iframe-fix_2019-03-13-00-10.json
+++ b/common/changes/office-ui-fabric-react/active-element-in-iframe-fix_2019-03-13-00-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "in casse of an iframe, get active element appropriately",
+      "comment": "in case of an iframe, get active element appropriately",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/active-element-in-iframe-fix_2019-03-13-00-10.json
+++ b/common/changes/office-ui-fabric-react/active-element-in-iframe-fix_2019-03-13-00-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "in casse of an iframe, get active element appropriately",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/active-element-in-iframe-fix_2019-03-13-00-10.json
+++ b/common/changes/office-ui-fabric-react/active-element-in-iframe-fix_2019-03-13-00-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "in case of an iframe, get active element appropriately",
+      "comment": "Popup: If framed, set focus to frame's activeElement on dismiss",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -96,11 +96,7 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
         onKeyDown={this._onKeyDown}
-        style={{
-          overflowY: this.state.needsVerticalScrollBar ? 'scroll' : undefined,
-          outline: 'none',
-          ...style
-        }}
+        style={{ overflowY: this.state.needsVerticalScrollBar ? 'scroll' : undefined, outline: 'none', ...style }}
       >
         {this.props.children}
       </div>

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -33,6 +33,7 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
       tempActive = doc.activeElement;
     }
 
+    // Seek inner-most frame's activeElement to set focus on dismissal
     while (tempActive !== null && tempActive instanceof HTMLIFrameElement) {
       if (tempActive.contentDocument !== null && tempActive.contentDocument.activeElement !== null) {
         tempActiveLastSeen = tempActive;

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -25,7 +25,27 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
   }
 
   public componentWillMount(): void {
-    this._originalFocusedElement = getDocument()!.activeElement as HTMLElement;
+    let tempActive: Element | null = null;
+    let tempActiveLastSeen: Element | null = null;
+    const doc: Document | undefined = getDocument();
+
+    if (doc) {
+      tempActive = doc.activeElement;
+    }
+
+    while (tempActive !== null && tempActive instanceof HTMLIFrameElement) {
+      if (tempActive.contentDocument !== null && tempActive.contentDocument.activeElement !== null) {
+        tempActiveLastSeen = tempActive;
+        tempActive = tempActive.contentDocument.activeElement;
+        if (tempActive === tempActiveLastSeen) {
+          break;
+        }
+      }
+    }
+
+    if (tempActive !== null) {
+      this._originalFocusedElement = tempActive as HTMLElement;
+    }
   }
 
   public componentDidMount(): void {
@@ -76,7 +96,11 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
         onKeyDown={this._onKeyDown}
-        style={{ overflowY: this.state.needsVerticalScrollBar ? 'scroll' : undefined, outline: 'none', ...style }}
+        style={{
+          overflowY: this.state.needsVerticalScrollBar ? 'scroll' : undefined,
+          outline: 'none',
+          ...style
+        }}
       >
         {this.props.children}
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7260 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Creating this `PR` and closing [8071](https://github.com/OfficeDev/office-ui-fabric-react/pull/8071) due to a bad merge. The comments on the linked `PR` are resolved
1. Types were added
2. In order to avoid the possibility of an `iFrame` referring to itself, resulting in an `infinite loop`, the following check was added

 ```ts
if (tempActive === tempActiveLastSeen) {
    break;
}
```

3. Could not add a unit test for this one, since this has been a difficult scenario to unit test.  

#### Broader context
In `Popup.tsx`, it tries to determine the active element of the site by doing

`this._originalFocusedElement = getDocument()!.activeElement as HTMLElement;`
The issue with that is if there is a frame, the active element will be a reference to the head of the frame, instead of the elements within it.

The fix is to find the active element using `getDocument()!.contentWindow.document.activeElement` in case of an `iframe` being present, as is the case mentioned in the bug.

The above `PR` addresses the conditions

1.  The `iFrame` contains an `active element`, as is the case reported in the issue
2. The `iFrame` contains a multi level nesting of `iFrames`, which contains an `active element`. To address this, the `while` loop was added

```ts
while (tempActive !== null && tempActive instanceof HTMLIFrameElement) {
  if (tempActive.contentDocument !== null && tempActive.contentDocument.activeElement !== null) {
    tempActiveLastSeen = tempActive;
    tempActive = tempActive.contentDocument.activeElement;
    if (tempActive === tempActiveLastSeen) {
      break;
    }
  }
}
```
#### Focus areas to test

Create a page with a `panel` containing an `iframe` and a focus element like a `textbox`.
On hitting the escape on the `panel`, open up a dialog box
On hitting `escape` on the `dialog`, control goes back to the focus element (`textbox`)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8290)