### PR TITLE
zhiliu/seperator

### DIFF
--- a/common/changes/@uifabric/experiments/zhiliu-seperator_2019-04-01-22-41.json
+++ b/common/changes/@uifabric/experiments/zhiliu-seperator_2019-04-01-22-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "add proxy component for experiments/Separator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "odbuild@microsoft.com"
+}

--- a/packages/experiments/src/Separator.ts
+++ b/packages/experiments/src/Separator.ts
@@ -1,0 +1,1 @@
+export * from 'office-ui-fabric-react/lib/Separator';

--- a/packages/experiments/src/Separator.ts
+++ b/packages/experiments/src/Separator.ts
@@ -1,1 +1,4 @@
+/**
+ * @deprecated Import from office-ui-fabric-react package instead.
+ */
 export * from 'office-ui-fabric-react/lib/Separator';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Separator from experiments were completely removed, this was a breaking change that breaks  odsp-fabric library since it is still depending it. I am adding back experiments/Separator and makes it re-export Separator from office-ui-fabric-react

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8557)