### PR TITLE
Fix focus zone virtual parent focus restoration. Fixes #8366.

### DIFF
--- a/common/changes/office-ui-fabric-react/focus-zone_2019-03-18-23-14.json
+++ b/common/changes/office-ui-fabric-react/focus-zone_2019-03-18-23-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix focus zone virtual parent focus restoration",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dahajek@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -268,7 +268,7 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
 
       // Only update the index path if we are not parked on the root.
       if (focusedElement !== root) {
-        const shouldRestoreFocus = elementContains(root, focusedElement);
+        const shouldRestoreFocus = elementContains(root, focusedElement, false);
 
         this._lastIndexPath = shouldRestoreFocus ? getElementIndexPath(root as HTMLElement, doc.activeElement as HTMLElement) : undefined;
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8366
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Fixes the scenario when a control inside of a  focus zone has a contextual menu and the focus is not restored correctly when you close the menu.

This is because FocusZone keeps track of the _lastIndexPath where the focus should be restored. It saves this path if it detects that an elementContains the focusedElement. This is true for ContextualMenu because it is a valid parent (virtual) in React, but not in DOM. The result path is saved but since the element was never the actual DOM parent this path is not valid and restores the focus incorrectly.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8368)