### PR TITLE
FocusTrapZone: Fix focus and blur callbacks

### DIFF
--- a/common/changes/office-ui-fabric-react/jspurlin-FTZFocusBlurCallbackFix_2019-03-20-14-30.json
+++ b/common/changes/office-ui-fabric-react/jspurlin-FTZFocusBlurCallbackFix_2019-03-20-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusTrapZone: Make sure to call passed in focus and blur handlers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jspurlin@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -127,10 +127,18 @@ export class FocusTrapZone extends BaseComponent<IFocusTrapZoneProps, {}> implem
   }
 
   private _onRootFocus = (ev: React.FocusEvent<HTMLDivElement>) => {
+    if (this.props.onFocus) {
+      this.props.onFocus(ev);
+    }
+
     this._hasFocus = true;
   };
 
   private _onRootBlur = (ev: React.FocusEvent<HTMLDivElement>) => {
+    if (this.props.onBlur) {
+      this.props.onBlur(ev);
+    }
+
     let relatedTarget = ev.relatedTarget;
     if (ev.relatedTarget === null) {
       // In IE11, due to lack of support, event.relatedTarget is always


### PR DESCRIPTION
- [X] Include a change request file using `$ npm run change`

#### Description of changes
#8216 broke the focus and blur callbacks on FocusTrapZone.

This PR makes sure to call the callbacks, if present in onRootFocus and onRootBlur handlers

#### Focus areas to test
Verified that the callbacks are being called again


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8404)