### PR TITLE
Dropdown: example updates, add correctly cased onRenderPlaceholder prop

### DIFF
--- a/apps/vr-tests/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests/src/stories/Dropdown.stories.tsx
@@ -108,7 +108,7 @@ storiesOf('Dropdown', module)
         label="Custom example:"
         id="Customdrop1"
         ariaLabel="Custom dropdown example"
-        onRenderPlaceHolder={(props: IDropdownProps): JSX.Element => {
+        onRenderPlaceholder={(props: IDropdownProps): JSX.Element => {
           return (
             <div className="dropdownExample-placeholder">
               <Icon style={{ marginRight: '8px' }} iconName={'MessageFill'} aria-hidden="true" />
@@ -120,7 +120,7 @@ storiesOf('Dropdown', module)
           const option = options[0];
 
           return (
-            <div className="dropdownExample-option">
+            <div>
               {option.data && option.data.icon && (
                 <Icon
                   style={{ marginRight: '8px' }}
@@ -135,7 +135,7 @@ storiesOf('Dropdown', module)
         }}
         onRenderOption={(option: IDropdownOption): JSX.Element => {
           return (
-            <div className="dropdownExample-option">
+            <div>
               {option.data && option.data.icon && (
                 <Icon
                   style={{ marginRight: '8px' }}

--- a/common/changes/office-ui-fabric-react/dropdown-examples_2019-03-27-23-34.json
+++ b/common/changes/office-ui-fabric-react/dropdown-examples_2019-03-27-23-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: add correctly cased onRenderPlaceholder prop and deprecate onRenderPlaceHolder, plus example updates",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3974,7 +3974,9 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
     onChanged?: (option: IDropdownOption, index?: number) => void;
     onDismiss?: () => void;
     onRenderCaretDown?: IRenderFunction<IDropdownProps>;
+    // @deprecated
     onRenderPlaceHolder?: IRenderFunction<IDropdownProps>;
+    onRenderPlaceholder?: IRenderFunction<IDropdownProps>;
     onRenderTitle?: IRenderFunction<IDropdownOption[]>;
     options: IDropdownOption[];
     // @deprecated

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -72,7 +72,8 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
     this._warnDeprecations({
       isDisabled: 'disabled',
       onChanged: 'onChange',
-      placeHolder: 'placeholder'
+      placeHolder: 'placeholder',
+      onRenderPlaceHolder: 'onRenderPlaceholder'
     });
 
     this._warnMutuallyExclusive({
@@ -159,6 +160,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
   public render(): JSX.Element {
     const id = this._id;
 
+    const props = this.props;
     const {
       className,
       label,
@@ -174,13 +176,13 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
       calloutProps,
       onRenderTitle = this._onRenderTitle,
       onRenderContainer = this._onRenderContainer,
-      onRenderPlaceHolder = this._onRenderPlaceholder,
       onRenderCaretDown = this._onRenderCaretDown
-    } = this.props;
+    } = props;
     const { isOpen, selectedIndices, hasFocus, calloutRenderEdge } = this.state;
+    const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._onRenderPlaceholder;
 
     const selectedOptions = this._getAllSelectedOptions(options, selectedIndices);
-    const divProps = getNativeProps(this.props, divProperties);
+    const divProps = getNativeProps(props, divProperties);
 
     const disabled = this._isDisabled();
 
@@ -209,7 +211,7 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
     this._classNames = getClassNames(propStyles, {
       theme,
       className,
-      hasError: Boolean(errorMessage && errorMessage.length > 0),
+      hasError: !!(errorMessage && errorMessage.length > 0),
       isOpen,
       required,
       disabled,
@@ -269,13 +271,13 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
                 {// If option is selected render title, otherwise render the placeholder text
                 selectedOptions.length
                   ? onRenderTitle(selectedOptions, this._onRenderTitle)
-                  : onRenderPlaceHolder(this.props, this._onRenderPlaceholder)}
+                  : onRenderPlaceholder(props, this._onRenderPlaceholder)}
               </span>
-              <span className={this._classNames.caretDownWrapper}>{onRenderCaretDown(this.props, this._onRenderCaretDown)}</span>
+              <span className={this._classNames.caretDownWrapper}>{onRenderCaretDown(props, this._onRenderCaretDown)}</span>
             </div>
           )}
         </KeytipData>
-        {isOpen && onRenderContainer(this.props, this._onRenderContainer)}
+        {isOpen && onRenderContainer(props, this._onRenderContainer)}
         {errorMessage && errorMessage.length > 0 && <div className={this._classNames.errorMessage}>{errorMessage}</div>}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.doc.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
-
 import { IDocPageProps } from '../../common/DocPage.types';
+
+import { DropdownBasicExample } from './examples/Dropdown.Basic.Example';
+import { DropdownControlledExample } from './examples/Dropdown.Controlled.Example';
+import { DropdownControlledMultiExample } from './examples/Dropdown.ControlledMulti.Example';
 import { DropdownCustomExample } from './examples/Dropdown.Custom.Example';
 import { DropdownErrorExample } from './examples/Dropdown.Error.Example';
 import { DropdownRequiredExample } from './examples/Dropdown.Required.Example';
@@ -9,9 +11,16 @@ import { DropdownStatus } from './Dropdown.checklist';
 
 const DropdownBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx') as string;
 const DropdownBasicExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx') as string;
+const DropdownControlledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Controlled.Example.tsx') as string;
+const DropdownControlledExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Controlled.Example.tsx') as string;
+const DropdownControlledMultiExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.ControlledMulti.Example.tsx') as string;
+const DropdownControlledMultiExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.ControlledMulti.Example.tsx') as string;
 const DropdownCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx') as string;
+const DropdownCustomExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx') as string;
 const DropdownErrorExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx') as string;
+const DropdownErrorExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx') as string;
 const DropdownRequiredExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx') as string;
+const DropdownRequiredExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx') as string;
 
 export const DropdownPageProps: IDocPageProps = {
   title: 'Dropdown',
@@ -20,25 +29,45 @@ export const DropdownPageProps: IDocPageProps = {
   componentStatus: DropdownStatus,
   examples: [
     {
-      title: 'Dropdown',
+      title: 'Basic Dropdowns',
       code: DropdownBasicExampleCode,
       view: <DropdownBasicExample />,
       codepenJS: DropdownBasicExampleCodepen
     },
     {
+      title: 'Controlled single-select Dropdown',
+      code: DropdownControlledExampleCode,
+      view: <DropdownControlledExample />,
+      codepenJS: DropdownControlledExampleCodepen
+    },
+    {
+      title: 'Controlled multi-select Dropdown',
+      code: DropdownControlledMultiExampleCode,
+      view: <DropdownControlledMultiExample />,
+      codepenJS: DropdownControlledMultiExampleCodepen
+    },
+    {
       title: 'Customized Dropdown',
       code: DropdownCustomExampleCode,
+      codepenJS: DropdownCustomExampleCodepen,
       view: <DropdownCustomExample />
     },
     {
-      title: 'Dropdown with Error Message',
+      title: 'Dropdown with error message',
       code: DropdownErrorExampleCode,
+      codepenJS: DropdownErrorExampleCodepen,
       view: <DropdownErrorExample />
     },
     {
       title: 'Required Dropdown',
       code: DropdownRequiredExampleCode,
-      view: <DropdownRequiredExample />
+      codepenJS: DropdownRequiredExampleCodepen,
+      view: (
+        <>
+          <p>This example also demonstrates how to programmatically set focus on and open a Dropdown.</p>
+          <DropdownRequiredExample />
+        </>
+      )
     }
   ],
   propertiesTablesSources: [

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -45,6 +45,12 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   /**
    * Optional custom renderer for placeholder text
    */
+  onRenderPlaceholder?: IRenderFunction<IDropdownProps>;
+
+  /**
+   * Optional custom renderer for placeholder text
+   * @deprecated Use `onRenderPlaceholder`
+   */
   onRenderPlaceHolder?: IRenderFunction<IDropdownProps>;
 
   /**

--- a/packages/office-ui-fabric-react/src/components/Dropdown/docs/DropdownDos.md
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/docs/DropdownDos.md
@@ -1,3 +1,3 @@
 - Use a Dropdown when there are multiple choices that can be collapsed under one title. Or if the list of items is long or when space is constrained.
-- Dropdowns contain shortened statements or words.
+- Use shortened statements or single words as options.
 - Use a Dropdown when the selected option is more important than the alternatives (in contrast to radio buttons where all the choices are visible putting more emphasis on the other options).

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.scss
@@ -1,8 +1,0 @@
-:global {
-  .docs-DropdownExample {
-    max-width: 300px;
-    .ms-Dropdown-container {
-      margin-bottom: 10px;
-    }
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Basic.Example.tsx
@@ -1,193 +1,45 @@
 import * as React from 'react';
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { Dropdown, IDropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import './Dropdown.Basic.Example.scss';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Dropdown, DropdownMenuItemType, IDropdownStyles, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 
-export class DropdownBasicExample extends BaseComponent<
-  {},
-  {
-    selectedItem?: { key: string | number | undefined };
-    selectedItems: string[];
-  }
-> {
-  private _basicDropdown = React.createRef<IDropdown>();
+const dropdownStyles: Partial<IDropdownStyles> = {
+  dropdown: { width: 300 }
+};
 
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      selectedItem: undefined,
-      selectedItems: []
-    };
-  }
+const options: IDropdownOption[] = [
+  { key: 'fruitsHeader', text: 'Fruits', itemType: DropdownMenuItemType.Header },
+  { key: 'apple', text: 'Apple' },
+  { key: 'banana', text: 'Banana' },
+  { key: 'orange', text: 'Orange', disabled: true },
+  { key: 'grape', text: 'Grape' },
+  { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
+  { key: 'vegetablesHeader', text: 'Vegetables', itemType: DropdownMenuItemType.Header },
+  { key: 'broccoli', text: 'Broccoli' },
+  { key: 'carrot', text: 'Carrot' },
+  { key: 'lettuce', text: 'Lettuce' }
+];
 
-  public render() {
-    const { selectedItem, selectedItems } = this.state;
+export const DropdownBasicExample: React.StatelessComponent = () => {
+  return (
+    <Stack gap={20}>
+      <Dropdown placeholder="Select an option" label="Basic uncontrolled example" options={options} styles={dropdownStyles} />
 
-    return (
-      <div className="docs-DropdownExample">
-        <Dropdown
-          placeholder="Select an Option"
-          label="Basic uncontrolled example:"
-          ariaLabel="Basic dropdown example"
-          options={[
-            { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
-            { key: 'A', text: 'Option a', title: 'I am option a.' },
-            { key: 'B', text: 'Option b' },
-            { key: 'C', text: 'Option c', disabled: true },
-            { key: 'D', text: 'Option d' },
-            { key: 'E', text: 'Option e' },
-            { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
-            { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
-            { key: 'F', text: 'Option f' },
-            { key: 'G', text: 'Option g' },
-            { key: 'H', text: 'Option h' },
-            { key: 'I', text: 'Option i' },
-            { key: 'J', text: 'Option j' }
-          ]}
-          onFocus={this._log('onFocus called')}
-          onBlur={this._log('onBlur called')}
-          componentRef={this._basicDropdown}
-        />
-        <PrimaryButton text="Set focus" onClick={this._onSetFocusButtonClicked} />
-        <Dropdown
-          label="Disabled uncontrolled example with defaultSelectedKey:"
-          defaultSelectedKey="D"
-          options={[
-            { key: 'A', text: 'Option a' },
-            { key: 'B', text: 'Option b' },
-            { key: 'C', text: 'Option c' },
-            { key: 'D', text: 'Option d' },
-            { key: 'E', text: 'Option e' },
-            { key: 'F', text: 'Option f' },
-            { key: 'G', text: 'Option g' }
-          ]}
-          onFocus={this._log('onFocus called')}
-          onBlur={this._log('onBlur called')}
-          disabled={true}
-        />
+      <Dropdown
+        label="Disabled example with defaultSelectedKey"
+        defaultSelectedKey="broccoli"
+        options={options}
+        disabled={true}
+        styles={dropdownStyles}
+      />
 
-        <Dropdown
-          label="Controlled example:"
-          selectedKey={selectedItem ? selectedItem.key : undefined}
-          onChange={this.changeState}
-          onFocus={this._log('onFocus called')}
-          onBlur={this._log('onBlur called')}
-          placeholder="Select an Option"
-          options={[
-            { key: 'A', text: 'Option a' },
-            { key: 'B', text: 'Option b' },
-            { key: 'C', text: 'Option c' },
-            { key: 'D', text: 'Option d' },
-            { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
-            { key: 'E', text: 'Option e' },
-            { key: 'F', text: 'Option f' },
-            { key: 'G', text: 'Option g' }
-          ]}
-        />
-
-        <Dropdown
-          placeholder="Select options"
-          label="Multi-Select uncontrolled example:"
-          defaultSelectedKeys={['Apple', 'Banana', 'Orange']}
-          onFocus={this._log('onFocus called')}
-          onBlur={this._log('onBlur called')}
-          multiSelect
-          options={[
-            { key: 'Header2', text: 'Fruits', itemType: DropdownMenuItemType.Header },
-            { key: 'Apple', text: 'apple' },
-            { key: 'Banana', text: 'banana' },
-            { key: 'Orange', text: 'orange', disabled: true },
-            { key: 'Grape', text: 'grape', disabled: true },
-            { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
-            { key: 'Header3', text: 'Lanuages', itemType: DropdownMenuItemType.Header },
-            { key: 'English', text: 'english' },
-            { key: 'French', text: 'french' },
-            { key: 'Germany', text: 'germany' }
-          ]}
-        />
-
-        <Dropdown
-          placeholder="Select options"
-          label="Multi-Select controlled example:"
-          selectedKeys={selectedItems}
-          onChange={this.onChangeMultiSelect}
-          onFocus={this._log('onFocus called')}
-          onBlur={this._log('onBlur called')}
-          multiSelect
-          options={[
-            { key: 'Header4', text: 'Colors', itemType: DropdownMenuItemType.Header },
-            { key: 'red', text: 'Red' },
-            { key: 'green', text: 'Green' },
-            { key: 'blue', text: 'Blue' },
-            { key: 'yellow', text: 'Yellow' },
-            { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
-            { key: 'Header5', text: 'Flower', itemType: DropdownMenuItemType.Header },
-            { key: 'rose', text: 'Rose' },
-            { key: 'lily', text: 'Lily' },
-            { key: 'sunflower', text: 'Sunflower' }
-          ]}
-        />
-        <Dropdown
-          label="Disabled uncontrolled example with defaultSelectedKey:"
-          defaultSelectedKeys={['GG', 'FF']}
-          multiSelect
-          options={[
-            { key: 'AA', text: 'Option a' },
-            { key: 'BB', text: 'Option b' },
-            { key: 'CC', text: 'Option c' },
-            { key: 'DD', text: 'Option d' },
-            { key: 'EE', text: 'Option e' },
-            { key: 'FF', text: 'Option f' },
-            { key: 'GG', text: 'Option g' }
-          ]}
-          disabled={true}
-          onFocus={this._log('onFocus called')}
-          onBlur={this._log('onBlur called')}
-        />
-      </div>
-    );
-  }
-
-  public changeState = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {
-    console.log('here is the things updating...' + item.key + ' ' + item.text + ' ' + item.selected);
-    this.setState({ selectedItem: item });
-  };
-
-  public onChangeMultiSelect = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {
-    const updatedSelectedItem = this.state.selectedItems ? this.copyArray(this.state.selectedItems) : [];
-    if (item.selected) {
-      // add the option if it's checked
-      updatedSelectedItem.push(item.key);
-    } else {
-      // remove the option if it's unchecked
-      const currIndex = updatedSelectedItem.indexOf(item.key);
-      if (currIndex > -1) {
-        updatedSelectedItem.splice(currIndex, 1);
-      }
-    }
-    this.setState({
-      selectedItems: updatedSelectedItem
-    });
-  };
-
-  public copyArray = (array: any[]): any[] => {
-    const newArray: any[] = [];
-    for (let i = 0; i < array.length; i++) {
-      newArray[i] = array[i];
-    }
-    return newArray;
-  };
-
-  private _onSetFocusButtonClicked = (): void => {
-    if (this._basicDropdown.current) {
-      this._basicDropdown.current.focus(true);
-    }
-  };
-
-  private _log(str: string): () => void {
-    return (): void => {
-      console.log(str);
-    };
-  }
-}
+      <Dropdown
+        placeholder="Select options"
+        label="Multi-select uncontrolled example"
+        defaultSelectedKeys={['apple', 'banana', 'grape']}
+        multiSelect
+        options={options}
+        styles={dropdownStyles}
+      />
+    </Stack>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Controlled.Example.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Dropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+
+export interface IDropdownControlledExampleState {
+  selectedItem?: { key: string | number | undefined };
+}
+
+export class DropdownControlledExample extends React.Component<{}, IDropdownControlledExampleState> {
+  public state: IDropdownControlledExampleState = {
+    selectedItem: undefined
+  };
+
+  public render() {
+    const { selectedItem } = this.state;
+
+    return (
+      <Dropdown
+        label="Controlled example"
+        selectedKey={selectedItem ? selectedItem.key : undefined}
+        onChange={this._onChange}
+        placeholder="Select an option"
+        options={[
+          { key: 'fruitsHeader', text: 'Fruits', itemType: DropdownMenuItemType.Header },
+          { key: 'apple', text: 'Apple' },
+          { key: 'banana', text: 'Banana' },
+          { key: 'orange', text: 'Orange', disabled: true },
+          { key: 'grape', text: 'Grape' },
+          { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
+          { key: 'vegetablesHeader', text: 'Vegetables', itemType: DropdownMenuItemType.Header },
+          { key: 'broccoli', text: 'Broccoli' },
+          { key: 'carrot', text: 'Carrot' },
+          { key: 'lettuce', text: 'Lettuce' }
+        ]}
+        styles={{ dropdown: { width: 300 } }}
+      />
+    );
+  }
+
+  private _onChange = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {
+    console.log(`Selection change: ${item.text} ${item.selected ? 'selected' : 'unselected'}`);
+    this.setState({ selectedItem: item });
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.ControlledMulti.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.ControlledMulti.Example.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { Dropdown, DropdownMenuItemType, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+
+export interface IDropdownControlledMultiExampleState {
+  selectedItems: string[];
+}
+
+export class DropdownControlledMultiExample extends React.Component<{}, IDropdownControlledMultiExampleState> {
+  public state: IDropdownControlledMultiExampleState = {
+    selectedItems: []
+  };
+
+  public render() {
+    const { selectedItems } = this.state;
+
+    return (
+      <Dropdown
+        placeholder="Select options"
+        label="Multi-select controlled example"
+        selectedKeys={selectedItems}
+        onChange={this._onChange}
+        multiSelect
+        options={[
+          { key: 'fruitsHeader', text: 'Fruits', itemType: DropdownMenuItemType.Header },
+          { key: 'apple', text: 'Apple' },
+          { key: 'banana', text: 'Banana' },
+          { key: 'orange', text: 'Orange', disabled: true },
+          { key: 'grape', text: 'Grape' },
+          { key: 'divider_1', text: '-', itemType: DropdownMenuItemType.Divider },
+          { key: 'vegetablesHeader', text: 'Vegetables', itemType: DropdownMenuItemType.Header },
+          { key: 'broccoli', text: 'Broccoli' },
+          { key: 'carrot', text: 'Carrot' },
+          { key: 'lettuce', text: 'Lettuce' }
+        ]}
+        styles={{ dropdown: { width: 300 } }}
+      />
+    );
+  }
+
+  private _onChange = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption): void => {
+    const newSelectedItems = [...this.state.selectedItems];
+    if (item.selected) {
+      // add the option if it's checked
+      newSelectedItems.push(item.key as string);
+    } else {
+      // remove the option if it's unchecked
+      const currIndex = newSelectedItems.indexOf(item.key as string);
+      if (currIndex > -1) {
+        newSelectedItems.splice(currIndex, 1);
+      }
+    }
+    this.setState({
+      selectedItems: newSelectedItems
+    });
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
@@ -1,51 +1,41 @@
 import * as React from 'react';
-import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
-import './Dropdown.Basic.Example.scss';
-import { DropdownMenuItemType, IDropdownOption, IDropdownProps } from './../Dropdown.types';
-import { Icon } from '../../../Icon';
+import { Dropdown, DropdownMenuItemType, IDropdownOption, IDropdownProps } from 'office-ui-fabric-react/lib/Dropdown';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
-export class DropdownCustomExample extends React.Component {
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      selectedItem: null
-    };
-  }
-
+export class DropdownCustomExample extends React.PureComponent {
   public render(): JSX.Element {
     return (
-      <div className="docs-DropdownExample">
-        <Dropdown
-          placeholder="Select an Option"
-          label="Custom example:"
-          ariaLabel="Custom dropdown example"
-          onRenderPlaceHolder={this._onRenderPlaceHolder}
-          onRenderTitle={this._onRenderTitle}
-          onRenderOption={this._onRenderOption}
-          onRenderCaretDown={this._onRenderCaretDown}
-          options={[
-            { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
-            { key: 'A', text: 'Option a', data: { icon: 'Memo' } },
-            { key: 'B', text: 'Option b', data: { icon: 'Print' } },
-            { key: 'C', text: 'Option c', data: { icon: 'ShoppingCart' } },
-            { key: 'D', text: 'Option d', data: { icon: 'Train' } },
-            { key: 'E', text: 'Option e', data: { icon: 'Repair' } },
-            { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
-            { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
-            { key: 'F', text: 'Option f', data: { icon: 'Running' } },
-            { key: 'G', text: 'Option g', data: { icon: 'EmojiNeutral' } },
-            { key: 'H', text: 'Option h', data: { icon: 'ChatInviteFriend' } },
-            { key: 'I', text: 'Option i', data: { icon: 'SecurityGroup' } },
-            { key: 'J', text: 'Option j', data: { icon: 'AddGroup' } }
-          ]}
-        />
-      </div>
+      <Dropdown
+        placeholder="Select an option"
+        label="Custom example"
+        ariaLabel="Custom dropdown example"
+        onRenderPlaceholder={this._onRenderPlaceholder}
+        onRenderTitle={this._onRenderTitle}
+        onRenderOption={this._onRenderOption}
+        onRenderCaretDown={this._onRenderCaretDown}
+        styles={{ dropdown: { width: 300 } }}
+        options={[
+          { key: 'Header', text: 'Options', itemType: DropdownMenuItemType.Header },
+          { key: 'A', text: 'Option a', data: { icon: 'Memo' } },
+          { key: 'B', text: 'Option b', data: { icon: 'Print' } },
+          { key: 'C', text: 'Option c', data: { icon: 'ShoppingCart' } },
+          { key: 'D', text: 'Option d', data: { icon: 'Train' } },
+          { key: 'E', text: 'Option e', data: { icon: 'Repair' } },
+          { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
+          { key: 'Header2', text: 'More options', itemType: DropdownMenuItemType.Header },
+          { key: 'F', text: 'Option f', data: { icon: 'Running' } },
+          { key: 'G', text: 'Option g', data: { icon: 'EmojiNeutral' } },
+          { key: 'H', text: 'Option h', data: { icon: 'ChatInviteFriend' } },
+          { key: 'I', text: 'Option i', data: { icon: 'SecurityGroup' } },
+          { key: 'J', text: 'Option j', data: { icon: 'AddGroup' } }
+        ]}
+      />
     );
   }
 
   private _onRenderOption = (option: IDropdownOption): JSX.Element => {
     return (
-      <div className="dropdownExample-option">
+      <div>
         {option.data && option.data.icon && (
           <Icon style={{ marginRight: '8px' }} iconName={option.data.icon} aria-hidden="true" title={option.data.icon} />
         )}
@@ -58,7 +48,7 @@ export class DropdownCustomExample extends React.Component {
     const option = options[0];
 
     return (
-      <div className="dropdownExample-option">
+      <div>
         {option.data && option.data.icon && (
           <Icon style={{ marginRight: '8px' }} iconName={option.data.icon} aria-hidden="true" title={option.data.icon} />
         )}
@@ -67,7 +57,7 @@ export class DropdownCustomExample extends React.Component {
     );
   };
 
-  private _onRenderPlaceHolder = (props: IDropdownProps): JSX.Element => {
+  private _onRenderPlaceholder = (props: IDropdownProps): JSX.Element => {
     return (
       <div className="dropdownExample-placeholder">
         <Icon style={{ marginRight: '8px' }} iconName={'MessageFill'} aria-hidden="true" />

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Error.Example.tsx
@@ -1,20 +1,24 @@
 import * as React from 'react';
 import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import './Dropdown.Basic.Example.scss';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 
-export class DropdownErrorExample extends BaseComponent<{}, {}> {
-  constructor(props: {}) {
-    super(props);
-  }
+export interface IDropdownErrorExampleState {
+  showError: boolean;
+}
 
-  public render(): JSX.Element {
+export class DropdownErrorExample extends React.Component<{}, IDropdownErrorExampleState> {
+  // Don't show the error message by default because it's annoying to screen reader users.
+  public state: IDropdownErrorExampleState = { showError: false };
+
+  public render() {
+    const { showError } = this.state;
     return (
-      <div className="docs-DropdownExample">
+      <Stack horizontal gap={30} verticalAlign="start">
+        <Toggle label="Show error message" onText="Yes" offText="No" checked={showError} onChange={this._updateShowError} />
         <Dropdown
-          placeholder="Select an Option"
-          label="Error message example:"
-          ariaLabel="Error message dropdown example"
+          placeholder="Select an option"
+          label="Dropdown with error message"
           options={[
             { key: 'A', text: 'Option a' },
             { key: 'B', text: 'Option b' },
@@ -22,9 +26,14 @@ export class DropdownErrorExample extends BaseComponent<{}, {}> {
             { key: 'D', text: 'Option d' },
             { key: 'E', text: 'Option e' }
           ]}
-          errorMessage="Error message"
+          errorMessage={showError ? 'This dropdown has an error' : undefined}
+          styles={{ dropdown: { width: 300 }, root: { height: 100 } }}
         />
-      </div>
+      </Stack>
     );
   }
+
+  private _updateShowError = (event: React.MouseEvent<HTMLElement>, checked?: boolean) => {
+    this.setState({ showError: !!checked });
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
@@ -1,36 +1,29 @@
 import * as React from 'react';
-import { Dropdown, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
+import { Dropdown, IDropdown } from 'office-ui-fabric-react/lib/Dropdown';
+import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 
-export class DropdownRequiredExample extends BaseComponent<{}, {}> {
-  constructor(props: {}) {
-    super(props);
-  }
+export const DropdownRequiredExample: React.StatelessComponent = () => {
+  const dropdownRef = React.createRef<IDropdown>();
+  const onSetFocus = () => dropdownRef.current!.focus(true);
 
-  public render(): JSX.Element {
-    return (
-      <div className="docs-DropdownExample">
-        <Dropdown
-          placeholder="Select an Option"
-          label="Required dropdown example:"
-          options={[
-            { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
-            { key: 'A', text: 'Option a', title: 'I am option a.' },
-            { key: 'B', text: 'Option b' },
-            { key: 'C', text: 'Option c', disabled: true },
-            { key: 'D', text: 'Option d' },
-            { key: 'E', text: 'Option e' },
-            { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
-            { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
-            { key: 'F', text: 'Option f' },
-            { key: 'G', text: 'Option g' },
-            { key: 'H', text: 'Option h' },
-            { key: 'I', text: 'Option i' },
-            { key: 'J', text: 'Option j' }
-          ]}
-          required={true}
-        />
-      </div>
-    );
-  }
-}
+  return (
+    <Stack horizontal gap={20} verticalAlign="end">
+      <Dropdown
+        componentRef={dropdownRef}
+        placeholder="Select an option"
+        label="Required dropdown example"
+        options={[
+          { key: 'A', text: 'Option a', title: 'I am option a.' },
+          { key: 'B', text: 'Option b' },
+          { key: 'C', text: 'Option c', disabled: true },
+          { key: 'D', text: 'Option d' },
+          { key: 'E', text: 'Option e' }
+        ]}
+        required={true}
+        styles={{ dropdown: { width: 300 } }}
+      />
+      <PrimaryButton text="Set focus" onClick={onSetFocus} />
+    </Stack>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -2,7 +2,25 @@
 
 exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
 <div
-  className="docs-DropdownExample"
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
   <div
     className=
@@ -37,12 +55,12 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       htmlFor="Dropdown0"
       id="Dropdown0-label"
     >
-      Basic uncontrolled example:
+      Basic uncontrolled example
     </label>
     <div
       aria-describedby="Dropdown0-option"
       aria-expanded="false"
-      aria-label="Basic dropdown example"
+      aria-labelledby="Dropdown0-label"
       className=
           ms-Dropdown
           {
@@ -65,6 +83,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 0px;
             position: relative;
             user-select: none;
+            width: 300px;
           }
           &:hover .ms-Dropdown-title {
             border-color: #212121;
@@ -135,15 +154,15 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      placeholder="Select an Option"
+      placeholder="Select an option"
       role="listbox"
       tabIndex={0}
     >
       <span
         aria-atomic={true}
-        aria-label="Select an Option"
+        aria-label="Select an option"
         aria-live="off"
-        aria-setsize={10}
+        aria-setsize={7}
         className=
             ms-Dropdown-title
             ms-Dropdown-titleIsPlaceHolder
@@ -176,7 +195,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
         role="option"
       >
         <span>
-          Select an Option
+          Select an option
         </span>
       </span>
       <span
@@ -214,130 +233,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       </span>
     </div>
   </div>
-  <button
-    className=
-        ms-Button
-        ms-Button--primary
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: #0078d4;
-          border-radius: 0px;
-          border: 1px solid transparent;
-          box-sizing: border-box;
-          color: #ffffff;
-          cursor: pointer;
-          display: inline-block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
-          min-width: 80px;
-          outline: transparent;
-          padding-bottom: 0;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-          position: relative;
-          text-align: center;
-          text-decoration: none;
-          user-select: none;
-          vertical-align: top;
-        }
-        &::-moz-focus-inner {
-          border: 0;
-        }
-        .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #ffffff;
-          bottom: 0px;
-          content: "";
-          left: 0px;
-          outline: 1px solid #666666;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-          z-index: 1;
-        }
-        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-          border: none;
-          bottom: -2px;
-          left: -2px;
-          outline-color: ButtonText;
-          right: -2px;
-          top: -2px;
-        }
-        &:active > * {
-          left: 0px;
-          position: relative;
-          top: 0px;
-        }
-        @media screen and (-ms-high-contrast: active){& {
-          -ms-high-contrast-adjust: none;
-          background-color: WindowText;
-          color: Window;
-        }
-        &:hover {
-          background-color: #106ebe;
-          color: #ffffff;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover {
-          background-color: Highlight;
-          color: Window;
-        }
-        &:active {
-          background-color: #005a9e;
-          color: #ffffff;
-        }
-        @media screen and (-ms-high-contrast: active){&:active {
-          -ms-high-contrast-adjust: none;
-          background-color: WindowText;
-          color: Window;
-        }
-    data-is-focusable={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    type="button"
-  >
-    <div
-      className=
-          ms-Button-flexContainer
-          {
-            align-items: center;
-            display: flex;
-            flex-wrap: nowrap;
-            height: 100%;
-            justify-content: center;
-          }
-    >
-      <div
-        className=
-            ms-Button-textContainer
-            {
-              flex-grow: 1;
-            }
-      >
-        <div
-          className=
-              ms-Button-label
-              {
-                font-weight: 600;
-                line-height: 100%;
-                margin-bottom: 0;
-                margin-left: 4px;
-                margin-right: 4px;
-                margin-top: 0;
-              }
-          id="id__1"
-        >
-          Set focus
-        </div>
-      </div>
-    </div>
-  </button>
   <div
     className=
         ms-Dropdown-container
@@ -368,16 +263,16 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Dropdown4"
-      id="Dropdown4-label"
+      htmlFor="Dropdown1"
+      id="Dropdown1-label"
     >
-      Disabled uncontrolled example with defaultSelectedKey:
+      Disabled example with defaultSelectedKey
     </label>
     <div
-      aria-describedby="Dropdown4-option"
+      aria-describedby="Dropdown1-option"
       aria-disabled={true}
       aria-expanded="false"
-      aria-labelledby="Dropdown4-label"
+      aria-labelledby="Dropdown1-label"
       className=
           ms-Dropdown
           is-disabled
@@ -401,6 +296,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 0px;
             position: relative;
             user-select: none;
+            width: 300px;
           }
           &:hover .ms-Dropdown-title {
             border-color: #212121;
@@ -453,7 +349,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={false}
-      id="Dropdown4"
+      id="Dropdown1"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -463,7 +359,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
-        aria-label="Option d"
+        aria-label="Broccoli"
         aria-live="off"
         className=
             ms-Dropdown-title
@@ -497,10 +393,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               border: 1px solid GrayText;
               color: GrayText;
             }
-        id="Dropdown4-option"
+        id="Dropdown1-option"
       >
         <span>
-          Option d
+          Broccoli
         </span>
       </span>
       <span
@@ -570,15 +466,15 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Dropdown5"
-      id="Dropdown5-label"
+      htmlFor="Dropdown2"
+      id="Dropdown2-label"
     >
-      Controlled example:
+      Multi-select uncontrolled example
     </label>
     <div
-      aria-describedby="Dropdown5-option"
+      aria-describedby="Dropdown2-option"
       aria-expanded="false"
-      aria-labelledby="Dropdown5-label"
+      aria-labelledby="Dropdown2-label"
       className=
           ms-Dropdown
           {
@@ -601,6 +497,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 0px;
             position: relative;
             user-select: none;
+            width: 300px;
           }
           &:hover .ms-Dropdown-title {
             border-color: #212121;
@@ -665,218 +562,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Dropdown5"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      placeholder="Select an Option"
-      role="listbox"
-      tabIndex={0}
-    >
-      <span
-        aria-atomic={true}
-        aria-label="Select an Option"
-        aria-live="off"
-        aria-setsize={7}
-        className=
-            ms-Dropdown-title
-            ms-Dropdown-titleIsPlaceHolder
-            {
-              background-color: #ffffff;
-              border-color: #a6a6a6;
-              border-style: solid;
-              border-width: 1px;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #666666;
-              cursor: pointer;
-              display: block;
-              height: 32px;
-              line-height: 30px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow: hidden;
-              padding-bottom: 0;
-              padding-left: 12px;
-              padding-right: 32px;
-              padding-top: 0;
-              position: relative;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            }
-        id="Dropdown5-option"
-        role="option"
-      >
-        <span>
-          Select an Option
-        </span>
-      </span>
-      <span
-        className=
-            ms-Dropdown-caretDownWrapper
-            {
-              cursor: pointer;
-              height: 32px;
-              line-height: 30px;
-              position: absolute;
-              right: 12px;
-              top: 1px;
-            }
-      >
-        <i
-          className=
-              ms-Dropdown-caretDown
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #666666;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-size: 12px;
-                font-style: normal;
-                font-weight: normal;
-                pointer-events: none;
-                speak: none;
-              }
-          data-icon-name="ChevronDown"
-          role="presentation"
-        >
-          
-        </i>
-      </span>
-    </div>
-  </div>
-  <div
-    className=
-        ms-Dropdown-container
-
-  >
-    <label
-      className=
-          ms-Label
-          ms-Dropdown-label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: inline-block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="Dropdown6"
-      id="Dropdown6-label"
-    >
-      Multi-Select uncontrolled example:
-    </label>
-    <div
-      aria-describedby="Dropdown6-option"
-      aria-expanded="false"
-      aria-labelledby="Dropdown6-label"
-      className=
-          ms-Dropdown
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            outline: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            user-select: none;
-          }
-          &:hover .ms-Dropdown-title {
-            border-color: #212121;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:focus .ms-Dropdown-title {
-            border-color: #0078d4;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-            background-color: Highlight;
-            border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-title {
-            border-color: #005a9e;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:hover .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          &:focus .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          &:hover .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:focus .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:active .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:hover .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:active .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-      data-is-focusable={true}
-      id="Dropdown6"
+      id="Dropdown2"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -887,7 +573,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
-        aria-label="apple"
+        aria-label="Apple"
         aria-live="off"
         className=
             ms-Dropdown-title
@@ -915,10 +601,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Dropdown6-option"
+        id="Dropdown2-option"
       >
         <span>
-          apple, banana, orange
+          Apple, Banana, Grape
         </span>
       </span>
       <span
@@ -947,416 +633,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
                 font-weight: normal;
                 pointer-events: none;
                 speak: none;
-              }
-          data-icon-name="ChevronDown"
-          role="presentation"
-        >
-          
-        </i>
-      </span>
-    </div>
-  </div>
-  <div
-    className=
-        ms-Dropdown-container
-
-  >
-    <label
-      className=
-          ms-Label
-          ms-Dropdown-label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: inline-block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="Dropdown7"
-      id="Dropdown7-label"
-    >
-      Multi-Select controlled example:
-    </label>
-    <div
-      aria-describedby="Dropdown7-option"
-      aria-expanded="false"
-      aria-labelledby="Dropdown7-label"
-      className=
-          ms-Dropdown
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            outline: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            user-select: none;
-          }
-          &:hover .ms-Dropdown-title {
-            border-color: #212121;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:focus .ms-Dropdown-title {
-            border-color: #0078d4;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-            background-color: Highlight;
-            border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-title {
-            border-color: #005a9e;
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:hover .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          &:focus .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-caretDown {
-            color: #212121;
-          }
-          &:hover .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:focus .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:active .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:hover .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:active .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-      data-is-focusable={true}
-      id="Dropdown7"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      placeholder="Select options"
-      tabIndex={0}
-    >
-      <span
-        aria-atomic={true}
-        aria-label="Select options"
-        aria-live="off"
-        className=
-            ms-Dropdown-title
-            ms-Dropdown-titleIsPlaceHolder
-            {
-              background-color: #ffffff;
-              border-color: #a6a6a6;
-              border-style: solid;
-              border-width: 1px;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #666666;
-              cursor: pointer;
-              display: block;
-              height: 32px;
-              line-height: 30px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow: hidden;
-              padding-bottom: 0;
-              padding-left: 12px;
-              padding-right: 32px;
-              padding-top: 0;
-              position: relative;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            }
-        id="Dropdown7-option"
-      >
-        <span>
-          Select options
-        </span>
-      </span>
-      <span
-        className=
-            ms-Dropdown-caretDownWrapper
-            {
-              cursor: pointer;
-              height: 32px;
-              line-height: 30px;
-              position: absolute;
-              right: 12px;
-              top: 1px;
-            }
-      >
-        <i
-          className=
-              ms-Dropdown-caretDown
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #666666;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-size: 12px;
-                font-style: normal;
-                font-weight: normal;
-                pointer-events: none;
-                speak: none;
-              }
-          data-icon-name="ChevronDown"
-          role="presentation"
-        >
-          
-        </i>
-      </span>
-    </div>
-  </div>
-  <div
-    className=
-        ms-Dropdown-container
-
-  >
-    <label
-      className=
-          ms-Label
-          ms-Dropdown-label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: inline-block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-      htmlFor="Dropdown8"
-      id="Dropdown8-label"
-    >
-      Disabled uncontrolled example with defaultSelectedKey:
-    </label>
-    <div
-      aria-describedby="Dropdown8-option"
-      aria-disabled={true}
-      aria-expanded="false"
-      aria-labelledby="Dropdown8-label"
-      className=
-          ms-Dropdown
-          is-disabled
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            outline: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            user-select: none;
-          }
-          &:hover .ms-Dropdown-title {
-            border-color: #212121;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          &:focus .ms-Dropdown-title {
-            border-color: #0078d4;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-            background-color: Highlight;
-            border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-            -ms-high-contrast-adjust: none;
-          }
-          &:active .ms-Dropdown-title {
-            border-color: #005a9e;
-          }
-          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-            border-color: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-            -ms-high-contrast-adjust: none;
-          }
-          &:hover .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:focus .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:active .ms-Dropdown-titleIsPlaceHolder {
-            color: #666666;
-          }
-          &:hover .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:active .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a80000;
-          }
-      data-is-focusable={false}
-      id="Dropdown8"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      tabIndex={-1}
-    >
-      <span
-        aria-atomic={true}
-        aria-label="Option g"
-        aria-live="off"
-        className=
-            ms-Dropdown-title
-            {
-              background-color: #f4f4f4;
-              border-color: #a6a6a6;
-              border-style: solid;
-              border-width: 1px;
-              border: none;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #a6a6a6;
-              cursor: default;
-              display: block;
-              height: 32px;
-              line-height: 30px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow: hidden;
-              padding-bottom: 0;
-              padding-left: 12px;
-              padding-right: 32px;
-              padding-top: 0;
-              position: relative;
-              text-overflow: ellipsis;
-              white-space: nowrap;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              border: 1px solid GrayText;
-              color: GrayText;
-            }
-        id="Dropdown8-option"
-      >
-        <span>
-          Option g, Option f
-        </span>
-      </span>
-      <span
-        className=
-            ms-Dropdown-caretDownWrapper
-            {
-              height: 32px;
-              line-height: 30px;
-              position: absolute;
-              right: 12px;
-              top: 1px;
-            }
-      >
-        <i
-          className=
-              ms-Dropdown-caretDown
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #a6a6a6;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-size: 12px;
-                font-style: normal;
-                font-weight: normal;
-                pointer-events: none;
-                speak: none;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: GrayText;
               }
           data-icon-name="ChevronDown"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = `
+exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`] = `
 <div
   className=
       ms-Dropdown-container
@@ -34,12 +34,12 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     htmlFor="Dropdown0"
     id="Dropdown0-label"
   >
-    Custom example
+    Controlled example
   </label>
   <div
     aria-describedby="Dropdown0-option"
     aria-expanded="false"
-    aria-label="Custom dropdown example"
+    aria-labelledby="Dropdown0-label"
     className=
         ms-Dropdown
         {
@@ -129,6 +129,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     data-is-focusable={true}
     id="Dropdown0"
     onBlur={[Function]}
+    onChange={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -141,7 +142,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       aria-atomic={true}
       aria-label="Select an option"
       aria-live="off"
-      aria-setsize={10}
+      aria-setsize={7}
       className=
           ms-Dropdown-title
           ms-Dropdown-titleIsPlaceHolder
@@ -173,36 +174,9 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       id="Dropdown0-option"
       role="option"
     >
-      <div
-        className="dropdownExample-placeholder"
-      >
-        <i
-          aria-hidden="true"
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-5";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-          data-icon-name="MessageFill"
-          role="presentation"
-          style={
-            Object {
-              "marginRight": "8px",
-            }
-          }
-        >
-          
-        </i>
-        <span>
-          Select an option
-        </span>
-      </div>
+      <span>
+        Select an option
+      </span>
     </span>
     <span
       className=
@@ -218,20 +192,23 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     >
       <i
         className=
-
+            ms-Dropdown-caretDown
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #666666;
               display: inline-block;
-              font-family: "FabricMDL2Icons-4";
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
               font-style: normal;
               font-weight: normal;
+              pointer-events: none;
               speak: none;
             }
-        data-icon-name="CirclePlus"
+        data-icon-name="ChevronDown"
         role="presentation"
       >
-        
+        
       </i>
     </span>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = `
+exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correctly 1`] = `
 <div
   className=
       ms-Dropdown-container
@@ -34,12 +34,12 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     htmlFor="Dropdown0"
     id="Dropdown0-label"
   >
-    Custom example
+    Multi-select controlled example
   </label>
   <div
     aria-describedby="Dropdown0-option"
     aria-expanded="false"
-    aria-label="Custom dropdown example"
+    aria-labelledby="Dropdown0-label"
     className=
         ms-Dropdown
         {
@@ -129,19 +129,18 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     data-is-focusable={true}
     id="Dropdown0"
     onBlur={[Function]}
+    onChange={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
-    placeholder="Select an option"
-    role="listbox"
+    placeholder="Select options"
     tabIndex={0}
   >
     <span
       aria-atomic={true}
-      aria-label="Select an option"
+      aria-label="Select options"
       aria-live="off"
-      aria-setsize={10}
       className=
           ms-Dropdown-title
           ms-Dropdown-titleIsPlaceHolder
@@ -171,38 +170,10 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             white-space: nowrap;
           }
       id="Dropdown0-option"
-      role="option"
     >
-      <div
-        className="dropdownExample-placeholder"
-      >
-        <i
-          aria-hidden="true"
-          className=
-
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: inline-block;
-                font-family: "FabricMDL2Icons-5";
-                font-style: normal;
-                font-weight: normal;
-                speak: none;
-              }
-          data-icon-name="MessageFill"
-          role="presentation"
-          style={
-            Object {
-              "marginRight": "8px",
-            }
-          }
-        >
-          
-        </i>
-        <span>
-          Select an option
-        </span>
-      </div>
+      <span>
+        Select options
+      </span>
     </span>
     <span
       className=
@@ -218,20 +189,23 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     >
       <i
         className=
-
+            ms-Dropdown-caretDown
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #666666;
               display: inline-block;
-              font-family: "FabricMDL2Icons-4";
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
               font-style: normal;
               font-weight: normal;
+              pointer-events: none;
               speak: none;
             }
-        data-icon-name="CirclePlus"
+        data-icon-name="ChevronDown"
         role="presentation"
       >
-        
+        
       </i>
     </span>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -2,12 +2,196 @@
 
 exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
 <div
-  className="docs-DropdownExample"
+  className=
+      ms-Stack
+      {
+        align-items: flex-start;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-left: 30px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
   <div
     className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Toggle0"
+    >
+      Show error message
+    </label>
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={false}
+        checked={false}
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
+        data-is-focusable={true}
+        id="Toggle0"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
+      >
+        <div
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #333333;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
+        />
+      </button>
+      <label
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
+      >
+        No
+      </label>
+    </div>
+  </div>
+  <div
+    className=
         ms-Dropdown-container
-
+        {
+          height: 100px;
+        }
   >
     <label
       className=
@@ -34,15 +218,15 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="Dropdown0"
-      id="Dropdown0-label"
+      htmlFor="Dropdown1"
+      id="Dropdown1-label"
     >
-      Error message example:
+      Dropdown with error message
     </label>
     <div
-      aria-describedby="Dropdown0-option"
+      aria-describedby="Dropdown1-option"
       aria-expanded="false"
-      aria-label="Error message dropdown example"
+      aria-labelledby="Dropdown1-label"
       className=
           ms-Dropdown
           {
@@ -65,6 +249,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             padding-top: 0px;
             position: relative;
             user-select: none;
+            width: 300px;
           }
           &:hover .ms-Dropdown-title {
             border-color: #212121;
@@ -129,28 +314,27 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             border-color: #a80000;
           }
       data-is-focusable={true}
-      id="Dropdown0"
+      id="Dropdown1"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      placeholder="Select an Option"
+      placeholder="Select an option"
       role="listbox"
       tabIndex={0}
     >
       <span
         aria-atomic={true}
-        aria-label="Select an Option"
+        aria-label="Select an option"
         aria-live="off"
         aria-setsize={5}
         className=
             ms-Dropdown-title
             ms-Dropdown-titleIsPlaceHolder
-            ms-Dropdown-title--hasError
             {
               background-color: #ffffff;
-              border-color: #a80000;
+              border-color: #a6a6a6;
               border-style: solid;
               border-width: 1px;
               box-shadow: none;
@@ -173,11 +357,11 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Dropdown0-option"
+        id="Dropdown1-option"
         role="option"
       >
         <span>
-          Select an Option
+          Select an option
         </span>
       </span>
       <span
@@ -213,21 +397,6 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
           
         </i>
       </span>
-    </div>
-    <div
-      className=
-
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #a80000;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-            padding-top: 5px;
-          }
-    >
-      Error message
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -2,7 +2,26 @@
 
 exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] = `
 <div
-  className="docs-DropdownExample"
+  className=
+      ms-Stack
+      {
+        align-items: flex-end;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-left: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
   <div
     className=
@@ -43,7 +62,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
       id="Dropdown0-label"
       required={true}
     >
-      Required dropdown example:
+      Required dropdown example
     </label>
     <div
       aria-describedby="Dropdown0-option"
@@ -73,6 +92,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             padding-top: 0px;
             position: relative;
             user-select: none;
+            width: 300px;
           }
           &:hover .ms-Dropdown-title {
             border-color: #212121;
@@ -143,16 +163,16 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      placeholder="Select an Option"
+      placeholder="Select an option"
       required={true}
       role="listbox"
       tabIndex={0}
     >
       <span
         aria-atomic={true}
-        aria-label="Select an Option"
+        aria-label="Select an option"
         aria-live="off"
-        aria-setsize={10}
+        aria-setsize={5}
         className=
             ms-Dropdown-title
             ms-Dropdown-titleIsPlaceHolder
@@ -185,7 +205,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
         role="option"
       >
         <span>
-          Select an Option
+          Select an option
         </span>
       </span>
       <span
@@ -223,5 +243,129 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
       </span>
     </div>
   </div>
+  <button
+    className=
+        ms-Button
+        ms-Button--primary
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #0078d4;
+          border-radius: 0px;
+          border: 1px solid transparent;
+          box-sizing: border-box;
+          color: #ffffff;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          outline: 1px solid #666666;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+        &:hover {
+          background-color: #106ebe;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          background-color: Highlight;
+          color: Window;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+        @media screen and (-ms-high-contrast: active){&:active {
+          -ms-high-contrast-adjust: none;
+          background-color: WindowText;
+          color: Window;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <div
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+    >
+      <div
+        className=
+            ms-Button-textContainer
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          className=
+              ms-Button-label
+              {
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__1"
+        >
+          Set focus
+        </div>
+      </div>
+    </div>
+  </button>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Convert Dropdown examples to css-in-js, split the "basic" example into multiple files, and other example improvements.

While updating the examples, I noticed a prop named `onRenderPlaceHolder`, which is not the correct casing--it should be `onRenderPlaceholder`. So I added that new prop and deprecated the incorrectly cased one.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8506)