### PR TITLE
GroupedList: Fix initial groups collapse state if isAllGroupsCollapsed is set as true

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-isAllCollapsed-grouped-list_2019-03-28-23-40.json
+++ b/common/changes/office-ui-fabric-react/keco-isAllCollapsed-grouped-list_2019-03-28-23-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupedList: Respect groupProps isAllGroupsCollapsed on initial render",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1281,6 +1281,8 @@ export const GroupedList: React_2.StatelessComponent<IGroupedListProps>;
 export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedListState> implements IGroupedList {
     constructor(props: IGroupedListProps);
     // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
     componentWillReceiveProps(newProps: IGroupedListProps): void;
     // (undocumented)
     static defaultProps: {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -72,6 +72,14 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     }
   }
 
+  public componentDidMount() {
+    const { groupProps, groups = [] } = this.props;
+
+    if (groupProps && groupProps.isAllGroupsCollapsed) {
+      this._setCollapseAllGroups(groups, groupProps.isAllGroupsCollapsed);
+    }
+  }
+
   public render(): JSX.Element {
     const { className, usePageCache, onShouldVirtualize, theme, styles, compact } = this.props;
     const { groups } = this.state;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -76,7 +76,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     const { groupProps, groups = [] } = this.props;
 
     if (groupProps && groupProps.isAllGroupsCollapsed) {
-      this._setCollapseAllGroups(groups, groupProps.isAllGroupsCollapsed);
+      this._setGroupsCollapsedState(groups, groupProps.isAllGroupsCollapsed);
     }
   }
 
@@ -125,7 +125,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
         onToggleCollapseAll(allCollapsed);
       }
 
-      this._setCollapseAllGroups(groups, allCollapsed);
+      this._setGroupsCollapsedState(groups, allCollapsed);
 
       this._updateIsSomeGroupExpanded();
 
@@ -133,7 +133,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
     }
   }
 
-  private _setCollapseAllGroups(groups: IGroup[], isCollapsed: boolean): void {
+  private _setGroupsCollapsedState(groups: IGroup[], isCollapsed: boolean): void {
     for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
       groups[groupIndex].isCollapsed = isCollapsed;
     }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -108,22 +108,26 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
   }
 
   public toggleCollapseAll(allCollapsed: boolean): void {
-    const { groups } = this.state;
+    const { groups = [] } = this.state;
     const { groupProps } = this.props;
     const onToggleCollapseAll = groupProps && groupProps.onToggleCollapseAll;
 
-    if (groups) {
+    if (groups.length > 0) {
       if (onToggleCollapseAll) {
         onToggleCollapseAll(allCollapsed);
       }
 
-      for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
-        groups[groupIndex].isCollapsed = allCollapsed;
-      }
+      this._setCollapseAllGroups(groups, allCollapsed);
 
       this._updateIsSomeGroupExpanded();
 
       this.forceUpdate();
+    }
+  }
+
+  private _setCollapseAllGroups(groups: IGroup[], isCollapsed: boolean): void {
+    for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      groups[groupIndex].isCollapsed = isCollapsed;
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8473
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes the case where initial render of `GroupedList` did not show _all of_ the groups as _collapsed_ when `groupProps: { isAllGroupsCollapsed: true }`.

This solution _does mutate props_ as the original code did. If folks have a solution to fix this bug that does not massive refactor, I'm all ears :).

cc: @ecraig12345 who has dealt with similar in the past (I think).

#### Focus areas to test

Thinking about what element(s) to target for unit test. Unit test to follow shortly..



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8527)