### PR TITLE
Update fabric-7 publish to use @next instead of @beta

### DIFF
--- a/scripts/publish-beta.js
+++ b/scripts/publish-beta.js
@@ -17,5 +17,5 @@ for (const package of packages) {
   const packagePath = path.resolve(__dirname, '..', package.projectFolder);
 
   console.log(`Publishing ${chalk.magenta(package.packageName)} in ${packagePath}`);
-  execSync('npm publish --tag beta', undefined, packagePath);
+  execSync('npm publish --tag next', undefined, packagePath);
 }


### PR DESCRIPTION
Use `next` tag.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8575)