### PR TITLE
Unignore bin directory when npm publishing migration tool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@ packages/styling/src/styles/ @phkuo
 # packages/utilities/
 packages/utilities/positioning/ @joschect
 packages/date-time @OfficeDev/uifabric-calendar @jh2he @evlevy
+packages/migration/ @ecraig12345 @kenotron
 
 ### Fabric
 # common/

--- a/common/changes/@uifabric/migration/unignore_2019-03-21-15-57.json
+++ b/common/changes/@uifabric/migration/unignore_2019-03-21-15-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/migration",
+      "comment": "migration: the bin directory was being ignored, this change makes sure the npm publish step will include the bin scripts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/migration",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/migration/.npmignore
+++ b/packages/migration/.npmignore
@@ -1,3 +1,4 @@
+!bin
 *.config.js
 *.nuspec
 *.yml


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

migration: the bin directory was being ignored, this change makes sure the npm publish step will include the bin scripts

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8417)