### PR TITLE
Don't generate version files for packages where it's irrelevant

### DIFF
--- a/common/changes/@uifabric/webpack-utils/codepen-version_2019-03-14-17-40.json
+++ b/common/changes/@uifabric/webpack-utils/codepen-version_2019-03-14-17-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/webpack-utils",
+      "comment": "Remove unneeded version file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/webpack-utils",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/webpack-utils/package.json
+++ b/packages/webpack-utils/package.json
@@ -2,9 +2,6 @@
   "name": "@uifabric/webpack-utils",
   "version": "0.7.4",
   "description": "Office UI Fabric utilities for Webpack bundler.",
-  "sideEffects": [
-    "lib/version.js"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"
@@ -30,7 +27,6 @@
     "webpack": ">=4.0.0"
   },
   "dependencies": {
-    "@uifabric/set-version": ">=1.1.3 <2.0.0",
     "loader-utils": "^1.1.0",
     "tslib": "^1.7.1"
   },

--- a/packages/webpack-utils/src/version.ts
+++ b/packages/webpack-utils/src/version.ts
@@ -1,4 +1,0 @@
-// @uifabric/webpack-utils@0.7.4
-// Do not modify this file, the file is generated as part of publish. The checked in version is a placeholder only.
-import { setVersion } from '@uifabric/set-version';
-setVersion('@uifabric/webpack-utils', '0.7.4');

--- a/scripts/tasks/generate-version-files.js
+++ b/scripts/tasks/generate-version-files.js
@@ -46,12 +46,17 @@ module.exports = function generateVersionFiles() {
   packageJsons.forEach(packageJsonPath => {
     const versionFile = path.join(path.dirname(packageJsonPath), 'src/version.ts');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath).toString());
-    let shouldGenerate = true;
+    const dependencies = packageJson.dependencies || {};
 
-    if (!fs.existsSync(path.dirname(versionFile)) || packageJsonPath.indexOf('set-version') > -1) {
+    if (
+      !fs.existsSync(path.dirname(versionFile)) ||
+      packageJsonPath.indexOf('set-version') > -1 ||
+      !dependencies['@uifabric/set-version']
+    ) {
       return;
     }
 
+    let shouldGenerate = true;
     if (fs.existsSync(versionFile) && process.argv.indexOf('-f') < 0) {
       const originVersionFileContent = fs.readFileSync(versionFile).toString();
       shouldGenerate = originVersionFileContent.indexOf(`${packageJson.name}@${packageJson.version}`) < 0;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

For certain packages, such as webpack loaders/utilities, `@uifabric/set-version` and the generated `version.ts` aren't really relevant. But checking in the new `@uifabric/codepen-loader` package without a dependency on `@uifabric/set-version` broke the nightly build, because `generate-version-files` still generated a version file for the new package (and the version file failed to compile due to the missing dep). 

The fix is to make `generate-version-files` skip packages which don't declare a dependency on `@uifabric/set-version`.

Also removed the set-version dep and version.ts from the webpack-utils package since it's not really relevant there.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8321)