### PR TITLE
Tooltip: fix for specificity wars with UHF

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-Tooltip_2019-04-03-02-28.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-Tooltip_2019-04-03-02-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: fixing the color and font size of subText not to be overriden by external UHF css.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-vibr@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -36,9 +36,11 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
     ],
     subText: [
       'ms-Tooltip-subtext',
-      fonts.small,
       {
-        color: palette.neutralPrimary,
+        // Using inherit here to avoid unintentional global overrides of the <p> tag.
+        fontSize: 'inherit',
+        fontWeight: 'inherit',
+        color: 'inherit',
         margin: 0
       }
     ]

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -27,8 +27,8 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
     content: [
       'ms-Tooltip-content',
       fonts.small,
-      palette.neutralPrimary,
       {
+        color: palette.neutralPrimary,
         wordWrap: 'break-word',
         overflowWrap: 'break-word',
         overflow: 'hidden'
@@ -37,6 +37,7 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
     subText: [
       'ms-Tooltip-subtext',
       {
+        fontSize: fonts.small.fontSize,
         margin: 0
       }
     ]

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -36,8 +36,9 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
     ],
     subText: [
       'ms-Tooltip-subtext',
+      fonts.small,
       {
-        fontSize: fonts.small.fontSize,
+        color: palette.neutralPrimary,
         margin: 0
       }
     ]


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

UHF wrapper for the website is overriding font size and color of the content of the tooltip. On the [HIG site](https://uifabric.azurewebsites.net/#/controls/web/tooltip) it's actually increasing it from 12px by design to 16px. This should help alleviate this issue by resetting the font size and color on the default renderer and still leaving it on the wrapper div for custom `onRenderContent` props.
![Screen Shot 2019-04-02 at 7 31 52 PM](https://user-images.githubusercontent.com/29514833/55449002-ca502100-557e-11e9-989b-bd774f1b238e.png)
![Screen Shot 2019-04-02 at 7 31 39 PM](https://user-images.githubusercontent.com/29514833/55449008-ccb27b00-557e-11e9-9765-6aa62f797c85.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8585)