### PR TITLE
DocumentCard: Removing blank 1px line below preview images in compact layout

### DIFF
--- a/apps/vr-tests/src/stories/DocumentCard.stories.tsx
+++ b/apps/vr-tests/src/stories/DocumentCard.stories.tsx
@@ -142,12 +142,26 @@ storiesOf('DocumentCard', module)
       {story()}
     </Screener>
   )
-  .addStory('Compact', () => (
+  .addStory('Compact with preview list', () => (
     <Fabric>
       <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
         <DocumentCardPreview {...previewPropsCompact} />
         <DocumentCardDetails>
           <DocumentCardTitle title="4 files were uploaded" shouldTruncate={true} />
+          {docActivity}
+        </DocumentCardDetails>
+      </DocumentCard>
+    </Fabric>
+  ))
+  .addStory('Compact with preview image', () => (
+    <Fabric>
+      <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCardPreview previewImages={[previewProps.previewImages[0]]} />
+        <DocumentCardDetails>
+          <DocumentCardTitle
+            title="Revenue stream proposal fiscal year 2016 version02.pptx"
+            shouldTruncate={true}
+          />
           {docActivity}
         </DocumentCardDetails>
       </DocumentCard>

--- a/common/changes/office-ui-fabric-react/documentCardImage_2019-03-25-18-55.json
+++ b/common/changes/office-ui-fabric-react/documentCardImage_2019-03-25-18-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DocumentCard: Removing blank 1px line below preview images in compact layout.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -61,7 +61,7 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
         {
           display: 'flex',
           maxWidth: '480px',
-          height: '109px',
+          height: '108px',
           selectors: {
             [`.${previewClassNames.root}`]: {
               borderRight: `1px solid ${palette.neutralLight}`,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -13,7 +13,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           border: 1px solid #eaeaea;
           box-sizing: border-box;
           display: flex;
-          height: 109px;
+          height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
@@ -572,7 +572,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           border: 1px solid #eaeaea;
           box-sizing: border-box;
           display: flex;
-          height: 109px;
+          height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
@@ -925,7 +925,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           border: 1px solid #eaeaea;
           box-sizing: border-box;
           display: flex;
-          height: 109px;
+          height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
@@ -1236,7 +1236,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           border: 1px solid #eaeaea;
           box-sizing: border-box;
           display: flex;
-          height: 109px;
+          height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8353
- [x] Include a change request file using `$ npm run change`

#### Description of changes

A blank 1px line was showing below the preview images in `DocumentCards` in compact layout mode. This PR includes an update to styling so that this line doesn't appear anymore, updates snapshots and adds a vr test.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8461)