### PR TITLE
Write test failure messages to stderr

### DIFF
--- a/scripts/jest/jest-reporter.js
+++ b/scripts/jest/jest-reporter.js
@@ -5,8 +5,23 @@ const DefaultReporter = require('jest-cli/build/reporters/default_reporter').def
  * when there are no errors.
  */
 class JestReporter extends DefaultReporter {
-  log(message) {
-    process.stdout.write(message + '\n');
+  constructor(...args) {
+    super(...args);
+
+    this._isLoggingError = false;
+    this.log = message => {
+      if (this._isLoggingError) {
+        process.stderr.write(message + '\n');
+      } else {
+        process.stdout.write(message + '\n');
+      }
+    };
+  }
+
+  printTestFileFailureMessage(...args) {
+    this._isLoggingError = true;
+    super.printTestFileFailureMessage(...args);
+    this._isLoggingError = false;
   }
 }
 


### PR DESCRIPTION
The custom jest reporter should send test failure messages to stderr so they show up nicely in `rush build` output.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8554)