### PR TITLE
Add contextual menu for documentation version switching

### DIFF
--- a/apps/fabric-website/src/pages/BlogPage/BlogPost.tsx
+++ b/apps/fabric-website/src/pages/BlogPage/BlogPost.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import './BlogPost.scss';
+import { getParameterByName } from '../../utilities/location';
 
 const blogData = require('../../data/blog-posts.json');
 
@@ -8,7 +9,7 @@ export class BlogPost extends React.Component<{}, {}> {
 
   constructor(props: {}) {
     super(props);
-    this._postId = this._getParameterByName('id');
+    this._postId = getParameterByName('id');
   }
 
   public render(): JSX.Element {
@@ -22,23 +23,5 @@ export class BlogPost extends React.Component<{}, {}> {
         <div className="BlogPost-content" dangerouslySetInnerHTML={{ __html: blogData[this._postId].content }} />
       </div>
     );
-  }
-
-  private _getParameterByName(name: string, url?: string): string {
-    if (!url) {
-      url = window.location.href;
-    }
-
-    name = name.replace(/[\[\]]/g, '\\$&');
-    let regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-      results = regex.exec(url);
-    if (!results) {
-      return null;
-    }
-
-    if (!results[2]) {
-      return '';
-    }
-    return decodeURIComponent(results[2].replace(/\+/g, ' '));
   }
 }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
@@ -79,10 +79,43 @@
 }
 
 .version {
+  margin-top: 16px;
+}
+
+.version,
+.versionLink,
+.versionText {
   color: $color-home-lighter;
   font-size: $ms-font-size-xs;
   font-weight: $ms-font-weight-regular;
-  margin-top: 16px;
+}
+
+.versionText {
+  text-decoration: underline;
+  color: inherit;
+}
+
+.versionLink {
+  border: 0;
+  padding: 0;
+  height: 15px;
+  text-decoration: none;
+
+  &:hover,
+  &:active,
+  &:active:hover {
+    color: $ms-color-white;
+  }
+
+  :global {
+    .ms-Button-flexContainer {
+      align-items: flex-start;
+    }
+
+    .ms-Button-menuIcon {
+      color: inherit;
+    }
+  }
 }
 
 @media screen and (min-width: $uhf-screen-min-mobile) {

--- a/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
@@ -56,6 +56,18 @@
   text-align: center;
 }
 
+.dropdownLabel {
+  font-size: $ms-font-size-m;
+  color: $ms-color-white;
+  margin-top: 22px;
+  margin-bottom: 4px;
+}
+
+.dropdown {
+  font-size: $ms-font-size-m;
+  width: 142px;
+}
+
 .primaryButton {
   @include ghostButton($ms-color-white, $color-home-darker);
   background-color: $ms-color-white;

--- a/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.module.scss
@@ -56,18 +56,6 @@
   text-align: center;
 }
 
