### PR TITLE
ComboBox: don't nullref when options are null.

### DIFF
--- a/common/changes/office-ui-fabric-react/cb-fix_2019-03-20-01-23.json
+++ b/common/changes/office-ui-fabric-react/cb-fix_2019-03-20-01-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox: if `options` are null, make sure the code doesn't crash.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1411,7 +1411,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * @returns - an array of the indices of the selected options, empty array if nothing is selected
    */
   private _getSelectedIndices(options: IComboBoxOption[] | undefined, selectedKeys: (string | number | undefined)[]): number[] {
-    if (options === undefined || selectedKeys === undefined) {
+    if (!options || !selectedKeys) {
       return [];
     }
 


### PR DESCRIPTION
Recently a change went into ComboBox that handles `options` as `undefined` but not as `null`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8401)