### PR TITLE
Test bundles now generates the right numbers.

### DIFF
--- a/apps/test-bundles/webpack.config.js
+++ b/apps/test-bundles/webpack.config.js
@@ -4,42 +4,48 @@ const resources = require('../../scripts/webpack/webpack-resources');
 
 // Files which should not be considered top-level entries.
 const TopLevelEntryFileExclusions = ['index.js', 'version.js', 'index.bundle.js'];
-const StatsFileName = 'test-bundles';
 
-module.exports = resources.createConfig(
-  StatsFileName,
-  true,
-  {
-    entry: _buildEntries('office-ui-fabric-react'),
-    externals: {
-      react: 'React',
-      'react-dom': 'ReactDOM'
-    },
-    plugins: [
+const Entries = _buildEntries('office-ui-fabric-react');
+
+module.exports = Object.keys(Entries).map(
+  entryName =>
+    resources.createConfig(
+      entryName,
+      true,
       {
-        apply: compiler => {
-          compiler.hooks.afterEmit.tap('AfterEmitPlugin', compilation => _copyStats('office-ui-fabric-react'));
+        entry: {
+          [entryName]: Entries[entryName]
+        },
+        externals: {
+          react: 'React',
+          'react-dom': 'ReactDOM'
         }
-      }
-    ]
-  },
-  true,
-  true
+        // plugins: [
+        //   {
+        //     apply: compiler => {
+        //       compiler.hooks.afterEmit.tap('AfterEmitPlugin', compilation => _copyStats('office-ui-fabric-react'));
+        //     }
+        //   }
+        // ]
+      },
+      true,
+      true
+    )[0]
 );
 
 /**
  * Copy the stats file to dist folder the package the bundles were generated from.
  */
-function _copyStats(packageName) {
-  try {
-    fs.copyFileSync(
-      path.join(__dirname, 'dist/test-bundles.stats.html'),
-      path.resolve(__dirname, `../../packages/${packageName}/dist/${StatsFileName}.stats.html`)
-    );
-  } catch (e) {
-    console.log(e);
-  }
-}
+// function _copyStats(packageName) {
+//   try {
+//     fs.copyFileSync(
+//       path.join(__dirname, 'dist/test-bundles.stats.html'),
+//       path.resolve(__dirname, `../../packages/${packageName}/dist/${StatsFileName}.stats.html`)
+//     );
+//   } catch (e) {
+//     console.log(e);
+//   }
+// }
 
 /**
  * Build webpack entries based on top level imports available in a package.


### PR DESCRIPTION
When you create bundle A using a single webpack entry, it produces some output.

When you add another entry to the same config, it can ALTER that output and produce different results for bundle A.

So I've changed the test-bundles config to bundle entrypoints individually to get real numbers:

Instead of:
```
module.exports = { 
  entry: { 
     A: 'a.js', 
     B: 'b.js' 
  } 
}
```

This:

```
module.exports = [
  { entry: { A: 'a.js' } },
  { entry: { B: 'b.js' } },
];
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8292)