### PR TITLE
Dropdown: onChange ev.target now always consistent

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-onchange_2019-03-29-18-15.json
+++ b/common/changes/office-ui-fabric-react/dropdown-onchange_2019-03-29-18-15.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Dropdown: The `onChange` callback's event target should always be the dropdown element, which contains the id attribute passed in through props.",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/dropdown-onchange_2019-03-29-18-15.json
+++ b/common/changes/office-ui-fabric-react/dropdown-onchange_2019-03-29-18-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: The `onChange` callback's event target should always be the dropdown element, which contains the id attribute passed in through props.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -330,7 +330,8 @@ export class DropdownBase extends BaseComponent<IDropdownInternalProps, IDropdow
       // for single-select, option passed in will always be selected.
       // for multi-select, flip the checked value
       const changedOpt = multiSelect ? { ...options[index], selected: !checked } : options[index];
-      onChange(event, changedOpt, index);
+
+      onChange({ ...event, target: this._dropDown.current as EventTarget }, changedOpt, index);
     }
 
     if (onChanged) {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -162,7 +162,10 @@ describe('Dropdown', () => {
       const onChangeSpy = jest.fn();
 
       try {
-        ReactDOM.render(<Dropdown label="testgroup" defaultSelectedKey="1" onChange={onChangeSpy} options={DEFAULT_OPTIONS} />, container);
+        ReactDOM.render(
+          <Dropdown id="foo" label="testgroup" defaultSelectedKey="1" onChange={onChangeSpy} options={DEFAULT_OPTIONS} />,
+          container
+        );
         dropdownRoot = container.querySelector('.ms-Dropdown') as HTMLElement;
 
         ReactTestUtils.Simulate.click(dropdownRoot);
@@ -171,6 +174,7 @@ describe('Dropdown', () => {
         ReactTestUtils.Simulate.click(secondItemElement);
       } finally {
         expect(onChangeSpy).toHaveBeenCalledWith(expect.anything(), DEFAULT_OPTIONS[2], 2);
+        expect(onChangeSpy.mock.calls[0][0].target.id).toEqual('foo');
       }
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #6849 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The Dropdown `onChange` event target now matches the expected element, which contains the id passed in through props.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8538)