### PR TITLE
GroupHeader & GroupFooter: Extend React.Component instead of BaseComponent

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-rm-group-basecomponent_2019-03-19-19-19.json
+++ b/common/changes/office-ui-fabric-react/keco-rm-group-basecomponent_2019-03-19-19-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupHeader & GroupFooter: Extend React.Component instead of BaseComponent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupFooter.base.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { classNamesFunction } from '../../Utilities';
 import { GroupSpacer } from './GroupSpacer';
 import { IGroupFooterStyleProps, IGroupFooterStyles, IGroupFooterProps } from './GroupFooter.types';
 const getClassNames = classNamesFunction<IGroupFooterStyleProps, IGroupFooterStyles>();
 
-export class GroupFooterBase extends BaseComponent<IGroupFooterProps, {}> {
+export class GroupFooterBase extends React.Component<IGroupFooterProps> {
   public render(): JSX.Element | null {
     const { group, groupLevel, footerText, indentWidth, styles, theme } = this.props;
     const classNames = getClassNames(styles, { theme: theme! });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, IClassNames, getRTL } from '../../Utilities';
+import { classNamesFunction, IClassNames, getRTL } from '../../Utilities';
 import { SelectionMode } from '../../utilities/selection/index';
 import { Check } from '../../Check';
 import { Icon } from '../../Icon';
@@ -15,7 +15,7 @@ export interface IGroupHeaderState {
   isLoadingVisible: boolean;
 }
 
-export class GroupHeaderBase extends BaseComponent<IGroupHeaderProps, IGroupHeaderState> {
+export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHeaderState> {
   public static defaultProps: IGroupHeaderProps = {
     expandButtonProps: { 'aria-label': 'expand collapse group' }
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`GroupedList` & `DetailsList` in grouped scenarios can benefit from its header and footer components not extending `BaseComponent` both in dependencies as well as runtime cost. Neither currently utilize anything within `BaseComponent` so it can be safely removed. I also verified ODSP usages.

#### Focus areas to test

- CI should pass.
- GroupedList and the like should render as expected.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8385)