### PR TITLE
Export Foundation from OUFR

### DIFF
--- a/common/changes/@uifabric/foundation/jg-export-foundation_2019-03-14-21-35.json
+++ b/common/changes/@uifabric/foundation/jg-export-foundation_2019-03-14-21-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/foundation",
+      "comment": "TSDoc fixes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-export-foundation_2019-03-14-21-35.json
+++ b/common/changes/office-ui-fabric-react/jg-export-foundation_2019-03-14-21-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Export Foundation package.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/foundation/src/IComponent.ts
+++ b/packages/foundation/src/IComponent.ts
@@ -1,7 +1,5 @@
 import { IStyle, IStyleSet, ITheme } from '@uifabric/styling';
 
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 // TODO: Known TypeScript issue is widening return type checks when using function type declarations.
 //        Effect is that mistyped property keys on returned style objects will not generate errors.
 //        This affects lookup types used as functional decorations on IComponent and IStatelessComponent, e.g.:
@@ -102,7 +100,13 @@ export type IViewRenderer<TViewProps> = (props?: TViewProps) => JSX.Element | nu
 
 /**
  * Component used by foundation to tie elements together.
- * @see createComponent for generic type documentation.
+ *
+ * * TComponentProps: A styleable props interface for the created component.
+ * * TTokens: The type for tokens props.
+ * * TStyleSet: The type for styles properties.
+ * * TViewProps: The props specific to the view, including processed properties outputted by optional state component. If state
+ * component is not provided, TComponentProps is the same as TViewProps.
+ * * TStatics: Static type for statics applied to created component object.
  */
 export interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
   /**

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -20,14 +20,7 @@ import { IDefaultSlotProps, ISlotCreator } from './ISlots';
  * Views should simply be stateless pure functions that receive all props needed for rendering their output.
  * State component is optional. If state is not provided, created component is essentially a functional stateless component.
  *
- * * TComponentProps: A styleable props interface for the created component.
- * * TTokens: The type for tokens props.
- * * TStyleSet: The type for styles properties.
- * * TViewProps: The props specific to the view, including processed properties outputted by optional state component. If state
- * component is not provided, TComponentProps is the same as TViewProps.
- * * TStatics: Static type for statics applied to created component object.
- *
- * @param {IComponent} component Component options. See IComponent for more detail.
+ * @param component - component Component options. See IComponent for more detail.
  */
 export function createComponent<
   TComponentProps,

