### PR TITLE
Calendar: Making calendar days aria-readonly: true so that Narrator doesn't read them as editable.

### DIFF
--- a/common/changes/office-ui-fabric-react/calendarEditable_2019-03-22-23-52.json
+++ b/common/changes/office-ui-fabric-react/calendarEditable_2019-03-22-23-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Calendar: Making calendar days aria-readonly: true so that Narrator doesn't read them as editable.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -322,6 +322,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                           onKeyDown={this._onDayKeyDown(day.originalDate, weekIndex, dayIndex)}
                           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
                           id={isNavigatedDate ? activeDescendantId : undefined}
+                          aria-readonly={true}
                           aria-selected={day.isInBounds ? day.isSelected : undefined}
                           data-is-focusable={allFocusable || (day.isInBounds ? true : undefined)}
                           ref={element => this._setDayRef(element, day, isNavigatedDate)}

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -195,6 +195,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="January 30, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -219,6 +220,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="January 31, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -243,6 +245,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 1, 2000"
+                        aria-readonly={true}
                         aria-selected={true}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -268,6 +271,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 2, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -292,6 +296,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 3, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -316,6 +321,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 4, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -340,6 +346,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 5, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -366,6 +373,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 6, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -390,6 +398,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 7, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -414,6 +423,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 8, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -438,6 +448,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 9, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -462,6 +473,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 10, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -486,6 +498,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 11, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -510,6 +523,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 12, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -536,6 +550,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 13, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -560,6 +575,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 14, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -584,6 +600,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 15, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -608,6 +625,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 16, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -632,6 +650,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 17, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -656,6 +675,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 18, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -680,6 +700,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 19, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -706,6 +727,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 20, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -730,6 +752,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 21, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -754,6 +777,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 22, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -778,6 +802,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 23, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -802,6 +827,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 24, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -826,6 +852,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 25, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -850,6 +877,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 26, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -876,6 +904,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 27, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -900,6 +929,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 28, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -924,6 +954,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="February 29, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -948,6 +979,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="March 1, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -972,6 +1004,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="March 2, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -996,6 +1029,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="March 3, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}
@@ -1020,6 +1054,7 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                       <button
                         aria-disabled={false}
                         aria-label="March 4, 2000"
+                        aria-readonly={true}
                         aria-selected={false}
                         className="ms-DatePicker-day-button"
                         data-is-focusable={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8415 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Days in the `Calendar` component were being announced as `editable`. This PR fixes them by adding `aria-readonly={true}` to the `Calendar` days and updating snapshots.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8447)