### PR TITLE
FocusZone: reduce global event listeners

### DIFF
--- a/common/changes/office-ui-fabric-react/focuszone-perf-tweak_2019-03-21-18-15.json
+++ b/common/changes/office-ui-fabric-react/focuszone-perf-tweak_2019-03-21-18-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: minor performance tweak to have a single capture keydown handler, rather than one per outer zone instance.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -52,8 +52,6 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
     direction: FocusZoneDirection.bidirectional
   };
 
-  private static _allFocusZones = [];
-
   private _disposables: Function[] = [];
   private _root = React.createRef<HTMLElement>();
   private _id: string;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -113,7 +113,7 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
     }
 
     if (root) {
-      const windowElement = root.ownerDocument!.defaultView!;
+      const windowElement = root.ownerDocument!.defaultView;
 
       let parentElement = getParent(root, ALLOW_VIRTUAL_ELEMENTS);
 
@@ -126,8 +126,9 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
       }
 
       if (windowElement && _outerZones.size === 1) {
-        this._disposables.push(on(windowElement, 'keydown', this._onKeyDownCapture, true), on(root, 'blur', this._onBlur, true));
+        this._disposables.push(on(windowElement, 'keydown', this._onKeyDownCapture, true));
       }
+      this._disposables.push(on(root, 'blur', this._onBlur, true));
 
       // Assign initial tab indexes so that we can set initial focus as appropriate.
       this._updateTabIndexes();


### PR DESCRIPTION
When a `FocusZone` is hosted, each outer zone creates a captured event listener for keydown presses, to adjust tab indexes when tab is pressed.

This change reduces the listeners down to a single listener, therefore reducing the work being done when typing characters.

There should be no changes in behavior here; just less work being done when keydowns occur.

This was requested as a performance optimization from Outlook. Happy to help.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8421)