### PR TITLE
Use lib: es5 to prevent IE 11 breaks

### DIFF
--- a/apps/fabric-website-resources/tsconfig.json
+++ b/apps/fabric-website-resources/tsconfig.json
@@ -15,16 +15,8 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
-    "types": [
-      "jest",
-      "webpack-env"
-    ]
+    "lib": ["es5", "dom"],
+    "types": ["jest", "webpack-env"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/apps/todo-app/tsconfig.json
+++ b/apps/todo-app/tsconfig.json
@@ -11,7 +11,8 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "strict": true,
-    "lib": ["es6", "dom"],
+    "skipLibCheck": true,
+    "lib": ["es5", "dom"],
     "types": ["webpack-env"]
   },
   "include": ["src"]

--- a/common/changes/@uifabric/azure-themes/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/azure-themes/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/azure-themes",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/azure-themes",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/charting/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/charting/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Remove IE 11-incompatible constructs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/dashboard/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/dashboard/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Remove IE 11-incompatible constructs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/date-time/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/date-time/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/date-time",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/example-app-base/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/example-app-base/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/example-app-base",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/experiments/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/fabric-website-resources/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website-resources",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/file-type-icons/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/file-type-icons/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/file-type-icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fluent-theme/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/fluent-theme/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fluent-theme",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/foundation/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/foundation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/icons/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/icons/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/icons",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/icons",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/jest-serializer-merge-styles/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/jest-serializer-merge-styles/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/jest-serializer-merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/merge-styles/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/merge-styles/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/merge-styles",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/migration/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/migration/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/migration",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/migration",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/react-cards/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/react-cards/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove IE 11-incompatible constructs",
+      "packageName": "@uifabric/react-cards",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/styling/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/styling",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/theme-samples/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/theme-samples/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/theme-samples",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/theme-samples",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/utilities/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/utilities",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/variants/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/variants/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/variants",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/variants",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/webpack-utils/lib_2019-03-21-17-58.json
+++ b/common/changes/@uifabric/webpack-utils/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/webpack-utils",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/webpack-utils",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/lib_2019-03-21-17-58.json
+++ b/common/changes/office-ui-fabric-react/lib_2019-03-21-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove IE 11-incompatible constructs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/azure-themes/tsconfig.json
+++ b/packages/azure-themes/tsconfig.json
@@ -15,20 +15,11 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es5", "dom"],
     "paths": {
-      "@uifabric/azure-themes/lib/*": [
-        "./src/*"
-      ],
-      "@uifabric/azure-themes": [
-        "./src"
-      ]
+      "@uifabric/azure-themes/lib/*": ["./src/*"],
+      "@uifabric/azure-themes": ["./src"]
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, find } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { IChartProps, IHorizontalBarChartProps, IHorizontalBarChartStyles, IChartDataPoint } from './index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
@@ -129,7 +129,7 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
   private _hoverOn(hoverValue: string | number | Date | null, lineColor: string, legend: string): void {
     if (!this.state.isCalloutVisible || this.state.legend !== legend) {
       const refArray = this.state.refArray;
-      const currentHoveredElement = refArray.find((currentElement: IRefArrayData) => currentElement.legendText === legend);
+      const currentHoveredElement = find(refArray, (currentElement: IRefArrayData) => currentElement.legendText === legend);
       this.setState({
         isCalloutVisible: true,
         hoverValue: hoverValue,

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { HoverCard, HoverCardType, IExpandingCardProps } from 'office-ui-fabric-react/lib/HoverCard';
-import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, find } from 'office-ui-fabric-react/lib/Utilities';
 import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
 import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { OverflowSet, IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
@@ -154,7 +154,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     // execute similar to "_onClick" and "_onLeave" logic at HoverCard onCardHide event
     const onHoverCardHideHandler = () => {
       if (this.state.selectedState) {
-        const selectedOverflowItem = legends.find((legend: ILegend) => legend.title === this.state.selectedLegend);
+        const selectedOverflowItem = find(legends, (legend: ILegend) => legend.title === this.state.selectedLegend);
         if (selectedOverflowItem) {
           this.setState({ selectedLegend: 'none', selectedState: false }, () => {
             if (selectedOverflowItem.action) {

--- a/packages/charting/tsconfig.json
+++ b/packages/charting/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "types": ["jest", "webpack-env"],
     "paths": {
       "@uifabric/charting/lib/*": ["./src/*"],

--- a/packages/dashboard/src/components/Card/Chart/Chart.tsx
+++ b/packages/dashboard/src/components/Card/Chart/Chart.tsx
@@ -187,28 +187,28 @@ export class Chart extends React.Component<IChartInternalProps, { _width: number
       // comparing prop with string union type 7Days | 30Days | 90Days | 180Days
       if (timeRange === '7Days') {
         for (let i = 0; i < 6; i++) {
-          const nextDate = new Date(sDate);
+          const nextDate = new Date(sDate.valueOf());
           nextDate.setDate(sDate.getDate() + 1);
           sDate = nextDate;
           tickValues.push(nextDate);
         }
       } else if (timeRange === '30Days') {
         for (let i = 0; i < 5; i++) {
-          const nextDate = new Date(sDate);
+          const nextDate = new Date(sDate.valueOf());
           nextDate.setDate(sDate.getDate() + 5);
           sDate = nextDate;
           tickValues.push(nextDate);
         }
       } else if (timeRange === '90Days') {
         for (let i = 0; i < 5; i++) {
-          const nextDate = new Date(sDate);
+          const nextDate = new Date(sDate.valueOf());
           nextDate.setDate(sDate.getDate() + 15);
           sDate = nextDate;
           tickValues.push(nextDate);
         }
       } else {
         for (let i = 0; i < 5; i++) {
-          const nextDate = new Date(sDate);
+          const nextDate = new Date(sDate.valueOf());
           nextDate.setMonth(sDate.getMonth() + 1);
           sDate = nextDate;
           tickValues.push(nextDate);

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutBase.tsx
@@ -102,7 +102,8 @@ function _createLayout(props: IDashboardGridLayoutBaseProps, layoutFromProps?: D
 
   const layouts: Layouts = {};
   if (layoutFromProps) {
-    for (const [key, value] of Object.entries(layoutFromProps)) {
+    for (const key of Object.keys(layoutFromProps)) {
+      const value = layoutFromProps[key as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutWithAddCardPanel/DashboardGridLayoutWithAddCardPanel.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridLayoutWithAddCardPanel/DashboardGridLayoutWithAddCardPanel.tsx
@@ -165,7 +165,7 @@ export class DashboardGridLayoutWithAddCardPanel extends BaseComponent<
     const lastCardIndex = currentLayout.length - 1;
     // checking if a dragging card action is performed.
     // If dragging is performed, dragging card is added to the layout whose id starts with 'n'
-    if (lastCardIndex > -1 && currentLayout[lastCardIndex].i!.startsWith('n')) {
+    if (lastCardIndex > -1 && currentLayout[lastCardIndex].i![0] === 'n') {
       const newlyAddedCardId = currentLayout[lastCardIndex].i!.substring(1);
       const newlyAddedCard = currentLayout[lastCardIndex];
       const addCardPanelCards = this.state.cardsForAddCardPanel;

--- a/packages/dashboard/src/components/DashboardGridLayout/DashboardGridSectionLayout.tsx
+++ b/packages/dashboard/src/components/DashboardGridLayout/DashboardGridSectionLayout.tsx
@@ -4,7 +4,8 @@ import {
   IDashboardGridLayoutStyles,
   IDashboardCardLayout,
   DashboardSectionMapping,
-  IDashboardGridLayoutProps
+  IDashboardGridLayoutProps,
+  DashboardGridBreakpointLayouts
 } from './DashboardGridLayout.types';
 import { DashboardGridLayoutBase } from './DashboardGridLayoutBase';
 import { ICard, CardSize } from '../Card/Card.types';
@@ -225,7 +226,8 @@ export class DashboardGridSectionLayout extends React.Component<IDashboardGridLa
   private _createLayout = (): Layouts => {
     const layouts: Layouts = {};
     if (this.props.layout) {
-      for (const [breakpoint, value] of Object.entries(this.props.layout)) {
+      for (const breakpoint of Object.keys(this.props.layout)) {
+        const value = this.props.layout[breakpoint as keyof DashboardGridBreakpointLayouts];
         if (value === undefined) {
           continue;
         }

--- a/packages/dashboard/src/components/DetailPanel/Body/Loading.tsx
+++ b/packages/dashboard/src/components/DetailPanel/Body/Loading.tsx
@@ -31,7 +31,7 @@ const loading: React.SFC<IDetailPanelLoadingProps> = (props: IDetailPanelLoading
         {/* group 1 */}
         {title && <Shimmer shimmerElements={[{ type: ElemType.line }]} width="100%" />}
         {/* group 2 */}
-        {Array.from({ length: count }).map((_: number, i: number) => {
+        {Array.apply(null, Array(count)).map((_: number, i: number) => {
           return (
             <div className={css.shimmerGroup} key={i}>
               <Shimmer shimmerElements={[{ type: ElemType.line }]} width="100%" />

--- a/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
+++ b/packages/dashboard/src/components/DetailPanel/DetailPanel.Base.tsx
@@ -147,7 +147,7 @@ class DetailPanelBase extends React.PureComponent<IDetailPanelBaseProps, IMainBo
           .catch((err: IDetailPanelErrorResult) => {
             // set message bar
             if (err && err.messageBannerSetting) {
-              const messageBannerSetting = Object.assign({}, err.messageBannerSetting);
+              const messageBannerSetting = { ...err.messageBannerSetting };
               if (messageBannerSetting.messageType === undefined) {
                 messageBannerSetting.messageType = MessageBarType.error;
               }

--- a/packages/dashboard/src/components/DetailPanel/Footer/ActionBar.tsx
+++ b/packages/dashboard/src/components/DetailPanel/Footer/ActionBar.tsx
@@ -54,7 +54,7 @@ const actionBar: React.SFC<DetailPanelActionBarProps> = (props: DetailPanelActio
       .catch((err: IDetailPanelErrorResult) => {
         if (err) {
           // set message banner
-          const messageBannerSetting = Object.assign({}, err.messageBannerSetting);
+          const messageBannerSetting = { ...err.messageBannerSetting };
           if (messageBannerSetting.messageType === undefined) {
             messageBannerSetting.messageType = MessageBarType.error;
           }

--- a/packages/dashboard/src/components/Section/examples/EditSections.Customization.Example.tsx
+++ b/packages/dashboard/src/components/Section/examples/EditSections.Customization.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Layout, Layouts } from 'react-grid-layout-fabric';
 import { EditSections } from '../EditSections';
 import { CardSize, DashboardGridBreakpointLayouts, ISection, IDashboardCardLayout, CardSizeToWidthHeight } from '@uifabric/dashboard';
+import { findIndex } from 'office-ui-fabric-react/lib/Utilities';
 
 export interface IEditSectionsExampleState {
   saveButtonDisabled: boolean;
@@ -149,7 +150,7 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
    * Example handler for onRenameSectionClick
    */
   private _onRenameSectionClick = (id: string): void => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = true;
 
@@ -163,7 +164,7 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
    * Example handler for onUpdateSectionTitle
    */
   private _onUpdateSectionTitle = (id: string, title: string) => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = false;
     newSections[index].title = title;
@@ -190,7 +191,8 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
   private _addLayoutForNewSection(id: string): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = JSON.parse(JSON.stringify(this.state.layout));
 
-    for (const [_, value] of Object.entries(newLayout)) {
+    for (const key of Object.keys(newLayout)) {
+      const value = newLayout[key as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }
@@ -234,7 +236,8 @@ export class EditSectionsCustomizationExample extends React.Component<{}, IEditS
 
   private _generateDashboardLayoutFromRGLLayout(allLayouts: Layouts): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = {};
-    for (const [breakPoint, value] of Object.entries(allLayouts)) {
+    for (const breakPoint of Object.keys(allLayouts)) {
+      const value = allLayouts[breakPoint as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }

--- a/packages/dashboard/src/components/Section/examples/EditSections.Example.tsx
+++ b/packages/dashboard/src/components/Section/examples/EditSections.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Layout, Layouts } from 'react-grid-layout-fabric';
 import { EditSections } from '../EditSections';
 import { CardSize, DashboardGridBreakpointLayouts, ISection, IDashboardCardLayout, CardSizeToWidthHeight } from '@uifabric/dashboard';
+import { findIndex } from 'office-ui-fabric-react/lib/Utilities';
 
 export interface IEditSectionsExampleState {
   saveButtonDisabled: boolean;
@@ -144,7 +145,7 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
    * Example handler for onRenameSectionClick
    */
   private _onRenameSectionClick = (id: string): void => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = true;
 
@@ -158,7 +159,7 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
    * Example handler for onUpdateSectionTitle
    */
   private _onUpdateSectionTitle = (id: string, title: string) => {
-    const index = this.state.sections.findIndex((section: ISection) => section.id === id);
+    const index = findIndex(this.state.sections, (section: ISection) => section.id === id);
     const newSections = JSON.parse(JSON.stringify(this.state.sections)); // deep clone
     newSections[index].isRenaming = false;
     newSections[index].title = title;
@@ -185,7 +186,8 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
   private _addLayoutForNewSection(id: string): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = JSON.parse(JSON.stringify(this.state.layout));
 
-    for (const [_, value] of Object.entries(newLayout)) {
+    for (const key of Object.keys(newLayout)) {
+      const value = newLayout[key as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }
@@ -229,7 +231,8 @@ export class EditSectionsExample extends React.Component<{}, IEditSectionsExampl
 
   private _generateDashboardLayoutFromRGLLayout(allLayouts: Layouts): DashboardGridBreakpointLayouts {
     const newLayout: DashboardGridBreakpointLayouts = {};
-    for (const [breakPoint, value] of Object.entries(allLayouts)) {
+    for (const breakPoint of Object.keys(allLayouts)) {
+      const value = allLayouts[breakPoint as keyof DashboardGridBreakpointLayouts];
       if (value === undefined) {
         continue;
       }

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -15,7 +15,8 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "skipLibCheck": true,
+    "lib": ["es5", "es2015.promise", "dom"],
     "types": ["jest", "webpack-env"],
     "paths": {
       "@uifabric/dashboard/lib/*": ["./src/*"],

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, classNamesFunction } from '@uifabric/utilities';
+import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, classNamesFunction, find } from '@uifabric/utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import {
@@ -509,7 +509,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
     if (!restrictedDates) {
       return false;
     }
-    const inRestrictedDates = !!restrictedDates.find((rd: Date) => {
+    const inRestrictedDates = !!find(restrictedDates, (rd: Date) => {
       return compareDates(rd, date);
     });
     return inRestrictedDates && !this._getIsBeforeMinDate(date) && !this._getIsAfterMaxDate(date);
@@ -643,7 +643,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
 
     // gets all the day refs for the given dates
     const dayInfosInRange = weeks!.reduce((accumulatedValue: IDayInfo[], currentWeek: IDayInfo[]) => {
-      return accumulatedValue.concat(currentWeek.filter((weekDay: IDayInfo) => dateRange.includes(weekDay.originalDate.getTime())));
+      return accumulatedValue.concat(currentWeek.filter((weekDay: IDayInfo) => dateRange.indexOf(weekDay.originalDate.getTime()) !== -1));
     }, []);
 
     let dayRefs: (HTMLElement | null)[] = [];

--- a/packages/date-time/src/utilities/dateMath/DateMath.ts
+++ b/packages/date-time/src/utilities/dateMath/DateMath.ts
@@ -189,7 +189,7 @@ export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firs
     if (dateRangeType !== DateRangeType.WorkWeek) {
       // push all days not in work week view
       datesArray.push(nextDate);
-    } else if (workWeekDays.includes(nextDate.getDay())) {
+    } else if (workWeekDays.indexOf(nextDate.getDay()) !== -1) {
       datesArray.push(nextDate);
     }
     nextDate = addDays(nextDate, 1);

--- a/packages/date-time/tsconfig.json
+++ b/packages/date-time/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "types": ["jest", "webpack-env"],
     "paths": {
       "@uifabric/date-time/lib/*": ["./src/*"],

--- a/packages/example-app-base/tsconfig.json
+++ b/packages/example-app-base/tsconfig.json
@@ -13,8 +13,8 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "outDir": "lib",
-    "lib": ["es2017", "dom"],
-    "types": ["webpack-env", "jest"]
+    "lib": ["es5", "dom"],
+    "types": ["webpack-env", "jest", "es6-promise"]
   },
   "include": ["src"]
 }

--- a/packages/experiments/tsconfig.json
+++ b/packages/experiments/tsconfig.json
@@ -15,8 +15,10 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
-    "types": ["jest", "webpack-env"],
+    "skipLibCheck": true,
+    "lib": ["es5", "dom"],
+    "typeRoots": ["node_modules/@types", "../../typings"],
+    "types": ["jest", "webpack-env", "custom-global"],
     "paths": {
       "@uifabric/experiments/lib/*": ["./src/*"],
       "@uifabric/experiments": ["./src"]

--- a/packages/file-type-icons/tsconfig.json
+++ b/packages/file-type-icons/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/fluent-theme/tsconfig.json
+++ b/packages/fluent-theme/tsconfig.json
@@ -15,20 +15,11 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es5", "dom"],
     "paths": {
-      "@uifabric/fluent-theme/lib/*": [
-        "./src/*"
-      ],
-      "@uifabric/fluent-theme": [
-        "./src"
-      ]
+      "@uifabric/fluent-theme/lib/*": ["./src/*"],
+      "@uifabric/fluent-theme": ["./src"]
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/foundation-scenarios/tsconfig.json
+++ b/packages/foundation-scenarios/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "types": ["jest", "webpack-env"],
     "paths": {
       "@uifabric/foundation-scenarios/lib/*": ["./src/*"],

--- a/packages/foundation/tsconfig.json
+++ b/packages/foundation/tsconfig.json
@@ -15,15 +15,8 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
-    "types": [
-      "jest"
-    ]
+    "lib": ["es5", "dom"],
+    "types": ["jest"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/jest-serializer-merge-styles/tsconfig.json
+++ b/packages/jest-serializer-merge-styles/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/merge-styles/tsconfig.json
+++ b/packages/merge-styles/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/migration/tsconfig.json
+++ b/packages/migration/tsconfig.json
@@ -17,7 +17,7 @@
     "preserveConstEnums": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017"],
     "types": ["jest", "node"],
     "paths": {
       "@uifabric/migration/lib/*": ["./src/*"],

--- a/packages/office-ui-fabric-react/src/common/shallowUntilTarget.ts
+++ b/packages/office-ui-fabric-react/src/common/shallowUntilTarget.ts
@@ -39,14 +39,9 @@ export function shallowUntilTarget<P, S>(
   const { maxTries, shallowOptions } = options;
 
   let root = shallow<P, S>(componentInstance, shallowOptions);
+  let rootType = root.type();
 
-  if (
-    typeof root.type() === 'string' ||
-    root
-      .type()
-      .toString()
-      .includes(TargetComponent)
-  ) {
+  if (typeof rootType === 'string' || rootType.toString().indexOf(TargetComponent) !== -1) {
     // Default shallow()
     // If type() is a string then it's a DOM Node.
     // If it were wrapped, it would be a React component.
@@ -56,17 +51,13 @@ export function shallowUntilTarget<P, S>(
   for (let tries = 1; tries <= maxTries; tries++) {
     // Check for target as a string to avoid conflicts
     // with decoratored components name
-    if (
-      root
-        .type()
-        .toString()
-        .includes(TargetComponent)
-    ) {
+    if (rootType.toString().indexOf(TargetComponent) !== -1) {
       // Now that we found the target component, render it.
       return root.first().shallow(shallowOptions);
     }
     // Unwrap the next component in the hierarchy.
     root = root.first().shallow(shallowOptions);
+    rootType = root.type();
   }
 
   throw new Error(

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, IRefObject, findIndex } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, IRefObject, findIndex, find } from '../../Utilities';
 import { ICalendarStrings, ICalendarIconStrings, ICalendarFormatDateCallbacks } from './Calendar.types';
 import { DayOfWeek, FirstWeekOfYear, DateRangeType } from '../../utilities/dateValues/DateValues';
 import { FocusZone } from '../../FocusZone';
@@ -815,7 +815,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     if (!restrictedDates) {
       return false;
     }
-    const restrictedDate = restrictedDates.find(rd => {
+    const restrictedDate = find(restrictedDates, rd => {
       return compareDates(rd, date);
     });
     return restrictedDate ? true : false;

--- a/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
@@ -4,7 +4,7 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as fs from 'fs';
 
-/**
+/*
  * These tests verify that Fabric components fulfill the following conditions:
  *
  *    1) The component accepts a className prop.
@@ -238,7 +238,8 @@ describe('Component File Conformance', () => {
 });
 
 describe('Top Level Component File Conformance', () => {
-  const privateComponents = new Set(['ContextualMenuItemWrapper']);
+  const privateComponents = new Set<string>();
+  privateComponents.add('ContextualMenuItemWrapper');
 
   const components: string[] = glob
     .sync(path.resolve(process.cwd(), 'src/components/**/index.ts*'))

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
@@ -65,10 +65,6 @@ export class ContextualMenuWithCustomMenuListExample extends React.Component<
   constructor(props: {}) {
     super(props);
 
-    this._renderMenuList = this._renderMenuList.bind(this);
-    this._onAbort = this._onAbort.bind(this);
-    this._onChange = this._onChange.bind(this);
-
     this.state = {
       items: ITEMS
     };
@@ -90,12 +86,12 @@ export class ContextualMenuWithCustomMenuListExample extends React.Component<
     );
   }
 
-  private _onAbort() {
+  private _onAbort = () => {
     this.setState({ items: ITEMS });
-  }
+  };
 
-  private _onChange(newValue: any) {
-    const filteredItems = ITEMS.filter(item => item.text && item.text.toLowerCase().includes(newValue.toLowerCase()));
+  private _onChange = (newValue: string) => {
+    const filteredItems = ITEMS.filter(item => item.text && item.text.toLowerCase().indexOf(newValue.toLowerCase()) !== -1);
 
     if (!filteredItems || !filteredItems.length) {
       filteredItems.push({
@@ -121,9 +117,9 @@ export class ContextualMenuWithCustomMenuListExample extends React.Component<
     this.setState((prevState, props) => ({
       items: filteredItems
     }));
-  }
+  };
 
-  private _renderMenuList(menuListProps: IContextualMenuListProps, defaultRender: IRenderFunction<IContextualMenuListProps>) {
+  private _renderMenuList = (menuListProps: IContextualMenuListProps, defaultRender: IRenderFunction<IContextualMenuListProps>) => {
     return (
       <div>
         <div style={{ borderBottom: '1px solid #ccc' }}>
@@ -140,5 +136,5 @@ export class ContextualMenuWithCustomMenuListExample extends React.Component<
         {defaultRender(menuListProps)}
       </div>
     );
-  }
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -97,11 +97,11 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     this._onRootRef = this._onRootRef.bind(this);
     this._isEventOnHeader = this._isEventOnHeader.bind(this);
     this._onDropIndexInfo = {
-      sourceIndex: Number.MIN_SAFE_INTEGER,
-      targetIndex: Number.MIN_SAFE_INTEGER
+      sourceIndex: -1,
+      targetIndex: -1
     };
     this._id = getId('header');
-    this._currentDropHintIndex = Number.MIN_SAFE_INTEGER;
+    this._currentDropHintIndex = -1;
   }
 
   public componentDidMount(): void {
@@ -136,8 +136,8 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
       const { columns = NO_COLUMNS } = this.props;
       if (previousColumns[this._onDropIndexInfo.sourceIndex].key === columns[this._onDropIndexInfo.targetIndex].key) {
         this._onDropIndexInfo = {
-          sourceIndex: Number.MIN_SAFE_INTEGER,
-          targetIndex: Number.MIN_SAFE_INTEGER
+          sourceIndex: -1,
+          targetIndex: -1
         };
       }
     }
@@ -347,7 +347,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
   }
 
   private _isValidCurrentDropHintIndex() {
-    return this._currentDropHintIndex! >= 0;
+    return this._currentDropHintIndex >= 0;
   }
 
   private _onDragOver(item: any, event: DragEvent): void {
@@ -363,15 +363,13 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
     // Target index will not get changed if draggeditem is after target item.
     if (this._draggedColumnIndex >= 0 && event) {
       const targetIndex =
-        this._draggedColumnIndex > this._currentDropHintIndex! ? this._currentDropHintIndex! : this._currentDropHintIndex! - 1;
-      let isValidDrop = false;
+        this._draggedColumnIndex > this._currentDropHintIndex ? this._currentDropHintIndex : this._currentDropHintIndex - 1;
+      const isValidDrop = this._isValidCurrentDropHintIndex();
       event.stopPropagation();
-      if (this._isValidCurrentDropHintIndex()) {
-        isValidDrop = true;
+      if (isValidDrop) {
         this._onDropIndexInfo.sourceIndex = this._draggedColumnIndex;
         this._onDropIndexInfo.targetIndex = targetIndex;
-      }
-      if (isValidDrop) {
+
         if (columnReorderProps && columnReorderProps.onColumnDrop) {
           const dragDropDetails: IColumnDragDropDetails = {
             draggedIndex: this._draggedColumnIndex,
@@ -422,7 +420,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
   private _resetDropHints(): void {
     if (this._currentDropHintIndex >= 0) {
       this._updateDropHintElement(this._dropHintDetails[this._currentDropHintIndex].dropHintElementRef, 'none');
-      this._currentDropHintIndex = Number.MIN_SAFE_INTEGER;
+      this._currentDropHintIndex = -1;
     }
   }
 
@@ -494,7 +492,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
       const clientRect = this._rootElement.getBoundingClientRect();
       const headerOriginX = clientRect.left;
       const eventXRelativePosition = clientX - headerOriginX;
-      const currentDropHintIndex = this._currentDropHintIndex!;
+      const currentDropHintIndex = this._currentDropHintIndex;
       if (this._isValidCurrentDropHintIndex()) {
         if (
           this._liesBetween(

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -529,11 +529,11 @@ describe('DetailsHeader', () => {
     // dragover b/w b&c and c&d -> dead zone b/w 370 and 810
     _RaiseEvent(detailsColSourceC, _DRAGOVER, 400);
     expect(header._draggedColumnIndex).toBe(2);
-    expect(header._currentDropHintIndex).toBe(Number.MIN_SAFE_INTEGER);
+    expect(header._currentDropHintIndex).toBe(-1);
 
     _RaiseEvent(detailsColTargetD, _DRAGOVER, 710);
     expect(header._draggedColumnIndex).toBe(2);
-    expect(header._currentDropHintIndex).toBe(Number.MIN_SAFE_INTEGER);
+    expect(header._currentDropHintIndex).toBe(-1);
 
     // dead zone : idx 2 and 3 -> no hint shown
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
@@ -694,7 +694,7 @@ describe('DetailsHeader', () => {
 
     // drop on source column itself -> drophintindex should not be set and hence target index not updated
     _RaiseEvent(detailsColTarget, _DROP, 500);
-    expect(header._currentDropHintIndex).toBe(Number.MIN_SAFE_INTEGER);
+    expect(header._currentDropHintIndex).toBe(-1);
     expect(_sourceIndex).toBe(2);
   });
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] = `
+<div
+  className=
+      ms-Fabric
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        color: #333333;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+      & button {
+        font-family: inherit;
+      }
+      & input {
+        font-family: inherit;
+      }
+      & textarea {
+        font-family: inherit;
+      }
+      button {
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        overflow: visible;
+      }
+>
+  <div
+    className=
+
+        {
+          display: block;
+          margin-bottom: 10px;
+        }
+  >
+    No items selected
+  </div>
+  <div
+    className=
+        ms-TextField
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 10px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          max-width: 300px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+        }
+  >
+    <div
+      className=
+          ms-TextField-wrapper
+
+    >
+      <label
+        className=
+            ms-Label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        htmlFor="TextField0"
+      >
+        Filter by name:
+      </label>
+      <div
+        className=
+            ms-TextField-fieldGroup
+            {
+              align-items: stretch;
+              background: #ffffff;
+              border: 1px solid #a6a6a6;
+              box-shadow: none;
+              box-sizing: border-box;
+              cursor: text;
+              display: flex;
+              flex-direction: row;
+              height: 32px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+            }
+            &:hover {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
+      >
+        <input
+          aria-invalid={false}
+          className=
+              ms-TextField-field
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                background: none;
+                border-radius: 0px;
+                border: none;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                min-width: 0px;
+                outline: 0px;
+                padding-bottom: 0;
+                padding-left: 12px;
+                padding-right: 12px;
+                padding-top: 0;
+                text-overflow: ellipsis;
+                width: 100%;
+              }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
+          id="TextField0"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+
+        {
+          cursor: default;
+          position: relative;
+        }
+  >
+    <div
+      className="ms-Viewport"
+      style={
+        Object {
+          "minHeight": 1,
+          "minWidth": 1,
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/examples/PeoplePicker.Types.Example.tsx
@@ -347,7 +347,7 @@ export class PeoplePickerTypesExample extends BaseComponent<any, IPeoplePickerEx
   };
 
   private _onItemSelected = (item: IPersonaProps): Promise<IPersonaProps> => {
-    const processedItem = Object.assign({}, item);
+    const processedItem = { ...item };
     processedItem.text = `${item.text} (selected)`;
     return new Promise<IPersonaProps>((resolve, reject) => setTimeout(() => resolve(processedItem), 250));
   };

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -189,7 +189,7 @@ export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firs
     if (dateRangeType !== DateRangeType.WorkWeek) {
       // push all days not in work week view
       datesArray.push(nextDate);
-    } else if (workWeekDays.includes(nextDate.getDay())) {
+    } else if (workWeekDays.indexOf(nextDate.getDay()) !== -1) {
       datesArray.push(nextDate);
     }
     nextDate = addDays(nextDate, 1);

--- a/packages/office-ui-fabric-react/tsconfig.json
+++ b/packages/office-ui-fabric-react/tsconfig.json
@@ -15,8 +15,10 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
-    "types": ["jest", "webpack-env"],
+    "lib": ["es5", "dom", "es2015.promise"],
+    "skipLibCheck": true,
+    "typeRoots": ["node_modules/@types", "../../typings"],
+    "types": ["jest", "webpack-env", "custom-global"],
     "paths": {
       "office-ui-fabric-react/lib/*": ["./src/*"]
     }

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.test.tsx
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.test.tsx
@@ -9,7 +9,7 @@ import { CardItemStyles } from './CardItem.styles';
 import { ICardItemProps, ICardItemTokens, ICardItemStyles } from './CardItem.types';
 
 import { IStylesFunction } from '@uifabric/foundation';
-import { createTheme } from 'office-ui-fabric-react';
+import { createTheme, find } from 'office-ui-fabric-react';
 
 const testTheme = createTheme({});
 
@@ -67,9 +67,9 @@ describe('Card Item', () => {
     expect(cardStyles).toBeInstanceOf(Array);
     expect(cardItemStylesArray).toBeInstanceOf(Array);
 
-    const cardPadding = (cardStyles as Array<any>).find(style => style.padding).padding;
+    const cardPadding = find(cardStyles as Array<any>, style => style.padding).padding;
 
-    const cardItemStyles = (cardItemStylesArray as Array<any>).find(style => style.marginLeft || style.marginRight);
+    const cardItemStyles = find(cardItemStylesArray as Array<any>, style => style.marginLeft || style.marginRight);
     const cardItemMarginLeft = cardItemStyles.marginLeft;
     const cardItemMarginRight = cardItemStyles.marginRight;
 

--- a/packages/react-cards/tsconfig.json
+++ b/packages/react-cards/tsconfig.json
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "types": ["jest", "webpack-env"],
     "paths": {
       "@uifabric/react-cards/lib/*": ["./src/*"],

--- a/packages/set-version/tsconfig.json
+++ b/packages/set-version/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "declaration": true,
     "sourceMap": true,
     "importHelpers": true,

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -14,7 +14,7 @@
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "types": ["jest", "webpack-env", "react"],
     "paths": {
       "@uifabric/styling": ["./src"]

--- a/packages/theme-samples/tsconfig.json
+++ b/packages/theme-samples/tsconfig.json
@@ -15,20 +15,11 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es5", "dom"],
     "paths": {
-      "@uifabric/theme-samples/lib/*": [
-        "./src/*"
-      ],
-      "@uifabric/theme-samples": [
-        "./src"
-      ]
+      "@uifabric/theme-samples/lib/*": ["./src/*"],
+      "@uifabric/theme-samples": ["./src"]
     }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -53,7 +53,10 @@ export function styled<
   const { scope, fields = DefaultFields } = customizable;
 
   class Wrapped extends React.Component<TComponentProps, {}> {
-    public static displayName = `Styled${Component.displayName || Component.name}`;
+    // Function.prototype.name is an ES6 feature, so the cast to any is required until we're
+    // able to drop IE 11 support and compile with ES6 libs
+    // tslint:disable-next-line:no-any
+    public static displayName = `Styled${Component.displayName || (Component as any).name}`;
 
     private _inCustomizerContext = false;
 

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "es2015.promise", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
@@ -14,7 +14,9 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "types": ["jest"]
+    "skipLibCheck": true,
+    "typeRoots": ["node_modules/@types", "../../typings"],
+    "types": ["jest", "custom-global"]
   },
   "include": ["src"]
 }

--- a/packages/variants/tsconfig.json
+++ b/packages/variants/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/packages/webpack-utils/tsconfig.json
+++ b/packages/webpack-utils/tsconfig.json
@@ -3,10 +3,7 @@
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
@@ -16,9 +13,7 @@
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
-    "preserveConstEnums": true,
+    "preserveConstEnums": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/scripts/lint-staged/tslint.js
+++ b/scripts/lint-staged/tslint.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const execSync = require('../exec-sync');
 const path = require('path');
 const fs = require('fs');
@@ -16,7 +18,7 @@ runTsLintOnFilesGroupedPerPackage(groupFilesByPackage(files));
  * in that package as the value.
  *
  * @param {string[]} files
- * @returns {[packageName: string]: string[]}
+ * @returns {{[packageName: string]: string[]}}
  */
 function groupFilesByPackage(files) {
   const rootDirectory = path.join(path.resolve(__dirname, '..', '..'), path.sep);
@@ -28,12 +30,15 @@ function groupFilesByPackage(files) {
 
       return [packageRoot, fileName];
     })
-    .reduce((acc, [package, file]) => {
-      if (!acc[package]) {
-        acc[package] = [];
+    .reduce((filesByPackage, [package, file]) => {
+      if (path.dirname(package) === 'typings') {
+        return filesByPackage; // ignore custom typings package
       }
-      acc[package].push(file);
-      return acc;
+      if (!filesByPackage[package]) {
+        filesByPackage[package] = [];
+      }
+      filesByPackage[package].push(file);
+      return filesByPackage;
     }, {});
 }
 
@@ -41,22 +46,20 @@ function groupFilesByPackage(files) {
  * Runs tslint for the staged files in the packages that require it.
  * Excludes all API extractor files.
  *
- * @param {[packageName: string]: string[]} filesGroupedByPackage
+ * @param {{[packageName: string]: string[]}} filesGroupedByPackage
  */
 function runTsLintOnFilesGroupedPerPackage(filesGroupedByPackage) {
   // Log an empty line on error to make the tslint output look better
   console.log('');
 
-  const fileEntries = Object.keys(filesGroupedByPackage).reduce((entries, package) => {
-    entries.push([package, filesGroupedByPackage[package]]);
-    return entries;
-  }, []);
+  /** @type {[string, string[]][]} */
+  // prettier-ignore
+  const fileEntries = (/** @type {any} */ Object.keys(filesGroupedByPackage)
+    .map(package => [package, filesGroupedByPackage[package]]));
 
   for (let [package, files] of fileEntries) {
     const tslintConfig = path.join(path.resolve(__dirname, '..', '..'), package, 'tslint.json');
-    let filteredFiles = files.filter(f => {
-      return !f.endsWith('.api.ts');
-    });
+    const filteredFiles = files.filter(f => !f.endsWith('.api.ts'));
 
     if (filteredFiles.length === 0) {
       continue;

--- a/scripts/templates/create-package/EmptyTsConfig.mustache
+++ b/scripts/templates/create-package/EmptyTsConfig.mustache
@@ -15,7 +15,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es5", "dom"],
     "types": ["jest", "webpack-env"],
     "paths": {
       "{{{packageNpmName}}}/lib/*": ["./src/*"],

--- a/typings/custom-global/index.d.ts
+++ b/typings/custom-global/index.d.ts
@@ -1,0 +1,54 @@
+// These declarations are meant to represent the parts of Map/WeakMap/Set that exist in IE 11.
+// Therefore, some functionality (such as constructor parameters) is intentionally missing.
+
+/** Partial Map interface representing what's available in IE 11 */
+declare interface Map<K, V> {
+  readonly size: number;
+  clear(): void;
+  delete(key: K): boolean;
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  /** WARNING: In IE 11, this method returns undefined rather than `this` */
+  set(key: K, value: V): this;
+}
+declare interface MapConstructor {
+  /** Map constructor. Does not accept parameters in IE 11. */
+  new <K = any, V = any>(): Map<K, V>;
+}
+/** Partial Map constructor representing what's available in IE 11 */
+declare var Map: MapConstructor;
+
+/** Partial WeakMap interface representing what's available in IE 11 */
+declare interface WeakMap<K extends object, V> {
+  delete(key: K): boolean;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  /** WARNING: In IE 11, this method returns undefined rather than `this` */
+  set(key: K, value: V): this;
+}
+
+declare interface WeakMapConstructor {
+  /** WeakMap constructor. Does not accept parameters in IE 11. */
+  new <K extends object = object, V = any>(): WeakMap<K, V>;
+}
+/** Partial WeakMap constructor representing what's available in IE 11 */
+declare var WeakMap: WeakMapConstructor;
+
+/** Partial Set interface representing what's available in IE 11 */
+declare interface Set<T> {
+  readonly size: number;
+  /** WARNING: In IE 11, this method returns undefined rather than `this` */
+  add(value: T): this;
+  clear(): void;
+  delete(value: T): boolean;
+  forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
+  has(value: T): boolean;
+}
+
+declare interface SetConstructor {
+  /** Set constructor. Does not accept parameters in IE 11. */
+  new <T = any>(): Set<T>;
+}
+/** Partial Set constructor representing what's available in IE 11 */
+declare var Set: SetConstructor;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Currently we rely on code reviews to prevent ES6 methods and objects, which aren't supported in IE 11, from slipping into our code. Switching all projects which run in the browser to use `"lib": ["es5"]` (and possibly other relevant libs) in tsconfig.json will prevent these issues.

Related changes:
* Replace instances of ES6 things with ES5-compatible things
* Add `"skipLibCheck": true` to tsconfig.json for projects which have dependencies whose typings use ES6 types
* In a couple instances where the usage is safe, add file-level declarations for Set/Map/WeakMap--either for tests (which run in Node not the browser) or one place where it checks for the class's existence before using it


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8414)