### PR TITLE
Beak Position Fix

### DIFF
--- a/common/changes/office-ui-fabric-react/beak-position-fix_2019-03-18-23-59.json
+++ b/common/changes/office-ui-fabric-react/beak-position-fix_2019-03-18-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "position anchoring was only applied to the Callout box itself but not the beak. Dynamically sized callouts would grow correctly, but the beak would be anchored to the incorrect edge, causing it to move away from the target. This update re-anchors the beak to the correct edge so dynamically sized Callouts do not change the beak position.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anhw@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/beak-position-fix_2019-03-18-23-59.json
+++ b/common/changes/office-ui-fabric-react/beak-position-fix_2019-03-18-23-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "position anchoring was only applied to the Callout box itself but not the beak. Dynamically sized callouts would grow correctly, but the beak would be anchored to the incorrect edge, causing it to move away from the target. This update re-anchors the beak to the correct edge so dynamically sized Callouts do not change the beak position.",
+      "comment": "Callout: Fix beak position for dynamically sized callouts.",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/utilities/positioning.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.test.ts
@@ -187,6 +187,8 @@ describe('Callout Positioning', () => {
         };
       }
     };
+    // create a dummy beak
+    const beakPos = new Rectangle(8, -8, 8, -8);
     const pos: IElementPosition = {
       elementRectangle: new Rectangle(400, 500, 400, 500),
       targetEdge: RectangleEdge.top,
@@ -209,11 +211,19 @@ describe('Callout Positioning', () => {
     expect(finalizedPosition.elementPosition.bottom).toBeUndefined();
 
     // With bounds introduced, if the elementRectangle is closer to one edge of bounds than another,
-    // should align to edge closes to bounds
+    // should align to edge closest to bounds
     // In this case, that's bottom (opposite of target) and right (closer to edge of bounds)
     finalizedPosition = __positioningTestPackage._finalizePositionData(pos, host as any, bounds);
     expect(finalizedPosition.elementPosition.right).toBeDefined();
     expect(finalizedPosition.elementPosition.bottom).toBeDefined();
+    expect(finalizedPosition.elementPosition.left).toBeUndefined();
+
+    // With bounds introduced, the alignment should apply to the beak as well, aligning it to
+    // the edge closest to bounds
+    // In this case, that's the bottom (opposite of target) and right (closer to edge of bounds)
+    const finalizedBeakPosition = __positioningTestPackage._finalizeBeakPosition(pos, beakPos, bounds);
+    expect(finalizedBeakPosition.elementPosition.right).toBeDefined();
+    expect(finalizedBeakPosition.elementPosition.bottom).toBeDefined();
     expect(finalizedPosition.elementPosition.left).toBeUndefined();
   });
 });

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -415,6 +415,27 @@ function _getFlankingEdges(edge: RectangleEdge): { positiveEdge: RectangleEdge; 
 }
 
 /**
+ * Retreive the final value for the return edge of elementRectangle.
+ * If the elementRectangle is closer to one side of the bounds versus the other, the return edge is flipped to grow inward.
+ *
+ * @param elementRectangle
+ * @param targetEdge
+ * @param bounds
+ * @param alignmentEdge
+ */
+function _finalizeReturnEdge(elementRectangle: Rectangle, returnEdge: RectangleEdge, bounds?: Rectangle): RectangleEdge {
+  if (
+    bounds &&
+    Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge)) >
+      Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge * -1))
+  ) {
+    return returnEdge * -1;
+  }
+
+  return returnEdge;
+}
+
+/**
  * Finalizes the element positon based on the hostElement. Only returns the
  * rectangle values to position such that they are anchored to the target.
  * This helps prevent resizing from looking very strange.
@@ -442,16 +463,11 @@ function _finalizeElementPosition(
   const hostRect: Rectangle = _getRectangleFromElement(hostElement);
   const elementEdge = coverTarget ? targetEdge : targetEdge * -1;
   const elementEdgeString = RectangleEdge[elementEdge];
-  let returnEdge = alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge;
-
-  // if the element is closer to one side of the bounds than the other, flip the return edge to ensure it grows inwards
-  if (
-    bounds &&
-    Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge)) >
-      Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge * -1))
-  ) {
-    returnEdge = returnEdge * -1;
-  }
+  const returnEdge = _finalizeReturnEdge(
+    elementRectangle,
+    alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge,
+    bounds
+  );
 
   returnValue[elementEdgeString] = _getRelativeEdgeDifference(elementRectangle, hostRect, elementEdge);
   returnValue[RectangleEdge[returnEdge]] = _getRelativeEdgeDifference(elementRectangle, hostRect, returnEdge);
@@ -558,12 +574,20 @@ function _positionElementWithinBounds(
   }
 }
 
-function _finalizeBeakPosition(elementPosition: IElementPosition, positionedBeak: Rectangle): ICalloutBeakPositionedInfo {
+function _finalizeBeakPosition(
+  elementPosition: IElementPosition,
+  positionedBeak: Rectangle,
+  bounds?: Rectangle
+): ICalloutBeakPositionedInfo {
   const targetEdge = elementPosition.targetEdge * -1;
   // The "host" element that we will use to help position the beak.
   const actualElement = new Rectangle(0, elementPosition.elementRectangle.width, 0, elementPosition.elementRectangle.height);
-  const returnEdge = elementPosition.alignmentEdge ? elementPosition.alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge;
   const returnValue: IPartialIRectangle = {};
+  const returnEdge = _finalizeReturnEdge(
+    elementPosition.elementRectangle,
+    elementPosition.alignmentEdge ? elementPosition.alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge,
+    bounds
+  );
 
   returnValue[RectangleEdge[targetEdge]] = _getEdgeValue(positionedBeak, targetEdge);
   returnValue[RectangleEdge[returnEdge]] = _getRelativeEdgeDifference(positionedBeak, actualElement, returnEdge);
@@ -756,7 +780,7 @@ function _positionCallout(
     : new Rectangle(0, window.innerWidth - getScrollbarWidth(), 0, window.innerHeight);
   const positionedElement: IElementPositionInfo = _positionElementRelative(positionProps, callout, boundingRect, previousPositions);
   const beakPositioned: Rectangle = _positionBeak(beakWidth, positionedElement);
-  const finalizedBeakPosition: ICalloutBeakPositionedInfo = _finalizeBeakPosition(positionedElement, beakPositioned);
+  const finalizedBeakPosition: ICalloutBeakPositionedInfo = _finalizeBeakPosition(positionedElement, beakPositioned, boundingRect);
   return {
     ..._finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget),
     beakPosition: finalizedBeakPosition

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -415,7 +415,7 @@ function _getFlankingEdges(edge: RectangleEdge): { positiveEdge: RectangleEdge; 
 }
 
 /**
- * Retreive the final value for the return edge of elementRectangle.
+ * Retrieve the final value for the return edge of elementRectangle.
  * If the elementRectangle is closer to one side of the bounds versus the other, the return edge is flipped to grow inward.
  *
  * @param elementRectangle

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -421,7 +421,6 @@ function _getFlankingEdges(edge: RectangleEdge): { positiveEdge: RectangleEdge; 
  * @param elementRectangle
  * @param targetEdge
  * @param bounds
- * @param alignmentEdge
  */
 function _finalizeReturnEdge(elementRectangle: Rectangle, returnEdge: RectangleEdge, bounds?: Rectangle): RectangleEdge {
   if (
@@ -791,6 +790,7 @@ function _positionCallout(
 /* tslint:disable:variable-name */
 export const __positioningTestPackage = {
   _finalizePositionData,
+  _finalizeBeakPosition,
   _calculateActualBeakWidthInPixels,
   _positionElementWithinBounds,
   _positionBeak,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
This is a patch related to PR #7778, which caused beak displacements on dynamically sized Callouts.

_Previously:_ Position anchoring was only applied to the Callout box itself but not the beak. Dynamically sized Callouts would grow correctly, but the beak would be anchored to the incorrect edge, causing it to move away from the target.

_Now:_ This update re-anchors the beak to the correct edge so dynamically sized Callouts do not change the beak position.

#### Focus areas to test

General Callout & beak placement behavior should not change at all.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8370)