### PR TITLE
CommandBar: Updating overflowButtonProps prop description

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBarMenuProps_2019-03-28-22-55.json
+++ b/common/changes/office-ui-fabric-react/commandBarMenuProps_2019-03-28-22-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Updating overflowButtonProps prop description.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -43,6 +43,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Props to be passed to overflow button.
    * If menuProps are passed through this prop, any items provided will be prepended to the top of the existing menu.
+   * Note that if you pass menuProps you need to at least supply an empty array for items, as it is a required prop of IContextualMenuProps.
    */
   overflowButtonProps?: IButtonProps;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8441 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updating `overflowButtonProps` prop description to mention that an empty array must be passed as `items`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8526)