### PR TITLE
TextField: clarify onBeforeChange docs

### DIFF
--- a/apps/todo-app/src/components/TodoForm.tsx
+++ b/apps/todo-app/src/components/TodoForm.tsx
@@ -47,9 +47,6 @@ export default class TodoForm extends BaseComponent<ITodoFormProps, ITodoFormSta
   constructor(props: ITodoFormProps) {
     super(props);
 
-    this._onSubmit = this._onSubmit.bind(this);
-    this._onBeforeTextFieldChange = this._onBeforeTextFieldChange.bind(this);
-
     this.state = {
       inputValue: '',
       errorMessage: ''
@@ -64,7 +61,7 @@ export default class TodoForm extends BaseComponent<ITodoFormProps, ITodoFormSta
           value={this.state.inputValue}
           componentRef={this._textField}
           placeholder={strings.inputBoxPlaceholder}
-          onBeforeChange={this._onBeforeTextFieldChange}
+          onChange={this._onTextFieldChange}
           autoComplete="off"
           errorMessage={this.state.errorMessage}
         />
@@ -98,12 +95,12 @@ export default class TodoForm extends BaseComponent<ITodoFormProps, ITodoFormSta
     }
   };
 
-  private _onBeforeTextFieldChange(newValue: string): void {
+  private _onTextFieldChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string | undefined): void => {
     this.setState({
-      inputValue: newValue,
+      inputValue: newValue || '',
       errorMessage: ''
     });
-  }
+  };
 
   private _getTitleErrorMessage(title: string): string {
     if (title.trim() === '') {

--- a/common/changes/office-ui-fabric-react/beforechange_2019-04-04-02-35.json
+++ b/common/changes/office-ui-fabric-react/beforechange_2019-04-04-02-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: clarify onBeforeChange documentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7209,7 +7209,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
         [key: string]: RegExp;
     };
     multiline?: boolean;
-    onBeforeChange?: (newValue: any) => void;
+    onBeforeChange?: (newValue?: string) => void;
     onChange?: (event: React_2.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     // @deprecated (undocumented)
     onChanged?: (newValue: any) => void;

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
@@ -37,13 +37,13 @@ export class ListBasicExample extends React.Component<IListBasicExampleProps, IL
 
     return (
       <FocusZone direction={FocusZoneDirection.vertical}>
-        <TextField label={'Filter by name' + resultCountText} onBeforeChange={this._onFilterChanged} />
+        <TextField label={'Filter by name' + resultCountText} onChange={this._onFilterChanged} />
         <List items={items} onRenderCell={this._onRenderCell} />
       </FocusZone>
     );
   }
 
-  private _onFilterChanged(text: string): void {
+  private _onFilterChanged(_: any, text: string): void {
     const { items } = this.props;
 
     this.setState({

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -175,9 +175,13 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 
   /**
    * Called after the input's value updates but before re-rendering.
+   * Unlike `onChange`, this is also called when the value is updated via props.
+   *
+   * NOTE: This should be used *very* rarely. `onChange` is more appropriate for most situations.
+   *
    * @param newValue - The new value. Type should be string.
    */
-  onBeforeChange?: (newValue: any) => void;
+  onBeforeChange?: (newValue?: string) => void;
 
   /**
    * Function called after validation completes.


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

~~The `onBeforeChange` callback in TextField seems redundant with `onChange`, so I'd like to deprecate it (for removal in v7) unless someone can think of a valid use case.~~

Turns out MaskedTextField uses `onBeforeChange` in a way that I can't immediately figure out how to duplicate with `onChange`, at least to make its tests pass (the scenarios in the tests seem to work fine in the UI...). So I'm leaving `onBeforeChange` un-deprecated for now and updating the docs to discourage using it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8604)