### PR TITLE
DetailsList: add headerInfo prop to IColumn

### DIFF
--- a/common/changes/office-ui-fabric-react/addedHeaderinfoAlongWithTooltipToShowSomeInformation_2019-04-05-10-47.json
+++ b/common/changes/office-ui-fabric-react/addedHeaderinfoAlongWithTooltipToShowSomeInformation_2019-04-05-10-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "added the headerInfo prop to the detailsColumn to give more information about that column in the tooltip",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "saishiva99@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -8,6 +8,7 @@ import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
 import { IDetailsColumnStyles } from './DetailsColumn.types';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 import { IDetailsColumnStyleProps, IDetailsColumnProps } from './DetailsColumn.types';
+import { TooltipHost } from '../Tooltip';
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 
@@ -116,6 +117,12 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
                     <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />
+                  )}
+
+                  {!!column.headerInfo && (
+                    <TooltipHost content={column.headerInfo} calloutProps={{ gapSpace: 0 }}>
+                      <Icon iconName={'Info'} className={classNames.nearIcon} ariaLabel={column.headerInfo} />
+                    </TooltipHost>
                   )}
                 </span>
               )

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -473,6 +473,10 @@ export interface IColumn {
    * Indicates whether a dropdown menu is open so that the appropriate ARIA attributes are rendered.
    */
   isMenuOpen?: boolean;
+  /**
+   *  it will give the Header info in the tooltip
+   */
+  headerInfo?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -44,7 +44,7 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
     }
 
     this._columns = [
-      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+      { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true, headerInfo: 'name column' },
       { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true }
     ];
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Added headerinfo prop in IColumn and consumed it in DetailColumn.tsx to show more information about column in an info icon within in the tool tip. below is the image for the same
![headerinfo](https://user-images.githubusercontent.com/33802398/55623195-e4c50d00-57bf-11e9-82dc-7ad3a37a5eb7.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8619)