### PR TITLE
Fluent-theme: fixing a TeachingBubbleContent styles not being applied.

### DIFF
--- a/common/changes/@uifabric/fluent-theme/v-bibr-fixTeachingBubble_2019-03-18-22-55.json
+++ b/common/changes/@uifabric/fluent-theme/v-bibr-fixTeachingBubble_2019-03-18-22-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "TeachingBubble: fixes bug were the styles for TeachingBubbleContent were not applied properly when not used directly.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -32,7 +32,7 @@ import { SliderStyles } from './styles/Slider.styles';
 import { SpinButtonStyles } from './styles/SpinButton.styles';
 import { SuggestionItemStyles, SuggestionsStyles } from './styles/PickerSuggestions.styles';
 import { TagItemStyles } from './styles/TagPicker.styles';
-import { TeachingBubbleStyles, TeachingBubbleContentStyles } from './styles/TeachingBubble.styles';
+import { TeachingBubbleStyles } from './styles/TeachingBubble.styles';
 import { TextFieldStyles } from './styles/TextField.styles';
 import { ToggleStyles } from './styles/Toggle.styles';
 
@@ -175,7 +175,7 @@ export const FluentStyles: any = {
     styles: TeachingBubbleStyles
   },
   TeachingBubbleContent: {
-    styles: TeachingBubbleContentStyles
+    styles: TeachingBubbleStyles
   },
   TextField: {
     styles: TextFieldStyles

--- a/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
@@ -3,23 +3,8 @@ import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react/lib/TeachingBubble';
 
 export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
-  const { theme } = props;
-  const { effects } = theme;
-
-  return {
-    subComponentStyles: {
-      callout: {
-        root: {
-          boxShadow: effects.elevation16
-        }
-      }
-    }
-  };
-};
-
-export const TeachingBubbleContentStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
   const { hasCondensedHeadline, hasSmallHeadline, theme } = props;
-  const { palette } = theme;
+  const { effects, palette } = theme;
 
   let headlineSize = FontSizes.size14;
   if (!hasCondensedHeadline && !hasSmallHeadline) {
@@ -43,6 +28,17 @@ export const TeachingBubbleContentStyles = (props: ITeachingBubbleStyleProps): P
       selectors: {
         '&:hover': {
           color: palette.black
+        },
+        '&:active': {
+          background: palette.themeDarkAlt,
+          color: palette.black
+        }
+      }
+    },
+    subComponentStyles: {
+      callout: {
+        root: {
+          boxShadow: effects.elevation16
         }
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Fixing fluent styles not being applied to `TeachingBubbleContent` when not used directly as in `Coachmark` examples. Pus fixing some of the clicking the close button styles.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8365)