### PR TITLE
Fix issue show less on the left nav shows up all items selected  in customize navigation

### DIFF
--- a/common/changes/@uifabric/dashboard/bugFix_319105_2019-04-01-14-30.json
+++ b/common/changes/@uifabric/dashboard/bugFix_319105_2019-04-01-14-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Fix issue show less on the left nav shows up all items selected  in customize navigation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "v-ragor@microsoft.com"
+}

--- a/packages/dashboard/src/components/Nav/Nav.tsx
+++ b/packages/dashboard/src/components/Nav/Nav.tsx
@@ -156,13 +156,17 @@ class NavComponent extends NavBase {
     return (
       <ul role="list">
         {links.map((link: INavLink, linkIndex: number) => {
+          if (enableCustomization && link.isHidden) {
+            // atleast one link is hidden
+            this._hasAtleastOneHiddenLink = true;
+          }
           if (enableCustomization && link.isHidden && !showMore) {
             // atleast one link is hidden
             this._hasAtleastOneHiddenLink = true;
 
             // "Show more" overrides isHidden property
             return null;
-          } else if (link.isShowMoreLink && !this._hasAtleastOneHiddenLink && !showMore) {
+          } else if (link.isShowMoreLink && !this._hasAtleastOneHiddenLink) {
             // there is no hidden link, hide "Show more" link
             return null;
           } else {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix issue show less on the left nav shows up all items selected  in customize navigation 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8549)