### PR TITLE
Add title native tool-tip for the refresh icon and close icon in DetailPanel with pivot

### DIFF
--- a/common/changes/@uifabric/dashboard/AddtooltipForIcons_2019-03-19-09-11.json
+++ b/common/changes/@uifabric/dashboard/AddtooltipForIcons_2019-03-19-09-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/dashboard",
-      "comment": "\"have added the tooltip for the refresh icon and close icon in the detail panel with pivot\"",
+      "comment": "Add title native tool-tip for the refresh icon and close icon in DetailPanel with pivot",
       "type": "patch"
     }
   ],

--- a/common/changes/@uifabric/dashboard/AddtooltipForIcons_2019-03-19-09-11.json
+++ b/common/changes/@uifabric/dashboard/AddtooltipForIcons_2019-03-19-09-11.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@uifabric/dashboard",
       "comment": "Add title native tool-tip for the refresh icon and close icon in DetailPanel with pivot",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@uifabric/dashboard",

--- a/common/changes/@uifabric/dashboard/AddtooltipForIcons_2019-03-19-09-11.json
+++ b/common/changes/@uifabric/dashboard/AddtooltipForIcons_2019-03-19-09-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "\"have added the tooltip for the refresh icon and close icon in the detail panel with pivot\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "v-sisom@microsoft.com"
+}

--- a/packages/dashboard/src/components/DetailPanel/BaseContainer.tsx
+++ b/packages/dashboard/src/components/DetailPanel/BaseContainer.tsx
@@ -19,15 +19,17 @@ const baseContainer: React.SFC<BodyContainerType> = (props: BodyContainerType) =
   };
 
   const _renderNav = () => {
-    const { onBack, onDismiss, onRefresh } = props;
+    const { onBack, onDismiss, onRefresh, refreshTooltip, closeTooltip } = props;
     return (
       <div className={css.navBar}>
         <div className={css.navLeft}>
           {onBack && !_shouldHideOnLoading() && <IconButton iconProps={{ iconName: 'Back' }} onClick={onBack} />}
         </div>
         <div className={css.navRight}>
-          {onRefresh && !_shouldHideOnLoading() && <IconButton iconProps={{ iconName: 'Refresh' }} onClick={onRefresh} />}
-          <IconButton iconProps={{ iconName: 'ChromeClose' }} onClick={onDismiss} />
+          {onRefresh && !_shouldHideOnLoading() && (
+            <IconButton iconProps={{ iconName: 'Refresh' }} onClick={onRefresh} title={refreshTooltip} />
+          )}
+          <IconButton iconProps={{ iconName: 'ChromeClose' }} onClick={onDismiss} title={closeTooltip} />
         </div>
       </div>
     );

--- a/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
+++ b/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
@@ -76,7 +76,7 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
 
   public render(): JSX.Element | null {
     const { pageReady, messageBanner, loadingElement, contentElement, currentL2Id, inlineLoading, actionBar, confirmation } = this.state;
-    const { onRefresh, panelSetting, globalMessageBanner } = this.props;
+    const { onRefresh, panelSetting, globalMessageBanner, refreshTooltip, closeTooltip } = this.props;
 
     // Render loading element
     if (!pageReady && !loadingElement) {
@@ -95,6 +95,8 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
           actionBar={confirmation.actionBar}
           inlineLoading={inlineLoading}
           loadingElement={loadingElement}
+          refreshTooltip={refreshTooltip}
+          closeTooltip={closeTooltip}
         />
       );
     }
@@ -115,6 +117,8 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
         actionBar={actionBar}
         loadingElement={loadingElement}
         inlineLoading={inlineLoading}
+        refreshTooltip={refreshTooltip}
+        closeTooltip={closeTooltip}
       />
     );
   }

--- a/packages/dashboard/src/components/DetailPanel/DetailPanel.types.ts
+++ b/packages/dashboard/src/components/DetailPanel/DetailPanel.types.ts
@@ -145,6 +145,14 @@ export interface IDetailPanelBaseProps {
    * Reject with @type {IDetailPanelErrorResult} to set the error state message bar
    */
   onRefresh?: FunctionCallback<void>;
+  /**
+   * tooltip for refresh icon
+   */
+  refreshTooltip?: string;
+  /**
+   * tooltip for close icon
+   */
+  closeTooltip?: string;
 
   /**
    * Call back on getting the customized loading animation to override the default
@@ -284,6 +292,14 @@ export interface IBaseContainerProps extends IBaseContainerExtendProps {
    * Footer to display if any
    */
   actionBar?: IDetailPanelActionBarProps;
+  /**
+   * tooltip for refresh icon
+   */
+  refreshTooltip?: string;
+  /**
+   * tooltip for close icon
+   */
+  closeTooltip?: string;
 
   /**
    * On dismiss the detail panel

--- a/packages/dashboard/src/components/DetailPanel/Examples/DetailPanel.Pivot.Example.tsx
+++ b/packages/dashboard/src/components/DetailPanel/Examples/DetailPanel.Pivot.Example.tsx
@@ -95,6 +95,8 @@ export class DetailPanelPivotExample extends React.PureComponent<{}, IDetailPane
           onPivotLinkClick={(key: string) => {
             console.log(key);
           }}
+          refreshTooltip={'Refresh'}
+          closeTooltip={'close'}
         />
       );
     } else {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `title` native tool-tip for the refresh icon and close icon in `DetailPanel` with pivot.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8375)