### PR TITLE
Shimmer performance

### DIFF
--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -10569,6 +10569,7 @@ interface IShimmerStyles {
   dataWrapper?: IStyle;
   root?: IStyle;
   screenReaderText?: IStyle;
+  shimmerGradient?: IStyle;
   shimmerWrapper?: IStyle;
 }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -429,7 +429,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -571,7 +571,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -713,7 +713,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -855,7 +855,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -997,7 +997,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -1139,7 +1139,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -1281,7 +1281,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -1423,7 +1423,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -1565,7 +1565,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;
@@ -1707,7 +1707,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 {
                                   animation-delay: 4.5s;
                                   animation-direction: normal;
-                                  animation-duration: 1.5s;
+                                  animation-duration: 2s;
                                   animation-iteration-count: infinite;
                                   animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                                   animation-timing-function: ease-in-out;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -402,19 +402,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -434,6 +424,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -452,6 +468,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -527,19 +544,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -559,6 +566,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -577,6 +610,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -652,19 +686,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -684,6 +708,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -702,6 +752,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -777,19 +828,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -809,6 +850,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -827,6 +894,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -902,19 +970,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -934,6 +992,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -952,6 +1036,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -1027,19 +1112,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -1059,6 +1134,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -1077,6 +1178,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -1152,19 +1254,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -1184,6 +1276,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -1202,6 +1320,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -1277,19 +1396,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -1309,6 +1418,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -1327,6 +1462,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -1402,19 +1538,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -1434,6 +1560,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -1452,6 +1604,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {
@@ -1527,19 +1680,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           className=
                               ms-Shimmer-shimmerWrapper
                               {
-                                animation-direction: normal;
-                                animation-duration: 2s;
-                                animation-iteration-count: infinite;
-                                animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-                                animation-timing-function: ease-in-out;
-                                background: #f3f2f1
-                                                  linear-gradient(
-                                                    to right,
-                                                    #f3f2f1 0%,
-                                                    #edebe9 50%,
-                                                    #f3f2f1 100%)
-                                                  0 0 / 90% 100%
-                                                  no-repeat;
+                                background-color: #f3f2f1;
+                                overflow: hidden;
+                                position: relative;
                                 transition: opacity 200ms;
                               }
                               @media screen and (-ms-high-contrast: active){& {
@@ -1559,6 +1702,32 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                           }
                         >
                           <div
+                            className=
+                                ms-Shimmer-shimmerGradient
+                                {
+                                  animation-delay: 4.5s;
+                                  animation-direction: normal;
+                                  animation-duration: 1.5s;
+                                  animation-iteration-count: infinite;
+                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-timing-function: ease-in-out;
+                                  background: #f3f2f1
+                                                      linear-gradient(
+                                                        to right,
+                                                        #f3f2f1 0%,
+                                                        #edebe9 50%,
+                                                        #f3f2f1 100%)
+                                                      0 0 / 90% 100%
+                                                      no-repeat;
+                                  height: 100%;
+                                  left: 0px;
+                                  position: absolute;
+                                  top: 0px;
+                                  transform: translate3d(-100%, 0, 0);
+                                  width: 100%;
+                                }
+                          />
+                          <div
                             style={
                               Object {
                                 "display": "flex",
@@ -1577,6 +1746,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                     font-size: 14px;
                                     font-weight: 400;
+                                    position: relative;
                                   }
                               style={
                                 Object {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -405,7 +405,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -427,11 +431,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -445,7 +448,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -547,7 +550,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -569,11 +576,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -587,7 +593,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -689,7 +695,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -711,11 +721,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -729,7 +738,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -831,7 +840,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -853,11 +866,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -871,7 +883,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -973,7 +985,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -995,11 +1011,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -1013,7 +1028,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -1115,7 +1130,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -1137,11 +1156,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -1155,7 +1173,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -1257,7 +1275,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -1279,11 +1301,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -1297,7 +1318,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -1399,7 +1420,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -1421,11 +1446,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -1439,7 +1463,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -1541,7 +1565,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -1563,11 +1591,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -1581,7 +1608,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />
@@ -1683,7 +1710,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                 background-color: #f3f2f1;
                                 overflow: hidden;
                                 position: relative;
+                                transform: translateZ(0);
                                 transition: opacity 200ms;
+                              }
+                              & > * {
+                                transform: translateZ(0);
                               }
                               @media screen and (-ms-high-contrast: active){& {
                                 background: WindowText
@@ -1705,11 +1736,10 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                             className=
                                 ms-Shimmer-shimmerGradient
                                 {
-                                  animation-delay: 4.5s;
                                   animation-direction: normal;
                                   animation-duration: 2s;
                                   animation-iteration-count: infinite;
-                                  animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                                  animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                                   animation-timing-function: ease-in-out;
                                   background: #f3f2f1
                                                       linear-gradient(
@@ -1723,7 +1753,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                   left: 0px;
                                   position: absolute;
                                   top: 0px;
-                                  transform: translate3d(-100%, 0, 0);
+                                  transform: translateX(-100%);
                                   width: 100%;
                                 }
                           />

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -82,6 +82,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
       <div {...divProps} className={this._classNames.root}>
         {!contentLoaded && (
           <div style={{ width: width ? width : '100%' }} className={this._classNames.shimmerWrapper}>
+            <div className={this._classNames.shimmerGradient} />
             {customElementsGroup ? (
               customElementsGroup
             ) : (

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -93,7 +93,7 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
                       0 0 / 90% 100%
                       no-repeat`,
         transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`,
-        animationDuration: '1.5s',
+        animationDuration: '2s',
         animationDelay: '4.5s',
         animationTimingFunction: 'ease-in-out',
         animationDirection: 'normal',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -13,19 +13,19 @@ const BACKGROUND_OFF_SCREEN_POSITION = '100%';
 
 const shimmerAnimation: string = keyframes({
   '0%': {
-    transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
+    transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`
   },
   '100%': {
-    transform: `translate3d(${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
+    transform: `translateX(${BACKGROUND_OFF_SCREEN_POSITION})`
   }
 });
 
 const shimmerAnimationRTL: string = keyframes({
   '100%': {
-    transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
+    transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`
   },
   '0%': {
-    transform: `translate3d(${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
+    transform: `translateX(${BACKGROUND_OFF_SCREEN_POSITION})`
   }
 });
 
@@ -52,9 +52,13 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
       {
         position: 'relative',
         overflow: 'hidden',
+        transform: 'translateZ(0)',
         backgroundColor: shimmerColor || palette.neutralLighter,
         transition: `opacity ${transitionAnimationInterval}ms`,
         selectors: {
+          '> *': {
+            transform: 'translateZ(0)'
+          },
           [HighContrastSelector]: {
             background: `WindowText
                         linear-gradient(
@@ -92,9 +96,8 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
                         ${shimmerColor || palette.neutralLighter} 100%)
                       0 0 / 90% 100%
                       no-repeat`,
-        transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`,
+        transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`,
         animationDuration: '2s',
-        animationDelay: '4.5s',
         animationTimingFunction: 'ease-in-out',
         animationDirection: 'normal',
         animationIterationCount: 'infinite',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -5,26 +5,27 @@ import { getRTL } from '../../Utilities';
 const GlobalClassNames = {
   root: 'ms-Shimmer-container',
   shimmerWrapper: 'ms-Shimmer-shimmerWrapper',
+  shimmerGradient: 'ms-Shimmer-shimmerGradient',
   dataWrapper: 'ms-Shimmer-dataWrapper'
 };
 
-const BACKGROUND_OFF_SCREEN_POSITION = '1000%';
+const BACKGROUND_OFF_SCREEN_POSITION = '100%';
 
 const shimmerAnimation: string = keyframes({
   '0%': {
-    backgroundPosition: `-${BACKGROUND_OFF_SCREEN_POSITION}`
+    transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
   },
   '100%': {
-    backgroundPosition: BACKGROUND_OFF_SCREEN_POSITION
+    transform: `translate3d(${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
   }
 });
 
 const shimmerAnimationRTL: string = keyframes({
   '100%': {
-    backgroundPosition: `-${BACKGROUND_OFF_SCREEN_POSITION}`
+    transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
   },
   '0%': {
-    backgroundPosition: BACKGROUND_OFF_SCREEN_POSITION
+    transform: `translate3d(${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`
   }
 });
 
@@ -49,19 +50,9 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
     shimmerWrapper: [
       classNames.shimmerWrapper,
       {
-        background: `${shimmerColor || palette.neutralLighter}
-                    linear-gradient(
-                      to right,
-                      ${shimmerColor || palette.neutralLighter} 0%,
-                      ${shimmerWaveColor || palette.neutralLight} 50%,
-                      ${shimmerColor || palette.neutralLighter} 100%)
-                    0 0 / 90% 100%
-                    no-repeat`,
-        animationDuration: '2s',
-        animationTimingFunction: 'ease-in-out',
-        animationDirection: 'normal',
-        animationIterationCount: 'infinite',
-        animationName: isRTL ? shimmerAnimationRTL : shimmerAnimation,
+        position: 'relative',
+        overflow: 'hidden',
+        backgroundColor: shimmerColor || palette.neutralLighter,
         transition: `opacity ${transitionAnimationInterval}ms`,
         selectors: {
           [HighContrastSelector]: {
@@ -83,6 +74,31 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
         bottom: '0',
         left: '0',
         right: '0'
+      }
+    ],
+    shimmerGradient: [
+      classNames.shimmerGradient,
+      {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        background: `${shimmerColor || palette.neutralLighter}
+                      linear-gradient(
+                        to right,
+                        ${shimmerColor || palette.neutralLighter} 0%,
+                        ${shimmerWaveColor || palette.neutralLight} 50%,
+                        ${shimmerColor || palette.neutralLighter} 100%)
+                      0 0 / 90% 100%
+                      no-repeat`,
+        transform: `translate3d(-${BACKGROUND_OFF_SCREEN_POSITION}, 0, 0)`,
+        animationDuration: '1.5s',
+        animationDelay: '4.5s',
+        animationTimingFunction: 'ease-in-out',
+        animationDirection: 'normal',
+        animationIterationCount: 'infinite',
+        animationName: isRTL ? shimmerAnimationRTL : shimmerAnimation
       }
     ],
     dataWrapper: [

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
@@ -167,8 +167,11 @@ export interface IShimmerStyles {
   /** Refers to the root wrapper element. */
   root?: IStyle;
 
-  /** Refers to wrapper element of the shimmer animation only. */
+  /** Refers to wrapper element of the shimmer only. */
   shimmerWrapper?: IStyle;
+
+  /** Refers to gradient element of the shimmer animation only. */
+  shimmerGradient?: IStyle;
 
   /** Refers to wrapper element of the children only. */
   dataWrapper?: IStyle;

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.styles.ts
@@ -17,7 +17,8 @@ export function getStyles(props: IShimmerElementsGroupStyleProps): IShimmerEleme
       {
         display: 'flex',
         alignItems: 'center',
-        flexWrap: flexWrap ? 'wrap' : 'nowrap'
+        flexWrap: flexWrap ? 'wrap' : 'nowrap',
+        position: 'relative'
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -22,7 +22,11 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
           background-color: #f3f2f1;
           overflow: hidden;
           position: relative;
+          transform: translateZ(0);
           transition: opacity 200ms;
+        }
+        & > * {
+          transform: translateZ(0);
         }
         @media screen and (-ms-high-contrast: active){& {
           background: WindowText
@@ -44,11 +48,10 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
       className=
           ms-Shimmer-shimmerGradient
           {
-            animation-delay: 4.5s;
             animation-direction: normal;
             animation-duration: 2s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+            animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
             animation-timing-function: ease-in-out;
             background: #f3f2f1
                                 linear-gradient(
@@ -62,7 +65,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
             left: 0px;
             position: absolute;
             top: 0px;
-            transform: translate3d(-100%, 0, 0);
+            transform: translateX(-100%);
             width: 100%;
           }
     />
@@ -280,7 +283,11 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
           background-color: #f3f2f1;
           overflow: hidden;
           position: relative;
+          transform: translateZ(0);
           transition: opacity 200ms;
+        }
+        & > * {
+          transform: translateZ(0);
         }
         @media screen and (-ms-high-contrast: active){& {
           background: WindowText
@@ -302,11 +309,10 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
       className=
           ms-Shimmer-shimmerGradient
           {
-            animation-delay: 4.5s;
             animation-direction: normal;
             animation-duration: 2s;
             animation-iteration-count: infinite;
-            animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+            animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
             animation-timing-function: ease-in-out;
             background: #f3f2f1
                                 linear-gradient(
@@ -320,7 +326,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
             left: 0px;
             position: absolute;
             top: 0px;
-            transform: translate3d(-100%, 0, 0);
+            transform: translateX(-100%);
             width: 100%;
           }
     />

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
           {
             animation-delay: 4.5s;
             animation-direction: normal;
-            animation-duration: 1.5s;
+            animation-duration: 2s;
             animation-iteration-count: infinite;
             animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
             animation-timing-function: ease-in-out;
@@ -304,7 +304,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
           {
             animation-delay: 4.5s;
             animation-direction: normal;
-            animation-duration: 1.5s;
+            animation-duration: 2s;
             animation-iteration-count: infinite;
             animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
             animation-timing-function: ease-in-out;

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -19,19 +19,9 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
     className=
         ms-Shimmer-shimmerWrapper
         {
-          animation-direction: normal;
-          animation-duration: 2s;
-          animation-iteration-count: infinite;
-          animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-          animation-timing-function: ease-in-out;
-          background: #f3f2f1
-                            linear-gradient(
-                              to right,
-                              #f3f2f1 0%,
-                              #edebe9 50%,
-                              #f3f2f1 100%)
-                            0 0 / 90% 100%
-                            no-repeat;
+          background-color: #f3f2f1;
+          overflow: hidden;
+          position: relative;
           transition: opacity 200ms;
         }
         @media screen and (-ms-high-contrast: active){& {
@@ -52,6 +42,32 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
   >
     <div
       className=
+          ms-Shimmer-shimmerGradient
+          {
+            animation-delay: 4.5s;
+            animation-direction: normal;
+            animation-duration: 1.5s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+            animation-timing-function: ease-in-out;
+            background: #f3f2f1
+                                linear-gradient(
+                                  to right,
+                                  #f3f2f1 0%,
+                                  #edebe9 50%,
+                                  #f3f2f1 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+            height: 100%;
+            left: 0px;
+            position: absolute;
+            top: 0px;
+            transform: translate3d(-100%, 0, 0);
+            width: 100%;
+          }
+    />
+    <div
+      className=
           ms-ShimmerElementsGroup-root
           {
             -moz-osx-font-smoothing: grayscale;
@@ -62,6 +78,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
+            position: relative;
           }
       style={
         Object {
@@ -260,19 +277,9 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
     className=
         ms-Shimmer-shimmerWrapper
         {
-          animation-direction: normal;
-          animation-duration: 2s;
-          animation-iteration-count: infinite;
-          animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-          animation-timing-function: ease-in-out;
-          background: #f3f2f1
-                            linear-gradient(
-                              to right,
-                              #f3f2f1 0%,
-                              #edebe9 50%,
-                              #f3f2f1 100%)
-                            0 0 / 90% 100%
-                            no-repeat;
+          background-color: #f3f2f1;
+          overflow: hidden;
+          position: relative;
           transition: opacity 200ms;
         }
         @media screen and (-ms-high-contrast: active){& {
@@ -292,6 +299,32 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
     }
   >
     <div
+      className=
+          ms-Shimmer-shimmerGradient
+          {
+            animation-delay: 4.5s;
+            animation-direction: normal;
+            animation-duration: 1.5s;
+            animation-iteration-count: infinite;
+            animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+            animation-timing-function: ease-in-out;
+            background: #f3f2f1
+                                linear-gradient(
+                                  to right,
+                                  #f3f2f1 0%,
+                                  #edebe9 50%,
+                                  #f3f2f1 100%)
+                                0 0 / 90% 100%
+                                no-repeat;
+            height: 100%;
+            left: 0px;
+            position: absolute;
+            top: 0px;
+            transform: translate3d(-100%, 0, 0);
+            width: 100%;
+          }
+    />
+    <div
       style={
         Object {
           "display": "flex",
@@ -310,6 +343,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -455,6 +489,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
@@ -150,6 +150,11 @@ export class ShimmerStylingExample extends React.Component<{}, {}> {
     return {
       shimmerWrapper: [
         {
+          backgroundColor: '#deecf9'
+        }
+      ],
+      shimmerGradient: [
+        {
           backgroundColor: '#deecf9',
           backgroundImage: 'linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%)'
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -57,19 +57,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -90,6 +80,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -100,6 +116,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -223,19 +240,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -256,6 +263,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -266,6 +299,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -389,19 +423,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -422,6 +446,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -432,6 +482,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -555,19 +606,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -588,6 +629,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -598,6 +665,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -792,19 +860,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -825,6 +883,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -835,6 +919,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -1405,19 +1490,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -1438,6 +1513,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -1448,6 +1549,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -2018,19 +2120,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -2051,6 +2143,32 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -2061,6 +2179,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -267,7 +267,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -450,7 +450,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -633,7 +633,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -887,7 +887,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -1517,7 +1517,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -2147,7 +2147,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -60,7 +60,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -82,11 +86,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -100,7 +103,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -243,7 +246,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -265,11 +272,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -283,7 +289,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -426,7 +432,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -448,11 +458,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -466,7 +475,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -609,7 +618,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -631,11 +644,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -649,7 +661,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -863,7 +875,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -885,11 +901,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -903,7 +918,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -1493,7 +1508,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -1515,11 +1534,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -1533,7 +1551,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -2123,7 +2141,11 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -2145,11 +2167,10 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -2163,7 +2184,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -61,7 +61,11 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -83,11 +87,10 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -101,7 +104,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -524,7 +527,11 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -546,11 +553,10 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -564,7 +570,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -933,7 +939,11 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -955,11 +965,10 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -973,7 +982,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -58,19 +58,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -90,6 +80,32 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       }
     >
       <div
+        className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
         style={
           Object {
             "display": "flex",
@@ -108,6 +124,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -253,6 +270,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -503,19 +521,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -535,6 +543,32 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       }
     >
       <div
+        className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
         style={
           Object {
             "display": "flex",
@@ -553,6 +587,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -644,6 +679,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -894,19 +930,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -926,6 +952,32 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       }
     >
       <div
+        className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
         style={
           Object {
             "display": "flex",
@@ -944,6 +996,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -1098,6 +1151,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {
@@ -1189,6 +1243,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {
@@ -1430,6 +1485,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -85,7 +85,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -548,7 +548,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -957,7 +957,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -195,7 +195,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;
@@ -548,7 +548,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             {
               animation-delay: 4.5s;
               animation-direction: normal;
-              animation-duration: 1.5s;
+              animation-duration: 2s;
               animation-iteration-count: infinite;
               animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
               animation-timing-function: ease-in-out;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -168,19 +168,9 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -201,6 +191,32 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <div
         className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
+        className=
             ms-ShimmerElementsGroup-root
             {
               -moz-osx-font-smoothing: grayscale;
@@ -211,6 +227,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
+              position: relative;
             }
         style={
           Object {
@@ -504,19 +521,9 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       className=
           ms-Shimmer-shimmerWrapper
           {
-            animation-direction: normal;
-            animation-duration: 2s;
-            animation-iteration-count: infinite;
-            animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-            animation-timing-function: ease-in-out;
-            background: #f3f2f1
-                              linear-gradient(
-                                to right,
-                                #f3f2f1 0%,
-                                #edebe9 50%,
-                                #f3f2f1 100%)
-                              0 0 / 90% 100%
-                              no-repeat;
+            background-color: #f3f2f1;
+            overflow: hidden;
+            position: relative;
             transition: opacity 200ms;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -536,6 +543,32 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
       }
     >
       <div
+        className=
+            ms-Shimmer-shimmerGradient
+            {
+              animation-delay: 4.5s;
+              animation-direction: normal;
+              animation-duration: 1.5s;
+              animation-iteration-count: infinite;
+              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-timing-function: ease-in-out;
+              background: #f3f2f1
+                                  linear-gradient(
+                                    to right,
+                                    #f3f2f1 0%,
+                                    #edebe9 50%,
+                                    #f3f2f1 100%)
+                                  0 0 / 90% 100%
+                                  no-repeat;
+              height: 100%;
+              left: 0px;
+              position: absolute;
+              top: 0px;
+              transform: translate3d(-100%, 0, 0);
+              width: 100%;
+            }
+      />
+      <div
         style={
           Object {
             "display": "flex",
@@ -554,6 +587,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -645,6 +679,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -171,7 +171,11 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -193,11 +197,10 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -211,7 +214,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />
@@ -524,7 +527,11 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
             background-color: #f3f2f1;
             overflow: hidden;
             position: relative;
+            transform: translateZ(0);
             transition: opacity 200ms;
+          }
+          & > * {
+            transform: translateZ(0);
           }
           @media screen and (-ms-high-contrast: active){& {
             background: WindowText
@@ -546,11 +553,10 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         className=
             ms-Shimmer-shimmerGradient
             {
-              animation-delay: 4.5s;
               animation-direction: normal;
               animation-duration: 2s;
               animation-iteration-count: infinite;
-              animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+              animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
               animation-timing-function: ease-in-out;
               background: #f3f2f1
                                   linear-gradient(
@@ -564,7 +570,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               left: 0px;
               position: absolute;
               top: 0px;
-              transform: translate3d(-100%, 0, 0);
+              transform: translateX(-100%);
               width: 100%;
             }
       />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -79,7 +79,11 @@ Array [
               background-color: #71afe5;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -101,11 +105,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background: #71afe5
                                     linear-gradient(
@@ -119,7 +122,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -744,7 +747,11 @@ Array [
               background-color: #71afe5;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -766,11 +773,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background: #71afe5
                                     linear-gradient(
@@ -784,7 +790,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -1182,7 +1188,11 @@ Array [
               background-color: #7AAFE7;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -1204,11 +1214,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background: #7AAFE7
                                     linear-gradient(
@@ -1222,7 +1231,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -1612,7 +1621,11 @@ Array [
               background-color: #deecf9;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -1634,11 +1647,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background-color: #deecf9;
                 background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
@@ -1654,7 +1666,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -1797,7 +1809,11 @@ Array [
               background-color: #deecf9;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -1819,11 +1835,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background-color: #deecf9;
                 background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
@@ -1839,7 +1854,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -1982,7 +1997,11 @@ Array [
               background-color: #deecf9;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -2004,11 +2023,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background-color: #deecf9;
                 background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
@@ -2024,7 +2042,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -2167,7 +2185,11 @@ Array [
               background-color: #deecf9;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -2189,11 +2211,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background-color: #deecf9;
                 background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
@@ -2209,7 +2230,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />
@@ -2352,7 +2373,11 @@ Array [
               background-color: #deecf9;
               overflow: hidden;
               position: relative;
+              transform: translateZ(0);
               transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
             }
             @media screen and (-ms-high-contrast: active){& {
               background: WindowText
@@ -2374,11 +2399,10 @@ Array [
           className=
               ms-Shimmer-shimmerGradient
               {
-                animation-delay: 4.5s;
                 animation-direction: normal;
                 animation-duration: 2s;
                 animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
                 animation-timing-function: ease-in-out;
                 background-color: #deecf9;
                 background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
@@ -2394,7 +2418,7 @@ Array [
                 left: 0px;
                 position: absolute;
                 top: 0px;
-                transform: translate3d(-100%, 0, 0);
+                transform: translateX(-100%);
                 width: 100%;
               }
         />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -76,19 +76,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
-              background: #71afe5
-                                linear-gradient(
-                                  to right,
-                                  #71afe5 0%,
-                                  #2b88d8 50%,
-                                  #71afe5 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              background-color: #71afe5;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -109,6 +99,32 @@ Array [
       >
         <div
           className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background: #71afe5
+                                    linear-gradient(
+                                      to right,
+                                      #71afe5 0%,
+                                      #2b88d8 50%,
+                                      #71afe5 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
+          className=
               ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
@@ -119,6 +135,7 @@ Array [
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -724,19 +741,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
-              background: #71afe5
-                                linear-gradient(
-                                  to right,
-                                  #71afe5 0%,
-                                  #2b88d8 50%,
-                                  #71afe5 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              background-color: #71afe5;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -756,6 +763,32 @@ Array [
         }
       >
         <div
+          className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background: #71afe5
+                                    linear-gradient(
+                                      to right,
+                                      #71afe5 0%,
+                                      #2b88d8 50%,
+                                      #71afe5 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
           style={
             Object {
               "display": "flex",
@@ -774,6 +807,7 @@ Array [
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {
@@ -865,6 +899,7 @@ Array [
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {
@@ -1144,19 +1179,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
-              background: #7AAFE7
-                                linear-gradient(
-                                  to right,
-                                  #7AAFE7 0%,
-                                  #bdd4ed 50%,
-                                  #7AAFE7 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              background-color: #7AAFE7;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -1176,6 +1201,32 @@ Array [
         }
       >
         <div
+          className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background: #7AAFE7
+                                    linear-gradient(
+                                      to right,
+                                      #7AAFE7 0%,
+                                      #bdd4ed 50%,
+                                      #7AAFE7 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
           style={
             Object {
               "display": "flex",
@@ -1194,6 +1245,7 @@ Array [
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {
@@ -1285,6 +1337,7 @@ Array [
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
                   font-weight: 400;
+                  position: relative;
                 }
             style={
               Object {
@@ -1556,21 +1609,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
               background-color: #deecf9;
-              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-              background: #f3f2f1
-                                linear-gradient(
-                                  to right,
-                                  #f3f2f1 0%,
-                                  #edebe9 50%,
-                                  #f3f2f1 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -1591,6 +1632,34 @@ Array [
       >
         <div
           className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
+          className=
               ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
@@ -1601,6 +1670,7 @@ Array [
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -1724,21 +1794,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
               background-color: #deecf9;
-              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-              background: #f3f2f1
-                                linear-gradient(
-                                  to right,
-                                  #f3f2f1 0%,
-                                  #edebe9 50%,
-                                  #f3f2f1 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -1759,6 +1817,34 @@ Array [
       >
         <div
           className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
+          className=
               ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
@@ -1769,6 +1855,7 @@ Array [
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -1892,21 +1979,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
               background-color: #deecf9;
-              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-              background: #f3f2f1
-                                linear-gradient(
-                                  to right,
-                                  #f3f2f1 0%,
-                                  #edebe9 50%,
-                                  #f3f2f1 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -1927,6 +2002,34 @@ Array [
       >
         <div
           className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
+          className=
               ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
@@ -1937,6 +2040,7 @@ Array [
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -2060,21 +2164,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
               background-color: #deecf9;
-              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-              background: #f3f2f1
-                                linear-gradient(
-                                  to right,
-                                  #f3f2f1 0%,
-                                  #edebe9 50%,
-                                  #f3f2f1 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -2095,6 +2187,34 @@ Array [
       >
         <div
           className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
+          className=
               ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
@@ -2105,6 +2225,7 @@ Array [
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {
@@ -2228,21 +2349,9 @@ Array [
         className=
             ms-Shimmer-shimmerWrapper
             {
-              animation-direction: normal;
-              animation-duration: 2s;
-              animation-iteration-count: infinite;
-              animation-name: keyframes 0%{background-position:-1000%;}100%{background-position:1000%;};
-              animation-timing-function: ease-in-out;
               background-color: #deecf9;
-              background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-              background: #f3f2f1
-                                linear-gradient(
-                                  to right,
-                                  #f3f2f1 0%,
-                                  #edebe9 50%,
-                                  #f3f2f1 100%)
-                                0 0 / 90% 100%
-                                no-repeat;
+              overflow: hidden;
+              position: relative;
               transition: opacity 200ms;
             }
             @media screen and (-ms-high-contrast: active){& {
@@ -2263,6 +2372,34 @@ Array [
       >
         <div
           className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-delay: 4.5s;
+                animation-direction: normal;
+                animation-duration: 1.5s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translate3d(-100%, 0, 0);
+                width: 100%;
+              }
+        />
+        <div
+          className=
               ms-ShimmerElementsGroup-root
               {
                 -moz-osx-font-smoothing: grayscale;
@@ -2273,6 +2410,7 @@ Array [
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
+                position: relative;
               }
           style={
             Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -103,7 +103,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -768,7 +768,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -1206,7 +1206,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -1636,7 +1636,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -1821,7 +1821,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -2006,7 +2006,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -2191,7 +2191,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;
@@ -2376,7 +2376,7 @@ Array [
               {
                 animation-delay: 4.5s;
                 animation-direction: normal;
-                animation-duration: 1.5s;
+                animation-duration: 2s;
                 animation-iteration-count: infinite;
                 animation-name: keyframes 0%{transform:translate3d(-100%, 0, 0);}100%{transform:translate3d(100%, 0, 0);};
                 animation-timing-function: ease-in-out;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8295 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The change improves the performance of the shimmer component by moving the animation from background-position to a new element with transforms.

Because the change involves a new element to animate it is classified as a breaking change. It will only break if the user is using the style override option.

#### Focus areas to test

I tried keeping the animation as close as possible. The timing may have changed.

#### Performance measurements

It was not possible to measure the before version on IE11 because the profile would freeze.
After looks like this:
<img width="1430" alt="Screenshot 2019-03-20 at 17 00 28" src="https://user-images.githubusercontent.com/3796208/54700917-315be780-4b34-11e9-9697-62ea8a3163dd.png">

Edge gives the following results. Showing a decrease in CPU usage but keeping the same 60fps.
Before:
<img width="1146" alt="Screenshot 2019-03-20 at 17 04 37" src="https://user-images.githubusercontent.com/3796208/54700973-46d11180-4b34-11e9-9b2e-20275d342b62.png">

After:
<img width="1143" alt="Screenshot 2019-03-20 at 17 04 49" src="https://user-images.githubusercontent.com/3796208/54700993-4e90b600-4b34-11e9-9270-8209a30383e0.png">

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8378)