### PR TITLE
SelectionZone: Disable user selection when selection mode is set to SelectionMode.none

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-selectionzone-mode-none_2019-04-04-03-31.json
+++ b/common/changes/office-ui-fabric-react/keco-selectionzone-mode-none_2019-04-04-03-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "SelectionZone: Disallow selection when selection mode is SelectionMode.none",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keco@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -277,6 +277,16 @@ describe('SelectionZone', () => {
   });
 });
 
+describe('SelectionZone - SelectionMode.none', () => {
+  beforeEach(() => _initializeSelection(SelectionMode.none));
+
+  it('does not select an item when selection mode is SelectionMode.none', () => {
+    ReactTestUtils.Simulate.mouseDown(_surface0);
+    expect(_selection.isIndexSelected(0)).toEqual(false);
+    expect(_selection.getSelectedCount()).toEqual(0);
+  });
+});
+
 function _simulateClick(el: Element, eventData?: ReactTestUtils.SyntheticEventData): void {
   ReactTestUtils.Simulate.mouseDown(el, eventData);
   ReactTestUtils.Simulate.focus(el, eventData);

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -279,6 +279,10 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
   };
 
   private _isSelectionDisabled(target: HTMLElement): boolean {
+    if (this._getSelectionMode() === SelectionMode.none) {
+      return true;
+    }
+
     while (target !== this._root.current) {
       if (this._hasAttribute(target, SELECTION_DISABLED_ATTRIBUTE_NAME)) {
         return true;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8543
- [x] Include a change request file using `$ npm run change`

#### Description of changes

One approach to resolve https://github.com/OfficeDev/office-ui-fabric-react/issues/8543. The problem here is that `SelectionZone` wraps `List` in `DetailsList.base` and allows selection via mouse "click" regardless of selection mode equal to `SelectionMode.none`, see:

https://github.com/OfficeDev/office-ui-fabric-react/blob/ee9b6edfc408e4073abf3bdfb96b03e589e78692/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx#L454

An alternative fix for this issue is to localize the change to `DetailsList.base`, see:

https://github.com/OfficeDev/office-ui-fabric-react/compare/master...KevinTCoughlin:keco/detailslist-selection-none

@dzearing, I defer to you. I am concerned about regression with this `SelectionZone` behavior change even tho it seems like `SelectionMode.none` should disable selection. The usage of `SelectionZone` across Fabric is quite broad.

#### Focus areas to test

I'm willing to invest in more test coverage for this pull-request once the approach is confirmed.

- CI should pass
- New `SelectionZone` test should pass.

The new unit test fails on `master`, see:

```shell
  ● SelectionZone - SelectionMode.none › does not select an item when selection mode is SelectionMode.none

    expect(received).toEqual(expected)

    Expected value to equal:
      false
    Received:
      true

      283 |   it('does not select an item when selection mode is SelectionMode.none', () => {
      284 |     ReactTestUtils.Simulate.mouseDown(_surface0);
    > 285 |     expect(_selection.isIndexSelected(0)).toEqual(false);
          |                                           ^
      286 |     expect(_selection.getSelectedCount()).toEqual(0);
      287 |   });
      288 | });
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8605)