### PR TITLE
Add lint rules against ES6 methods and objects that break IE 11

### DIFF
--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, find } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { IChartProps, IHorizontalBarChartProps, IHorizontalBarChartStyles, IChartDataPoint } from './index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
@@ -129,7 +129,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
   private _hoverOn(hoverValue: string | number | Date | null, lineColor: string, legend: string): void {
     if (!this.state.isCalloutVisible || this.state.legend !== legend) {
       const refArray = this.state.refArray;
-      const currentHoveredElement = refArray.find((currentElement: IRefArrayData) => currentElement.legendText === legend);
+      const currentHoveredElement = find(refArray, (currentElement: IRefArrayData) => currentElement.legendText === legend);
       this.setState({
         isCalloutVisible: true,
         hoverValue: hoverValue,

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { HoverCard, HoverCardType, IExpandingCardProps } from 'office-ui-fabric-react/lib/HoverCard';
-import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, find } from 'office-ui-fabric-react/lib/Utilities';
 import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
 import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { OverflowSet, IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
@@ -154,7 +154,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     // execute similar to "_onClick" and "_onLeave" logic at HoverCard onCardHide event
     const onHoverCardHideHandler = () => {
       if (this.state.selectedState) {
-        const selectedOverflowItem = legends.find((legend: ILegend) => legend.title === this.state.selectedLegend);
+        const selectedOverflowItem = find(legends, (legend: ILegend) => legend.title === this.state.selectedLegend);
         if (selectedOverflowItem) {
           this.setState({ selectedLegend: 'none', selectedState: false }, () => {
             if (selectedOverflowItem.action) {

--- a/packages/codepen-loader/tslint.json
+++ b/packages/codepen-loader/tslint.json
@@ -1,4 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
-  "rules": {}
+  "rules": {
+    "ban": false
+  }
 }

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
@@ -102,7 +102,8 @@ function _createLayout(props: IDashboardGridLayoutBaseProps, layoutFromProps?: D
 
   const layouts: Layouts = {};
   if (layoutFromProps) {
-    for (const [key, value] of Object.entries(layoutFromProps)) {
+    for (const key of Object.keys(layoutFromProps)) {
+      const value = layoutFromProps[key as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutWithAddCardPanel/DashboardGridLayoutWithAddCardPanel.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutWithAddCardPanel/DashboardGridLayoutWithAddCardPanel.tsx
@@ -165,7 +165,7 @@ export class DashboardGridLayoutWithAddCardPanel extends BaseComponent<
     const lastCardIndex = currentLayout.length - 1;
     // checking if a dragging card action is performed.
     // If dragging is performed, dragging card is added to the layout whose id starts with 'n'
-    if (lastCardIndex > -1 && currentLayout[lastCardIndex].i!.startsWith('n')) {
+    if (lastCardIndex > -1 && currentLayout[lastCardIndex].i![0] === 'n') {
       const newlyAddedCardId = currentLayout[lastCardIndex].i!.substring(1);
       const newlyAddedCard = currentLayout[lastCardIndex];
       const addCardPanelCards = this.state.cardsForAddCardPanel;

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridSectionLayout.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridSectionLayout.tsx
@@ -4,7 +4,8 @@ import {
   IDashboardGridLayoutStyles,
   IDashboardCardLayout,
   DashboardSectionMapping,
-  IDashboardGridLayoutProps
+  IDashboardGridLayoutProps,
+  DashboardGridBreakpointLayouts
 } from './DashboardGridLayout.types';
 import { DashboardGridLayoutBase } from './DashboardGridLayoutBase';
 import { ICard, CardSize } from '../Card/Card.types';
@@ -225,7 +226,8 @@ export class DashboardGridSectionLayout extends React.Component<IDashboardGridLa
   private _createLayout = (): Layouts => {
     const layouts: Layouts = {};
     if (this.props.layout) {
-      for (const [breakpoint, value] of Object.entries(this.props.layout)) {
+      for (const breakpoint of Object.keys(this.props.layout)) {
+        const value = this.props.layout[breakpoint as keyof DashboardGridBreakpointLayouts];
         if (value === undefined) {
           continue;
         }

--- a/packages/dashboard/src/components/DetailPanel/Body/Loading.tsx
+++ b/packages/dashboard/src/components/DetailPanel/Body/Loading.tsx
@@ -31,7 +31,7 @@ const loading: React.SFC<IDetailPanelLoadingProps> = (props: IDetailPanelLoading
         {/* group 1 */}
         {title && <Shimmer shimmerElements={[{ type: ElemType.line }]} width="100%" />}
         {/* group 2 */}
-        {Array.from({ length: count }).map((_: number, i: number) => {
+        {Array.apply(null, Array(count)).map((_: number, i: number) => {
           return (
             <div className={css.shimmerGroup} key={i}>
               <Shimmer shimmerElements={[{ type: ElemType.line }]} width="100%" />

--- a/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
+++ b/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
@@ -143,7 +143,7 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
           .catch((err: IDetailPanelErrorResult) => {
             // set message bar
             if (err && err.messageBannerSetting) {
-              const messageBannerSetting = Object.assign({}, err.messageBannerSetting);
+              const messageBannerSetting = { ...err.messageBannerSetting };
               if (messageBannerSetting.messageType === undefined) {
                 messageBannerSetting.messageType = MessageBarType.error;
               }

--- a/packages/dashboard/src/components/DetailPanel/Footer/ActionBar.tsx
+++ b/packages/dashboard/src/components/DetailPanel/Footer/ActionBar.tsx
@@ -54,7 +54,7 @@ const actionBar: React.SFC<DetailPanelActionBarProps> = (props: DetailPanelActio
       .catch((err: IDetailPanelErrorResult) => {
         if (err) {
           // set message banner
-          const messageBannerSetting = Object.assign({}, err.messageBannerSetting);
+          const messageBannerSetting = { ...err.messageBannerSetting };
           if (messageBannerSetting.messageType === undefined) {
             messageBannerSetting.messageType = MessageBarType.error;
           }

--- a/packages/dashboard/src/components/Section/examples/EditSections.Customization.Example.tsx
+++ b/packages/dashboard/src/components/Section/examples/EditSections.Customization.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Layout, Layouts } from 'react-grid-layout-fabric';
 import { EditSections } from '../EditSections';
 import { CardSize, DashboardGridBreakpointLayouts, ISection, IDashboardCardLayout, CardSizeToWidthHeight } from '@uifabric/dashboard';
+import { findIndex } from 'office-ui-fabric-react/lib/Utilities';
 
 export interface IEditSectionsExampleState {
   saveButtonDisabled: boolean;
@@ -149,7 +150,7 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
    * Example handler for onRenameSectionClick
    */
   private _onRenameSectionClick = (id: string): void => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = true;
 
@@ -163,7 +164,7 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
    * Example handler for onUpdateSectionTitle
    */
   private _onUpdateSectionTitle = (id: string, title: string) => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = false;
     newSections[index].title = title;
@@ -190,7 +191,8 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
   private _addLayoutForNewSection(id: string): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = JSON.parse(JSON.stringify(this.state.layout));
 
-    for (const [_, value] of Object.entries(newLayout)) {
+    for (const key of Object.keys(newLayout)) {
+      const value = newLayout[key as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }
@@ -234,7 +236,8 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
 
   private _generateDashboardLayoutFromRGLLayout(allLayouts: Layouts): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = {};
-    for (const [breakPoint, value] of Object.entries(allLayouts)) {
+    for (const breakPoint of Object.keys(allLayouts)) {
+      const value = allLayouts[breakPoint as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }

--- a/packages/dashboard/src/components/Section/examples/EditSections.Example.tsx
+++ b/packages/dashboard/src/components/Section/examples/EditSections.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Layout, Layouts } from 'react-grid-layout-fabric';
 import { EditSections } from '../EditSections';
 import { CardSize, DashboardGridBreakpointLayouts, ISection, IDashboardCardLayout, CardSizeToWidthHeight } from '@uifabric/dashboard';
+import { findIndex } from 'office-ui-fabric-react/lib/Utilities';
 
 export interface IEditSectionsExampleState {
   saveButtonDisabled: boolean;
@@ -144,7 +145,7 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
    * Example handler for onRenameSectionClick
    */
   private _onRenameSectionClick = (id: string): void => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = true;
 
@@ -158,7 +159,7 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
    * Example handler for onUpdateSectionTitle
    */
   private _onUpdateSectionTitle = (id: string, title: string) => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = false;
     newSections[index].title = title;
@@ -185,7 +186,8 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
   private _addLayoutForNewSection(id: string): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = JSON.parse(JSON.stringify(this.state.layout));
 
-    for (const [_, value] of Object.entries(newLayout)) {
+    for (const key of Object.keys(newLayout)) {
+      const value = newLayout[key as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }
@@ -229,7 +231,8 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
 
   private _generateDashboardLayoutFromRGLLayout(allLayouts: Layouts): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = {};
-    for (const [breakPoint, value] of Object.entries(allLayouts)) {
+    for (const breakPoint of Object.keys(allLayouts)) {
+      const value = allLayouts[breakPoint as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, classNamesFunction } from '@uifabric/utilities';
+import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, classNamesFunction, find } from '@uifabric/utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import {
@@ -509,7 +509,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
     if (!restrictedDates) {
       return false;
     }
-    const inRestrictedDates = !!restrictedDates.find((rd: Date) => {
+    const inRestrictedDates = !!find(restrictedDates, (rd: Date) => {
       return compareDates(rd, date);
     });
     return inRestrictedDates && !this._getIsBeforeMinDate(date) && !this._getIsAfterMaxDate(date);
@@ -643,7 +643,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
 
     // gets all the day refs for the given dates
     const dayInfosInRange = weeks!.reduce((accumulatedValue: IDayInfo[], currentWeek: IDayInfo[]) => {
-      return accumulatedValue.concat(currentWeek.filter((weekDay: IDayInfo) => dateRange.includes(weekDay.originalDate.getTime())));
+      return accumulatedValue.concat(currentWeek.filter((weekDay: IDayInfo) => dateRange.indexOf(weekDay.originalDate.getTime()) !== -1));
     }, []);
 
     let dayRefs: (HTMLElement | null)[] = [];

--- a/packages/date-time/src/utilities/dateMath/DateMath.ts
+++ b/packages/date-time/src/utilities/dateMath/DateMath.ts
@@ -189,7 +189,7 @@ export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firs
     if (dateRangeType !== DateRangeType.WorkWeek) {
       // push all days not in work week view
       datesArray.push(nextDate);
-    } else if (workWeekDays.includes(nextDate.getDay())) {
+    } else if (workWeekDays.indexOf(nextDate.getDay()) !== -1) {
       datesArray.push(nextDate);
     }
     nextDate = addDays(nextDate, 1);

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.test.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.test.tsx
@@ -8,6 +8,9 @@ import { PersonaTestImages } from '@uifabric/experiments/lib/common/TestImages';
 import { Icon, Image, Text } from 'office-ui-fabric-react';
 import { setRTL } from '../../Utilities';
 
+// Disable "ban" rule which gives spurious errors about .find()
+// tslint:disable:ban
+
 const testPersonaCoinStyles: IPersonaCoinComponent['styles'] = {
   root: 'test-cn-root',
   image: 'test-cn-image',

--- a/packages/experiments/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/experiments/src/components/Sidebar/Sidebar.test.tsx
@@ -8,6 +8,9 @@ import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { ISidebar, ISidebarProps, Sidebar, SidebarButton } from './index';
 
+// Disable "ban" rule which gives spurious errors about .find()
+// tslint:disable:ban
+
 describe('Sidebar', () => {
   let sidebarButtonExampleProps: ISidebarProps;
   let sidebarAccordionExampleProps: ISidebarProps;

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -214,9 +214,11 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
             finalSize = {
               width: finalSize.width * finalScaleFactor,
+              // tslint:disable-next-line:ban (for .fill)
               height: grid.mode === TilesGridMode.fill ? finalSize.height * finalScaleFactor : grid.minRowHeight
             };
           } else if (
+            // tslint:disable-next-line:ban (for .fill)
             (grid.mode === TilesGridMode.fill || grid.mode === TilesGridMode.fillHorizontal) &&
             (!isLastRow || scaleFactor <= grid.maxScaleFactor)
           ) {
@@ -225,6 +227,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
             finalSize = {
               width: finalSize.width * finalScaleFactor,
+              // tslint:disable-next-line:ban (for .fill)
               height: grid.mode === TilesGridMode.fill ? finalSize.height * finalScaleFactor : grid.minRowHeight
             };
           }
@@ -413,6 +416,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
         const totalMargin = grid.spacing * (i - rowStart);
         currentRow.scaleFactor = (boundsWidth - totalMargin) / (rowWidth - totalMargin);
 
+        // tslint:disable-next-line:ban (for .fill)
         if ((grid.mode === TilesGridMode.fill || grid.mode === TilesGridMode.fillHorizontal) && currentRow.isLastRow) {
           if (i - rowStart > 0) {
             // If the grid is in 'fill' mode, and there is underflow in the last row, then by default, flexbox will
@@ -445,6 +449,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
       if (
         !isAtGridEnd &&
+        // tslint:disable-next-line:ban (for .fill)
         currentRow.scaleFactor > (grid.mode === TilesGridMode.fill || grid.mode === TilesGridMode.fillHorizontal ? grid.maxScaleFactor : 1)
       ) {
         // If the last computed row is not the end of the grid, and the content cannot scale to fit the width,
@@ -496,6 +501,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
     const itemWidthOverHeight = item.aspectRatio || 1;
     const margin = grid.spacing / 2;
+    // tslint:disable-next-line:ban (for .fill)
     const isFill = gridMode === TilesGridMode.fill || gridMode === TilesGridMode.fillHorizontal;
     const width = itemWidthOverHeight * grid.minRowHeight;
 

--- a/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
+++ b/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
@@ -131,6 +131,7 @@ export function getTileCells(
       spacing: isLargeSize ? 8 : 12,
       marginBottom: shimmerMode ? 0 : 40,
       minRowHeight: isLargeSize ? 171 : 135,
+      // tslint:disable-next-line:ban (for .fill)
       mode: group.type === 'document' ? (size === 'small' ? TilesGridMode.fillHorizontal : TilesGridMode.stack) : TilesGridMode.fill,
       key: group.key,
       isPlaceholder: shimmerMode

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Basic.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Basic.Example.tsx
@@ -41,6 +41,7 @@ export class TilesListBasicExample extends React.Component<{}, ITilesListBasicEx
     const gridSegment: ITilesGridSegment<IBasicItem> = {
       items: this.state.items,
       key: 'grid',
+      // tslint:disable-next-line:ban (for .fill)
       mode: TilesGridMode.fill,
       minRowHeight: 100,
       spacing: 10

--- a/packages/office-ui-fabric-react/src/common/shallowUntilTarget.ts
+++ b/packages/office-ui-fabric-react/src/common/shallowUntilTarget.ts
@@ -39,14 +39,9 @@ export function shallowUntilTarget<P, S>(
   const { maxTries, shallowOptions } = options;
 
   let root = shallow<P, S>(componentInstance, shallowOptions);
+  let rootType = root.type();
 
-  if (
-    typeof root.type() === 'string' ||
-    root
-      .type()
-      .toString()
-      .includes(TargetComponent)
-  ) {
+  if (typeof rootType === 'string' || rootType.toString().indexOf(TargetComponent) !== -1) {
     // Default shallow()
     // If type() is a string then it's a DOM Node.
     // If it were wrapped, it would be a React component.
@@ -56,17 +51,13 @@ export function shallowUntilTarget<P, S>(
   for (let tries = 1; tries <= maxTries; tries++) {
     // Check for target as a string to avoid conflicts
     // with decoratored components name
-    if (
-      root
-        .type()
-        .toString()
-        .includes(TargetComponent)
-    ) {
+    if (rootType.toString().indexOf(TargetComponent) !== -1) {
       // Now that we found the target component, render it.
       return root.first().shallow(shallowOptions);
     }
     // Unwrap the next component in the hierarchy.
     root = root.first().shallow(shallowOptions);
+    rootType = root.type();
   }
 
   throw new Error(

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, IRefObject, findIndex } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, IRefObject, findIndex, find } from '../../Utilities';
 import { ICalendarStrings, ICalendarIconStrings, ICalendarFormatDateCallbacks } from './Calendar.types';
 import { DayOfWeek, FirstWeekOfYear, DateRangeType } from '../../utilities/dateValues/DateValues';
 import { FocusZone } from '../../FocusZone';
@@ -815,7 +815,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     if (!restrictedDates) {
       return false;
     }
-    const restrictedDate = restrictedDates.find(rd => {
+    const restrictedDate = find(restrictedDates, rd => {
       return compareDates(rd, date);
     });
     return restrictedDate ? true : false;

--- a/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
@@ -10,6 +10,9 @@ import * as mergeStylesSerializer from '@uifabric/jest-serializer-merge-styles';
 
 const ReactDOM = require('react-dom');
 
+// Disable "ban" rule which gives spurious errors about .find()
+// tslint:disable:ban
+
 // Extend Jest Expect to allow us to map each component example to its own snapshot file.
 const snapshotsStateMap = new Map();
 const jestSnapshot = require('jest-snapshot');
@@ -49,7 +52,7 @@ expect.extend({
       snapshotsStateMap.set(absoluteSnapshotFile, snapshotState);
     }
 
-    const newThis = Object.assign({}, this, { snapshotState });
+    const newThis = { ...this, snapshotState };
     const patchedToMatchSnapshot = jestSnapshot.toMatchSnapshot.bind(newThis);
 
     return patchedToMatchSnapshot(received);

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
@@ -95,7 +95,7 @@ export class ContextualMenuWithCustomMenuListExample extends React.Component<
   }
 
   private _onChange(newValue: any) {
-    const filteredItems = ITEMS.filter(item => item.text && item.text.toLowerCase().includes(newValue.toLowerCase()));
+    const filteredItems = ITEMS.filter(item => item.text && item.text.toLowerCase().indexOf(newValue.toLowerCase()) !== -1);
 
     if (!filteredItems || !filteredItems.length) {
       filteredItems.push({

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -97,11 +97,11 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     this._onRootRef = this._onRootRef.bind(this);
     this._isEventOnHeader = this._isEventOnHeader.bind(this);
     this._onDropIndexInfo = {
-      sourceIndex: Number.MIN_SAFE_INTEGER,
-      targetIndex: Number.MIN_SAFE_INTEGER
+      sourceIndex: -1,
+      targetIndex: -1
     };
     this._id = getId('header');
-    this._currentDropHintIndex = Number.MIN_SAFE_INTEGER;
+    this._currentDropHintIndex = -1;
   }
 
   public componentDidMount(): void {
@@ -347,7 +347,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
   }
 
   private _isValidCurrentDropHintIndex() {
-    return this._currentDropHintIndex! >= 0;
+    return this._currentDropHintIndex >= 0;
   }
 
   private _onDragOver(item: any, event: DragEvent): void {
@@ -363,15 +363,13 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     // Target index will not get changed if draggeditem is after target item.
     if (this._draggedColumnIndex >= 0 && event) {
       const targetIndex =
-        this._draggedColumnIndex > this._currentDropHintIndex! ? this._currentDropHintIndex! : this._currentDropHintIndex! - 1;
-      let isValidDrop = false;
+        this._draggedColumnIndex > this._currentDropHintIndex ? this._currentDropHintIndex : this._currentDropHintIndex - 1;
+      const isValidDrop = this._isValidCurrentDropHintIndex();
       event.stopPropagation();
-      if (this._isValidCurrentDropHintIndex()) {
-        isValidDrop = true;
+      if (isValidDrop) {
         this._onDropIndexInfo.sourceIndex = this._draggedColumnIndex;
         this._onDropIndexInfo.targetIndex = targetIndex;
-      }
-      if (isValidDrop) {
+
         if (columnReorderProps && columnReorderProps.onColumnDrop) {
           const dragDropDetails: IColumnDragDropDetails = {
             draggedIndex: this._draggedColumnIndex,
@@ -422,7 +420,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
   private _resetDropHints(): void {
     if (this._currentDropHintIndex >= 0) {
       this._updateDropHintElement(this._dropHintDetails[this._currentDropHintIndex].dropHintElementRef, 'none');
-      this._currentDropHintIndex = Number.MIN_SAFE_INTEGER;
+      this._currentDropHintIndex = -1;
     }
   }
 
@@ -494,7 +492,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
       const clientRect = this._rootElement.getBoundingClientRect();
       const headerOriginX = clientRect.left;
       const eventXRelativePosition = clientX - headerOriginX;
-      const currentDropHintIndex = this._currentDropHintIndex!;
+      const currentDropHintIndex = this._currentDropHintIndex;
       if (this._isValidCurrentDropHintIndex()) {
         if (
           this._liesBetween(

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -347,7 +347,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
   };
 
   private _onItemSelected = (item: IPersonaProps): Promise<IPersonaProps> => {
-    const processedItem = Object.assign({}, item);
+    const processedItem = { ...item };
     processedItem.text = `${item.text} (selected)`;
     return new Promise<IPersonaProps>((resolve, reject) => setTimeout(() => resolve(processedItem), 250));
   };

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -189,7 +189,7 @@ export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firs
     if (dateRangeType !== DateRangeType.WorkWeek) {
       // push all days not in work week view
       datesArray.push(nextDate);
-    } else if (workWeekDays.includes(nextDate.getDay())) {
+    } else if (workWeekDays.indexOf(nextDate.getDay()) !== -1) {
       datesArray.push(nextDate);
     }
     nextDate = addDays(nextDate, 1);

--- a/packages/tslint-rules/tslint.json
+++ b/packages/tslint-rules/tslint.json
@@ -1,12 +1,7 @@
 {
-  "extends": [
-    "tslint-react"
-  ],
+  "extends": ["tslint-react"],
   "linterOptions": {
-    "exclude": [
-      "temp/*.ts",
-      "etc/*.ts"
-    ]
+    "exclude": ["temp/*.ts", "etc/*.ts"]
   },
   "rules": {
     "deprecation": true,
@@ -24,9 +19,7 @@
       "when": "always"
     },
     "jsx-no-bind": true,
-    "jsx-boolean-value": [
-      "never"
-    ],
+    "jsx-boolean-value": ["never"],
     "jsx-equals-spacing": "never",
     "jsx-key": true,
     "jsx-no-lambda": true,
@@ -34,18 +27,10 @@
     "jsx-wrap-multiline": false,
     "jsx-no-multiline-js": false,
     "jsx-no-string-ref": true,
-    "jsx-ban-props": [
-      true,
-      [
-        "style",
-        "Use className and provide css rules instead of using inline styles."
-      ]
-    ],
+    "jsx-ban-props": [true, ["style", "Use className and provide css rules instead of using inline styles."]],
     "no-duplicate-variable": true,
     "use-isnan": true,
-    "triple-equals": [
-      true
-    ],
+    "triple-equals": [true],
     "max-line-length": [
       true,
       {
@@ -55,54 +40,23 @@
     ],
     "no-arg": true,
     "radix": true,
-    "typedef": [
-      true,
-      "call-signature",
-      "parameter",
-      "arrow-parameter",
-      "property-declaration"
-    ],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "prefer-const": true,
-    "quotemark": [
-      true,
-      "single",
-      "jsx-double",
-      "avoid-escape"
-    ],
+    "quotemark": [true, "single", "jsx-double", "avoid-escape"],
     "no-inferrable-types": false,
     "no-null-keyword": false,
     "export-name": false,
-    "trailing-comma": [
-      false
-    ],
-    "whitespace": [
-      false
-    ],
+    "trailing-comma": [false],
+    "whitespace": [false],
     "no-switch-case-fall-through": false,
-    "variable-name": [
-      true,
-      "check-format",
-      "allow-leading-underscore",
-      "allow-pascal-case",
-      "ban-keywords"
-    ],
+    "variable-name": [true, "check-format", "allow-leading-underscore", "allow-pascal-case", "ban-keywords"],
     "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
+    "comment-format": [true, "check-space"],
     "curly": true,
     "eofline": false,
     "forin": true,
-    "indent": [
-      true,
-      "spaces",
-      2
-    ],
-    "interface-name": [
-      true,
-      "always-prefix"
-    ],
+    "indent": [true, "spaces", 2],
+    "interface-name": [true, "always-prefix"],
     "label-position": true,
     "member-access": true,
     "member-ordering": [
@@ -131,14 +85,7 @@
     "no-any": true,
     "no-bitwise": true,
     "no-consecutive-blank-lines": true,
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
+    "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
     "no-constant-condition": true,
     "no-construct": true,
     "no-debugger": true,
@@ -158,18 +105,8 @@
     "no-with-statement": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
-    ],
-    "semicolon": [
-      true,
-      "always",
-      "ignore-bound-class-methods"
-    ],
+    "one-line": [true, "check-open-brace", "check-catch", "check-else", "check-whitespace"],
+    "semicolon": [true, "always", "ignore-bound-class-methods"],
     "typedef-whitespace": [
       true,
       {
@@ -181,6 +118,46 @@
       }
     ],
     "use-named-parameter": true,
-    "react-a11y-tabindex-no-positive": true
+    "react-a11y-tabindex-no-positive": true,
+    "ban": [
+      true,
+      { "name": "Set", "message": "Not supported in IE 11" },
+      { "name": "WeakSet", "message": "Not supported in IE 11" },
+      { "name": "Map", "message": "Not supported in IE 11" },
+      { "name": "WeakMap", "message": "Not supported in IE 11" },
+      { "name": "Symbol", "message": "Not supported in IE 11" },
+      { "name": ["Array", "from"], "message": "Not supported in IE 11" },
+      { "name": ["Array", "of"], "message": "Not supported in IE 11" },
+      { "name": ["Object", "assign"], "message": "Not supported in IE 11" },
+      { "name": ["Object", "entries"], "message": "Not supported in IE 11" },
+      { "name": ["Object", "fromEntries"], "message": "Not supported in IE 11" },
+      { "name": ["Object", "values"], "message": "Not supported in IE 11" },
+      { "name": ["Number", "MIN_SAFE_INTEGER"], "message": "Not supported in IE 11" },
+      { "name": ["Number", "MAX_SAFE_INTEGER"], "message": "Not supported in IE 11" },
+      { "name": ["*", "codePointAt"], "message": "String.prototype.codePointAt is not supported in IE 11" },
+      {
+        "name": ["*", "normalize"],
+        "message": "String.prototype.normalize is not supported in IE 11 (disable this rule if using a different .normalize)"
+      },
+      {
+        "name": ["*", "repeat"],
+        "message": "String.prototype.repeat is not supported in IE 11 (disable this rule if using a different .repeat)"
+      },
+      { "name": ["*", "startsWith"], "message": "String.prototype.startsWith is not supported in IE 11" },
+      { "name": ["*", "endsWith"], "message": "String.prototype.endsWith is not supported in IE 11" },
+      {
+        "name": ["*", "includes"],
+        "message": "String.prototype.includes and Array.prototype.includes are not supported in IE 11 (disable this rule if using a different .includes)"
+      },
+      { "name": ["*", "padStart"], "message": "String.prototype.padStart is not supported in IE 11" },
+      { "name": ["*", "padEnd"], "message": "String.prototype.padEnd is not supported in IE 11" },
+      { "name": ["*", "copyWithin"], "message": "Array.prototype.copyWithin is not supported in IE 11" },
+      {
+        "name": ["*", "find"],
+        "message": "Array.prototype.find is not supported in IE 11 (disable this rule if using a different .find)"
+      },
+      { "name": ["*", "findIndex"], "message": "Array.prototype.findIndex is not supported in IE 11" },
+      { "name": ["*", "fill"], "message": "Array.prototype.fill is not supported in IE 11 (disable this rule if using a different .fill)" }
+    ]
   }
 }

--- a/packages/webpack-utils/tslint.json
+++ b/packages/webpack-utils/tslint.json
@@ -4,6 +4,7 @@
     "deprecation": false,
     "no-function-expression": false,
     "no-any": false,
-    "no-inferrable-types": false
+    "no-inferrable-types": false,
+    "ban": false
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Currently we rely on code reviews to prevent ES6 methods and objects, which aren't supported in IE 11, from slipping into our code. This PR adds a bunch of tslint rules using the built-in "ban" rule to prevent those things from slipping in. (Scroll all the way down in the file list to see the rules...)

#### Concerns

The rules for entire objects or static methods are quite straightforward, e.g.:
`{ "name": "Set", "message": "Not supported in IE 11" }`
`{ "name": ["Array", "from"], "message": "Not supported in IE 11" }`

However, the "ban" rule doesn't have great handling of prototype methods: e.g., to ban `Array.prototype.find`, you have to do a blanket ban of `["*", "find"]`--which also catches `ReactWrapper.prototype.find` and requires the lint rule to manually be disabled in a LOT of test files. (But not banning `find` isn't great either since it's one of the more likely methods to be used by accident.)

      {
        "name": ["*", "find"],
        "message": "Array.prototype.find is not supported in IE 11 (disable this rule if using a different .find)"
      }

I couldn't find any type-aware ban rule variants in a quick search, and don't really want to write my own. Open to suggestions on what to do here.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8308)