### PR TITLE
Add session storage to index of fabric website for version check

### DIFF
--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -45,7 +45,6 @@
     var productionParam = getParameterByName('isProduction');
     var noCompress = isLocal || getParameterByName('noCompress');
     var devhost = getParameterByName('devhost');
-    var fabricVersion = getParameterByName('fabricVer');
 
     var entryPointFilename = 'fabric-sitev5';
     var appPath = '';
@@ -64,7 +63,7 @@
       var fabricVersions = [5, 6];
 
       // Get fabricVer from URL param, session value, or latest version in array
-      fabricVersion = Number(
+      var fabricVersion = Number(
         getParameterByName('fabricVer') ||
         window.sessionStorage.getItem('fabricVer') ||
         fabricVersions[fabricVersions.length - 1]

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -63,21 +63,17 @@
       // Update as new fabric versions and its documentation are supported
       var fabricVersions = [5, 6];
 
-      // Check if query is set, or if query and session storage are null
-      if ((fabricVersion !== null) || (fabricVersion === null && window.sessionStorage.getItem('fabricVer') === null)) {
-        // If url param is null, set as latest version
-        if (fabricVersion === null) {
-          fabricVersion = fabricVersions[fabricVersions.length - 1];
-        }
+      // Get fabricVer from URL param, session value, or latest version in array
+      fabricVersion = Number(
+        getParameterByName('fabricVer') ||
+        window.sessionStorage.getItem('fabricVer') ||
+        fabricVersions[fabricVersions.length - 1]
+      );
 
-        // Set session value if it's in array
-        if (fabricVersions.indexOf(Number(fabricVersion)) > -1) {
-          window.sessionStorage.setItem('fabricVer', fabricVersion);
-        }
+      // Set session value if it's in array
+      if (fabricVersions.indexOf(fabricVersion) > -1) {
+        window.sessionStorage.setItem('fabricVer', fabricVersion);
       }
-
-      // Get value from session storage
-      fabricVersion = Number(window.sessionStorage.getItem('fabricVer'));
 
       var prefixVer = fabricVersions.indexOf(fabricVersion) > -1 && fabricVersion !== fabricVersions.slice(-1)[0] ?
         'v' + fabricVersion + '-' :

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -62,7 +62,22 @@
     if (!isLocal) {
       // Update as new fabric versions and its documentation are supported
       var fabricVersions = [5, 6];
-      fabricVersion = Number(fabricVersion);
+
+      // Check if query is set, or if query and session storage are null
+      if ((fabricVersion !== null) || (fabricVersion === null && window.sessionStorage.getItem('fabricVer') === null)) {
+        // If url param is null, set as latest version
+        if (fabricVersion === null) {
+          fabricVersion = fabricVersions[fabricVersions.length - 1];
+        }
+
+        // Set session value if it's in array
+        if (fabricVersions.indexOf(Number(fabricVersion)) > -1) {
+          window.sessionStorage.setItem('fabricVer', fabricVersion);
+        }
+      }
+
+      // Get value from session storage
+      fabricVersion = Number(window.sessionStorage.getItem('fabricVer'));
 
       var prefixVer = fabricVersions.indexOf(fabricVersion) > -1 && fabricVersion !== fabricVersions.slice(-1)[0] ?
         'v' + fabricVersion + '-' :

--- a/common/changes/@uifabric/fabric-website/edwl-2019-03-addSessionStorageFabricWebsite_2019-03-26-23-36.json
+++ b/common/changes/@uifabric/fabric-website/edwl-2019-03-addSessionStorageFabricWebsite_2019-03-26-23-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Add session storage to index to preserve fabricVer between page navigation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "edwl@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add session storage to index of fabric website to preserve `fabricVer` when navigation between pages and query doesn't persist.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8483)