### PR TITLE
ColorPicker: Showing picked color in high contrast mode

### DIFF
--- a/common/changes/office-ui-fabric-react/colorPickerHighContrast_2019-03-21-23-03.json
+++ b/common/changes/office-ui-fabric-react/colorPickerHighContrast_2019-03-21-23-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ColorPicker: Showing picked color in high contrast mode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ColorPicker, Toggle, getColorFromString, IColor } from 'office-ui-fabric-react/lib/index';
-import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { mergeStyleSets, HighContrastSelector } from 'office-ui-fabric-react/lib/Styling';
 import { updateA } from 'office-ui-fabric-react/lib/utilities/color/index';
 
 const classNames = mergeStyleSets({
@@ -14,7 +14,12 @@ const classNames = mergeStyleSets({
     width: 100,
     height: 100,
     margin: '16px 0',
-    border: '1px solid #c8c6c4'
+    border: '1px solid #c8c6c4',
+    selectors: {
+      [HighContrastSelector]: {
+        MsHighContrastAdjust: 'none'
+      }
+    }
   }
 });
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1005,6 +1005,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             margin-top: 16px;
             width: 100px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+          }
       style={
         Object {
           "backgroundColor": "#ffffff",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8393 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The picked color in the `ColorPicker` example is shown in a rectangle to the right of the picker. However, this color was not being shown when using High Contrast Mode. This PR fixes that and updates snapshots.

__Before__:
![image](https://user-images.githubusercontent.com/7798177/54646006-fd60c380-4a5a-11e9-96b0-60865208d534.png)

__After__:
![image](https://user-images.githubusercontent.com/7798177/54790762-80695180-4bf4-11e9-908c-03a869a6336b.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8429)