### PR TITLE
Image: Fix width prop doc block typos

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-spelling_2019-03-13-16-52.json
+++ b/common/changes/office-ui-fabric-react/keco-spelling_2019-03-13-16-52.json
@@ -1,0 +1,9 @@
+{
+  "changes": [{
+    "packageName": "office-ui-fabric-react",
+    "comment": "Image: Fix typo in width prop doc block",
+    "type": "none"
+  }],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -215,7 +215,7 @@ export interface IImageStyleProps {
   width?: number | string;
 
   /**
-   * Image height valye
+   * Image height value
    */
   height?: number | string;
 }

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -210,7 +210,7 @@ export interface IImageStyleProps {
   isNotImageFit?: boolean;
 
   /**
-   * Image width valye
+   * Image width value
    */
   width?: number | string;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8296
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes doc block typos in Image props.

#### Focus areas to test

None


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8298)