### PR TITLE
Add red border when required TextField is empty and goes out of focus

### DIFF
--- a/common/changes/office-ui-fabric-react/textfield-req-red-border_2019-03-14-08-20.json
+++ b/common/changes/office-ui-fabric-react/textfield-req-red-border_2019-03-14-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add red border around required TextField when empty",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -11146,6 +11146,8 @@ interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElement | HTM
 
 // @public (undocumented)
 interface ITextFieldState {
+  // (undocumented)
+  color: string;
   errorMessage: string;
   isFocused: boolean;
   // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -317,6 +317,11 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                  style={
+                    Object {
+                      "border": "",
+                    }
+                  }
                 >
                   <input
                     aria-invalid={false}
@@ -464,6 +469,11 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                  style={
+                    Object {
+                      "border": "",
+                    }
+                  }
                 >
                   <input
                     aria-invalid={false}
@@ -611,6 +621,11 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                  style={
+                    Object {
+                      "border": "",
+                    }
+                  }
                 >
                   <input
                     aria-invalid={false}
@@ -758,6 +773,11 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                  style={
+                    Object {
+                      "border": "",
+                    }
+                  }
                 >
                   <input
                     aria-invalid={false}
@@ -905,6 +925,11 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                  style={
+                    Object {
+                      "border": "",
+                    }
+                  }
                 >
                   <input
                     aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -89,6 +89,11 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -85,6 +85,11 @@ exports[`MaskedTextField renders TextField correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <input
         aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -30,6 +30,9 @@ export interface ITextFieldState {
    * - If we have done the validation and there is validation error, errorMessage is the validation error message.
    */
   errorMessage: string;
+
+  /* The color of the border to be used in case of a required TextField */
+  color: string;
 }
 
 const DEFAULT_STATE_VALUE = '';
@@ -106,7 +109,8 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
     this.state = {
       value: this._latestValue,
       isFocused: false,
-      errorMessage: ''
+      errorMessage: '',
+      color: ''
     };
 
     this._delayedValidate = this._async.debounce(this._validate, this.props.deferredValidationTime);
@@ -230,7 +234,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
       <div className={this._classNames.root}>
         <div className={this._classNames.wrapper}>
           {onRenderLabel(this.props, this._onRenderLabel)}
-          <div className={this._classNames.fieldGroup}>
+          <div className={this._classNames.fieldGroup} style={{ border: this.state.color }}>
             {(addonString !== undefined || this.props.onRenderAddon) && (
               <div className={this._classNames.prefix}>{onRenderAddon(this.props, this._onRenderAddon)}</div>
             )}
@@ -346,6 +350,12 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
   }
 
   private _onFocus = (ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+    if (ev.target.required) {
+      if (!ev.target.value) {
+        this.setState({ color: '' });
+      }
+    }
+
     if (this.props.onFocus) {
       this.props.onFocus(ev);
     }
@@ -357,6 +367,11 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
   };
 
   private _onBlur = (ev: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+    if (ev.target.required) {
+      if (!ev.target.value) {
+        this.setState({ color: '1px solid rgb(168, 0, 0)' });
+      }
+    }
     if (this.props.onBlur) {
       this.props.onBlur(ev);
     }
@@ -441,6 +456,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
         aria-invalid={!!this.state.errorMessage}
         aria-label={this.props.ariaLabel}
         readOnly={this.props.readOnly}
+        required={this.props.required}
         onFocus={this._onFocus}
         onBlur={this._onBlur}
       />
@@ -464,6 +480,7 @@ export class TextFieldBase extends BaseComponent<ITextFieldProps, ITextFieldStat
         aria-describedby={this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby']}
         aria-invalid={!!this.state.errorMessage}
         readOnly={this.props.readOnly}
+        required={this.props.required}
         onFocus={this._onFocus}
         onBlur={this._onBlur}
       />

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.deprecated.test.tsx.snap
@@ -57,6 +57,11 @@ exports[`TextField deprecated renders with deprecated props affecting styling 1`
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -86,6 +86,11 @@ exports[`TextField renders TextField correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <input
         aria-invalid={false}
@@ -242,6 +247,11 @@ exports[`TextField renders TextField multiline resizable correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <textarea
         aria-invalid={false}
@@ -400,6 +410,11 @@ exports[`TextField renders TextField multiline unresizable correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <textarea
         aria-invalid={false}
@@ -579,6 +594,11 @@ exports[`TextField renders multiline TextField correctly with errorMessage 1`] =
           &:focus, &:hover {
             border-color: #a80000;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <div
         className=
@@ -814,6 +834,11 @@ exports[`TextField renders multiline TextField correctly with props affecting st
           &:focus, &:hover {
             border-color: #a80000;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <div
         className=
@@ -1051,6 +1076,11 @@ exports[`TextField should resepect user component and subcomponent styling 1`] =
           &:focus, &:hover {
             border-color: #a80000;
           }
+      style={
+        Object {
+          "border": "",
+        }
+      }
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -324,6 +324,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                    style={
+                      Object {
+                        "border": "",
+                      }
+                    }
                   >
                     <input
                       aria-invalid={false}
@@ -471,6 +476,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                    style={
+                      Object {
+                        "border": "",
+                      }
+                    }
                   >
                     <input
                       aria-invalid={false}
@@ -618,6 +628,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                    style={
+                      Object {
+                        "border": "",
+                      }
+                    }
                   >
                     <input
                       aria-invalid={false}
@@ -765,6 +780,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                    style={
+                      Object {
+                        "border": "",
+                      }
+                    }
                   >
                     <input
                       aria-invalid={false}
@@ -912,6 +932,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                    style={
+                      Object {
+                        "border": "",
+                      }
+                    }
                   >
                     <input
                       aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -90,6 +90,11 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -93,6 +93,11 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -98,6 +98,11 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -93,6 +93,11 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}
@@ -316,6 +321,11 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -124,6 +124,11 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -124,6 +124,11 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -131,6 +131,11 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}
@@ -332,6 +337,11 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                 @media screen and (-ms-high-contrast: active){&:after {
                   right: -14px;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -93,6 +93,11 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -125,6 +125,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -456,6 +456,11 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -269,6 +269,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-invalid={false}
@@ -420,6 +425,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -206,6 +206,11 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -206,6 +206,11 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -204,6 +204,11 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.NoTabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.NoTabbable.Example.tsx.shot
@@ -178,6 +178,11 @@ exports[`Component Examples renders FocusTrapZone.NoTabbable.Example.tsx correct
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}
@@ -302,6 +307,11 @@ exports[`Component Examples renders FocusTrapZone.NoTabbable.Example.tsx correct
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}
@@ -426,6 +436,11 @@ exports[`Component Examples renders FocusTrapZone.NoTabbable.Example.tsx correct
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -303,6 +303,11 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}
@@ -906,6 +911,11 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -303,6 +303,11 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}
@@ -1049,6 +1054,11 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -176,6 +176,11 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3549,6 +3549,11 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+            style={
+              Object {
+                "border": "",
+              }
+            }
           >
             <input
               aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -2336,6 +2336,11 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                  style={
+                    Object {
+                      "border": "",
+                    }
+                  }
                 >
                   <input
                     aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AllErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AllErrorMessage.Example.tsx.shot
@@ -92,6 +92,11 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription1"
@@ -226,6 +231,11 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription3"
@@ -406,6 +416,11 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription5"
@@ -571,6 +586,11 @@ exports[`Component Examples renders TextField.AllErrorMessage.Example.tsx correc
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-describedby="TextFieldDescription7"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AutoComplete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.AutoComplete.Example.tsx.shot
@@ -89,6 +89,11 @@ exports[`Component Examples renders TextField.AutoComplete.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -88,6 +88,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -241,6 +246,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -393,6 +403,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -551,6 +566,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -706,6 +726,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription9"
@@ -864,6 +889,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -1018,6 +1048,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -91,6 +91,11 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-invalid={false}
@@ -247,6 +252,11 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -195,6 +195,11 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -88,6 +88,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -238,6 +243,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -392,6 +402,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription5"
@@ -550,6 +565,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -700,6 +720,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -854,6 +879,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription11"
@@ -1022,6 +1052,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -1173,6 +1208,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -1324,6 +1364,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -1492,6 +1537,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -1647,6 +1697,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription21"
@@ -1810,6 +1865,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-invalid={false}
@@ -2087,6 +2147,11 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
               &:focus, &:hover {
                 border-color: #a80000;
               }
+          style={
+            Object {
+              "border": "",
+            }
+          }
         >
           <input
             aria-describedby="TextFieldDescription28"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Icon.Example.tsx.shot
@@ -88,6 +88,11 @@ exports[`Component Examples renders TextField.Icon.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -265,6 +270,11 @@ exports[`Component Examples renders TextField.Icon.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -90,6 +90,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-invalid={false}
@@ -249,6 +254,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-invalid={false}
@@ -414,6 +424,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-invalid={false}
@@ -575,6 +590,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-describedby="TextFieldDescription7"
@@ -739,6 +759,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-invalid={false}
@@ -896,6 +921,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <textarea
           aria-invalid={false}
@@ -1049,6 +1079,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.OnRenderDescription.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.OnRenderDescription.Example.tsx.shot
@@ -60,6 +60,11 @@ exports[`Component Examples renders TextField.OnRenderDescription.Example.tsx co
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Placeholder.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Placeholder.Example.tsx.shot
@@ -60,6 +60,11 @@ exports[`Component Examples renders TextField.Placeholder.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -184,6 +189,11 @@ exports[`Component Examples renders TextField.Placeholder.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -320,6 +330,11 @@ exports[`Component Examples renders TextField.Placeholder.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:after {
               right: -14px;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -448,6 +463,11 @@ exports[`Component Examples renders TextField.Placeholder.Example.tsx correctly 
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription7"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Prefix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Prefix.Example.tsx.shot
@@ -60,6 +60,11 @@ exports[`Component Examples renders TextField.Prefix.Example.tsx correctly 1`] =
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <div
           className=
@@ -239,6 +244,11 @@ exports[`Component Examples renders TextField.Prefix.Example.tsx correctly 1`] =
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -60,6 +60,11 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <div
           className=
@@ -265,6 +270,11 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -99,6 +99,11 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -258,6 +263,11 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Suffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Suffix.Example.tsx.shot
@@ -60,6 +60,11 @@ exports[`Component Examples renders TextField.Suffix.Example.tsx correctly 1`] =
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Underlined.Example.tsx.shot
@@ -105,6 +105,11 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -270,6 +275,11 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -447,6 +457,11 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-invalid={false}
@@ -620,6 +635,11 @@ exports[`Component Examples renders TextField.Underlined.Example.tsx correctly 1
             &:focus, &:hover {
               border-color: #a80000;
             }
+        style={
+          Object {
+            "border": "",
+          }
+        }
       >
         <input
           aria-describedby="TextFieldDescription7"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8213 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
If it is a `required` field, set the color of the `TextField` to `red` on losing `focus`, and unset the `red` color when `focus` is regained. 

#### Focus areas to test
1. Have a required TextField
2. Place focus on the TextField
3. Click elsewhere leaving the TextField empty
4. The border of the TextField should now be `red`

![red-border](https://user-images.githubusercontent.com/8922176/54341374-06830800-45f7-11e9-866e-49b5b2be9198.gif)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8311)