### PR TITLE
Modal scrolling

### DIFF
--- a/common/changes/office-ui-fabric-react/modal-scrolling_2019-04-02-18-43.json
+++ b/common/changes/office-ui-fabric-react/modal-scrolling_2019-04-02-18-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Modal: constrain scrollableContent height to window.innerHeight (fix for DetailsList virtualization)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/modal-scrolling_2019-04-02-18-43.json
+++ b/common/changes/office-ui-fabric-react/modal-scrolling_2019-04-02-18-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Modal: constrain scrollableContent height to window.innerHeight (fix for DetailsList virtualization)",
+      "comment": "Modal: constrain scrollableContent height to 100vh and window.innerHeight for mobile Safari to support DetailsList virtualization",
       "type": "patch"
     }
   ],

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
@@ -78,7 +78,8 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       classNames.scrollableContent,
       {
         overflowY: 'auto',
-        flexGrow: 1
+        flexGrow: 1,
+        maxHeight: window.innerHeight
       },
       scrollableContentClassName
     ],

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
@@ -79,7 +79,12 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       {
         overflowY: 'auto',
         flexGrow: 1,
-        maxHeight: window.innerHeight
+        maxHeight: '100vh',
+        selectors: {
+          ['@supports (-webkit-overflow-scrolling: touch)']: {
+            maxHeight: window.innerHeight
+          }
+        }
       },
       scrollableContentClassName
     ],

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -151,8 +151,11 @@ exports[`Modal renders Modal correctly 1`] = `
                 ms-Modal-scrollableContent
                 {
                   flex-grow: 1;
-                  max-height: 768px;
+                  max-height: 100vh;
                   overflow-y: auto;
+                }
+                @supports (-webkit-overflow-scrolling: touch){& {
+                  max-height: 768px;
                 }
             data-is-scrollable={true}
           >
@@ -307,8 +310,11 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
                 ms-Modal-scrollableContent
                 {
                   flex-grow: 1;
-                  max-height: 768px;
+                  max-height: 100vh;
                   overflow-y: auto;
+                }
+                @supports (-webkit-overflow-scrolling: touch){& {
+                  max-height: 768px;
                 }
             data-is-scrollable={true}
           >

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`Modal renders Modal correctly 1`] = `
                 ms-Modal-scrollableContent
                 {
                   flex-grow: 1;
+                  max-height: 768px;
                   overflow-y: auto;
                 }
             data-is-scrollable={true}
@@ -306,6 +307,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
                 ms-Modal-scrollableContent
                 {
                   flex-grow: 1;
+                  max-height: 768px;
                   overflow-y: auto;
                 }
             data-is-scrollable={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8548 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The parent div of a DetailsList needs a constrained height in order for DetailsList virtualization to work. This pull request adds `maxHeight: window.innerHeight` to the scrollableContent div in a Modal so that, when a DetailsList is the direct child of a Modal (i.e. is not wrapped in some other customer-defined div), it is able to scroll properly. This is described further in this issue comment: https://github.com/OfficeDev/office-ui-fabric-react/issues/8548#issuecomment-479144863

Before this change (DetailsList inside a Modal, virtualization not working):
![modal-detailslist-scrolling-broken](https://user-images.githubusercontent.com/6687333/55428187-6bb68300-553d-11e9-9d77-09a9422dc872.gif)

After this change (DetailsList inside a Modal, virtualization working):
![modal-detailslist-scrolling-working](https://user-images.githubusercontent.com/6687333/55428195-71ac6400-553d-11e9-90db-2253a4e802ac.gif)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8568)