### PR TITLE
Toggle onoff click

### DIFF
--- a/common/changes/office-ui-fabric-react/toggle-onoff-click_2019-04-03-23-24.json
+++ b/common/changes/office-ui-fabric-react/toggle-onoff-click_2019-04-03-23-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Toggle: make on/off text clickable",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -77,10 +77,27 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
       onOffMissing: !onText && !offText
     });
 
+    const labelId = `${this._id}-label`;
+    const stateTextId = `${this._id}-stateText`;
+
+    // The following properties take priority for what Narrator should read:
+    // 1. ariaLabel
+    // 2. onAriaLabel (if checked) or offAriaLabel (if not checked)
+    // 3. label
+    // 4. onText (if checked) or offText (if not checked)
+    let labelledById: string | undefined = undefined;
+    if (!ariaLabel && !badAriaLabel) {
+      if (label) {
+        labelledById = labelId;
+      } else if (stateText) {
+        labelledById = stateTextId;
+      }
+    }
+
     return (
       <RootType className={classNames.root} hidden={(toggleNativeProps as any).hidden}>
         {label && (
-          <Label htmlFor={this._id} className={classNames.label}>
+          <Label htmlFor={this._id} className={classNames.label} id={labelId}>
             {label}
           </Label>
         )}
@@ -103,12 +120,17 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
                 data-is-focusable={true}
                 onChange={this._noop}
                 onClick={this._onClick}
+                aria-labelledby={labelledById}
               >
                 <div className={classNames.thumb} />
               </button>
             )}
           </KeytipData>