--- a/packages/foundation/src/slots.tsx
+++ b/packages/foundation/src/slots.tsx
@@ -27,11 +27,11 @@ import {
  * This function is a slot resolver that automatically evaluates slot functions to generate React elements.
  * A byproduct of this resolver is that it removes slots from the React hierarchy by bypassing React.createElement.
  *
- * To use this function on a per-file basis, put the following directive in a comment block: @jsx withSlots
- * Usage of this pragma also requires an import statement of SlotModule such as: import { withSlots } from '@uifabric/foundation';
- * Also, this directive must be the FIRST LINE in the file to work correctly.
+ * To use this function on a per-file basis, use the jsx directive targeting withSlots.
+ * This directive must be the FIRST LINE in the file to work correctly.
+ * Usage of this pragma also requires withSlots import statement.
  *
- * @see React.createElement
+ * See React.createElement
  */
 // Can't use typeof on React.createElement since it's overloaded. Approximate createElement's signature for now and widen as needed.
 export function withSlots<P>(
@@ -71,8 +71,8 @@ export function withSlots<P>(
 
 /**
  * This function creates factories that render ouput depending on the user ISlotProp props passed in.
- * @param ComponentType Base component to render when not overridden by user props.
- * @param options Factory options, including defaultProp value for shorthand prop mapping.
+ * @param ComponentType - Base component to render when not overridden by user props.
+ * @param options - Factory options, including defaultProp value for shorthand prop mapping.
  * @returns ISlotFactory function used for rendering slots.
  */
 export function createFactory<TProps>(
@@ -118,8 +118,8 @@ const defaultFactory = memoizeFunction(type => createFactory(type));
 
 /**
  * This function generates slots that can be used in JSX given a definition of slots and their corresponding types.
- * @param userProps Props as pass to component.
- * @param slots Slot definition object defining the default slot component for each slot.
+ * @param userProps - Props as pass to component.
+ * @param slots - Slot definition object defining the default slot component for each slot.
  * @returns A set of created slots that components can render in JSX.
  */
 export function getSlots<TProps extends TSlots, TSlots extends ISlotProps<TProps, TSlots>>(

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -778,6 +778,12 @@ export function correctRGB(color: IRGB): IRGB;
 // @public
 export function createArray<T>(size: number, getItem: (index: number) => T): T[];
 
+// @public
+export function createComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}>(component: IComponent<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React.StatelessComponent<TComponentProps> & TStatics;
+
+// @public
+export function createFactory<TProps>(ComponentType: React.ComponentType<TProps>, options?: IFactoryOptions<TProps>): ISlotFactory<TProps>;
+
 // @public (undocumented)
 export function createFontStyles(localeCode: string | null): IFontStyles;
 
@@ -1447,6 +1453,9 @@ export function getScrollbarWidth(): number;
 
 // @public
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
+
+// @public
+export function getSlots<TProps extends TSlots, TSlots extends ISlotProps<TProps, TSlots>>(userProps: TProps, slots: ISlotDefinition<Required<TSlots>>): ISlots<Required<TSlots>>;
 
 // @public (undocumented)
 export function getSubmenuItems(item: IContextualMenuItem): IContextualMenuItem[] | undefined;
@@ -3047,6 +3056,18 @@ interface ICommandBarStyles {
   root?: IStyle;
   // (undocumented)
   secondarySet?: IStyle;
+}
+
+// @public
+interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
+  displayName: string;
+  factoryOptions?: IFactoryOptions<TComponentProps>;
+  fields?: string[];
+  state?: IStateComponentType<TComponentProps, TViewProps>;
+  statics?: TStatics;
+  styles?: IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet>;
+  tokens?: ITokenFunctionOrObject<TViewProps, TTokens>;
+  view: IViewComponent<TViewProps>;
 }
 
 // @public (undocumented)
@@ -6879,6 +6900,12 @@ interface IDeclaredEventsByName {
 }
 
 // @public
+interface IDefaultSlotProps<TSlots> {
+  // (undocumented)
+  _defaultStyles: IComponentStyles<TSlots>;
+}
+
+// @public
 interface IDelayedRenderProps extends React.Props<{}> {
   delay?: number;
 }
@@ -7992,6 +8019,11 @@ interface IFacepileStyles {
   root: IStyle;
   // (undocumented)
   screenReaderOnly: IStyle;
+}
+
+// @public
+interface IFactoryOptions<TProps> {
+  defaultProp?: keyof TProps | 'children';
 }
 
 // @public
@@ -9755,6 +9787,12 @@ interface IPositioningContainerState {
   positions?: IPositionedData;
 }
 
+// @public
+interface IProcessedSlotProps {
+  // (undocumented)
+  className?: string;
+}
+
 // @public (undocumented)
 interface IProgressIndicatorProps extends React.ClassAttributes<ProgressIndicatorBase> {
   ariaValueText?: string;
@@ -10605,6 +10643,12 @@ interface ISliderStyles {
 }
 
 // @public
+interface ISlotCreator<TProps> {
+  // (undocumented)
+  create?: ISlotFactory<TProps>;
+}
+
+// @public
 export function isMac(reset?: boolean): boolean;
 
 // WARNING: Because this definition is explicitly marked as @internal, an underscore prefix ("_") should be added to its name
@@ -10805,6 +10849,18 @@ interface IStickyState {
   isStickyBottom: boolean;
   // (undocumented)
   isStickyTop: boolean;
+}
+
+// @public
+interface IStyleableComponentProps<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>> {
+  // (undocumented)
+  className?: string;
+  // (undocumented)
+  styles?: IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet>;
+  // (undocumented)
+  theme?: ITheme;
+  // (undocumented)
+  tokens?: ITokenFunctionOrObject<TViewProps, TTokens>;
 }
 
 // @public
@@ -11271,6 +11327,14 @@ interface ITheme extends IScheme {
 }
 
 // @public (undocumented)
+interface IThemeProviderProps {
+  // (undocumented)
+  scheme?: ISchemeNames;
+  // (undocumented)
+  theme?: ITheme;
+}
+
+// @public (undocumented)
 interface IThemeRules {
   // (undocumented)
   [key: string]: IThemeSlotRule;
@@ -11350,6 +11414,10 @@ interface IToggleStyles {
   root: IStyle;
   text: IStyle;
   thumb: IStyle;
+}
+
+// @public
+interface ITokenBaseArray<TViewProps, TTokens> extends Array<IToken<TViewProps, TTokens>> {
 }
 
 // @public (undocumented)
@@ -12969,6 +13037,9 @@ export function warnDeprecations<P>(componentName: string, props: P, deprecation
 // @public
 export function warnMutuallyExclusive<P>(componentName: string, props: P, exclusiveMap: ISettingsMap<P>): void;
 
+// @public
+export function withSlots<P>(type: ISlot<P> | React.SFC<P> | string, props?: React.Attributes & P | null, ...children: React.ReactNode[]): React.ReactElement<P> | JSX.Element | null;
+
 // @public (undocumented)
 module ZIndexes {
   // (undocumented)
@@ -13050,6 +13121,34 @@ module ZIndexes {
 // WARNING: Unsupported export: IBaseFloatingPickerSuggestionProps
 // WARNING: Unsupported export: FocusZoneTabbableElements
 // WARNING: Unsupported export: FocusZoneTabbableElements
+// WARNING: Unsupported export: IPropsWithChildren
+// WARNING: Unsupported export: IComponentStyles
+// WARNING: Unsupported export: IStylesFunction
+// WARNING: Unsupported export: IStylesFunctionOrObject
+// WARNING: Unsupported export: IToken
+// WARNING: Unsupported export: ITokenFunction
+// WARNING: Unsupported export: ITokenFunctionOrObject
+// WARNING: Unsupported export: ITokenBase
+// WARNING: Unsupported export: ICustomizationProps
+// WARNING: Unsupported export: IStateComponentProps
+// WARNING: Unsupported export: IStateComponentType
+// WARNING: Unsupported export: IViewComponent
+// WARNING: Unsupported export: IViewRenderer
+// WARNING: Unsupported export: IHTMLSlot
+// WARNING: Unsupported export: IHTMLElementSlot
+// WARNING: Unsupported export: ISlottableComponentType
+// WARNING: Unsupported export: ISlottableReactType
+// WARNING: Unsupported export: ISlotDefinition
+// WARNING: Unsupported export: ISlot
+// WARNING: Unsupported export: ISlotFactory
+// WARNING: Unsupported export: ISlots
+// WARNING: Unsupported export: ISlotProps
+// WARNING: Unsupported export: ISlotProp
+// WARNING: Unsupported export: ISlotPropValue
+// WARNING: Unsupported export: ISlotPropRenderFunction
+// WARNING: Unsupported export: ISlotRenderer
+// WARNING: Unsupported export: ISlotRender
+// WARNING: Unsupported export: ThemeProvider
 // WARNING: Unsupported export: Grid
 // WARNING: Unsupported export: IGroupHeaderStyleProps
 // WARNING: Unsupported export: IGroupFooterStyleProps

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -27,6 +27,7 @@ export * from './Facepile';
 export * from './FloatingPicker';
 export * from './FocusTrapZone';
 export * from './FocusZone';
+export * from './Foundation';
 export * from './Grid';
 export * from './GroupedList';
 export * from './HoverCard';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Importing utilities like `ThemeProvider` directly from `@uifabric/foundation` package and using them with Fabric components causes some issues with React.Context having multiple instances. This PR exports Foundation from OUFR so that it can be used with Fabric components.

#### Focus areas to test

n/a

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8327)