### PR TITLE
Breadcrumb: Add aria-hidden to true on custom divider example

### DIFF
--- a/common/changes/office-ui-fabric-react/edwl-2019-03-addAriaHiddenBreadCrumbExample_2019-03-19-18-09.json
+++ b/common/changes/office-ui-fabric-react/edwl-2019-03-addAriaHiddenBreadCrumbExample_2019-03-19-18-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Breadcrumb: Update custom divider example to have aria-hidden on divider",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -112,7 +112,9 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
     const tooltipText = dividerProps.item ? dividerProps.item.text : '';
     return (
       <TooltipHost content={`Show ${tooltipText} contents`} calloutProps={{ gapSpace: 0 }}>
-        <span style={{ cursor: 'pointer' }}>/</span>
+        <span aria-hidden="true" style={{ cursor: 'pointer' }}>
+          /
+        </span>
       </TooltipHost>
     );
   };

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -1287,6 +1287,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onMouseLeave={[Function]}
                 >
                   <span
+                    aria-hidden="true"
                     style={
                       Object {
                         "cursor": "pointer",
@@ -1443,6 +1444,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onMouseLeave={[Function]}
                 >
                   <span
+                    aria-hidden="true"
                     style={
                       Object {
                         "cursor": "pointer",
@@ -1599,6 +1601,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onMouseLeave={[Function]}
                 >
                   <span
+                    aria-hidden="true"
                     style={
                       Object {
                         "cursor": "pointer",
@@ -1755,6 +1758,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onMouseLeave={[Function]}
                 >
                   <span
+                    aria-hidden="true"
                     style={
                       Object {
                         "cursor": "pointer",
@@ -1911,6 +1915,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   onMouseLeave={[Function]}
                 >
                   <span
+                    aria-hidden="true"
                     style={
                       Object {
                         "cursor": "pointer",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8119
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes #8119 and is related to #8380 to be consistent with having aria-hidden=true if Icon is presentational

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8381)