-          {stateText && <Label className={classNames.text}>{stateText}</Label>}
+          {stateText && (
+            <Label htmlFor={this._id} className={classNames.text} id={stateTextId}>
+              {stateText}
+            </Label>
+          )}
         </div>
       </RootType>
     );

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.deprecated.test.tsx
@@ -28,29 +28,7 @@ describe('Toggle', () => {
   });
 
   it('renders aria-label based on onAriaLabel when Toggle is ON', () => {
-    let isToggledValue;
-    const callback = (isToggled: boolean) => {
-      isToggledValue = isToggled;
-    };
-
-    const component = mount<React.ReactInstance>(
-      <Toggle label="Label" onChanged={callback} offAriaLabel="offLabel" onAriaLabel="onLabel" />
-    );
-
-    expect(
-      component
-        .find('button')
-        .first()
-        .getDOMNode()
-        .getAttribute('aria-label')
-    ).toEqual('offLabel');
-
-    component
-      .find('button')
-      .first()
-      .simulate('click');
-
-    expect(isToggledValue).toEqual(true);
+    const component = mount(<Toggle label="Label" onAriaLabel="onLabel" defaultChecked />);
 
     expect(
       component
@@ -59,5 +37,29 @@ describe('Toggle', () => {
         .getDOMNode()
         .getAttribute('aria-label')
     ).toEqual('onLabel');
+  });
+
+  it('has no aria-labelledby attribute when checked if onAriaLabel is provided', () => {
+    const component = mount(<Toggle label="Label" onAriaLabel="OnAriaLabel" defaultChecked />);
+
+    expect(
+      component
+        .find('button')
+        .first()
+        .getDOMNode()
+        .getAttribute('aria-labelledby')
+    ).toBeNull();
+  });
+
+  it('has no aria-labelledby attribute when unchecked if offAriaLabel is provided', () => {
+    const component = mount(<Toggle label="Label" offAriaLabel="OffAriaLabel" />);
+
+    expect(
+      component
+        .find('button')
+        .first()
+        .getDOMNode()
+        .getAttribute('aria-labelledby')
+    ).toBeNull();
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -142,4 +142,54 @@ describe('Toggle', () => {
     expect((component as React.Component<any, any>).state.checked).toEqual(true);
     expect(onSubmit.called).toEqual(false);
   });
+
+  describe('aria-labelledby', () => {
+    it('has no aria-labelledby attribute if ariaLabel is provided', () => {
+      const component = mount(<Toggle label="Label" ariaLabel="AriaLabel" />);
+
+      expect(
+        component
+          .find('button')
+          .first()
+          .getDOMNode()
+          .getAttribute('aria-labelledby')
+      ).toBeNull();
+    });
+
+    it('is labelled by the label element if no aria labels are provided', () => {
+      const component = mount(<Toggle label="Label" id="ToggleId" />);
+
+      expect(
+        component
+          .find('button')
+          .first()
+          .getDOMNode()
+          .getAttribute('aria-labelledby')
+      ).toBe('ToggleId-label');
+    });
+
+    it('is labelled by the state text element if no aria labels are provided and no label is provided', () => {
+      const component = mount(<Toggle onText="On" offText="Off" id="ToggleId" />);
+
+      expect(
+        component
+          .find('button')
+          .first()
+          .getDOMNode()
+          .getAttribute('aria-labelledby')
+      ).toBe('ToggleId-stateText');
+    });
+
+    it('is labelled by the state text element if no aria labels are provided and no label is provided', () => {
+      const component = mount(<Toggle onText="On" offText="Off" id="ToggleId" />);
+
+      expect(
+        component
+          .find('button')
+          .first()
+          .getDOMNode()
+          .getAttribute('aria-labelledby')
+      ).toBe('ToggleId-stateText');
+    });
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`Toggle renders toggle correctly 1`] = `
           word-wrap: break-word;
         }
     htmlFor="Toggle1"
+    id="Toggle1-label"
   >
     Label
   </label>
@@ -152,6 +153,7 @@ exports[`Toggle renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
+      aria-labelledby="Toggle1-label"
       className=
           ms-Toggle-background
           {
@@ -268,6 +270,7 @@ exports[`Toggle renders toggle correctly with inline label 1`] = `
           word-wrap: break-word;
         }
     htmlFor="Toggle2"
+    id="Toggle2-label"
   >
     Label
   </label>
@@ -281,6 +284,7 @@ exports[`Toggle renders toggle correctly with inline label 1`] = `
   >
     <button
       aria-checked={false}
+      aria-labelledby="Toggle2-label"
       className=
           ms-Toggle-background
           {
@@ -396,6 +400,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           word-wrap: break-word;
         }
     htmlFor="Toggle3"
+    id="Toggle3-label"
   >
     Label
   </label>
@@ -409,6 +414,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
   >
     <button
       aria-checked={false}
+      aria-labelledby="Toggle3-label"
       className=
           ms-Toggle-background
           {
@@ -514,6 +520,8 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
             padding-top: 0;
             user-select: none;
           }
+      htmlFor="Toggle3"
+      id="Toggle3-stateText"
     >
       Off
     </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -78,6 +78,7 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
             word-wrap: break-word;
           }
       htmlFor="Toggle0"
+      id="Toggle0-label"
     >
       Check to start loading photos
     </label>
@@ -91,6 +92,7 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle0-label"
         className=
             ms-Toggle-background
             {
@@ -196,6 +198,8 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle0"
+        id="Toggle0-stateText"
       >
         Pause
       </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1053,6 +1053,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               word-wrap: break-word;
             }
         htmlFor="Toggle10"
+        id="Toggle10-label"
       >
         Hide alpha slider
       </label>
@@ -1066,6 +1067,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle10-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -386,6 +386,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             word-wrap: break-word;
           }
       htmlFor="Toggle4"
+      id="Toggle4-label"
     >
       Allow freeform
     </label>
@@ -399,6 +400,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={true}
+        aria-labelledby="Toggle4-label"
         checked={true}
         className=
             ms-Toggle-background
@@ -517,6 +519,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             word-wrap: break-word;
           }
       htmlFor="Toggle5"
+      id="Toggle5-label"
     >
       Auto-complete
     </label>
@@ -530,6 +533,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle5-label"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -80,6 +80,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Enable compact mode
       </label>
@@ -93,6 +94,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -199,6 +201,8 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Normal
         </label>
@@ -247,6 +251,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               word-wrap: break-word;
             }
         htmlFor="Toggle1"
+        id="Toggle1-label"
       >
         Enable modal selection
       </label>
@@ -260,6 +265,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle1-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -366,6 +372,8 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle1"
+          id="Toggle1-stateText"
         >
           Normal
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -53,6 +53,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Enable column reorder
       </label>
@@ -66,6 +67,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
       >
         <button
           aria-checked={true}
+          aria-labelledby="Toggle0-label"
           checked={true}
           className=
               ms-Toggle-background
@@ -179,6 +181,8 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Enabled
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -173,6 +173,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               word-wrap: break-word;
             }
         htmlFor="Toggle3"
+        id="Toggle3-label"
       >
         Compact mode
       </label>
@@ -186,6 +187,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle3-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -303,6 +305,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               word-wrap: break-word;
             }
         htmlFor="Toggle4"
