### PR TITLE
Dialog: title can now receive JSX content.

### DIFF
--- a/common/changes/office-ui-fabric-react/dialog-title_2019-03-20-15-25.json
+++ b/common/changes/office-ui-fabric-react/dialog-title_2019-03-20-15-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dialog: changing type of `title` prop to allow JSX to be injected.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.ts
@@ -7237,7 +7237,7 @@ interface IDialogContentProps extends React.ClassAttributes<DialogContentBase> {
   subText?: string;
   subTextId?: string;
   theme?: ITheme;
-  title?: string;
+  title?: string | JSX.Element;
   titleId?: string;
   topButtonsProps?: IButtonProps[];
   type?: DialogType;
@@ -7338,7 +7338,7 @@ interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiv
   subText?: string;
   theme?: ITheme;
   // @deprecated
-  title?: string;
+  title?: string | JSX.Element;
   // @deprecated
   topButtonsProps?: IButtonProps[];
   // @deprecated

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 
 import { mount } from 'enzyme';
-
 import { DialogBase } from './Dialog.base';
 import { DialogContent } from './DialogContent';
 import { DialogType } from './DialogContent.types'; // for express fluent assertions
@@ -10,6 +9,22 @@ import { DialogType } from './DialogContent.types'; // for express fluent assert
 /* tslint:disable:no-unused-expression */ describe('Dialog', () => {
   it('renders Dialog correctly', () => {
     const component = renderer.create(<DialogContent />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders Dialog with a jsx title', () => {
+    const component = renderer.create(
+      <DialogContent
+        type={DialogType.normal}
+        title={
+          <div>
+            <span>I am span 1</span>
+            <span>I am span 2</span>
+          </div>
+        }
+      />
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -113,7 +113,7 @@ export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithRe
    * The title text to display at the top of the dialog.
    * @deprecated Pass through via `dialogContentProps` instead.
    */
-  title?: string;
+  title?: string | JSX.Element;
 
   /**
    * The subtext to display in the dialog.

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -67,7 +67,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   /**
    * The title text to display at the top of the dialog.
    */
-  title?: string;
+  title?: string | JSX.Element;
 
   /**
    * Responsive mode passed in from decorator.

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -87,3 +87,100 @@ exports[`Dialog renders Dialog correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`Dialog renders Dialog with a jsx title 1`] = `
+<div
+  className=
+
+      {
+        flex-grow: 1;
+        overflow-y: hidden;
+      }
+>
+  <div
+    className=
+        ms-Dialog-header
+        {
+          box-sizing: border-box;
+          position: relative;
+          width: 100%;
+        }
+  >
+    <p
+      aria-level={2}
+      className=
+          ms-Dialog-title
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #333333;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 21px;
+            font-weight: 100;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            padding-bottom: 20px;
+            padding-left: 28px;
+            padding-right: 36px;
+            padding-top: 20px;
+          }
+      role="heading"
+    >
+      <div>
+        <span>
+          I am span 1
+        </span>
+        <span>
+          I am span 2
+        </span>
+      </div>
+    </p>
+    <div
+      className=
+
+          {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 12px;
+            padding-top: 12px;
+            position: absolute;
+            right: 0;
+            top: 0;
+          }
+          & > * {
+            flex: 0 0 auto;
+          }
+    />
+  </div>
+  <div
+    className=
+        ms-Dialog-inner
+        {
+          padding-bottom: 20px;
+          padding-left: 28px;
+          padding-right: 28px;
+          padding-top: 0;
+        }
+  >
+    <div
+      className=
+          ms-Dialog-content
+          {
+            position: relative;
+            width: 100%;
+          }
+          & .ms-Button.ms-Button--compount {
+            margin-bottom: 20px;
+          }
+          &:last-child {
+            margin-bottom: 0;
+          }
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8238
- [X] Include a change request file using `$ npm run change`

#### Description of changes

You can now provide JSX as the title of a Dialog, which can enable scenarios like having glyphs/icons next to the content.

```tsx
        <Dialog
          dialogContentProps={{        
            title: <><Icon iconName="upload"/>Awesome</>
          }}
        >...
        </Dialog>
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8405)