### PR TITLE
Drop trailing space in DetailsList header aria-labeledby

### DIFF
--- a/common/changes/office-ui-fabric-react/users-nabena-extraspace-arealabeledby-detailsheader_2019-03-13-17-20.json
+++ b/common/changes/office-ui-fabric-react/users-nabena-extraspace-arealabeledby-detailsheader_2019-03-13-17-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Drop space from DetailsList header aria-labeledby",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "b.nabil@live.fr"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -83,7 +83,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                 <span
                   id={`${parentId}-${column.key}`}
                   aria-label={column.isIconOnly ? column.name : undefined}
-                  aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name `}
+                  aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name`}
                   className={classNames.cellTitle}
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
                   role={

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -338,7 +338,7 @@ exports[`DetailsHeader can render 1`] = `
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header0-a-name "
+        aria-labelledby="header0-a-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -527,7 +527,7 @@ exports[`DetailsHeader can render 1`] = `
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header0-b-name "
+        aria-labelledby="header0-b-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -738,7 +738,7 @@ exports[`DetailsHeader can render 1`] = `
       <span
         aria-expanded={false}
         aria-haspopup={true}
-        aria-labelledby="header0-c-name "
+        aria-labelledby="header0-c-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1109,7 +1109,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header2-a-name "
+        aria-labelledby="header2-a-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1298,7 +1298,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header2-b-name "
+        aria-labelledby="header2-b-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1509,7 +1509,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
       <span
         aria-expanded={false}
         aria-haspopup={true}
-        aria-labelledby="header2-c-name "
+        aria-labelledby="header2-c-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -1978,7 +1978,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     >
       <span
         aria-haspopup={false}
-        aria-labelledby="header6-a-name "
+        aria-labelledby="header6-a-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2168,7 +2168,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
       <span
         aria-describedby="header6-b-tooltip"
         aria-haspopup={false}
-        aria-labelledby="header6-b-name "
+        aria-labelledby="header6-b-name"
         className=
             ms-DetailsHeader-cellTitle
             {
@@ -2404,7 +2404,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         aria-describedby="header6-c-tooltip"
         aria-expanded={false}
         aria-haspopup={true}
-        aria-labelledby="header6-c-name "
+        aria-labelledby="header6-c-name"
         className=
             ms-DetailsHeader-cellTitle
             {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -384,7 +384,7 @@ exports[`DetailsList renders List correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header6-key-name "
+                aria-labelledby="header6-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -966,7 +966,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               <span
                 aria-describedby="header0-column_key_0-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header0-column_key_0-name "
+                aria-labelledby="header0-column_key_0-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1121,7 +1121,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               <span
                 aria-describedby="header0-column_key_1-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header0-column_key_1-name "
+                aria-labelledby="header0-column_key_1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1276,7 +1276,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               <span
                 aria-describedby="header0-column_key_2-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header0-column_key_2-name "
+                aria-labelledby="header0-column_key_2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1431,7 +1431,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               <span
                 aria-describedby="header0-column_key_3-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header0-column_key_3-name "
+                aria-labelledby="header0-column_key_3-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1586,7 +1586,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
               <span
                 aria-describedby="header0-column_key_4-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header0-column_key_4-name "
+                aria-labelledby="header0-column_key_4-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2134,7 +2134,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header12-key-name "
+                aria-labelledby="header12-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2716,7 +2716,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-key-name "
+                aria-labelledby="header9-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2904,7 +2904,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-name-name "
+                aria-labelledby="header9-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3092,7 +3092,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-value-name "
+                aria-labelledby="header9-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3674,7 +3674,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               <span
                 aria-describedby="header3-column_key_0-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_0-name "
+                aria-labelledby="header3-column_key_0-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3832,7 +3832,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               <span
                 aria-describedby="header3-column_key_1-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_1-name "
+                aria-labelledby="header3-column_key_1-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3990,7 +3990,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               <span
                 aria-describedby="header3-column_key_2-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_2-name "
+                aria-labelledby="header3-column_key_2-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4148,7 +4148,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               <span
                 aria-describedby="header3-column_key_3-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_3-name "
+                aria-labelledby="header3-column_key_3-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4306,7 +4306,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
               <span
                 aria-describedby="header3-column_key_4-tooltip"
                 aria-haspopup={false}
-                aria-labelledby="header3-column_key_4-name "
+                aria-labelledby="header3-column_key_4-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -4717,7 +4717,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header15-key-name "
+                aria-labelledby="header15-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -384,7 +384,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-key-name "
+                aria-labelledby="header0-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -516,7 +516,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-name-name "
+                aria-labelledby="header0-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -648,7 +648,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header0-value-name "
+                aria-labelledby="header0-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1193,7 +1193,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-key-name "
+                aria-labelledby="header9-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1325,7 +1325,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-name-name "
+                aria-labelledby="header9-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -1457,7 +1457,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header9-value-name "
+                aria-labelledby="header9-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2534,7 +2534,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header3-key-name "
+                aria-labelledby="header3-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2666,7 +2666,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header3-name-name "
+                aria-labelledby="header3-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -2798,7 +2798,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header3-value-name "
+                aria-labelledby="header3-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3343,7 +3343,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header6-key-name "
+                aria-labelledby="header6-key-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3475,7 +3475,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header6-name-name "
+                aria-labelledby="header6-name-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {
@@ -3607,7 +3607,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             >
               <span
                 aria-haspopup={false}
-                aria-labelledby="header6-value-name "
+                aria-labelledby="header6-value-name"
                 className=
                     ms-DetailsHeader-cellTitle
                     {


### PR DESCRIPTION
<Disclaimer: This is my first contribution to this project, please advise If I did something not respecting the process, thanks!>

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Fix the DetailsList header aria-labeledby having an extra space.

{
  "changes": [
    {
      "packageName": "office-ui-fabric-react",
      "comment": "Drop space from DetailsList header aria-labeledby",
      "type": "patch"
    }
  ],
  "packageName": "office-ui-fabric-react",
  "email": "b.nabil@live.fr"
}

Please let me know if the change file needs to be included in another way.
Also, let me know if I should create an issue for this bug.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8301)