### PR TITLE
Add shouldComponentUpdate to ContextualMenuItems to ensure items are only updated when needed.

### DIFF
--- a/common/changes/office-ui-fabric-react/ddlbrena-ctxMenuUpdate_2019-03-18-17-27.json
+++ b/common/changes/office-ui-fabric-react/ddlbrena-ctxMenuUpdate_2019-03-18-17-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add shouldComponentUpdate to ContextualMenuItems to ensure items are only updated when needed.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "ddlbrena@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
@@ -46,6 +46,50 @@ describe('ContextualMenuButton', () => {
       expect(onClickMock).toHaveBeenCalledTimes(1);
       expect(onClickMock).toHaveBeenCalledWith(menuItem, expect.objectContaining(mockEvent));
     });
+
+    it('does not update when props values do not change', () => {
+      let reactCalls: number = 0;
+      jest.spyOn(ContextualMenuButton.prototype, 'render').mockImplementation(() => {
+        reactCalls += 1;
+        return null;
+      });
+      const props = {
+        item: menuItem,
+        classNames: menuClassNames,
+        index: 0,
+        focusableElementIndex: 0,
+        totalItemCount: 1
+      };
+      const component = mount(
+        <ContextualMenuButton
+          {...props}
+        />
+      );
+      component.setProps({ ...props });
+      expect(reactCalls).toEqual(1);
+    });
+
+    it('does update when props values do change', () => {
+      let reactCalls: number = 0;
+      jest.spyOn(ContextualMenuButton.prototype, 'render').mockImplementation(() => {
+        reactCalls += 1;
+        return null;
+      });
+      const props = {
+        item: menuItem,
+        classNames: menuClassNames,
+        index: 0,
+        focusableElementIndex: 0,
+        totalItemCount: 1
+      };
+      const component = mount(
+        <ContextualMenuButton
+          {...props}
+        />
+      );
+      component.setProps({ ...props, index: 1 });
+      expect(reactCalls).toEqual(2);
+    });
   });
 });
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
@@ -48,9 +48,9 @@ describe('ContextualMenuButton', () => {
     });
 
     it('does not update when props values do not change', () => {
-      let reactCalls: number = 0;
+      const renderMock = jest.fn();
       jest.spyOn(ContextualMenuButton.prototype, 'render').mockImplementation(() => {
-        reactCalls += 1;
+        renderMock();
         return null;
       });
       const props = {
@@ -66,13 +66,13 @@ describe('ContextualMenuButton', () => {
         />
       );
       component.setProps({ ...props });
-      expect(reactCalls).toEqual(1);
+      expect(renderMock).toHaveBeenCalledTimes(1);
     });
 
     it('does update when props values do change', () => {
-      let reactCalls: number = 0;
+      const renderMock = jest.fn();
       jest.spyOn(ContextualMenuButton.prototype, 'render').mockImplementation(() => {
-        reactCalls += 1;
+        renderMock();
         return null;
       });
       const props = {
@@ -88,7 +88,7 @@ describe('ContextualMenuButton', () => {
         />
       );
       component.setProps({ ...props, index: 1 });
-      expect(reactCalls).toEqual(2);
+      expect(renderMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.test.tsx
@@ -48,11 +48,7 @@ describe('ContextualMenuButton', () => {
     });
 
     it('does not update when props values do not change', () => {
-      const renderMock = jest.fn();
-      jest.spyOn(ContextualMenuButton.prototype, 'render').mockImplementation(() => {
-        renderMock();
-        return null;
-      });
+      const renderMock = jest.spyOn(ContextualMenuButton.prototype, 'render');
       const props = {
         item: menuItem,
         classNames: menuClassNames,
@@ -60,21 +56,17 @@ describe('ContextualMenuButton', () => {
         focusableElementIndex: 0,
         totalItemCount: 1
       };
-      const component = mount(
-        <ContextualMenuButton
-          {...props}
-        />
-      );
+      const component = mount(<ContextualMenuButton {...props} />);
+
       component.setProps({ ...props });
+
       expect(renderMock).toHaveBeenCalledTimes(1);
+
+      renderMock.mockRestore();
     });
 
     it('does update when props values do change', () => {
-      const renderMock = jest.fn();
-      jest.spyOn(ContextualMenuButton.prototype, 'render').mockImplementation(() => {
-        renderMock();
-        return null;
-      });
+      const renderMock = jest.spyOn(ContextualMenuButton.prototype, 'render');
       const props = {
         item: menuItem,
         classNames: menuClassNames,
@@ -82,13 +74,13 @@ describe('ContextualMenuButton', () => {
         focusableElementIndex: 0,
         totalItemCount: 1
       };
-      const component = mount(
-        <ContextualMenuButton
-          {...props}
-        />
-      );
+      const component = mount(<ContextualMenuButton {...props} />);
+
       component.setProps({ ...props, index: 1 });
+
       expect(renderMock).toHaveBeenCalledTimes(2);
+
+      renderMock.mockRestore();
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuItemWrapper.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { BaseComponent } from '../../../Utilities';
+import { BaseComponent, shallowCompare } from '../../../Utilities';
 import { IContextualMenuItemWrapperProps } from './ContextualMenuItemWrapper.types';
 import { IContextualMenuItem } from '../../../ContextualMenu';
 
 export class ContextualMenuItemWrapper extends BaseComponent<IContextualMenuItemWrapperProps, {}> {
+  public shouldComponentUpdate(newProps: IContextualMenuItemWrapperProps): boolean {
+    return !shallowCompare(newProps, this.props);
+  }
+
   protected _onItemMouseEnter = (ev: React.MouseEvent<HTMLElement>): void => {
     const { item, onItemMouseEnter } = this.props;
     if (onItemMouseEnter) {


### PR DESCRIPTION
Add shouldComponentUpdate to ContextualMenuItems to ensure items are only updated when needed.

This is specifically needed for cases when menus are being persisted.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8360)