### PR TITLE
Text: move under Utilities category on livesite

### DIFF
--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -222,14 +222,6 @@ export const AppState: IAppState = {
                 require.ensure([], require => cb(require<any>('../../pages/Components/SpinButtonComponentPage').SpinButtonComponentPage))
             },
             {
-              title: 'Text',
-              url: '#/components/text',
-              isFilterable: true,
-              component: () => <LoadingComponent title="Text" />,
-              getComponent: cb =>
-                require.ensure([], require => cb(require<any>('../../pages/Components/TextComponentPage').TextComponentPage))
-            },
-            {
               title: 'TextField',
               url: '#/components/textfield',
               isFilterable: true,
@@ -803,6 +795,14 @@ export const AppState: IAppState = {
               component: () => <LoadingComponent title="Selection" />,
               getComponent: cb =>
                 require.ensure([], require => cb(require<any>('../../pages/Components/SelectionUtilityPage').SelectionUtilityPage))
+            },
+            {
+              title: 'Text',
+              url: '#/components/text',
+              isFilterable: true,
+              component: () => <LoadingComponent title="Text" />,
+              getComponent: cb =>
+                require.ensure([], require => cb(require<any>('../../pages/Components/TextComponentPage').TextComponentPage))
             },
             {
               title: 'Themes',

--- a/common/changes/@uifabric/fabric-website/moveText_2019-03-29-18-07.json
+++ b/common/changes/@uifabric/fabric-website/moveText_2019-03-29-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "move Text under Utilities",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "natalie.ethell@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Per Peter's suggestion, these changes move Text under "Utilities" on the livesite. It currently lives under "Basic Inputs".

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8537)