### PR TITLE
Fixing componentURL to point to correct url

### DIFF
--- a/common/changes/office-ui-fabric-react/peoplePickerURL_2019-03-21-20-48.json
+++ b/common/changes/office-ui-fabric-react/peoplePickerURL_2019-03-21-20-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixing componentURL to point to correct url.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker/ExtendedPeoplePicker.doc.tsx
@@ -8,7 +8,7 @@ export const ExtendedPeoplePickerPageProps: IDocPageProps = {
   title: 'ExtendedPeoplePicker',
   componentName: 'ExtendedPeoplePicker',
   componentUrl:
-    'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/ExtendedPeoplePicker',
+    'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/ExtendedPicker/PeoplePicker',
   examples: [
     {
       title: 'Extended People Picker',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The `componentURL` attribute was pointing to an unexisting URL that return error 404. This PR fixes this to point to a correct URL.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8425)