+        id="Toggle4-label"
       >
         Show index of first item in view when unmounting
       </label>
@@ -316,6 +319,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle4-label"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -62,6 +62,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
       htmlFor="Toggle0"
+      id="Toggle0-label"
     >
       Show error message
     </label>
@@ -75,6 +76,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle0-label"
         checked={false}
         className=
             ms-Toggle-background
@@ -181,6 +183,8 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle0"
+        id="Toggle0-stateText"
       >
         No
       </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -103,6 +103,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             word-wrap: break-word;
           }
       htmlFor="Toggle1"
+      id="Toggle1-label"
     >
       Controlled component
     </label>
@@ -116,6 +117,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle1-label"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Use trap zone
       </label>
@@ -81,6 +82,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -187,6 +189,8 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Off
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Use trap zone
       </label>
@@ -81,6 +82,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -187,6 +189,8 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Off
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Use trap zone
       </label>
@@ -81,6 +82,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -187,6 +189,8 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Off
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Use trap zone
       </label>
@@ -81,6 +82,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -187,6 +189,8 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Off
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -183,6 +183,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               word-wrap: break-word;
             }
         htmlFor="Toggle3"
+        id="Toggle3-label"
       >
         Enable trap zone 1
       </label>
@@ -196,6 +197,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle3-label"
           className=
               ms-Toggle-background
               {
@@ -301,6 +303,8 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle3"
+          id="Toggle3-stateText"
         >
           Off
         </label>
@@ -487,6 +491,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 word-wrap: break-word;
               }
           htmlFor="Toggle7"
+          id="Toggle7-label"
         >
           Enable trap zone 2
         </label>
@@ -500,6 +505,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         >
           <button
             aria-checked={false}
+            aria-labelledby="Toggle7-label"
             className=
                 ms-Toggle-background
                 {
@@ -605,6 +611,8 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   padding-top: 0;
                   user-select: none;
                 }
+            htmlFor="Toggle7"
+            id="Toggle7-stateText"
           >
             Off
           </label>
@@ -791,6 +799,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   word-wrap: break-word;
                 }
             htmlFor="Toggle11"
+            id="Toggle11-label"
           >
             Enable trap zone 3
           </label>
@@ -804,6 +813,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           >
             <button
               aria-checked={false}
+              aria-labelledby="Toggle11-label"
               className=
                   ms-Toggle-background
                   {
@@ -909,6 +919,8 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     padding-top: 0;
                     user-select: none;
                   }
+              htmlFor="Toggle11"
+              id="Toggle11-stateText"
             >
               Off
             </label>
@@ -1096,6 +1108,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   word-wrap: break-word;
                 }
             htmlFor="Toggle15"
+            id="Toggle15-label"
           >
             Enable trap zone 4
           </label>
@@ -1109,6 +1122,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           >
             <button
               aria-checked={false}
+              aria-labelledby="Toggle15-label"
               className=
                   ms-Toggle-background
                   {
@@ -1214,6 +1228,8 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     padding-top: 0;
                     user-select: none;
                   }
+              htmlFor="Toggle15"
+              id="Toggle15-stateText"
             >
               Off
             </label>
@@ -1401,6 +1417,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 word-wrap: break-word;
               }
           htmlFor="Toggle19"
+          id="Toggle19-label"
         >
           Enable trap zone 5
         </label>
@@ -1414,6 +1431,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         >
           <button
             aria-checked={false}
+            aria-labelledby="Toggle19-label"
             className=
                 ms-Toggle-background
                 {
@@ -1519,6 +1537,8 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   padding-top: 0;
                   user-select: none;
                 }
