### PR TITLE
CommandBar: Meeting color contrast accessibility standards in examples

### DIFF
--- a/common/changes/office-ui-fabric-react/commandBarContrast_2019-04-02-16-47.json
+++ b/common/changes/office-ui-fabric-react/commandBarContrast_2019-04-02-16-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Meeting color contrast accessibility standards in examples.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
@@ -15,7 +15,7 @@ export class CommandBarButtonAsExample extends React.Component<{}, {}> {
           styles={{
             ...props.styles,
             textContainer: { fontSize: 18 },
-            icon: { color: 'red' }
+            icon: { color: '#E20000' }
           }}
         />
       );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -169,7 +169,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
-                          color: red;
+                          color: #E20000;
                           display: inline-block;
                           flex-shrink: 0;
                           font-family: "FabricMDL2Icons";
@@ -356,7 +356,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
-                          color: red;
+                          color: #E20000;
                           display: inline-block;
                           flex-shrink: 0;
                           font-family: "FabricMDL2Icons";
@@ -514,7 +514,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
-                          color: red;
+                          color: #E20000;
                           display: inline-block;
                           flex-shrink: 0;
                           font-family: "FabricMDL2Icons";
@@ -672,7 +672,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
-                          color: red;
+                          color: #E20000;
                           display: inline-block;
                           flex-shrink: 0;
                           font-family: "FabricMDL2Icons";
@@ -979,7 +979,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
-                          color: red;
+                          color: #E20000;
                           display: inline-block;
                           flex-shrink: 0;
                           font-family: "FabricMDL2Icons";
@@ -1149,7 +1149,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                           {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
-                            color: red;
+                            color: #E20000;
                             display: inline-block;
                             flex-shrink: 0;
                             font-family: "FabricMDL2Icons";
@@ -1295,7 +1295,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                           {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
-                            color: red;
+                            color: #E20000;
                             display: inline-block;
                             flex-shrink: 0;
                             font-family: "FabricMDL2Icons";


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Bug 9 in #6390 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adjusting text foreground color in examples to meet accessibility standards.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8566)