### PR TITLE
Button: Fixing SplitButton styling issues and correctly placing divider

### DIFF
--- a/common/changes/@uifabric/experiments/splitButtonDivider_2019-04-02-00-56.json
+++ b/common/changes/@uifabric/experiments/splitButtonDivider_2019-04-02-00-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Fixing SplitButton styling issues and correctly placing divider.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/Button.styles.ts
+++ b/packages/experiments/src/components/Button/Button.styles.ts
@@ -53,7 +53,7 @@ const enabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenRe
 const disabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
   const { semanticColors } = theme;
   return {
-    backgroundColor: theme.semanticColors.buttonBackgroundDisabled,
+    backgroundColor: semanticColors.buttonBackgroundDisabled,
     backgroundColorHovered: semanticColors.buttonBackgroundDisabled,
     backgroundColorPressed: semanticColors.buttonBackgroundDisabled,
 

--- a/packages/experiments/src/components/Button/SplitMenuButton/SplitMenuButton.styles.ts
+++ b/packages/experiments/src/components/Button/SplitMenuButton/SplitMenuButton.styles.ts
@@ -2,16 +2,44 @@ import { getFocusStyle } from '../../../Styling';
 import { ISplitMenuButtonComponent, ISplitMenuButtonStylesReturnType, ISplitMenuButtonTokenReturnType } from './SplitMenuButton.types';
 
 const baseTokens: ISplitMenuButtonComponent['tokens'] = (props, theme): ISplitMenuButtonTokenReturnType => {
+  const { semanticColors } = theme;
   return {
-    contentPadding: '8px 0px 8px 10px'
+    backgroundColor: semanticColors.buttonBackground,
+    color: semanticColors.buttonText,
+    contentPadding: '8px 10px'
   };
 };
 
-export const SplitMenuButtonTokens: ISplitMenuButtonComponent['tokens'] = (props, theme): ISplitMenuButtonTokenReturnType => [baseTokens];
+const primaryTokens: ISplitMenuButtonComponent['tokens'] = (props, theme): ISplitMenuButtonTokenReturnType => {
+  const { semanticColors } = theme;
+  return {
+    backgroundColor: semanticColors.primaryButtonBackground,
+    color: semanticColors.primaryButtonText
+  };
+};
+
+const disabledTokens: ISplitMenuButtonComponent['tokens'] = (props, theme): ISplitMenuButtonTokenReturnType => {
+  const { semanticColors } = theme;
+  return {
+    backgroundColor: semanticColors.buttonBackgroundDisabled,
+    color: semanticColors.disabledText
+  };
+};
+
+export const SplitMenuButtonTokens: ISplitMenuButtonComponent['tokens'] = (props, theme): ISplitMenuButtonTokenReturnType => [
+  baseTokens,
+  props.primary && primaryTokens,
+  (props.primaryActionDisabled || props.disabled) && disabledTokens
+];
 
 export const SplitMenuButtonStyles: ISplitMenuButtonComponent['styles'] = (props, theme, tokens): ISplitMenuButtonStylesReturnType => {
   return {
-    root: [getFocusStyle(theme)],
+    root: [
+      getFocusStyle(theme),
+      {
+        backgroundColor: tokens.backgroundColor
+      }
+    ],
     button: {
       selectors: {
         '> *': {
@@ -20,11 +48,11 @@ export const SplitMenuButtonStyles: ISplitMenuButtonComponent['styles'] = (props
       }
     },
     splitDivider: {
-      borderColor: tokens.color,
       borderRight: '1px solid',
+      borderColor: tokens.color,
       boxSizing: 'border-box',
-      height: '100%',
-      padding: '8px 0px',
+      height: 'calc(100% - 16px)',
+      margin: '8px 0px',
       width: 1
     }
   };

--- a/packages/experiments/src/components/Button/SplitMenuButton/SplitMenuButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitMenuButton/SplitMenuButton.view.tsx
@@ -39,8 +39,6 @@ export const SplitMenuButtonView: ISplitMenuButtonComponent['view'] = props => {
   return (
     <Slots.root role="button" aria-disabled={disabled} horizontal as="span" verticalAlign="stretch">
       <Slots.button
-        styles={styles}
-        tokens={tokens}
         primary={primary}
         disabled={primaryActionDisabled || disabled}
         aria-disabled={primaryActionDisabled || disabled}
@@ -48,17 +46,11 @@ export const SplitMenuButtonView: ISplitMenuButtonComponent['view'] = props => {
         {...rest}
       >
         {children}
-        <Slots.splitDivider />
       </Slots.button>
 
-      <Slots.menuButton
-        styles={styles}
-        tokens={tokens}
-        primary={primary}
-        disabled={disabled}
-        onClick={onSecondaryActionClick}
-        menu={Menu}
-      />
+      <Slots.splitDivider />
+
+      <Slots.menuButton primary={primary} disabled={disabled} onClick={onSecondaryActionClick} menu={Menu} />
     </Slots.root>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

A bug in foundation was recently discovered where the tokens specified in the `.styles` files weren't being passed on to the `view`. This created a situation where unexpected behavior arose whenever a component was created using other foundation components as its base. This bug was fixed recently in #8247, but this made some styling problems arise from an incorrect use of this pattern in `SplitMenuButton`. This PR fixes those issues while also fixing another styling bug that existed whenever the `SplitButton` contents didn't fill up the `minWidth` of the `SplitButton`, in which case the divider didn't line up in between the two `Button` stops, the regular `Button` on the left and the `MenuButton` on the right.

__Before:__
![image](https://user-images.githubusercontent.com/7798177/55368832-bf2ac180-54a8-11e9-989e-8affbed3588d.png)

__After:__
![image](https://user-images.githubusercontent.com/7798177/55368926-2779a300-54a9-11e9-9cad-2d957512e0a4.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8561)