+            htmlFor="Toggle19"
+            id="Toggle19-stateText"
           >
             Off
           </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.NoTabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.NoTabbable.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders FocusTrapZone.NoTabbable.Example.tsx correct
               word-wrap: break-word;
             }
         htmlFor="Toggle0"
+        id="Toggle0-label"
       >
         Use trap zone
       </label>
@@ -81,6 +82,7 @@ exports[`Component Examples renders FocusTrapZone.NoTabbable.Example.tsx correct
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle0-label"
           checked={false}
           className=
               ms-Toggle-background
@@ -187,6 +189,8 @@ exports[`Component Examples renders FocusTrapZone.NoTabbable.Example.tsx correct
                 padding-top: 0;
                 user-select: none;
               }
+          htmlFor="Toggle0"
+          id="Toggle0-stateText"
         >
           Off
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -962,6 +962,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               <button
                 aria-checked={false}
                 aria-describedby="ktp-layer-id ktp-a-1"
+                aria-labelledby="Toggle19-stateText"
                 className=
                     ms-Toggle-background
                     {
@@ -1069,6 +1070,8 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                       padding-top: 0;
                       user-select: none;
                     }
+                htmlFor="Toggle19"
+                id="Toggle19-stateText"
               >
                 No
               </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -970,6 +970,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-labelledby="Toggle21-stateText"
         className=
             ms-Toggle-background
             {
@@ -1082,6 +1083,8 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle21"
+        id="Toggle21-stateText"
       >
         Enabled
       </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
       htmlFor="Toggle1"
+      id="Toggle1-label"
     >
       Show host
     </label>
@@ -55,6 +56,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-labelledby="Toggle1-label"
         checked={true}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -483,6 +483,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
               word-wrap: break-word;
             }
         htmlFor="Toggle4"
+        id="Toggle4-label"
       >
         Delay Suggestion Results
       </label>
@@ -496,6 +497,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       >
         <button
           aria-checked={false}
+          aria-labelledby="Toggle4-label"
           className=
               ms-Toggle-background
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -41,6 +41,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
             word-wrap: break-word;
           }
       htmlFor="Toggle0"
+      id="Toggle0-label"
     >
       Toggle to load content
     </label>
@@ -54,6 +55,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle0-label"
         checked={false}
         className=
             ms-Toggle-background
@@ -166,6 +168,8 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle0"
+        id="Toggle0-stateText"
       >
         Shimmer
       </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -40,6 +40,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle0-stateText"
         checked={false}
         className=
             ms-Toggle-background
@@ -146,6 +147,8 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle0"
+        id="Toggle0-stateText"
       >
         Toggle to load content
       </label>
@@ -375,6 +378,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle1-stateText"
         checked={false}
         className=
             ms-Toggle-background
@@ -481,6 +485,8 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle1"
+        id="Toggle1-stateText"
       >
         Toggle to load content
       </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -65,6 +65,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             word-wrap: break-word;
           }
       htmlFor="Toggle0"
+      id="Toggle0-label"
     >
       Show text fields
     </label>
@@ -78,6 +79,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle0-label"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -48,6 +48,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
       htmlFor="Toggle0"
+      id="Toggle0-label"
     >
       Enabled and checked
     </label>
