### PR TITLE
Legend css in high contrast

### DIFF
--- a/common/changes/@uifabric/charting/LegendCssInHighContrast_2019-03-19-09-36.json
+++ b/common/changes/@uifabric/charting/LegendCssInHighContrast_2019-03-19-09-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "\"added the background color and opacity for legends in the high contrast mode \"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "v-sisom@microsoft.com"
+}

--- a/packages/charting/src/components/Legends/Legends.styles.ts
+++ b/packages/charting/src/components/Legends/Legends.styles.ts
@@ -19,6 +19,12 @@ export const getStyles = (props: ILegendStyleProps): ILegendsStyles => {
       margin: props.overflow ? '16px 0px 16px 16px' : ''
     },
     rect: {
+      selectors: {
+        '@media screen and (-ms-high-contrast: active)': {
+          backgroundColor: props.colorOnSelectedState,
+          opacity: props.colorOnSelectedState === palette.white ? '0.6' : ''
+        }
+      },
       width: '12px',
       height: '12px',
       backgroundColor: props.colorOnSelectedState,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

added the background color and opacity for the legends in the high contrast mode.

**before fix**:-

![legends before](https://user-images.githubusercontent.com/33802398/54596153-12892280-4a5a-11e9-9853-7503af10a88b.png)

**after fix**:-

![legends after](https://user-images.githubusercontent.com/33802398/54596170-1cab2100-4a5a-11e9-9772-5760b5d5ac86.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8376)