### PR TITLE
Panel high contrast border

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-highcontrast-border_2019-04-04-18-32.json
+++ b/common/changes/office-ui-fabric-react/panel-highcontrast-border_2019-04-04-18-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: add border to main div in high contrast",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -4,6 +4,7 @@ import {
   AnimationVariables,
   DefaultFontStyles,
   getGlobalClassNames,
+  HighContrastSelector,
   ScreenWidthMinMedium,
   ScreenWidthMinLarge,
   ScreenWidthMinXLarge,
@@ -258,8 +259,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
           ['@supports (-webkit-overflow-scrolling: touch)']: {
             maxHeight: windowHeight
           },
-          '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)': {
-            // For IE high contrast mode
+          [HighContrastSelector]: {
             borderLeft: `1px solid ${palette.neutralLight}`,
             borderRight: `1px solid ${palette.neutralLight}`
           },

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -258,6 +258,11 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
           ['@supports (-webkit-overflow-scrolling: touch)']: {
             maxHeight: windowHeight
           },
+          '@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)': {
+            // For IE high contrast mode
+            borderLeft: `1px solid ${palette.neutralLight}`,
+            borderRight: `1px solid ${palette.neutralLight}`
+          },
           ...getPanelBreakpoints(type)
         }
       },

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -260,8 +260,8 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
             maxHeight: windowHeight
           },
           [HighContrastSelector]: {
-            borderLeft: `1px solid ${palette.neutralLight}`,
-            borderRight: `1px solid ${palette.neutralLight}`
+            borderLeft: `3px solid ${palette.neutralLight}`,
+            borderRight: `3px solid ${palette.neutralLight}`
           },
           ...getPanelBreakpoints(type)
         }

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`Panel renders Panel correctly 1`] = `
               @supports (-webkit-overflow-scrolling: touch){& {
                 max-height: 768px;
               }
-              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+              @media screen and (-ms-high-contrast: active){& {
                 border-left: 1px solid #eaeaea;
                 border-right: 1px solid #eaeaea;
               }

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -150,6 +150,10 @@ exports[`Panel renders Panel correctly 1`] = `
               @supports (-webkit-overflow-scrolling: touch){& {
                 max-height: 768px;
               }
+              @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                border-left: 1px solid #eaeaea;
+                border-right: 1px solid #eaeaea;
+              }
               @media (min-width: 480px){& {
                 width: 340px;
               }

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -151,8 +151,8 @@ exports[`Panel renders Panel correctly 1`] = `
                 max-height: 768px;
               }
               @media screen and (-ms-high-contrast: active){& {
-                border-left: 1px solid #eaeaea;
-                border-right: 1px solid #eaeaea;
+                border-left: 3px solid #eaeaea;
+                border-right: 3px solid #eaeaea;
               }
               @media (min-width: 480px){& {
                 width: 340px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -236,8 +236,8 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                   max-height: 768px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
-                  border-left: 1px solid #eaeaea;
-                  border-right: 1px solid #eaeaea;
+                  border-left: 3px solid #eaeaea;
+                  border-right: 3px solid #eaeaea;
                 }
                 @media (min-width: 480px){& {
                   width: 340px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -235,6 +235,10 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                 @supports (-webkit-overflow-scrolling: touch){& {
                   max-height: 768px;
                 }
+                @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                  border-left: 1px solid #eaeaea;
+                  border-right: 1px solid #eaeaea;
+                }
                 @media (min-width: 480px){& {
                   width: 340px;
                 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -235,7 +235,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                 @supports (-webkit-overflow-scrolling: touch){& {
                   max-height: 768px;
                 }
-                @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none){& {
+                @media screen and (-ms-high-contrast: active){& {
                   border-left: 1px solid #eaeaea;
                   border-right: 1px solid #eaeaea;
                 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8588 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This pull request adds a left and right border to the main Panel div in high contrast mode.

Before (Panel indistinguishable from the rest of the page):
![panel-hc-before](https://user-images.githubusercontent.com/6687333/55579858-12318e00-56ce-11e9-9e75-d8ae42749981.PNG)

After: (Panel separated from the rest of the page with the border):
![panel-hc-after](https://user-images.githubusercontent.com/6687333/55579900-2ffef300-56ce-11e9-9557-4848ace38fa0.PNG)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8609)