### PR TITLE
revert fix to find active element within iframe

### DIFF
--- a/common/changes/office-ui-fabric-react/revert-active-element-in-iframe-fix_2019-03-22-01-08.json
+++ b/common/changes/office-ui-fabric-react/revert-active-element-in-iframe-fix_2019-03-22-01-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Popup: Revert change to find active element within iframe",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -25,28 +25,7 @@ export class Popup extends BaseComponent<IPopupProps, IPopupState> {
   }
 
   public componentWillMount(): void {
-    let tempActive: Element | null = null;
-    let tempActiveLastSeen: Element | null = null;
-    const doc: Document | undefined = getDocument();
-
-    if (doc) {
-      tempActive = doc.activeElement;
-    }
-
-    // Seek inner-most frame's activeElement to set focus on dismissal
-    while (tempActive !== null && tempActive instanceof HTMLIFrameElement) {
-      if (tempActive.contentDocument !== null && tempActive.contentDocument.activeElement !== null) {
-        tempActiveLastSeen = tempActive;
-        tempActive = tempActive.contentDocument.activeElement;
-        if (tempActive === tempActiveLastSeen) {
-          break;
-        }
-      }
-    }
-
-    if (tempActive !== null) {
-      this._originalFocusedElement = tempActive as HTMLElement;
-    }
+    this._originalFocusedElement = getDocument()!.activeElement as HTMLElement;
   }
 
   public componentDidMount(): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8431
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Revert changes caused by PR https://github.com/OfficeDev/office-ui-fabric-react/pull/8290 causing infinite loop upon showing a popup when an iframe is focused

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8432)