### PR TITLE
Calendar: Fixing typo is scss.

### DIFF
--- a/common/changes/office-ui-fabric-react/calendarTypo_2019-03-20-21-39.json
+++ b/common/changes/office-ui-fabric-react/calendarTypo_2019-03-20-21-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Calendar: Fixing typo is scss.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -295,7 +295,7 @@ $Calendar-dayPicker-margin: 10px;
   .weekNumbers {
     border-right: 1px solid $ms-color-neutralLight;
     box-sizing: border-box;
-    width: 28x;
+    width: 28px;
     padding: 0;
     .dayWrapper {
       color: $ms-color-neutralSecondary;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8407
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR fixes a typo in `Calendar.scss` where `28x` was specified instead of `28px`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8412)