### PR TITLE
fixing tsjest warnings

### DIFF
--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -164,7 +164,7 @@ dependencies:
   stickyfilljs: 2.1.0
   storybook-readme: 3.3.0
   style-loader: 0.21.0
-  ts-jest: 24.0.0
+  ts-jest: 24.0.1
   ts-loader: 4.5.0
   tslib: 1.9.3
   tslint: 5.12.1
@@ -13727,7 +13727,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
-  /ts-jest/24.0.0:
+  /ts-jest/24.0.1:
     dependencies:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
@@ -13736,7 +13736,7 @@ packages:
       make-error: 1.3.5
       mkdirp: 0.5.1
       resolve: 1.10.0
-      semver: 5.6.0
+      semver: 5.7.0
       yargs-parser: 10.1.0
     dev: false
     engines:
@@ -13745,8 +13745,8 @@ packages:
     peerDependencies:
       jest: '>=24 <25'
     resolution:
-      integrity: sha512-o8BO3TkMREpAATaFTrXkovMsCpBl2z4NDBoLJuWZcJJj1ijI49UnvDMfVpj+iogn/Jl8Pbhuei5nc/Ti+frEHw==
-  /ts-jest/24.0.0/jest@24.1.0:
+      integrity: sha512-mgNZmYPuGBNgYpUzchI7vdSr6zATQI0TrSyzREnXHuPCvlW8T1DQ/fdscgx4ivS5vAMUGUaoxGdWIVHC5I8imw==
+  /ts-jest/24.0.1/jest@24.1.0:
     dependencies:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
@@ -13756,17 +13756,17 @@ packages:
       make-error: 1.3.5
       mkdirp: 0.5.1
       resolve: 1.10.0
-      semver: 5.6.0
+      semver: 5.7.0
       yargs-parser: 10.1.0
     dev: false
     engines:
       node: '>= 6'
     hasBin: true
-    id: registry.npmjs.org/ts-jest/24.0.0
+    id: registry.npmjs.org/ts-jest/24.0.1
     peerDependencies:
       jest: '>=24 <25'
     resolution:
-      integrity: sha512-o8BO3TkMREpAATaFTrXkovMsCpBl2z4NDBoLJuWZcJJj1ijI49UnvDMfVpj+iogn/Jl8Pbhuei5nc/Ti+frEHw==
+      integrity: sha512-mgNZmYPuGBNgYpUzchI7vdSr6zATQI0TrSyzREnXHuPCvlW8T1DQ/fdscgx4ivS5vAMUGUaoxGdWIVHC5I8imw==
   /ts-loader/4.5.0:
     dependencies:
       chalk: 2.4.2
@@ -15041,7 +15041,7 @@ packages:
       sass-loader: /sass-loader/6.0.7/node-sass@4.11.0+webpack@4.29.5
       source-map-loader: 0.2.4
       style-loader: 0.21.0
-      ts-jest: /ts-jest/24.0.0/jest@24.1.0
+      ts-jest: /ts-jest/24.0.1/jest@24.1.0
       ts-loader: 4.5.0
       tslint: /tslint/5.12.1/typescript@3.3.3
       tslint-microsoft-contrib: /tslint-microsoft-contrib/5.2.1/tslint@5.12.1+typescript@3.3.3
@@ -15055,7 +15055,7 @@ packages:
     dev: false
     name: '@rush-temp/build'
     resolution:
-      integrity: sha512-dfDE51HSnQL9a0AGM7eOsNdANNhUz/2MDnQiQWtvFJbrck3U7NC4V8y8/X3Ml9MPZi3hVPC/No6vWOm9i3RocA==
+      integrity: sha512-X6g7Euha31SFH+AMh798owKli0ayAMfnCxt6HTWSUUtcmC8ZoGJkES+UUDQ2HvkzEVajsQxDTC19/6t7e5gWag==
       tarball: 'file:projects/build.tgz'
     version: 0.0.0
   'file:projects/charting.tgz':
@@ -15113,13 +15113,13 @@ packages:
       loader-utils: 1.2.3
       prettier: 1.16.4
       recast: 0.15.5
-      ts-jest: 24.0.0
+      ts-jest: 24.0.1
       tslib: 1.9.3
       webpack: 4.29.5
     dev: false
     name: '@rush-temp/codepen-loader'
     resolution:
-      integrity: sha512-FKnO1ixbXBscVWIWy0K61/KxKIUjosvrasHwSRKIPbY0UFwSNESL0MTwZa2K6Bt15itLiU6ucTCmKh+vW3WkUQ==
+      integrity: sha512-Gc8QnDRvj5fOpLk6sZ8SrlTr0VogDiHLIIf9oe8WUn7I4vcEkIeD8/VnXDsTYDEfiqLOJR5Nn5jMDTvLyjsjCw==
       tarball: 'file:projects/codepen-loader.tgz'
     version: 0.0.0
   'file:projects/dashboard.tgz':
@@ -15909,7 +15909,7 @@ specifiers:
   stickyfilljs: ^2.1.0
   storybook-readme: ^3.3.0
   style-loader: ^0.21.0
-  ts-jest: 24.0.0
+  ts-jest: 24.0.1
   ts-loader: ^4.1.0
   tslib: ^1.7.1
   tslint: ^5.7.0

--- a/packages/codepen-loader/package.json
+++ b/packages/codepen-loader/package.json
@@ -30,7 +30,7 @@
     "@types/prettier": "^1.16.1",
     "@uifabric/prettier-rules": "^1.0.1",
     "@uifabric/tslint-rules": "^1.0.1",
-    "ts-jest": "24.0.0",
+    "ts-jest": "24.0.1",
     "webpack": "4.29.5"
   },
   "dependencies": {

--- a/scripts/jest/jest-resources.js
+++ b/scripts/jest/jest-resources.js
@@ -20,6 +20,8 @@ module.exports = {
           '.(ts|tsx)': resolve.sync('ts-jest/dist')
         },
 
+        transformIgnorePatterns: ['/node_modules/', '/lib-commonjs/', '\\.js$'],
+
         reporters: [path.resolve(__dirname, './jest-reporter.js')],
 
         testRegex: '(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$',
@@ -32,6 +34,7 @@ module.exports = {
         globals: {
           'ts-jest': {
             tsConfig: path.resolve(process.cwd(), 'tsconfig.json'),
+            packageJson: path.resolve(process.cwd(), 'package.json'),
             diagnostics: false
           }
         },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -61,7 +61,7 @@
     "sass-loader": "^6.0.6",
     "source-map-loader": "^0.2.1",
     "style-loader": "^0.21.0",
-    "ts-jest": "24.0.0",
+    "ts-jest": "24.0.1",
     "ts-loader": "^4.1.0",
     "tslint": "^5.7.0",
     "tslint-microsoft-contrib": "^5.0.1",


### PR DESCRIPTION
#### Pull request checklist

#### Description of changes

I fixed some of the tsjest warnings with fixes from JD's fixes in ts-jest. This should allow incremental builds to happen in fabric-7.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8611)