@@ -61,6 +62,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-labelledby="Toggle0-label"
         className=
             ms-Toggle-background
             {
@@ -175,6 +177,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle0"
+        id="Toggle0-stateText"
       >
         On
       </label>
@@ -219,6 +223,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
       htmlFor="Toggle1"
+      id="Toggle1-label"
     >
       Enabled and unchecked
     </label>
@@ -232,6 +237,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
+        aria-labelledby="Toggle1-label"
         className=
             ms-Toggle-background
             {
@@ -339,6 +345,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle1"
+        id="Toggle1-stateText"
       >
         Off
       </label>
@@ -387,6 +395,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             color: GrayText;
           }
       htmlFor="Toggle2"
+      id="Toggle2-label"
     >
       Disabled and checked
     </label>
@@ -401,6 +410,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
+        aria-labelledby="Toggle2-label"
         className=
             ms-Toggle-background
             {
@@ -506,6 +516,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&& {
               color: GrayText;
             }
+        htmlFor="Toggle2"
+        id="Toggle2-stateText"
       >
         On
       </label>
@@ -553,6 +565,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             color: GrayText;
           }
       htmlFor="Toggle3"
+      id="Toggle3-label"
     >
       Disabled and unchecked
     </label>
@@ -567,6 +580,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={false}
         aria-disabled={true}
+        aria-labelledby="Toggle3-label"
         className=
             ms-Toggle-background
             {
@@ -670,6 +684,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&& {
               color: GrayText;
             }
+        htmlFor="Toggle3"
+        id="Toggle3-stateText"
       >
         Off
       </label>
@@ -717,6 +733,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
       htmlFor="Toggle4"
+      id="Toggle4-label"
     >
       With inline label
     </label>
@@ -730,6 +747,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-labelledby="Toggle4-label"
         className=
             ms-Toggle-background
             {
@@ -844,6 +862,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               user-select: none;
             }
+        htmlFor="Toggle4"
+        id="Toggle4-stateText"
       >
         On
       </label>
@@ -894,6 +914,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             color: GrayText;
           }
       htmlFor="Toggle5"
+      id="Toggle5-label"
     >
       Disabled with inline label
     </label>
@@ -908,6 +929,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
+        aria-labelledby="Toggle5-label"
         className=
             ms-Toggle-background
             {
@@ -1013,6 +1035,8 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&& {
               color: GrayText;
             }
+        htmlFor="Toggle5"
+        id="Toggle5-stateText"
       >
         On
       </label>
@@ -1061,6 +1085,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
       htmlFor="Toggle6"
+      id="Toggle6-label"
     >
       With inline label and without onText and offText
     </label>
@@ -1074,6 +1099,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
+        aria-labelledby="Toggle6-label"
         className=
             ms-Toggle-background
             {
@@ -1200,6 +1226,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             color: GrayText;
           }
       htmlFor="Toggle7"
+      id="Toggle7-label"
     >
       Disabled with inline label and without onText and offText
     </label>
@@ -1214,6 +1241,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
+        aria-labelledby="Toggle7-label"
         className=
             ms-Toggle-background
             {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8577 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This pull request allows users to change the "checked" state of a Toggle by clicking its On/Off text. Previously, only the Toggle label had this behavior.

The change is accomplished by making the on/off text element be "for" the Toggle button, just like the label element is. Just this change alone would result in undesired screen reader behavior, where if both the label and the on/off text are provided, narrator would read the on/off text instead of the label. To mitigate this, this PR also adds the `aria-labelledby` attribute to the Toggle button. This attribute follows these rules (in order of priority - e.g. rule 2 only applies if no ariaLabel property is provided, etc.):

1. If the `ariaLabel` property is provided, Narrator will read the provided ariaLabel (no `aria-labelledby` attribute is set).
2. If the deprecated `onAriaLabel` is provided and the Toggle is checked, Narrator will read the provided onAriaLabel (no `aria-labelledby` attribute is set).
3. If the deprecated `offAriaLabel` is provided and the Toggle is not checked, Narrator will read the provided offAriaLabel (no `aria-labelledby` attribute is set).
4. If the `label` property is provided, Narrator will read the provided label (`aria-labelledby` is the id of the label element).
5. If the `onText` property is provided and the Toggle is checked, Narrator will read the provided onText (`aria-labelledby` is the id of the stateText element).
6. If the `offText` property is provided and the Toggle is checked, Narrator will read the provided offText (`aria-labelledby` is the id of the stateText element).

Discussion question: should the deprecated `onAriaLabel` and `offAriaLabel` properties take precedence over the `label`, `onText`, and `offText` properties for what Narrator should read? This would be a very simple code change, it's just a question of what the desired behavior is.

#### Focus areas to test

1. Clicking the on or off text (if provided) should trigger the Toggle.
2. Clicking the label (if provided) should still trigger the Toggle (as it did before this PR).
3. Narrator should read the correct text according to the rules described above.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8597)