### PR TITLE
Added 'order' property to StackItem

### DIFF
--- a/common/changes/office-ui-fabric-react/stackorder_2019-03-28-09-17.json
+++ b/common/changes/office-ui-fabric-react/stackorder_2019-03-28-09-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Added order property to StackItem",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jussi@jussipalo.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6688,6 +6688,7 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
     className?: string;
     disableShrink?: boolean;
     grow?: boolean | number | 'inherit' | 'initial' | 'unset';
+    order?: number | string;
     shrink?: boolean | number | 'inherit' | 'initial' | 'unset';
     verticalFill?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
@@ -11,7 +11,7 @@ const alignMap: { [key: string]: string } = {
 };
 
 export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemStylesReturnType => {
-  const { grow, shrink, disableShrink, align, verticalFill, className } = props;
+  const { grow, shrink, disableShrink, align, verticalFill, className, order } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -34,7 +34,10 @@ export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemS
       align && {
         alignSelf: alignMap[align] || align
       },
-      className
+      className,
+      order && {
+        order: order
+      }
     ]
     // TODO: this cast may be hiding some potential issues with styling and name
     //        lookups and should be removed

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
@@ -11,7 +11,7 @@ const alignMap: { [key: string]: string } = {
 };
 
 export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemStylesReturnType => {
-  const { grow, shrink, disableShrink, align, verticalFill, className, order } = props;
+  const { grow, shrink, disableShrink, align, verticalFill, order, className } = props;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -34,10 +34,10 @@ export const styles: IStackItemComponent['styles'] = (props, theme): IStackItemS
       align && {
         alignSelf: alignMap[align] || align
       },
-      className,
       order && {
         order: order
-      }
+      },
+      className
     ]
     // TODO: this cast may be hiding some potential issues with styling and name
     //        lookups and should be removed

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
@@ -45,6 +45,11 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
    * @defaultvalue true
    */
   verticalFill?: boolean;
+  /**
+   * Defines order of the StackItem
+   * @defaultvalue 0
+   */
+  order?: number | string;
 }
 
 export interface IStackItemTokens {}

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.types.ts
@@ -45,8 +45,9 @@ export interface IStackItemProps extends IStackItemSlots, IStyleableComponentPro
    * @defaultvalue true
    */
   verticalFill?: boolean;
+
   /**
-   * Defines order of the StackItem
+   * Defines order of the StackItem.
    * @defaultvalue 0
    */
   order?: number | string;

--- a/packages/office-ui-fabric-react/src/components/Stack/examples/Stack.Horizontal.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Stack/examples/Stack.Horizontal.Basic.Example.tsx
@@ -25,6 +25,19 @@ export class HorizontalStackBasicExample extends React.Component<{}, {}> {
           <span>Item Three</span>
         </Stack>
 
+        <span>Ordered stack</span>
+        <Stack horizontal disableShrink className={styles.root}>
+          <Stack.Item order={2}>
+            <span>Item One</span>
+          </Stack.Item>
+          <Stack.Item order={3}>
+            <span>Item Two</span>
+          </Stack.Item>
+          <Stack.Item order={1}>
+            <span>Item Three</span>
+          </Stack.Item>
+        </Stack>
+
         <span>Horizontal gap between items</span>
         <Stack horizontal disableShrink gap={10} padding={10} className={styles.root}>
           <span>Item One</span>

--- a/packages/office-ui-fabric-react/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Stack/examples/Stack.Vertical.Basic.Example.tsx
@@ -25,6 +25,19 @@ export class VerticalStackBasicExample extends React.Component<{}, {}> {
           <span>Item Three</span>
         </Stack>
 
+        <span>Ordered stack</span>
+        <Stack className={styles.root}>
+          <Stack.Item order={2}>
+            <span>Item One</span>
+          </Stack.Item>
+          <Stack.Item order={3}>
+            <span>Item Two</span>
+          </Stack.Item>
+          <Stack.Item order={1}>
+            <span>Item Three</span>
+          </Stack.Item>
+        </Stack>
+
         <span>Vertical gap between items</span>
         <Stack gap={10} padding={10} className={styles.root}>
           <span>Item One</span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Basic.Example.tsx.shot
@@ -58,6 +58,89 @@ exports[`Component Examples renders Stack.Horizontal.Basic.Example.tsx correctly
     </span>
   </div>
   <span>
+    Ordered stack
+  </span>
+  <div
+    className=
+        ms-Stack
+        {
+          background: #71afe5;
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 0;
+        }
+  >
+    <div
+      className=
+          ms-StackItem
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            flex-shrink: 0;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            order: 2;
+            width: auto;
+          }
+    >
+      <span>
+        Item One
+      </span>
+    </div>
+    <div
+      className=
+          ms-StackItem
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            flex-shrink: 0;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            order: 3;
+            width: auto;
+          }
+    >
+      <span>
+        Item Two
+      </span>
+    </div>
+    <div
+      className=
+          ms-StackItem
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            flex-shrink: 0;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            order: 1;
+            width: auto;
+          }
+    >
+      <span>
+        Item Three
+      </span>
+    </div>
+  </div>
+  <span>
     Horizontal gap between items
   </span>
   <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Basic.Example.tsx.shot
@@ -58,6 +58,89 @@ exports[`Component Examples renders Stack.Vertical.Basic.Example.tsx correctly 1
     </span>
   </div>
   <span>
+    Ordered stack
+  </span>
+  <div
+    className=
+        ms-Stack
+        {
+          background: #71afe5;
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: column;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-top: 0px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
+  >
+    <div
+      className=
+          ms-StackItem
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            flex-shrink: 1;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            order: 2;
+            width: auto;
+          }
+    >
+      <span>
+        Item One
+      </span>
+    </div>
+    <div
+      className=
+          ms-StackItem
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            flex-shrink: 1;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            order: 3;
+            width: auto;
+          }
+    >
+      <span>
+        Item Two
+      </span>
+    </div>
+    <div
+      className=
+          ms-StackItem
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            flex-shrink: 1;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            order: 1;
+            width: auto;
+          }
+    >
+      <span>
+        Item Three
+      </span>
+    </div>
+  </div>
+  <span>
     Vertical gap between items
   </span>
   <div


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ npm run change`

#### Description of changes
Added `order` property to StackItem. Makes it possible to order flexbox items.

#### Focus areas to test
When order property is defined, browser should render the items in the given order.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8515)