-.dropdownLabel {
-  font-size: $ms-font-size-m;
-  color: $ms-color-white;
-  margin-top: 22px;
-  margin-bottom: 4px;
-}
-
-.dropdown {
-  font-size: $ms-font-size-m;
-  width: 142px;
-}
-
 .primaryButton {
   @include ghostButton($ms-color-white, $color-home-darker);
   background-color: $ms-color-white;

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -41,12 +41,6 @@ export class HomePage extends React.Component<any, IHomepageState> {
   }
 
   public render(): JSX.Element {
-    const selectedOption = fabricVersionOptions.filter(option => {
-      return option.data === this.state.fabricVer;
-    });
-
-    const selectedKey = selectedOption.length ? selectedOption[0].key : undefined;
-
     return (
       <div>
         <div className={styles.hero}>

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -61,7 +61,12 @@ export class HomePage extends React.Component<any, IHomepageState> {
                 shouldFocusOnMount: true,
                 items: fabricVersionOptions,
                 directionalHint: DirectionalHint.bottomAutoEdge,
-                onItemClick: this._onVersionMenuClick
+                onItemClick: this._onVersionMenuClick,
+                styles: {
+                  root: {
+                    minWidth: '100px'
+                  }
+                }
               }}
             >
               <span className={styles.versionText}>Fabric React {reactPackageData.version}</span>

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -22,8 +22,6 @@ export interface IHomepageState {
 }
 
 export class HomePage extends React.Component<any, IHomepageState> {
-  private _linkButton: HTMLElement;
-
   constructor(props: {}) {
     super(props);
     const version = getParameterByName('fabricVer', window.location.href);

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -1,26 +1,36 @@
 import * as React from 'react';
-import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { css, getId } from 'office-ui-fabric-react/lib/Utilities';
 import { Dropdown, IDropdownOption, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
 import * as stylesImport from './HomePage.module.scss';
 import { getParameterByName } from '../../utilities/location';
+import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 const styles: any = stylesImport;
 
 const corePackageData = require('office-ui-fabric-core/package.json');
 const reactPackageData = require('office-ui-fabric-react/package.json');
 
+const versionLinkId = getId('versionLink');
+
 // Update as new Fabric versions are released
-const fabricVersionOptions: IDropdownOption[] = [{ key: 'A', text: 'Fabric 6', data: '6' }, { key: 'B', text: 'Fabric 5', data: '5' }];
+const fabricVersionOptions: IContextualMenuItem[] = [{ key: 'A', text: 'Fabric 6', data: '6' }, { key: 'B', text: 'Fabric 5', data: '5' }];
 
 export interface IHomepageState {
   fabricVer: string;
+  isVersionMenuOpen: boolean;
 }
 
 export class HomePage extends React.Component<any, IHomepageState> {
+  private _linkButton: HTMLElement;
+
   constructor(props: {}) {
     super(props);
     const version = getParameterByName('fabricVer', window.location.href);
+
     this.state = {
-      fabricVer: !!version ? version : fabricVersionOptions[0].data
+      fabricVer: !!version ? version : fabricVersionOptions[0].data,
+      isVersionMenuOpen: false
     };
   }
 
@@ -48,16 +58,23 @@ export class HomePage extends React.Component<any, IHomepageState> {
             Get started
           </a>
           <span className={styles.version}>
-            Fabric Core {corePackageData.version} and Fabric React {reactPackageData.version}
+            Fabric Core {corePackageData.version} and&nbsp;
+            <ActionButton
+              className={styles.versionLink}
+              allowDisabledFocus={true}
+              menuProps={{
+                gapSpace: 3,
+                beakWidth: 8,
+                isBeakVisible: true,
+                shouldFocusOnMount: true,
+                items: fabricVersionOptions,
+                directionalHint: DirectionalHint.bottomAutoEdge,
+                onItemClick: this._onVersionMenuClick
+              }}
+            >
+              <span className={styles.versionText}>Fabric React {reactPackageData.version}</span>
+            </ActionButton>
           </span>
-          <div className={styles.dropdownLabel}>View Fabric version</div>
-          <Dropdown
-            className={styles.dropdown}
-            ariaLabel="Fabric version"
-            options={fabricVersionOptions}
-            selectedKey={selectedKey}
-            onChange={this._setFabricVersion}
-          />
         </div>
 
         <div className={styles.flavors}>
@@ -226,7 +243,7 @@ export class HomePage extends React.Component<any, IHomepageState> {
     return baseURL + '?' + newAdditionalURL + rowsText;
   }
 
-  private _setFabricVersion = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {
+  private _onVersionMenuClick = (event, item: IContextualMenuItem): void => {
     this.setState({ fabricVer: item.data });
   };
 }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -1,13 +1,42 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { Dropdown, IDropdownOption, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
 import * as stylesImport from './HomePage.module.scss';
+import { getParameterByName } from '../../utilities/location';
 const styles: any = stylesImport;
 
 const corePackageData = require('office-ui-fabric-core/package.json');
 const reactPackageData = require('office-ui-fabric-react/package.json');
 
-export class HomePage extends React.Component<any, any> {
+// Update as new Fabric versions are released
+const fabricVersionOptions: IDropdownOption[] = [{ key: 'A', text: 'Fabric 6', data: '6' }, { key: 'B', text: 'Fabric 5', data: '5' }];
+
+export interface IHomepageState {
+  fabricVer: string;
+}
+
+export class HomePage extends React.Component<any, IHomepageState> {
+  constructor(props: {}) {
+    super(props);
+    const version = getParameterByName('fabricVer', window.location.href);
+    this.state = {
+      fabricVer: !!version ? version : fabricVersionOptions[0].data
+    };
+  }
+
+  public componentDidUpdate(prevProps: any, prevState: IHomepageState): void {
+    if (prevState.fabricVer !== this.state.fabricVer) {
+      window.location.href = this._updateURLParameter(window.location.href, 'fabricVer', this.state.fabricVer);
+    }
+  }
+
   public render(): JSX.Element {
+    const selectedOption = fabricVersionOptions.filter(option => {
+      return option.data === this.state.fabricVer;
+    });
+
+    const selectedKey = selectedOption.length ? selectedOption[0].key : undefined;
+
     return (
       <div>
         <div className={styles.hero}>
@@ -21,6 +50,14 @@ export class HomePage extends React.Component<any, any> {
           <span className={styles.version}>
             Fabric Core {corePackageData.version} and Fabric React {reactPackageData.version}
           </span>
+          <div className={styles.dropdownLabel}>View Fabric version</div>
+          <Dropdown
+            className={styles.dropdown}
+            ariaLabel="Fabric version"
+            options={fabricVersionOptions}
+            selectedKey={selectedKey}
+            onChange={this._setFabricVersion}
+          />
         </div>
 
         <div className={styles.flavors}>
@@ -32,9 +69,7 @@ export class HomePage extends React.Component<any, any> {
               alt="React logo"
             />
             <span className={styles.flavorTitle}>Built with React</span>
-            <span className={styles.flavorDescription}>
-              Fabric&rsquo;s robust, up-to-date components are built with React
-            </span>
+            <span className={styles.flavorDescription}>Fabric&rsquo;s robust, up-to-date components are built with React</span>
             <a href="#/components" className={styles.button}>
               See components
             </a>
@@ -59,8 +94,7 @@ export class HomePage extends React.Component<any, any> {
           <div>
             <span className={styles.productTitle}>SharePoint</span>
             <span className={styles.productDescription}>
-              New SharePoint experiences are built with Fabric and the SharePoint Framework comes with it baked in to
-              make things simple.{' '}
+              New SharePoint experiences are built with Fabric and the SharePoint Framework comes with it baked in to make things simple.{' '}
               <a
                 className={styles.homePageLink}
                 href="https://dev.office.com/sharepoint/docs/spfx/web-parts/get-started/use-fabric-react-components"
@@ -82,8 +116,8 @@ export class HomePage extends React.Component<any, any> {
           <div>
             <span className={styles.productTitle}>Office Add-ins</span>
             <span className={styles.productDescription}>
-              Fabric is the official UX design framework for Office Add-ins. With Fabric, add-ins blend seamlessly with
-              Word, Excel, PowerPoint, and Outlook.{' '}
+              Fabric is the official UX design framework for Office Add-ins. With Fabric, add-ins blend seamlessly with Word, Excel,
+              PowerPoint, and Outlook.{' '}
               <a className={styles.homePageLink} href="http://dev.office.com/docs/add-ins/design/add-in-design">
                 Learn more
               </a>
@@ -101,19 +135,16 @@ export class HomePage extends React.Component<any, any> {
         <div className={styles.featured}>
           <span className={styles.featuredTitle}>Highlights</span>
           <span className={styles.featuredDescription}>
-            Fabric offers a variety of UI elements to help you create an experience that delights users and complements
-            Office 365.
+            Fabric offers a variety of UI elements to help you create an experience that delights users and complements Office 365.
           </span>
           <ul className={styles.featureList} aria-label="List of highlighted features">
             <li>
               <a href="#/styles/icons">
                 <img
-                  src={
-                    'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-icons.svg'
-                  }
+                  src={'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-icons.svg'}
                   width="240"
                   height="112"
-                  alt="Illustrations of <icons className=&quot;&quot;></icons>"
+                  alt='Illustrations of <icons className=""></icons>'
                 />
                 <span>Icons</span>
               </a>
@@ -121,9 +152,7 @@ export class HomePage extends React.Component<any, any> {
             <li>
               <a href="#/styles/typography">
                 <img
-                  src={
-                    'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-typography.svg'
-                  }
+                  src={'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-typography.svg'}
                   width="240"
                   height="112"
                   alt="Illustration of different font weights."
@@ -134,9 +163,7 @@ export class HomePage extends React.Component<any, any> {
             <li>
               <a href="#/styles/brand-icons">
                 <img
-                  src={
-                    'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-brand.svg'
-                  }
+                  src={'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-brand.svg'}
                   width="240"
                   height="112"
                   alt="Word, Excel, OneNote, PowerPoint icons."
@@ -147,9 +174,7 @@ export class HomePage extends React.Component<any, any> {
             <li>
               <a href="#/components/button">
                 <img
-                  src={
-                    'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-buttons.svg'
-                  }
+                  src={'https://static2.sharepointonline.com/files/fabric/fabric-website/images/home-highlights-buttons.svg'}
                   width="240"
                   height="112"
                   alt="Illustrated representation of buttons."
@@ -159,19 +184,19 @@ export class HomePage extends React.Component<any, any> {
             </li>
           </ul>
           <span className={styles.trademark}>
-            All trademarks are the property of their respective owners. Usage of Fabric assets, such as fonts and icons,
-            is subject to the{' '}
+            All trademarks are the property of their respective owners. Usage of Fabric assets, such as fonts and icons, is subject to the{' '}
             <a
               className={styles.homePageLink}
               href="https://static2.sharepointonline.com/files/fabric/assets/microsoft_fabric_assets_license_agreement_10262017.pdf"
             >
               assets license agreement
-            </a>.
+            </a>
+            .
           </span>
           <span className={styles.featuredTitle}>Design Toolkit</span>
           <span className={styles.featuredDescription} id={styles.toolkitDescription}>
-            The Fabric design toolkit is built with Adobe XD and provides controls and layout templates that enable you
-            to create seamless, beautiful Office experiences.{' '}
+            The Fabric design toolkit is built with Adobe XD and provides controls and layout templates that enable you to create seamless,
+            beautiful Office experiences.{' '}
             <a className={styles.homePageLink} href="#/resources">
               Learn more
             </a>
@@ -180,4 +205,28 @@ export class HomePage extends React.Component<any, any> {
       </div>
     );
   }
+
+  private _updateURLParameter(url: string, param: string, paramVal: string) {
+    let newAdditionalURL = '';
+    let tempArray = url.split('?');
+    const baseURL = tempArray[0];
+    const additionalURL = tempArray[1];
+    let temp = '';
+    if (additionalURL) {
+      tempArray = additionalURL.split('&');
+      for (let i = 0; i < tempArray.length; i++) {
+        if (tempArray[i].split('=')[0] !== param) {
+          newAdditionalURL += temp + tempArray[i];
+          temp = '&';
+        }
+      }
+    }
+
+    let rowsText = temp + '' + param + '=' + paramVal;
+    return baseURL + '?' + newAdditionalURL + rowsText;
+  }
+
+  private _setFabricVersion = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {
+    this.setState({ fabricVer: item.data });
+  };
 }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { css, getId } from 'office-ui-fabric-react/lib/Utilities';
 import { Dropdown, IDropdownOption, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
 import * as stylesImport from './HomePage.module.scss';
-import { getParameterByName } from '../../utilities/location';
+import { getParameterByName, updateUrlParameter } from '../../utilities/location';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
@@ -24,7 +24,7 @@ export interface IHomepageState {
 export class HomePage extends React.Component<any, IHomepageState> {
   constructor(props: {}) {
     super(props);
-    const version = getParameterByName('fabricVer', window.location.href);
+    const version = getParameterByName('fabricVer');
 
     this.state = {
       fabricVer: !!version ? version : fabricVersionOptions[0].data,
@@ -34,7 +34,7 @@ export class HomePage extends React.Component<any, IHomepageState> {
 
   public componentDidUpdate(prevProps: any, prevState: IHomepageState): void {
     if (prevState.fabricVer !== this.state.fabricVer) {
-      window.location.href = this._updateURLParameter(window.location.href, 'fabricVer', this.state.fabricVer);
+      window.location.href = updateUrlParameter('fabricVer', this.state.fabricVer);
     }
   }
 
@@ -218,26 +218,6 @@ export class HomePage extends React.Component<any, IHomepageState> {
         </div>
       </div>
     );
-  }
-
-  private _updateURLParameter(url: string, param: string, paramVal: string) {
-    let newAdditionalURL = '';
-    let tempArray = url.split('?');
-    const baseURL = tempArray[0];
-    const additionalURL = tempArray[1];
-    let temp = '';
-    if (additionalURL) {
-      tempArray = additionalURL.split('&');
-      for (let i = 0; i < tempArray.length; i++) {
-        if (tempArray[i].split('=')[0] !== param) {
-          newAdditionalURL += temp + tempArray[i];
-          temp = '&';
-        }
-      }
-    }
-
-    let rowsText = temp + '' + param + '=' + paramVal;
-    return baseURL + '?' + newAdditionalURL + rowsText;
   }
 
   private _onVersionMenuClick = (event, item: IContextualMenuItem): void => {

--- a/apps/fabric-website/src/utilities/location.ts
+++ b/apps/fabric-website/src/utilities/location.ts
@@ -9,3 +9,23 @@ export const hasUHF: boolean =
  * Determines if the site is running locally.
  */
 export const isLocal: boolean = window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
+
+// Todo: Move URL Utilities here (see BlogPost.tsx and index.html)
+
+export const getParameterByName = (name: string, url?: string): string => {
+  if (!url) {
+    url = window.location.href;
+  }
+
+  name = name.replace(/[\[\]]/g, '\\$&');
+  const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+    results = regex.exec(url);
+  if (!results) {
+    return null;
+  }
+
+  if (!results[2]) {
+    return '';
+  }
+  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+};

--- a/apps/fabric-website/src/utilities/location.ts
+++ b/apps/fabric-website/src/utilities/location.ts
@@ -10,8 +10,6 @@ export const hasUHF: boolean =
  */
 export const isLocal: boolean = window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
 
-// Todo: Move URL Utilities here (see BlogPost.tsx and index.html)
-
 /**
  * Get URL parameters by name
  * @param name - Name of the URL parameter to look for

--- a/apps/fabric-website/src/utilities/location.ts
+++ b/apps/fabric-website/src/utilities/location.ts
@@ -12,6 +12,11 @@ export const isLocal: boolean = window.location.hostname === 'localhost' || wind
 
 // Todo: Move URL Utilities here (see BlogPost.tsx and index.html)
 
+/**
+ * Get URL parameters by name
+ * @param name - Name of the URL parameter to look for
+ * @param url - Target URL. If URL is not defined, look for window.location.href
+ */
 export const getParameterByName = (name: string, url?: string): string => {
   if (!url) {
     url = window.location.href;
@@ -28,4 +33,34 @@ export const getParameterByName = (name: string, url?: string): string => {
     return '';
   }
   return decodeURIComponent(results[2].replace(/\+/g, ' '));
+};
+
+/**
+ * Update a URL GET variable with a new parameter
+ * @param param - Parameter name
+ * @param paramVal - Updated value
+ * @param url - Optional URL to update/check.  If undefined, then use window.location.href
+ */
+export const updateUrlParameter = (param: string, paramVal: string, url?: string): string => {
+  if (!url) {
+    url = window.location.href;
+  }
+
+  let newAdditionalURL = '';
+  let tempArray = url.split('?');
+  const baseURL = tempArray[0];
+  const additionalURL = tempArray[1];
+  let temp = '';
+  if (additionalURL) {
+    tempArray = additionalURL.split('&');
+    for (let i = 0; i < tempArray.length; i++) {
+      if (tempArray[i].split('=')[0] !== param) {
+        newAdditionalURL += temp + tempArray[i];
+        temp = '&';
+      }
+    }
+  }
+
+  const rowsText = temp + '' + param + '=' + paramVal;
+  return baseURL + '?' + newAdditionalURL + rowsText;
 };

--- a/common/changes/@uifabric/fabric-website/edwl-2019-03-fabricVersionSwitch_2019-03-19-23-24.json
+++ b/common/changes/@uifabric/fabric-website/edwl-2019-03-fabricVersionSwitch_2019-03-19-23-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "HomePage: Add ContextualMenu to enable switching documentation versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "edwl@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

- Move `getParameterByName` to location utility
- Add a `ContextualMenu` to `HomePage.tsx` to control version switching of documentation between Fabric 5 and 6.  This simply appends a URL param of `fabricVer=6` or `fabricVer=5`.  The logic for pulling the correct manifest file was created in PR #8343 

Screenshots:
**HomePage**
![image](https://user-images.githubusercontent.com/1291968/54648278-de662f80-4a62-11e9-9344-9e732b141208.png)

**Menu Open**
![image](https://user-images.githubusercontent.com/1291968/54648550-ed011680-4a63-11e9-963b-277fa47fe795.png)


#### Focus areas to test

(optional)
