### PR TITLE
Breadcrumb: last-child styling

### DIFF
--- a/common/changes/@uifabric/fluent-theme/huaxi-breadcrumb-last-child_2019-03-13-22-16.json
+++ b/common/changes/@uifabric/fluent-theme/huaxi-breadcrumb-last-child_2019-03-13-22-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Breadcrumb: fixed last-child styling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "huaxi@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Breadcrumb.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Breadcrumb.styles.ts
@@ -32,10 +32,6 @@ export const BreadcrumbStyles = (props: IBreadcrumbStyleProps): Partial<IBreadcr
     fontWeight: FontWeights.regular,
     color: palette.neutralSecondary,
     selectors: {
-      '&:last-child': {
-        fontWeight: FontWeights.semibold,
-        color: palette.neutralPrimary
-      },
       '.ms-Fabric--isFocusVisible &:focus': {
         // Necessary due to changes of Link component not using getFocusStyle.
         outline: 'none'
@@ -47,12 +43,23 @@ export const BreadcrumbStyles = (props: IBreadcrumbStyleProps): Partial<IBreadcr
     }
   };
 
+  const lastChildItem = {
+    fontWeight: FontWeights.semibold,
+    color: palette.neutralPrimary
+  };
+
   return {
     root: {
       marginTop: 11
     },
     itemLink: itemStyle,
     item: itemStyle,
+    listItem: {
+      selectors: {
+        '&:last-child .ms-Breadcrumb-itemLink': lastChildItem,
+        '&:last-child .ms-Breadcrumb-item': lastChildItem
+      }
+    },
     overflowButton: {
       color: palette.neutralSecondary,
       selectors: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
All `.item` or `.itemLink` is literally the last-child for `.listItem`. Therefore, we should change it to ,`.listItem:last-child .item` or `.listItem:last-child .itemLink` instead.

#### Focus areas to test
Breadcrumb with fluent-styling
(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8304)