### PR TITLE
Avoid setting role in case of empty list

### DIFF
--- a/common/changes/office-ui-fabric-react/empty-list-no-role_2019-03-15-07-00.json
+++ b/common/changes/office-ui-fabric-react/empty-list-no-role_2019-03-15-07-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List: Avoid setting role to list in case of empty list",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.test.tsx
@@ -79,7 +79,7 @@ describe('List', () => {
 
       const listRoot = wrapper.find(List);
 
-      expect(listRoot.getDOMNode().getAttribute('role')).toEqual(null);
+      expect(listRoot.getDOMNode().getAttribute('role')).toBeNull();
     });
 
     it("sets the row elements' role to 'listitem'", done => {

--- a/packages/office-ui-fabric-react/src/components/List/List.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.test.tsx
@@ -72,6 +72,16 @@ describe('List', () => {
       expect(listRoot.getDOMNode().getAttribute('role')).toEqual('list');
     });
 
+    it("does not set the root element's role in case of an empty list", done => {
+      const wrapper = mount(<List items={mockData(0)} />);
+
+      wrapper.setProps({ items: mockData(0), onPagesUpdated: (pages: IPage[]) => done() });
+
+      const listRoot = wrapper.find(List);
+
+      expect(listRoot.getDOMNode().getAttribute('role')).toEqual(null);
+    });
+
     it("sets the row elements' role to 'listitem'", done => {
       const wrapper = mount(<List items={mockData(100)} />);
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -359,7 +359,7 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
   }
 
   public render(): JSX.Element {
-    const { className, role } = this.props;
+    const { className, role = 'list' } = this.props;
     const { pages = [] } = this.state;
     const pageElements: JSX.Element[] = [];
     const divProps = getNativeProps(this.props, divProperties);
@@ -369,20 +369,12 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     }
 
     return (
-      <div ref={this._root} {...divProps} role={this._getRole(role, pageElements)} className={css('ms-List', className)}>
+      <div ref={this._root} {...divProps} role={pageElements.length > 0 ? role : undefined} className={css('ms-List', className)}>
         <div ref={this._surface} className={css('ms-List-surface')} role="presentation">
           {pageElements}
         </div>
       </div>
     );
-  }
-
-  private _getRole(role: string | undefined, pageElements: JSX.Element[]): string | undefined {
-    if (role === undefined) {
-      return pageElements.length === 0 ? undefined : 'list';
-    } else {
-      return role;
-    }
   }
 
   private _shouldVirtualize(props: IListProps = this.props): boolean {

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -369,7 +369,12 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     }
 
     return (
-      <div ref={this._root} {...divProps} role={role === undefined ? 'list' : role} className={css('ms-List', className)}>
+      <div
+        ref={this._root}
+        {...divProps}
+        role={role === undefined ? (pageElements.length === 0 ? '' : 'list') : role}
+        className={css('ms-List', className)}
+      >
         <div ref={this._surface} className={css('ms-List-surface')} role="presentation">
           {pageElements}
         </div>

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -369,17 +369,20 @@ export class List extends BaseComponent<IListProps, IListState> implements IList
     }
 
     return (
-      <div
-        ref={this._root}
-        {...divProps}
-        role={role === undefined ? (pageElements.length === 0 ? '' : 'list') : role}
-        className={css('ms-List', className)}
-      >
+      <div ref={this._root} {...divProps} role={this._getRole(role, pageElements)} className={css('ms-List', className)}>
         <div ref={this._surface} className={css('ms-List-surface')} role="presentation">
           {pageElements}
         </div>
       </div>
     );
+  }
+
+  private _getRole(role: string | undefined, pageElements: JSX.Element[]): string | undefined {
+    if (role === undefined) {
+      return pageElements.length === 0 ? undefined : 'list';
+    } else {
+      return role;
+    }
   }
 
   private _shouldVirtualize(props: IListProps = this.props): boolean {

--- a/packages/office-ui-fabric-react/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/List/__snapshots__/List.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`List renders List correctly 1`] = `
 <div
   className="ms-List"
-  role="list"
 >
   <div
     className="ms-List-surface"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8206 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Added a condition that checks the length of the list and sets the role to list only if the length is not 0

#### Focus areas to test
1. Create an empty list.
2. Ensure the div rendering the list should not have the role set to 'list 

Earlier
![image](https://user-images.githubusercontent.com/8922176/54411428-a0f15300-46ac-11e9-8a8e-5bfcfeee2f2b.png)

After fix
![empty-list-after-fix](https://user-images.githubusercontent.com/8922176/54465092-af844c80-4736-11e9-8c1a-606b5b199bd2.PNG)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8337)