### PR TITLE
Add dependencies on codepen-loader to get it to build

### DIFF
--- a/common/changes/@uifabric/date-time/codepen_2019-03-15-22-16.json
+++ b/common/changes/@uifabric/date-time/codepen_2019-03-15-22-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/date-time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/codepen_2019-03-15-22-16.json
+++ b/common/changes/office-ui-fabric-react/codepen_2019-03-15-22-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -31,6 +31,7 @@
     "@types/react-dom": "16.0.5",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.13.0",
+    "@uifabric/codepen-loader": ">=0.1.0 <1.0.0",
     "@uifabric/example-app-base": ">=6.12.2 <7.0.0",
     "@uifabric/jest-serializer-merge-styles": ">=6.0.7 <7.0.0",
     "@uifabric/prettier-rules": ">=1.0.1 <2.0.0",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -42,6 +42,7 @@
     "@types/resemblejs": "~1.3.28",
     "@types/sinon": "2.2.2",
     "@types/webpack-env": "1.13.0",
+    "@uifabric/codepen-loader": ">=0.1.0 <1.0.0",
     "@uifabric/foundation": ">=0.7.2 <1.0.0",
     "@uifabric/jest-serializer-merge-styles": ">=6.0.7 <7.0.0",
     "@uifabric/prettier-rules": ">=1.0.1 <2.0.0",


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

The codepen-loader package wasn't getting built for some reason, which broke npm start. Adding a dependency on the package in oufr fixes this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8344)