### PR TITLE
Handle TSDoc default value tag

### DIFF
--- a/common/changes/@uifabric/example-app-base/handleAllDefaultTags_2019-04-01-18-34.json
+++ b/common/changes/@uifabric/example-app-base/handleAllDefaultTags_2019-04-01-18-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "handle TSDoc default value tag",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/parser/BaseParser.ts
+++ b/packages/example-app-base/src/utilities/parser/BaseParser.ts
@@ -56,7 +56,7 @@ export class BaseParser {
   protected eatWord(word: string): string | undefined {
     const len = word.length;
 
-    if (this.peekAhead(len) === word) {
+    if (this.peekAhead(len).toLowerCase() === word) {
       this._currLocation += len;
       return word;
     }

--- a/packages/example-app-base/src/utilities/parser/BaseParser.ts
+++ b/packages/example-app-base/src/utilities/parser/BaseParser.ts
@@ -56,7 +56,7 @@ export class BaseParser {
   protected eatWord(word: string): string | undefined {
     const len = word.length;
 
-    if (this.peekAhead(len).toLowerCase() === word) {
+    if (this.peekAhead(len) === word) {
       this._currLocation += len;
       return word;
     }

--- a/packages/example-app-base/src/utilities/parser/InterfaceParserHelper.ts
+++ b/packages/example-app-base/src/utilities/parser/InterfaceParserHelper.ts
@@ -5,6 +5,7 @@ import { IInterfaceProperty, InterfacePropertyType } from './interfaces';
 
 const JSDOC_DEFAULT = '@default';
 const JSDOC_DEFAULTVALUE = '@defaultvalue';
+const TSDOC_DEFAULTVALUE = '@defaultValue';
 const JSDOC_DEPRECATED = '@deprecated';
 /**
  * Supporting enum for the parser, used internally within the parser only.
@@ -95,7 +96,7 @@ export class InterfaceParserHelper extends BaseParser {
               // go to next line
               this.eatSpacesAndNewlines();
             } else if (this.peek() === '@') {
-              if (this.eatWord(JSDOC_DEFAULTVALUE) || this.eatWord(JSDOC_DEFAULT)) {
+              if (this.eatWord(JSDOC_DEFAULTVALUE) || this.eatWord(TSDOC_DEFAULTVALUE) || this.eatWord(JSDOC_DEFAULT)) {
                 // this parser assumes @default values won't have a bunch of asterisks in the middle of it.
                 tmp = this.eatUntil(/[\*\n]/);
                 defaultValue = tmp;

--- a/packages/example-app-base/src/utilities/parser/Parse.ts
+++ b/packages/example-app-base/src/utilities/parser/Parse.ts
@@ -11,7 +11,7 @@ import { EnumParserHelper } from './EnumParserHelper';
  *       It should otherwise be reasonably robust to handle various commenting or even code layout
  *       styles within the interface or enum.
  *
- * To specify default values for interfaces, use the JSDoc @default or @defaultvalue markup.
+ * To specify default values for interfaces, use the JSDoc @default or @defaultvalue or TSDoc @defaultValue markup.
  * The rest of the line after @default will be captured as the default value.
  *
  * @export


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Right now, we only handle JSDoc `@default` and `@defaultvalue` tags. We should also support TSDoc `@defaultValue` tags.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8553)