### PR TITLE
Make API extractor tasks actually read the config

### DIFF
--- a/scripts/find-config.js
+++ b/scripts/find-config.js
@@ -6,6 +6,9 @@
  * @returns The config file's path, or undefined if not found
  */
 function findConfig(configName, lookInCommon) {
+  if (!configName) {
+    return undefined;
+  }
   const fs = require('fs');
   const path = require('path');
   const rootPath = path.resolve('/');

--- a/scripts/read-config.js
+++ b/scripts/read-config.js
@@ -12,11 +12,9 @@ const jju = require('jju');
  */
 function readConfig(file) {
   file = findConfig(file);
-  if (!file) {
-    return;
+  if (file && fs.existsSync(file)) {
+    return jju.parse(fs.readFileSync(file, 'utf8'));
   }
-
-  return jju.parse(fs.readFileSync(file, 'utf8'));
 }
 
 module.exports = readConfig;

--- a/scripts/tasks/api-extractor.js
+++ b/scripts/tasks/api-extractor.js
@@ -1,3 +1,11 @@
+// @ts-check
+
+const path = require('path');
+const readConfig = require('../read-config');
 const { apiExtractorVerifyTask, apiExtractorUpdateTask } = require('just-scripts');
-exports.verifyApiExtractor = apiExtractorVerifyTask();
-exports.updateApiExtractor = apiExtractorUpdateTask();
+
+const configPath = path.resolve(process.cwd(), 'config/api-extractor.json');
+const config = readConfig(configPath) || {};
+
+exports.verifyApiExtractor = apiExtractorVerifyTask(config, undefined);
+exports.updateApiExtractor = apiExtractorUpdateTask(config, undefined);


### PR DESCRIPTION
If a project's `config/api-extractor.json` exists, it should be passed to the API extractor Just tasks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8323)