### PR TITLE
List and other example updates

### DIFF
--- a/common/changes/office-ui-fabric-react/list-examples_2019-03-27-23-59.json
+++ b/common/changes/office-ui-fabric-react/list-examples_2019-03-27-23-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "List and other example updates",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/docs/ButtonOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Button/docs/ButtonOverview.md
@@ -4,4 +4,4 @@ When considering their place in a layout, contemplate the order in which a user 
 
 While buttons can technically be used to navigate a user to another part of the experience, this is not recommended unless that navigation is part of an action or their flow.
 
-Note that both iconProps and menuIconProps take <a href='#/components/icon'>IIconProps</a> to specify name and type.
+Note that both `iconProps` and `menuIconProps` take <a href='#/components/icon'>`IIconProps`</a> to specify icon name and type.

--- a/packages/office-ui-fabric-react/src/components/Link/examples/Link.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/examples/Link.Basic.Example.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import './Link.Example.scss';
+import * as styles from './Link.Example.scss';
 
 export class LinkBasicExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div className="docs-LinkExample">
+      <div className={styles.linkExample}>
         <span>When a link has an href, </span>
         <Link href="http://dev.office.com/fabric/components/link">it renders as an anchor tag.</Link>
         <span> Without an href, </span>

--- a/packages/office-ui-fabric-react/src/components/Link/examples/Link.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Link/examples/Link.Example.scss
@@ -1,37 +1,35 @@
 @import '../../../common/common';
 
 // UHF overrides link color and state so we need to re-assign them for the website documentation
