### PR TITLE
Defer SelectionZone traversal until first RAF after mount

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-selectionzone-render_2019-03-13-23-29.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-selectionzone-render_2019-03-13-23-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SelectionZone: Defer dom inspection until interaction",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-selectionzone-render_2019-03-13-23-29.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-selectionzone-render_2019-03-13-23-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "SelectionZone: Defer dom inspection until RAF",
+      "comment": "SelectionZone: Defer dom inspection until interaction",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/u-mahuangh-fix-selectionzone-render_2019-03-13-23-29.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-fix-selectionzone-render_2019-03-13-23-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "SelectionZone: Defer dom inspection until interaction",
+      "comment": "SelectionZone: Defer dom inspection until RAF",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -245,6 +245,16 @@ describe('SelectionZone', () => {
     expect(_selection.getSelectedCount()).toEqual(0);
   });
 
+  it('can remove selection after the first click event rebinding', () => {
+    _selection.setAllSelected(true);
+
+    _simulateClick(_toggle0);
+    // Raise real browser event.
+    document.documentElement.click();
+
+    expect(_selection.getSelectedCount()).toEqual(0);
+  });
+
   it('does not select an item on mousedown of the surface with no modifiers', () => {
     ReactTestUtils.Simulate.mouseDown(_invoke0);
     expect(_selection.isIndexSelected(0)).toEqual(false);

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -26,10 +26,11 @@ let _surface3: Element;
 let _onItemInvokeCalled: number;
 let _lastItemInvoked: any;
 
-function _initializeSelection(selectionMode = SelectionMode.multiple): void {
+function _initializeSelection(selectionMode = SelectionMode.multiple, hostDocument: Document = document): Element {
   _selection = new Selection();
   _selection.setItems([{ key: 'a' }, { key: 'b' }, { key: 'c' }, { key: 'd' }]);
-  _selectionZone = ReactTestUtils.renderIntoDocument(
+  const hostElement = hostDocument.createElement('div');
+  _selectionZone = ReactDOM.render(
     <SelectionZone
       selection={_selection}
       selectionMode={selectionMode}
@@ -73,7 +74,8 @@ function _initializeSelection(selectionMode = SelectionMode.multiple): void {
       </div>
 
       <div id="surface3" data-selection-index="3" />
-    </SelectionZone>
+    </SelectionZone>,
+    hostElement
   );
 
   _componentElement = ReactDOM.findDOMNode(_selectionZone) as Element;
@@ -90,6 +92,8 @@ function _initializeSelection(selectionMode = SelectionMode.multiple): void {
 
   _onItemInvokeCalled = 0;
   _lastItemInvoked = undefined;
+
+  return hostElement;
 }
 
 describe('SelectionZone', () => {
@@ -236,25 +240,6 @@ describe('SelectionZone', () => {
     expect(_selection.isIndexSelected(2)).toEqual(false);
   });
 
-  it('can remove selection if you click on dead space', () => {
-    _selection.setAllSelected(true);
-
-    // Raise real browser event.
-    document.documentElement.click();
-
-    expect(_selection.getSelectedCount()).toEqual(0);
-  });
-
-  it('can remove selection after the first click event rebinding', () => {
-    _selection.setAllSelected(true);
-
-    _simulateClick(_toggle0);
-    // Raise real browser event.
-    document.documentElement.click();
-
-    expect(_selection.getSelectedCount()).toEqual(0);
-  });
-
   it('does not select an item on mousedown of the surface with no modifiers', () => {
     ReactTestUtils.Simulate.mouseDown(_invoke0);
     expect(_selection.isIndexSelected(0)).toEqual(false);
@@ -274,6 +259,80 @@ describe('SelectionZone', () => {
   it('selects an item when a button is clicked that has data-selection-select', () => {
     ReactTestUtils.Simulate.keyDown(_select1, { which: KeyCodes.enter });
     expect(_selection.isIndexSelected(1)).toEqual(true);
+  });
+});
+
+describe('SelectionZone', () => {
+  class RafLifecycle {
+    public animationId: number = 0;
+    public queuedAnimationFrameCallbacks: { [key: number]: () => void } = {};
+
+    public consumeAnimationFrames = () => {
+      for (const callbackId in this.queuedAnimationFrameCallbacks) {
+        if (this.queuedAnimationFrameCallbacks[callbackId]) {
+          this.queuedAnimationFrameCallbacks[callbackId]();
+        }
+      }
+      this.queuedAnimationFrameCallbacks = {};
+    };
+
+    public bindToWindow(window: Window) {
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+        this.queuedAnimationFrameCallbacks[++this.animationId] = cb;
+        return this.animationId;
+      });
+      jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(cb => {
+        delete this.queuedAnimationFrameCallbacks[cb];
+      });
+    }
+  }
+
+  const globalWindowRafs: RafLifecycle = new RafLifecycle();
+
+  beforeEach(() => {
+    globalWindowRafs.bindToWindow(window);
+  });
+
+  it('can remove selection if you click on dead space on a frame after the component mounted', () => {
+    _initializeSelection();
+    _selection.setAllSelected(true);
+    globalWindowRafs.consumeAnimationFrames();
+
+    // Raise real browser event.
+    document.documentElement.click();
+
+    expect(_selection.getSelectedCount()).toEqual(0);
+  });
+
+  it('does nothing if you click on dead space on the same frame the component mounted', () => {
+    _initializeSelection();
+    _selection.setAllSelected(true);
+
+    // Raise real browser event.
+    document.documentElement.click();
+
+    globalWindowRafs.consumeAnimationFrames();
+
+    expect(_selection.getSelectedCount()).not.toEqual(0);
+  });
+
+  it('does not throw if you unmount the component in the same frame it is mounted', () => {
+    const host = _initializeSelection();
+    ReactDOM.unmountComponentAtNode(host);
+
+    expect(() => {
+      globalWindowRafs.consumeAnimationFrames();
+    }).not.toThrow();
+  });
+
+  it('does not leak events if you unmount the component in the same frame it is mounted', () => {
+    const host = _initializeSelection();
+    ReactDOM.unmountComponentAtNode(host);
+
+    globalWindowRafs.consumeAnimationFrames();
+
+    const eventListenerRecords = _selectionZone._events._eventRecords;
+    expect(eventListenerRecords).toEqual([]);
   });
 });
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -72,11 +72,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
 
   public componentDidMount(): void {
     const win = getWindow(this._root.current);
-    const scrollElement = findScrollableParent(this._root.current);
 
     // Track the latest modifier keys globally.
     this._events.on(win, 'keydown, keyup', this._updateModifiers, true);
-    this._events.on(scrollElement, 'click', this._tryClearOnEmptyClick);
+    this._events.on(document, 'click', this._findScrollParentAndTryClearOnEmptyClick);
     this._events.on(document.body, 'touchstart', this._onTouchStartCapture, true);
     this._events.on(document.body, 'touchend', this._onTouchStartCapture, true);
   }
@@ -487,6 +486,27 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     }
 
     this._clearAndSelectIndex(index);
+  }
+
+  /**
+   * To avoid high startup cost of traversing the DOM on component mount,
+   * defer finding the scrollable parent until a click interaction.
+   *
+   * The styles will probably already calculated since we're running in a click handler,
+   * so this is less likely to cause layout thrashing then doing it in mount.
+   *
+   * @param ev the click event
+   */
+  private _findScrollParentAndTryClearOnEmptyClick(ev: MouseEvent) {
+    const scrollParent = findScrollableParent(this._root.current);
+    // unbind this handler and replace binding with a binding on the actual scrollable parent
+    this._events.off(document, 'click', this._findScrollParentAndTryClearOnEmptyClick);
+    this._events.on(scrollParent, 'click', this._tryClearOnEmptyClick);
+
+    // If we clicked inside the scrollable parent, call through to the handler on this click.
+    if ((scrollParent && ev.target instanceof Node && scrollParent.contains(ev.target)) || scrollParent === ev.target) {
+      this._tryClearOnEmptyClick(ev);
+    }
   }
 
   private _tryClearOnEmptyClick(ev: MouseEvent): void {

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -69,32 +69,15 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   private _shouldHandleFocusTimeoutId: number | undefined;
   private _isTouch: boolean;
   private _isTouchTimeoutId: number | undefined;
-  private _findScrollParentAnimationFrameId: number | undefined;
 
   public componentDidMount(): void {
     const win = getWindow(this._root.current);
 
     // Track the latest modifier keys globally.
     this._events.on(win, 'keydown, keyup', this._updateModifiers, true);
+    this._events.on(document, 'click', this._findScrollParentAndTryClearOnEmptyClick);
     this._events.on(document.body, 'touchstart', this._onTouchStartCapture, true);
     this._events.on(document.body, 'touchend', this._onTouchStartCapture, true);
-
-    const animationFrameWindow = win || window;
-    this._findScrollParentAnimationFrameId = animationFrameWindow.requestAnimationFrame(() => {
-      const scrollParent = findScrollableParent(this._root.current);
-      if (scrollParent === null) {
-        return;
-      }
-      this._events.on(scrollParent, 'click', this._tryClearOnEmptyClick);
-      this._findScrollParentAnimationFrameId = undefined;
-    });
-  }
-
-  public componentWillUnmount() {
-    if (this._findScrollParentAnimationFrameId !== undefined) {
-      const animationFrameWindow = (this._root.current && getWindow(this._root.current)) || window;
-      animationFrameWindow.cancelAnimationFrame(this._findScrollParentAnimationFrameId);
-    }
   }
 
   public render(): JSX.Element {
@@ -503,6 +486,27 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     }
 
     this._clearAndSelectIndex(index);
+  }
+
+  /**
+   * To avoid high startup cost of traversing the DOM on component mount,
+   * defer finding the scrollable parent until a click interaction.
+   *
+   * The styles will probably already calculated since we're running in a click handler,
+   * so this is less likely to cause layout thrashing then doing it in mount.
+   *
+   * @param ev the click event
+   */
+  private _findScrollParentAndTryClearOnEmptyClick(ev: MouseEvent) {
+    const scrollParent = findScrollableParent(this._root.current);
+    // unbind this handler and replace binding with a binding on the actual scrollable parent
+    this._events.off(document, 'click', this._findScrollParentAndTryClearOnEmptyClick);
+    this._events.on(scrollParent, 'click', this._tryClearOnEmptyClick);
+
+    // If we clicked inside the scrollable parent, call through to the handler on this click.
+    if ((scrollParent && ev.target instanceof Node && scrollParent.contains(ev.target)) || scrollParent === ev.target) {
+      this._tryClearOnEmptyClick(ev);
+    }
   }
 
   private _tryClearOnEmptyClick(ev: MouseEvent): void {

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -494,8 +494,6 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
    *
    * The styles will probably already calculated since we're running in a click handler,
    * so this is less likely to cause layout thrashing then doing it in mount.
-   *
-   * @param ev the click event
    */
   private _findScrollParentAndTryClearOnEmptyClick(ev: MouseEvent) {
     const scrollParent = findScrollableParent(this._root.current);


### PR DESCRIPTION
#### Pull request checklist

Defer SelectionZone traversal until first interaction with the document after mount.

- ~~[ ] Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ npm run change`

#### Motivation for the change

Reading from the DOM blocks script execution on evaluating the styles of the the newly mounted components. In examples in Fabric this isn't an issue. However, in Outlook, we're using SelectionZones in the RecipientWells of our email compose. 

It takes several dropped frames to run this calculation on the newly mounted DOM

![image](https://user-images.githubusercontent.com/1174858/54380503-e11eea00-4648-11e9-9940-ee36ca26cdf9.png)

By moving it to a click handler, we remove this forced style calculation and trade it off for a presumably cheaper calculation after the first interaction (e.g. after the document's stylesheet has already been evaluated)

![image](https://user-images.githubusercontent.com/1174858/54381058-0fe99000-464a-11e9-9c7d-dac296e361ce.png)

I'm open to doing this in a RAF as opposed to on the next click. To me it made sense to avoid incurring the cost at all for keyboard-only users. I'd be worried about

- how often do we expect the DOM to be invalidated in a RAF vs a click handler?
- If it is invalidated in a RAF, then that time will still be considered part of the "startup" time as far as the user is concerned
- If it is invalidated in a click handler, then the application may start to feel unresponsive or sluggish in that first click



#### Focus areas to test

SelectionZone

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8322)