### PR TITLE
Change width to min-width for BaseFloatingPicker

### DIFF
--- a/common/changes/office-ui-fabric-react/constant-floating-picker-suggestions-width_2019-03-23-01-05.json
+++ b/common/changes/office-ui-fabric-react/constant-floating-picker-suggestions-width_2019-03-23-01-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FloatingPicker: Change width to min-width for Suggestions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.scss
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.scss
@@ -5,6 +5,6 @@
   }
 
   :global(.ms-Suggestions) {
-    width: 300px;
-    }
+    min-width: 300px;
+  }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8231 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
The floating picker suggestion list width was set to 300px. So having a callout of a larger width results in the callout having an empty space after the picker

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8448)