-:global {
-  .docs-LinkExample {
-    .ms-Link {
-      // Element: ms-Link root component
-      .root {
+.linkExample {
+  :global(.ms-Link) {
+    // Element: ms-Link root component
+    .root {
+      color: $ms-color-themePrimary;
+      margin: 0;
+      overflow: inherit;
+      padding: 0;
+      text-overflow: inherit;
+    }
+
+    // State: The button is not disabled.
+    .isEnabled {
+      &:active,
+      &:hover,
+      &:active:hover {
+        color: $ms-color-themeDarker;
+      }
+
+      &:focus {
         color: $ms-color-themePrimary;
-        margin: 0;
-        overflow: inherit;
-        padding: 0;
-        text-overflow: inherit;
       }
+    }
 
-      // State: The button is not disabled.
-      .isEnabled {
-        &:active,
-        &:hover,
-        &:active:hover {
-          color: $ms-color-themeDarker;
-        }
-
-        &:focus {
-          color: $ms-color-themePrimary;
-        }
-      }
-
-      // State: The button is disabled.
-      .isDisabled {
-        color: $ms-color-neutralTertiary;
-        pointer-events: none;
-        cursor: default;
-      }
+    // State: The button is disabled.
+    .isDisabled {
+      color: $ms-color-neutralTertiary;
+      pointer-events: none;
+      cursor: default;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/List/docs/ListOverview.md
+++ b/packages/office-ui-fabric-react/src/components/List/docs/ListOverview.md
@@ -1,24 +1,22 @@
 List provides a base component for rendering large sets of items. It is agnostic of layout, the tile component used, and selection management. These concerns can be layered separately.
 
-**Performance is important, and DOM content is expensive. Therefore limit what you render.** Unlike a simple for loop that renders all items in a set, a List uses ui virtualization. It only renders a subset of items, and as you scroll around, the subset of rendered content is shifted to what you're looking at. This gives a much better experience for large sets, especially when the per-item components are complex/render intensive/network intensive.
+**Performance is important, and DOM content is expensive. Therefore, limit what you render.** List applies this principle by using UI virtualization. Unlike a simple `for` loop that renders all items in a set, a List only renders a subset of items, and as you scroll around, the subset of rendered content is shifted. This gives a much better experience for large sets, especially when the per-item components are complex/render-intensive/network-intensive.
 
-Lists break down the set of items passed in into pages. Only pages within a "materialized window" are actually rendered. As that window changes due to scroll events, pages that fall outside that window are removed, and their layout space is remembered and pushed into spacer elements. This gives the user the experience of browsing massive amounts of content but only using a small number of actual elements. This gives the browser much less layout to resolve, and gives React DOM diffing much less content to worry about.
+List breaks down the set of items passed in into pages. Only pages within a "materialized window" are actually rendered. As that window changes due to scroll events, pages that fall outside that window are removed, and their layout space is remembered and pushed into spacer elements. This gives the user the experience of browsing massive amounts of content but only using a small number of actual elements. This gives the browser much less layout to resolve, and gives React DOM diffing much less content to worry about.
 
-Note: although `onRenderCell` is an optional member of `IListProps`, if you do not provide the method, the `List` will still attempt to render the `name` property for each object within the provided `items` array.
+Note: if `onRenderCell` is not provided in `IListProps`, the List will attempt to render the `name` property for each object in the `items` array.
 
 ## My scrollable content isn't updating on scroll! What should I do?
 
 Add the `data-is-scrollable="true"` attribute to your scrollable element containing the List.
 
-By default, List will use the `BODY` element as the scrollable element. If you contain the List within a scrollable `DIV` using `overflow: auto` or `scroll`, the List needs to listen for scroll events on that element instead. On initialization, the List will traverse up the DOM looking for the first element with the `data-is-scrollable` attribute to know when element to listen to for knowing when to re-evaulate the visible window.
+By default, List will use the `<body>` element as the scrollable element. If you contain the List within a scrollable `<div>` using `overflow: auto` or `scroll`, the List needs to listen for scroll events on that element instead. On initialization, the List will traverse up the DOM looking for the first element with the `data-is-scrollable` attribute to know which element to listen to for knowing when to re-evaulate the visible window.
 
 ## My List is not re-rendering when I mutate its items! What should I do?
 
-To determine if the List should re-render its contents, the component performs a referential equality check within its `shouldComponentUpdate` method.
-This is done to minimize the performance overhead associating with re-rendering the virtualized List pages, as recommended by the [React documentation](https://reactjs.org/docs/optimizing-performance.html#the-power-of-not-mutating-data).
+To determine if the List should re-render its contents, the component performs a referential equality check on the `items` array in its `shouldComponentUpdate` method. This is done to minimize the performance overhead associating with re-rendering the virtualized List pages, as recommended by the [React documentation](https://reactjs.org/docs/optimizing-performance.html#the-power-of-not-mutating-data).
 
-As a result of this implementation, the List will not determine it should re-render if the array values are mutated.
-To avoid this problem, we recommend re-creating the items array backing the List by using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
+As a result of this implementation, the List will not determine it should re-render if values _within_ the array are mutated. To avoid this problem, we recommend re-creating the `items` array using a method such as `Array.prototype.concat` or ES6 spread syntax shown below:
 
 ```tsx
 public appendItems(): void {
@@ -36,4 +34,4 @@ public render(): JSX.Element {
 }
 ```
 
-By re-creating the items array without mutating the values, the List will correctly determine its contents have changed and that it should re-render the new values.
+Since the `items` array has been re-created, the List will conclude that its contents have changed and it should re-render the new values.

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.scss
@@ -1,48 +1,47 @@
 @import '../../../common/common';
 
-:global {
-  .ms-ListBasicExample-itemCell {
-    @include focus-border();
+.itemCell {
+  @include focus-border();
 
-    min-height: 54px;
-    padding: 10px;
-    box-sizing: border-box;
-    border-bottom: 1px solid $bodyDividerColor;
-    display: flex;
-  }
+  min-height: 54px;
+  padding: 10px;
+  box-sizing: border-box;
+  border-bottom: 1px solid $bodyDividerColor;
+  display: flex;
 
-  .ms-ListBasicExample-itemCell:hover {
+  &:hover {
     background: #EEE;
   }
+}
 
-  .ms-ListBasicExample-itemImage {
-    flex-shrink: 0;
-  }
 
-  .ms-ListBasicExample-itemContent {
-    @include margin-left(10px);
-    overflow: hidden;
-    flex-grow: 1;
-  }
+.itemImage {
+  flex-shrink: 0;
+}
 
-  .ms-ListBasicExample-itemName {
-    @include ms-font-xl;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+.itemContent {
+  @include margin-left(10px);
+  overflow: hidden;
+  flex-grow: 1;
+}
 
-  .ms-ListBasicExample-itemIndex {
-    font-size: $ms-font-size-s;
-    color: $ms-color-neutralTertiary;
-    margin-bottom: 10px;
-  }
+.itemName {
+  @include ms-font-xl;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-  .ms-ListBasicExample-chevron {
-    align-self: center;
-    @include margin-left(10px);
-    color: $ms-color-neutralTertiary;
-    font-size: $ms-font-size-l;
-    flex-shrink: 0;
-  }
+.itemIndex {
+  font-size: $ms-font-size-s;
+  color: $ms-color-neutralTertiary;
+  margin-bottom: 10px;
+}
+
+.chevron {
+  align-self: center;
+  @include margin-left(10px);
+  color: $ms-color-neutralTertiary;
+  font-size: $ms-font-size-l;
+  flex-shrink: 0;
 }

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
@@ -5,7 +5,7 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { List } from 'office-ui-fabric-react/lib/List';
-import './List.Basic.Example.scss';
+import * as styles from './List.Basic.Example.scss';
 
 export type IExampleItem = { name: string; thumbnail: string; description: string };
 
@@ -54,14 +54,14 @@ export class ListBasicExample extends React.Component<IListBasicExampleProps, IL
 
   private _onRenderCell(item: IExampleItem, index: number | undefined): JSX.Element {
     return (
-      <div className="ms-ListBasicExample-itemCell" data-is-focusable={true}>
-        <Image className="ms-ListBasicExample-itemImage" src={item.thumbnail} width={50} height={50} imageFit={ImageFit.cover} />
-        <div className="ms-ListBasicExample-itemContent">
-          <div className="ms-ListBasicExample-itemName">{item.name}</div>
-          <div className="ms-ListBasicExample-itemIndex">{`Item ${index}`}</div>
-          <div className="ms-ListBasicExample-itemDesc">{item.description}</div>
+      <div className={styles.itemCell} data-is-focusable={true}>
+        <Image className={styles.itemImage} src={item.thumbnail} width={50} height={50} imageFit={ImageFit.cover} />
+        <div className={styles.itemContent}>
+          <div className={styles.itemName}>{item.name}</div>
+          <div className={styles.itemIndex}>{`Item ${index}`}</div>
+          <div>{item.description}</div>
         </div>
-        <Icon className="ms-ListBasicExample-chevron" iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'} />
+        <Icon className={styles.chevron} iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'} />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.scss
@@ -1,39 +1,33 @@
 @import '../../../common/common';
 
-:global {
-  .ms-ListScrollingExample {
-    &-container {
-      overflow: auto;
-      max-height: 500px;
-      margin-top: 20px;
-    }
+.container {
+  overflow: auto;
+  max-height: 500px;
+  margin-top: 20px;
+}
 
-    &-itemCell {
-      .ms-ListScrollingExample-itemContent {
-        @include ms-font-m;
-        @include ms-normalize;
-        @include ms-clearfix;
-        position: relative;
-        display: block;
+.itemContent {
+  @include ms-font-m;
+  @include ms-normalize;
+  @include ms-clearfix;
+  position: relative;
+  display: block;
 
-        border-left: 3px solid $ms-color-themePrimary;
-        padding-left: 27px; // Reduce padding to allow room for border.
+  border-left: 3px solid $ms-color-themePrimary;
+  padding-left: 27px; // Reduce padding to allow room for border.
+}
 
-        &-odd {
-          height: 50px;
-          line-height: 50px;
-          background: $ms-color-neutralLighter;
-        }
+.itemContentOdd {
+  height: 50px;
+  line-height: 50px;
+  background: $ms-color-neutralLighter;
+}
 
-        &-even {
-          height: 25px;
-          line-height: 25px;
-        }
-      }
-    }
+.itemContentEven {
+  height: 25px;
+  line-height: 25px;
+}
 
-    &-selected {
-      background: lightblue;
-    }
-  }
+.selected {
+  background: lightblue;
 }

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Scrolling.Example.tsx
@@ -5,8 +5,8 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { List, ScrollToMode } from 'office-ui-fabric-react/lib/List';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import './List.Scrolling.Example.scss';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import * as styles from './List.Scrolling.Example.scss';
 
 export type IExampleItem = { name: string };
 
@@ -72,7 +72,7 @@ export class ListScrollingExample extends React.Component<IListScrollingExampleP
             onChange={this._onShowItemIndexInViewChanged}
           />
         </div>
-        <div className="ms-ListScrollingExample-container" data-is-scrollable={true}>
+        <div className={styles.container} data-is-scrollable={true}>
           <List ref={this._resolveList} items={items} getPageHeight={this._getPageHeight} onRenderCell={this._onRenderCell} />
         </div>
       </FocusZone>
@@ -123,14 +123,8 @@ export class ListScrollingExample extends React.Component<IListScrollingExampleP
 
   private _onRenderCell = (item: IExampleItem, index: number): JSX.Element => {
     return (
-      <div className="ms-ListScrollingExample-itemCell" data-is-focusable={true}>
-        <div
-          className={css(
-            'ms-ListScrollingExample-itemContent',
-            index % 2 === 0 && 'ms-ListScrollingExample-itemContent-even',
-            index % 2 === 1 && 'ms-ListScrollingExample-itemContent-odd'
-          )}
-        >
+      <div data-is-focusable={true}>
+        <div className={css(styles.itemContent, index % 2 === 0 ? styles.itemContentEven : styles.itemContentOdd)}>
           {index} &nbsp; {item.name}
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.scss
@@ -1,37 +1,35 @@
 @import '../../../common/common';
 
-:global {
-  .ms-MarqueeSelectionBasicExample-photoList {
-    display: inline-block;
-    border: 1px solid $ms-color-neutralTertiary;
-    margin: 0;
-    padding: 10px;
-    overflow: hidden;
-    user-select: none;
-  }
+.photoList {
+  display: inline-block;
+  border: 1px solid $ms-color-neutralTertiary;
+  margin: 0;
+  padding: 10px;
+  overflow: hidden;
+  user-select: none;
+}
 
-  .ms-MarqueeSelectionBasicExample-photoCell {
-    position: relative;
-    display: inline-block;
-    margin: 2px;
-    box-sizing: border-box;
-    background: $ms-color-neutralLighter;
-    line-height: 100px;
-    vertical-align: middle;
-    text-align: center;
+.photoCell {
+  position: relative;
+  display: inline-block;
+  margin: 2px;
+  box-sizing: border-box;
+  background: $ms-color-neutralLighter;
+  line-height: 100px;
+  vertical-align: middle;
+  text-align: center;
 
-    &.is-selected {
-      background: $ms-color-themeLighter;
+  &:global(.is-selected) {
+    background: $ms-color-themeLighter;
 
-      &:after {
-        content: '';
-        position: absolute;
-        right: 0px;
-        left: 0px;
-        top: 0px;
-        bottom: 0px;
-        border: 1px solid $ms-color-themePrimary;
-      }
+    &:after {
+      content: '';
+      position: absolute;
+      right: 0px;
+      left: 0px;
+      top: 0px;
+      bottom: 0px;
+      border: 1px solid $ms-color-themePrimary;
     }
   }
 }

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.tsx
@@ -3,9 +3,8 @@ import * as React from 'react';
 import { css, createArray } from 'office-ui-fabric-react/lib/Utilities';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { MarqueeSelection, Selection, IObjectWithKey } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import './MarqueeSelection.Basic.Example.scss';
-import * as exampleStylesImport from '../../../common/_exampleStyles.scss';
-const exampleStyles: any = exampleStylesImport;
+import * as styles from './MarqueeSelection.Basic.Example.scss';
+import * as exampleStyles from '../../../common/_exampleStyles.scss';
 
 interface IPhoto extends IObjectWithKey {
   url: string;
@@ -59,11 +58,11 @@ export class MarqueeSelectionBasicExample extends React.Component<{}, IMarqueeSe
       <MarqueeSelection selection={this._selection} isEnabled={this.state.isMarqueeEnabled}>
         <Checkbox className={exampleStyles.exampleCheckbox} label="Is marquee enabled" defaultChecked={true} onChange={this._onChange} />
         <p>Drag a rectangle around the items below to select them:</p>
-        <ul className="ms-MarqueeSelectionBasicExample-photoList">
+        <ul className={styles.photoList}>
           {PHOTOS.map((photo, index) => (
             <div
               key={index}
-              className={css('ms-MarqueeSelectionBasicExample-photoCell', this._selection.isIndexSelected(index) && 'is-selected')}
+              className={css(styles.photoCell, this._selection.isIndexSelected(index) && 'is-selected')}
               data-is-focusable={true}
               data-selection-index={index}
               onClick={this._log('clicked')}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.doc.tsx
@@ -14,6 +14,7 @@ const SearchBoxUnderlinedExampleCode = require('!raw-loader!office-ui-fabric-rea
 const SearchBoxDisabledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Disabled.Example.tsx') as string;
 const SearchBoxCustomIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.CustomIcon.Example.tsx') as string;
 const SearchBoxSmallExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
+const SearchBoxSmallExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx') as string;
 
 export const SearchBoxPageProps: IDocPageProps = {
   title: 'SearchBox',
@@ -45,6 +46,7 @@ export const SearchBoxPageProps: IDocPageProps = {
     {
       title: 'SearchBox with fixed width and custom event handling',
       code: SearchBoxSmallExampleCode,
+      codepenJS: SearchBoxSmallExampleCodepen,
       view: <SearchBoxSmallExample />
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.scss
@@ -1,7 +1,0 @@
-:global {
-
-  .ms-SearchBoxSmallExample {
-    width: 208px;
-  }
-
-}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
@@ -1,26 +1,24 @@
 import * as React from 'react';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
-import './SearchBox.Small.Example.scss';
 
 // tslint:disable:jsx-no-lambda
 export class SearchBoxSmallExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div className="ms-SearchBoxSmallExample">
-        <SearchBox
-          placeholder="Search"
-          onEscape={ev => {
-            console.log('Custom onEscape Called');
-          }}
-          onClear={ev => {
-            console.log('Custom onClear Called');
-          }}
-          onChange={newValue => console.log('SearchBox onChange fired: ' + newValue)}
-          onSearch={newValue => console.log('SearchBox onSearch fired: ' + newValue)}
-          onFocus={() => console.log('onFocus called')}
-          onBlur={() => console.log('onBlur called')}
-        />
-      </div>
+      <SearchBox
+        styles={{ root: { width: 200 } }}
+        placeholder="Search"
+        onEscape={ev => {
+          console.log('Custom onEscape Called');
+        }}
+        onClear={ev => {
+          console.log('Custom onClear Called');
+        }}
+        onChange={newValue => console.log('SearchBox onChange fired: ' + newValue)}
+        onSearch={newValue => console.log('SearchBox onSearch fired: ' + newValue)}
+        onFocus={() => console.log('onFocus called')}
+        onBlur={() => console.log('onBlur called')}
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
-<div
-  className="docs-LinkExample"
->
+<div>
   <span>
     When a link has an href, 
   </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -165,11 +165,9 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
   <p>
     Drag a rectangle around the items below to select them:
   </p>
-  <ul
-    className="ms-MarqueeSelectionBasicExample-photoList"
-  >
+  <ul>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={0}
       onClick={[Function]}
@@ -183,7 +181,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       0
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={1}
       onClick={[Function]}
@@ -197,7 +195,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       1
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={2}
       onClick={[Function]}
@@ -211,7 +209,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       2
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={3}
       onClick={[Function]}
@@ -225,7 +223,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       3
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={4}
       onClick={[Function]}
@@ -239,7 +237,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       4
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={5}
       onClick={[Function]}
@@ -253,7 +251,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       5
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={6}
       onClick={[Function]}
@@ -267,7 +265,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       6
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={7}
       onClick={[Function]}
@@ -281,7 +279,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       7
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={8}
       onClick={[Function]}
@@ -295,7 +293,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       8
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={9}
       onClick={[Function]}
@@ -309,7 +307,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       9
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={10}
       onClick={[Function]}
@@ -323,7 +321,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       10
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={11}
       onClick={[Function]}
@@ -337,7 +335,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       11
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={12}
       onClick={[Function]}
@@ -351,7 +349,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       12
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={13}
       onClick={[Function]}
@@ -365,7 +363,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       13
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={14}
       onClick={[Function]}
@@ -379,7 +377,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       14
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={15}
       onClick={[Function]}
@@ -393,7 +391,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       15
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={16}
       onClick={[Function]}
@@ -407,7 +405,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       16
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={17}
       onClick={[Function]}
@@ -421,7 +419,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       17
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={18}
       onClick={[Function]}
@@ -435,7 +433,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       18
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={19}
       onClick={[Function]}
@@ -449,7 +447,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       19
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={20}
       onClick={[Function]}
@@ -463,7 +461,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       20
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={21}
       onClick={[Function]}
@@ -477,7 +475,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       21
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={22}
       onClick={[Function]}
@@ -491,7 +489,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       22
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={23}
       onClick={[Function]}
@@ -505,7 +503,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       23
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={24}
       onClick={[Function]}
@@ -519,7 +517,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       24
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={25}
       onClick={[Function]}
@@ -533,7 +531,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       25
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={26}
       onClick={[Function]}
@@ -547,7 +545,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       26
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={27}
       onClick={[Function]}
@@ -561,7 +559,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       27
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={28}
       onClick={[Function]}
@@ -575,7 +573,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       28
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={29}
       onClick={[Function]}
@@ -589,7 +587,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       29
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={30}
       onClick={[Function]}
@@ -603,7 +601,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       30
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={31}
       onClick={[Function]}
@@ -617,7 +615,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       31
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={32}
       onClick={[Function]}
@@ -631,7 +629,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       32
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={33}
       onClick={[Function]}
@@ -645,7 +643,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       33
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={34}
       onClick={[Function]}
@@ -659,7 +657,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       34
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={35}
       onClick={[Function]}
@@ -673,7 +671,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       35
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={36}
       onClick={[Function]}
@@ -687,7 +685,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       36
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={37}
       onClick={[Function]}
@@ -701,7 +699,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       37
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={38}
       onClick={[Function]}
@@ -715,7 +713,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       38
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={39}
       onClick={[Function]}
@@ -729,7 +727,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       39
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={40}
       onClick={[Function]}
@@ -743,7 +741,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       40
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={41}
       onClick={[Function]}
@@ -757,7 +755,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       41
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={42}
       onClick={[Function]}
@@ -771,7 +769,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       42
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={43}
       onClick={[Function]}
@@ -785,7 +783,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       43
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={44}
       onClick={[Function]}
@@ -799,7 +797,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       44
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={45}
       onClick={[Function]}
@@ -813,7 +811,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       45
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={46}
       onClick={[Function]}
@@ -827,7 +825,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       46
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={47}
       onClick={[Function]}
@@ -841,7 +839,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       47
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={48}
       onClick={[Function]}
@@ -855,7 +853,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       48
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={49}
       onClick={[Function]}
@@ -869,7 +867,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       49
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={50}
       onClick={[Function]}
@@ -883,7 +881,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       50
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={51}
       onClick={[Function]}
@@ -897,7 +895,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       51
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={52}
       onClick={[Function]}
@@ -911,7 +909,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       52
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={53}
       onClick={[Function]}
@@ -925,7 +923,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       53
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={54}
       onClick={[Function]}
@@ -939,7 +937,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       54
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={55}
       onClick={[Function]}
@@ -953,7 +951,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       55
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={56}
       onClick={[Function]}
@@ -967,7 +965,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       56
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={57}
       onClick={[Function]}
@@ -981,7 +979,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       57
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={58}
       onClick={[Function]}
@@ -995,7 +993,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       58
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={59}
       onClick={[Function]}
@@ -1009,7 +1007,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       59
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={60}
       onClick={[Function]}
@@ -1023,7 +1021,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       60
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={61}
       onClick={[Function]}
@@ -1037,7 +1035,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       61
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={62}
       onClick={[Function]}
@@ -1051,7 +1049,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       62
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={63}
       onClick={[Function]}
@@ -1065,7 +1063,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       63
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={64}
       onClick={[Function]}
@@ -1079,7 +1077,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       64
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={65}
       onClick={[Function]}
@@ -1093,7 +1091,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       65
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={66}
       onClick={[Function]}
@@ -1107,7 +1105,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       66
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={67}
       onClick={[Function]}
@@ -1121,7 +1119,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       67
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={68}
       onClick={[Function]}
@@ -1135,7 +1133,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       68
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={69}
       onClick={[Function]}
@@ -1149,7 +1147,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       69
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={70}
       onClick={[Function]}
@@ -1163,7 +1161,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       70
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={71}
       onClick={[Function]}
@@ -1177,7 +1175,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       71
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={72}
       onClick={[Function]}
@@ -1191,7 +1189,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       72
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={73}
       onClick={[Function]}
@@ -1205,7 +1203,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       73
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={74}
       onClick={[Function]}
@@ -1219,7 +1217,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       74
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={75}
       onClick={[Function]}
@@ -1233,7 +1231,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       75
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={76}
       onClick={[Function]}
@@ -1247,7 +1245,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       76
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={77}
       onClick={[Function]}
@@ -1261,7 +1259,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       77
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={78}
       onClick={[Function]}
@@ -1275,7 +1273,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       78
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={79}
       onClick={[Function]}
@@ -1289,7 +1287,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       79
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={80}
       onClick={[Function]}
@@ -1303,7 +1301,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       80
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={81}
       onClick={[Function]}
@@ -1317,7 +1315,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       81
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={82}
       onClick={[Function]}
@@ -1331,7 +1329,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       82
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={83}
       onClick={[Function]}
@@ -1345,7 +1343,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       83
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={84}
       onClick={[Function]}
@@ -1359,7 +1357,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       84
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={85}
       onClick={[Function]}
@@ -1373,7 +1371,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       85
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={86}
       onClick={[Function]}
@@ -1387,7 +1385,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       86
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={87}
       onClick={[Function]}
@@ -1401,7 +1399,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       87
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={88}
       onClick={[Function]}
@@ -1415,7 +1413,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       88
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={89}
       onClick={[Function]}
@@ -1429,7 +1427,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       89
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={90}
       onClick={[Function]}
@@ -1443,7 +1441,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       90
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={91}
       onClick={[Function]}
@@ -1457,7 +1455,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       91
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={92}
       onClick={[Function]}
@@ -1471,7 +1469,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       92
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={93}
       onClick={[Function]}
@@ -1485,7 +1483,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       93
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={94}
       onClick={[Function]}
@@ -1499,7 +1497,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       94
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={95}
       onClick={[Function]}
@@ -1513,7 +1511,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       95
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={96}
       onClick={[Function]}
@@ -1527,7 +1525,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       96
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={97}
       onClick={[Function]}
@@ -1541,7 +1539,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       97
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={98}
       onClick={[Function]}
@@ -1555,7 +1553,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       98
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={99}
       onClick={[Function]}
@@ -1569,7 +1567,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       99
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={100}
       onClick={[Function]}
@@ -1583,7 +1581,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       100
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={101}
       onClick={[Function]}
@@ -1597,7 +1595,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       101
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={102}
       onClick={[Function]}
@@ -1611,7 +1609,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       102
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={103}
       onClick={[Function]}
@@ -1625,7 +1623,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       103
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={104}
       onClick={[Function]}
@@ -1639,7 +1637,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       104
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={105}
       onClick={[Function]}
@@ -1653,7 +1651,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       105
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={106}
       onClick={[Function]}
@@ -1667,7 +1665,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       106
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={107}
       onClick={[Function]}
@@ -1681,7 +1679,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       107
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={108}
       onClick={[Function]}
@@ -1695,7 +1693,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       108
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={109}
       onClick={[Function]}
@@ -1709,7 +1707,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       109
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={110}
       onClick={[Function]}
@@ -1723,7 +1721,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       110
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={111}
       onClick={[Function]}
@@ -1737,7 +1735,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       111
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={112}
       onClick={[Function]}
@@ -1751,7 +1749,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       112
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={113}
       onClick={[Function]}
@@ -1765,7 +1763,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       113
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={114}
       onClick={[Function]}
@@ -1779,7 +1777,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       114
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={115}
       onClick={[Function]}
@@ -1793,7 +1791,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       115
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={116}
       onClick={[Function]}
@@ -1807,7 +1805,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       116
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={117}
       onClick={[Function]}
@@ -1821,7 +1819,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       117
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={118}
       onClick={[Function]}
@@ -1835,7 +1833,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       118
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={119}
       onClick={[Function]}
@@ -1849,7 +1847,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       119
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={120}
       onClick={[Function]}
@@ -1863,7 +1861,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       120
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={121}
       onClick={[Function]}
@@ -1877,7 +1875,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       121
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={122}
       onClick={[Function]}
@@ -1891,7 +1889,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       122
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={123}
       onClick={[Function]}
@@ -1905,7 +1903,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       123
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={124}
       onClick={[Function]}
@@ -1919,7 +1917,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       124
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={125}
       onClick={[Function]}
@@ -1933,7 +1931,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       125
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={126}
       onClick={[Function]}
@@ -1947,7 +1945,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       126
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={127}
       onClick={[Function]}
@@ -1961,7 +1959,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       127
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={128}
       onClick={[Function]}
@@ -1975,7 +1973,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       128
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={129}
       onClick={[Function]}
@@ -1989,7 +1987,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       129
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={130}
       onClick={[Function]}
@@ -2003,7 +2001,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       130
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={131}
       onClick={[Function]}
@@ -2017,7 +2015,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       131
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={132}
       onClick={[Function]}
@@ -2031,7 +2029,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       132
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={133}
       onClick={[Function]}
@@ -2045,7 +2043,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       133
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={134}
       onClick={[Function]}
@@ -2059,7 +2057,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       134
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={135}
       onClick={[Function]}
@@ -2073,7 +2071,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       135
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={136}
       onClick={[Function]}
@@ -2087,7 +2085,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       136
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={137}
       onClick={[Function]}
@@ -2101,7 +2099,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       137
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={138}
       onClick={[Function]}
@@ -2115,7 +2113,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       138
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={139}
       onClick={[Function]}
@@ -2129,7 +2127,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       139
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={140}
       onClick={[Function]}
@@ -2143,7 +2141,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       140
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={141}
       onClick={[Function]}
@@ -2157,7 +2155,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       141
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={142}
       onClick={[Function]}
@@ -2171,7 +2169,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       142
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={143}
       onClick={[Function]}
@@ -2185,7 +2183,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       143
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={144}
       onClick={[Function]}
@@ -2199,7 +2197,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       144
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={145}
       onClick={[Function]}
@@ -2213,7 +2211,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       145
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={146}
       onClick={[Function]}
@@ -2227,7 +2225,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       146
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={147}
       onClick={[Function]}
@@ -2241,7 +2239,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       147
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={148}
       onClick={[Function]}
@@ -2255,7 +2253,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       148
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={149}
       onClick={[Function]}
@@ -2269,7 +2267,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       149
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={150}
       onClick={[Function]}
@@ -2283,7 +2281,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       150
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={151}
       onClick={[Function]}
@@ -2297,7 +2295,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       151
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={152}
       onClick={[Function]}
@@ -2311,7 +2309,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       152
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={153}
       onClick={[Function]}
@@ -2325,7 +2323,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       153
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={154}
       onClick={[Function]}
@@ -2339,7 +2337,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       154
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={155}
       onClick={[Function]}
@@ -2353,7 +2351,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       155
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={156}
       onClick={[Function]}
@@ -2367,7 +2365,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       156
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={157}
       onClick={[Function]}
@@ -2381,7 +2379,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       157
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={158}
       onClick={[Function]}
@@ -2395,7 +2393,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       158
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={159}
       onClick={[Function]}
@@ -2409,7 +2407,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       159
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={160}
       onClick={[Function]}
@@ -2423,7 +2421,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       160
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={161}
       onClick={[Function]}
@@ -2437,7 +2435,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       161
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={162}
       onClick={[Function]}
@@ -2451,7 +2449,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       162
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={163}
       onClick={[Function]}
@@ -2465,7 +2463,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       163
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={164}
       onClick={[Function]}
@@ -2479,7 +2477,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       164
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={165}
       onClick={[Function]}
@@ -2493,7 +2491,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       165
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={166}
       onClick={[Function]}
@@ -2507,7 +2505,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       166
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={167}
       onClick={[Function]}
@@ -2521,7 +2519,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       167
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={168}
       onClick={[Function]}
@@ -2535,7 +2533,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       168
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={169}
       onClick={[Function]}
@@ -2549,7 +2547,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       169
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={170}
       onClick={[Function]}
@@ -2563,7 +2561,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       170
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={171}
       onClick={[Function]}
@@ -2577,7 +2575,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       171
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={172}
       onClick={[Function]}
@@ -2591,7 +2589,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       172
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={173}
       onClick={[Function]}
@@ -2605,7 +2603,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       173
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={174}
       onClick={[Function]}
@@ -2619,7 +2617,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       174
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={175}
       onClick={[Function]}
@@ -2633,7 +2631,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       175
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={176}
       onClick={[Function]}
@@ -2647,7 +2645,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       176
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={177}
       onClick={[Function]}
@@ -2661,7 +2659,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       177
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={178}
       onClick={[Function]}
@@ -2675,7 +2673,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       178
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={179}
       onClick={[Function]}
@@ -2689,7 +2687,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       179
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={180}
       onClick={[Function]}
@@ -2703,7 +2701,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       180
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={181}
       onClick={[Function]}
@@ -2717,7 +2715,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       181
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={182}
       onClick={[Function]}
@@ -2731,7 +2729,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       182
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={183}
       onClick={[Function]}
@@ -2745,7 +2743,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       183
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={184}
       onClick={[Function]}
@@ -2759,7 +2757,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       184
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={185}
       onClick={[Function]}
@@ -2773,7 +2771,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       185
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={186}
       onClick={[Function]}
@@ -2787,7 +2785,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       186
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={187}
       onClick={[Function]}
@@ -2801,7 +2799,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       187
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={188}
       onClick={[Function]}
@@ -2815,7 +2813,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       188
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={189}
       onClick={[Function]}
@@ -2829,7 +2827,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       189
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={190}
       onClick={[Function]}
@@ -2843,7 +2841,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       190
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={191}
       onClick={[Function]}
@@ -2857,7 +2855,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       191
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={192}
       onClick={[Function]}
@@ -2871,7 +2869,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       192
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={193}
       onClick={[Function]}
@@ -2885,7 +2883,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       193
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={194}
       onClick={[Function]}
@@ -2899,7 +2897,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       194
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={195}
       onClick={[Function]}
@@ -2913,7 +2911,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       195
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={196}
       onClick={[Function]}
@@ -2927,7 +2925,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       196
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={197}
       onClick={[Function]}
@@ -2941,7 +2939,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       197
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={198}
       onClick={[Function]}
@@ -2955,7 +2953,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       198
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={199}
       onClick={[Function]}
@@ -2969,7 +2967,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       199
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={200}
       onClick={[Function]}
@@ -2983,7 +2981,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       200
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={201}
       onClick={[Function]}
@@ -2997,7 +2995,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       201
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={202}
       onClick={[Function]}
@@ -3011,7 +3009,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       202
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={203}
       onClick={[Function]}
@@ -3025,7 +3023,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       203
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={204}
       onClick={[Function]}
@@ -3039,7 +3037,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       204
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={205}
       onClick={[Function]}
@@ -3053,7 +3051,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       205
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={206}
       onClick={[Function]}
@@ -3067,7 +3065,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       206
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={207}
       onClick={[Function]}
@@ -3081,7 +3079,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       207
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={208}
       onClick={[Function]}
@@ -3095,7 +3093,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       208
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={209}
       onClick={[Function]}
@@ -3109,7 +3107,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       209
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={210}
       onClick={[Function]}
@@ -3123,7 +3121,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       210
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={211}
       onClick={[Function]}
@@ -3137,7 +3135,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       211
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={212}
       onClick={[Function]}
@@ -3151,7 +3149,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       212
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={213}
       onClick={[Function]}
@@ -3165,7 +3163,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       213
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={214}
       onClick={[Function]}
@@ -3179,7 +3177,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       214
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={215}
       onClick={[Function]}
@@ -3193,7 +3191,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       215
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={216}
       onClick={[Function]}
@@ -3207,7 +3205,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       216
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={217}
       onClick={[Function]}
@@ -3221,7 +3219,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       217
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={218}
       onClick={[Function]}
@@ -3235,7 +3233,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       218
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={219}
       onClick={[Function]}
@@ -3249,7 +3247,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       219
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={220}
       onClick={[Function]}
@@ -3263,7 +3261,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       220
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={221}
       onClick={[Function]}
@@ -3277,7 +3275,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       221
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={222}
       onClick={[Function]}
@@ -3291,7 +3289,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       222
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={223}
       onClick={[Function]}
@@ -3305,7 +3303,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       223
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={224}
       onClick={[Function]}
@@ -3319,7 +3317,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       224
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={225}
       onClick={[Function]}
@@ -3333,7 +3331,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       225
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={226}
       onClick={[Function]}
@@ -3347,7 +3345,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       226
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={227}
       onClick={[Function]}
@@ -3361,7 +3359,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       227
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={228}
       onClick={[Function]}
@@ -3375,7 +3373,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       228
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={229}
       onClick={[Function]}
@@ -3389,7 +3387,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       229
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={230}
       onClick={[Function]}
@@ -3403,7 +3401,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       230
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={231}
       onClick={[Function]}
@@ -3417,7 +3415,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       231
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={232}
       onClick={[Function]}
@@ -3431,7 +3429,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       232
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={233}
       onClick={[Function]}
@@ -3445,7 +3443,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       233
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={234}
       onClick={[Function]}
@@ -3459,7 +3457,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       234
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={235}
       onClick={[Function]}
@@ -3473,7 +3471,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       235
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={236}
       onClick={[Function]}
@@ -3487,7 +3485,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       236
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={237}
       onClick={[Function]}
@@ -3501,7 +3499,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       237
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={238}
       onClick={[Function]}
@@ -3515,7 +3513,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       238
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={239}
       onClick={[Function]}
@@ -3529,7 +3527,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       239
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={240}
       onClick={[Function]}
@@ -3543,7 +3541,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       240
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={241}
       onClick={[Function]}
@@ -3557,7 +3555,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       241
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={242}
       onClick={[Function]}
@@ -3571,7 +3569,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       242
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={243}
       onClick={[Function]}
@@ -3585,7 +3583,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       243
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={244}
       onClick={[Function]}
@@ -3599,7 +3597,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       244
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={245}
       onClick={[Function]}
@@ -3613,7 +3611,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       245
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={246}
       onClick={[Function]}
@@ -3627,7 +3625,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       246
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={247}
       onClick={[Function]}
@@ -3641,7 +3639,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       247
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={248}
       onClick={[Function]}
@@ -3655,7 +3653,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       248
     </div>
     <div
-      className="ms-MarqueeSelectionBasicExample-photoCell"
+      className=""
       data-is-focusable={true}
       data-selection-index={249}
       onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -2,132 +2,129 @@
 
 exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = `
 <div
-  className="ms-SearchBoxSmallExample"
+  className=
+      ms-SearchBox
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        align-items: stretch;
+        background-color: #ffffff;
+        border: 1px solid #a6a6a6;
+        box-shadow: none;
+        box-sizing: border-box;
+        color: #333333;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 1px;
+        padding-left: 4px;
+        padding-right: 0;
+        padding-top: 1px;
+        width: 200px;
+      }
+      @media screen and (-ms-high-contrast: active){& {
+        border: 1px solid WindowText;
+      }
+      &:hover {
+        border-color: #212121;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+      }
+      &:hover $iconContainer {
+        color: #005a9e;
+      }
+  onFocusCapture={[Function]}
 >
   <div
+    aria-hidden={true}
     className=
-        ms-SearchBox
+        ms-SearchBox-iconContainer
         {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          align-items: stretch;
-          background-color: #ffffff;
-          border: 1px solid #a6a6a6;
+          color: #0078d4;
+          cursor: text;
+          display: flex;
+          flex-direction: column;
+          flex-shrink: 0;
+          font-size: 16px;
+          justify-content: center;
+          text-align: center;
+          transition: width 0.167s;
+          width: 32px;
+        }
+    onClick={[Function]}
+  >
+    <i
+      className=
+          ms-SearchBox-icon
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            font-family: "FabricMDL2Icons";
+            font-style: normal;
+            font-weight: normal;
+            opacity: 1;
+            speak: none;
+            transition: opacity 0.167s 0s;
+          }
+      data-icon-name="Search"
+      role="presentation"
+    >
+      
+    </i>
+  </div>
+  <input
+    aria-label="Search"
+    className=
+        ms-SearchBox-field
+        {
+          background-color: transparent;
+          border: none;
           box-shadow: none;
           box-sizing: border-box;
           color: #333333;
-          display: flex;
-          flex-direction: row;
-          flex-wrap: nowrap;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
+          flex: 1 1 0px;
+          font-family: inherit;
+          font-size: inherit;
+          font-weight: inherit;
           margin-bottom: 0px;
           margin-left: 0px;
           margin-right: 0px;
           margin-top: 0px;
-          padding-bottom: 1px;
-          padding-left: 4px;
-          padding-right: 0;
-          padding-top: 1px;
+          min-width: 0px;
+          outline: none;
+          overflow: hidden;
+          padding-bottom: 0.5px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          text-overflow: ellipsis;
         }
-        @media screen and (-ms-high-contrast: active){& {
-          border: 1px solid WindowText;
+        &::-ms-clear {
+          display: none;
         }
-        &:hover {
-          border-color: #212121;
+        &::placeholder {
+          color: #666666;
+          opacity: 1;
         }
-        @media screen and (-ms-high-contrast: active){&:hover {
-          border-color: Highlight;
+        &:-ms-input-placeholder {
+          color: #666666;
         }
-        &:hover $iconContainer {
-          color: #005a9e;
-        }
-    onFocusCapture={[Function]}
-  >
-    <div
-      aria-hidden={true}
-      className=
-          ms-SearchBox-iconContainer
-          {
-            color: #0078d4;
-            cursor: text;
-            display: flex;
-            flex-direction: column;
-            flex-shrink: 0;
-            font-size: 16px;
-            justify-content: center;
-            text-align: center;
-            transition: width 0.167s;
-            width: 32px;
-          }
-      onClick={[Function]}
-    >
-      <i
-        className=
-            ms-SearchBox-icon
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: inline-block;
-              font-family: "FabricMDL2Icons";
-              font-style: normal;
-              font-weight: normal;
-              opacity: 1;
-              speak: none;
-              transition: opacity 0.167s 0s;
-            }
-        data-icon-name="Search"
-        role="presentation"
-      >
-        
-      </i>
-    </div>
-    <input
-      aria-label="Search"
-      className=
-          ms-SearchBox-field
-          {
-            background-color: transparent;
-            border: none;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            flex: 1 1 0px;
-            font-family: inherit;
-            font-size: inherit;
-            font-weight: inherit;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            min-width: 0px;
-            outline: none;
-            overflow: hidden;
-            padding-bottom: 0.5px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            text-overflow: ellipsis;
-          }
-          &::-ms-clear {
-            display: none;
-          }
-          &::placeholder {
-            color: #666666;
-            opacity: 1;
-          }
-          &:-ms-input-placeholder {
-            color: #666666;
-          }
-      id="SearchBox0"
-      onChange={[Function]}
-      onInput={[Function]}
-      onKeyDown={[Function]}
-      placeholder="Search"
-      value=""
-    />
-  </div>
+    id="SearchBox0"
+    onChange={[Function]}
+    onInput={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Search"
+    value=""
+  />
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update List, Link, and MarqueeSelection examples to use CSS modules instead of global class names. The examples still need a full css-in-js conversion later, but hopefully getting rid of global class names wherever possible will keep more global class names from popping up in new code and introducing unpredictable styling behavior.

Other changes:
- List and Button overview text updates
- Convert the last remaining SearchBox example using scss to css-in-js

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8508)