### PR TITLE
FocusZone: reset alignment when receiving focus for first time

### DIFF
--- a/common/changes/office-ui-fabric-react/focuszone-align_2019-03-22-17-55.json
+++ b/common/changes/office-ui-fabric-react/focuszone-align_2019-03-22-17-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: focus alignment is now reset when first receiving focus (programatically or via `defaultActiveElement`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -704,6 +704,75 @@ describe('FocusZone', () => {
     setRTL(false);
   });
 
+  it('can focus correctly when receiving initial focus, bidirectionally', () => {
+    const component = ReactTestUtils.renderIntoDocument(
+      <div {...{ onFocusCapture: _onFocus }}>
+        <FocusZone>
+          <button className="a">a</button>
+          <button className="b">b</button>
+          <button className="c">c</button>
+          <button className="d">d</button>
+        </FocusZone>
+      </div>
+    );
+
+    const focusZone = ReactDOM.findDOMNode(component as React.ReactInstance)!.firstChild as Element;
+    const buttonA = focusZone.querySelector('.a') as HTMLElement;
+    const buttonB = focusZone.querySelector('.b') as HTMLElement;
+    const buttonC = focusZone.querySelector('.c') as HTMLElement;
+    const buttonD = focusZone.querySelector('.d') as HTMLElement;
+
+    // Set up a grid like so:
+    // A B
+    // C D
+    //
+    // We will focus B, and then down arrow, expecting D to be focused.
+
+    setupElement(buttonA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 30
+      }
+    });
+
+    setupElement(buttonB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
+
+    setupElement(buttonC, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 0,
+        right: 20
+      }
+    });
+
+    setupElement(buttonD, {
+      clientRect: {
+        top: 20,
+        bottom: 40,
+        left: 20,
+        right: 40
+      }
+    });
+
+    // Focus the first button.
+    ReactTestUtils.Simulate.focus(buttonB);
+    expect(lastFocusedElement).toBe(buttonB);
+
+    // Pressing down should go to d.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.down });
+    expect(lastFocusedElement).toBe(buttonD);
+  });
+
   it('can use arrows bidirectionally with data-no-vertical-wrap', () => {
     const component = ReactTestUtils.renderIntoDocument(
       <div {...{ onFocusCapture: _onFocus }}>

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -766,6 +766,8 @@ describe('FocusZone', () => {
 
     // Focus the first button.
     ReactTestUtils.Simulate.focus(buttonB);
+    expect(buttonA.getAttribute('tabindex')).toBe('-1');
+    expect(buttonB.getAttribute('tabindex')).toBe('0');
     expect(lastFocusedElement).toBe(buttonB);
 
     // Pressing down should go to d.

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -309,11 +309,11 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
     }
 
     if (newActiveElement && newActiveElement !== this._activeElement) {
-      this._activeElement = newActiveElement;
-
-      if (isImmediateDescendant) {
-        this._setFocusAlignment(this._activeElement);
+      if (isImmediateDescendant || !this._activeElement) {
+        this._setFocusAlignment(newActiveElement, true, true);
       }
+
+      this._activeElement = newActiveElement;
     }
 
     if (onActiveElementChanged) {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -308,12 +308,20 @@ export class FocusZone extends React.Component<IFocusZoneProps, {}> implements I
       }
     }
 
+    const initialElementFocused = !this._activeElement;
+
+    // If the new active element is a child of this zone and received focus,
+    // update alignment an immediate descendant
     if (newActiveElement && newActiveElement !== this._activeElement) {
-      if (isImmediateDescendant || !this._activeElement) {
-        this._setFocusAlignment(newActiveElement, true, true);
+      if (isImmediateDescendant || initialElementFocused) {
+        this._setFocusAlignment(newActiveElement, initialElementFocused);
       }
 
       this._activeElement = newActiveElement;
+
+      if (initialElementFocused) {
+        this._updateTabIndexes();
+      }
     }
 
     if (onActiveElementChanged) {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Photos.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Photos.Example.tsx
@@ -11,7 +11,6 @@ export interface IPhoto {
   url: string;
   width: number;
   height: number;
-  onClick: (ev: React.MouseEvent<HTMLElement>) => void;
 }
 
 export class FocusZonePhotosExample extends React.Component<{}, { items: IPhoto[] }> {
@@ -27,7 +26,6 @@ export class FocusZonePhotosExample extends React.Component<{}, { items: IPhoto[
 
     return (
       <FocusZone as="ul" className="ms-FocusZoneExamples-photoList">
-        <p>Note: clicking on the items below will remove them, illustrating how FocusZone will retain focus even when items are removed.</p>
         {items.map((item: IPhoto, index) => (
           <li
             key={item.id}
@@ -36,7 +34,6 @@ export class FocusZonePhotosExample extends React.Component<{}, { items: IPhoto[
             aria-setsize={items.length}
             aria-label="Photo"
             data-is-focusable={true}
-            onClick={item.onClick}
           >
             <Image src={item.url} width={item.width} height={item.height} />
           </li>
@@ -63,20 +60,7 @@ export class FocusZonePhotosExample extends React.Component<{}, { items: IPhoto[
       id,
       url: `http://placehold.it/${randomWidth}x100`,
       width: randomWidth,
-      height: 100,
-      onClick: (ev: React.MouseEvent<HTMLElement>) => {
-        const items: IPhoto[] = this.state.items.filter((item: IPhoto) => item.id !== id);
-
-        this.setState({ items });
-
-        // If we have run out of items, repopulate in a couple seconds.
-        if (items.length === 0) {
-          setTimeout(() => this.setState({ items: this._getInitialItems() }), 2000);
-        }
-
-        ev.preventDefault();
-        ev.stopPropagation();
-      }
+      height: 100
     };
   }
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Photos.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Photos.Example.tsx.shot
@@ -9,16 +9,12 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
   onMouseDownCapture={[Function]}
   role="presentation"
 >
-  <p>
-    Note: clicking on the items below will remove them, illustrating how FocusZone will retain focus even when items are removed.
-  </p>
   <li
     aria-label="Photo"
     aria-posinset={1}
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -62,7 +58,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -106,7 +101,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -150,7 +144,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -194,7 +187,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -238,7 +230,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -282,7 +273,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -326,7 +316,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -370,7 +359,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -414,7 +402,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -458,7 +445,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -502,7 +488,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -546,7 +531,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -590,7 +574,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -634,7 +617,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -678,7 +660,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -722,7 +703,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -766,7 +746,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -810,7 +789,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=
@@ -854,7 +832,6 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
     aria-setsize={20}
     className="ms-FocusZoneExamples-photoCell"
     data-is-focusable={true}
-    onClick={[Function]}
   >
     <div
       className=


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8437 #3250 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Now DatePicker and other scenarios using bidirectional FocusZones will reset focus alignment when receiving focus for the first time.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8439)