### PR TITLE
Toggle Experiment: Remove invalid 'this' references

### DIFF
--- a/common/changes/@uifabric/experiments/jg-fix--toggle_2019-03-21-01-36.json
+++ b/common/changes/@uifabric/experiments/jg-fix--toggle_2019-03-21-01-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Toggle: Fix invalid references to this object.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/experiments/src/components/Toggle/Toggle.view.tsx
+++ b/packages/experiments/src/components/Toggle/Toggle.view.tsx
@@ -8,7 +8,7 @@ import { IToggleComponent, IToggleProps, IToggleSlots } from './Toggle.types';
 
 export const ToggleView: IToggleComponent['view'] = props => {
   const { as: RootType = 'div', label, ariaLabel, checked, disabled, onChange, keytipProps, onClick, toggleButtonRef } = props;
-  const toggleNativeProps = getNativeProps(this.props, inputProperties, ['defaultChecked']);
+  const toggleNativeProps = getNativeProps(props, inputProperties, ['defaultChecked']);
 
   const Slots = getSlots<IToggleProps, IToggleSlots>(props, {
     root: RootType,
@@ -19,9 +19,13 @@ export const ToggleView: IToggleComponent['view'] = props => {
     text: Label
   });
 
+  // TODO: need to fix this._id usage. should _id come from state?
+  // const id = this._id;
+  const id = undefined;
+
   return (
     <Slots.root>
-      <Slots.label htmlFor={this._id}>{label}</Slots.label>
+      <Slots.label htmlFor={id}>{label}</Slots.label>
       <Slots.container>
         <KeytipData keytipProps={keytipProps} ariaDescribedBy={(toggleNativeProps as any)['aria-describedby']} disabled={disabled}>
           {(keytipAttributes: any): JSX.Element => (
@@ -29,7 +33,7 @@ export const ToggleView: IToggleComponent['view'] = props => {
               {...toggleNativeProps}
               {...keytipAttributes}
               disabled={disabled}
-              id={this._id}
+              id={id}
               type="button"
               role="switch" // ARIA 1.1 definition; "checkbox" in ARIA 1.0
               ref={toggleButtonRef}

--- a/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
+++ b/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`ToggleView renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
+      checked={false}
       className=
           ms-Toggle-background
           {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Found lingering references to `this` while doing perf analysis.

#### Focus areas to test

Snapshot updated.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8413)