### PR TITLE
Persona: latin characters rendered in any of the text fields now truncate on the correct side

### DIFF
--- a/common/changes/office-ui-fabric-react/dir-fix_2019-04-05-16-07.json
+++ b/common/changes/office-ui-fabric-react/dir-fix_2019-04-05-16-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Persona: now sets dir=auto for text fields rendered in persona.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -128,7 +128,11 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
     renderFunction: IRenderFunction<IPersonaProps> | undefined,
     defaultRenderFunction: IRenderFunction<IPersonaProps> | undefined
   ): JSX.Element {
-    return <div className={classNames}>{renderFunction && renderFunction(this.props, defaultRenderFunction)}</div>;
+    return (
+      <div dir="auto" className={classNames}>
+        {renderFunction && renderFunction(this.props, defaultRenderFunction)}
+      </div>
+    );
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -140,6 +141,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -153,6 +155,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -166,6 +169,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <span>
       Persona Children
@@ -302,6 +306,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -328,6 +333,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -341,6 +347,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -354,6 +361,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -500,6 +508,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -526,6 +535,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -539,6 +549,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -552,6 +563,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -671,6 +683,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -697,6 +710,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -710,6 +724,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -723,6 +738,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -856,6 +872,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -868,6 +885,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -881,6 +899,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -894,6 +913,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -1092,6 +1112,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1118,6 +1139,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1145,6 +1167,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1172,6 +1195,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1408,6 +1432,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1434,6 +1459,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1461,6 +1487,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1488,6 +1515,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -167,6 +168,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -180,6 +182,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -193,6 +196,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -312,6 +316,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -338,6 +343,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -351,6 +357,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -364,6 +371,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -497,6 +505,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -509,6 +518,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -522,6 +532,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -535,6 +546,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -114,6 +114,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -140,6 +141,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -153,6 +155,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -166,6 +169,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <span>
       Persona Children
@@ -302,6 +306,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -328,6 +333,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -341,6 +347,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -354,6 +361,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -500,6 +508,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -526,6 +535,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -539,6 +549,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -552,6 +563,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -671,6 +683,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -697,6 +710,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -710,6 +724,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -723,6 +738,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -856,6 +872,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -868,6 +885,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -881,6 +899,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
     <div
       className=
@@ -894,6 +913,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     />
   </div>
 </div>
@@ -1092,6 +1112,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1118,6 +1139,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1145,6 +1167,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1172,6 +1195,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1408,6 +1432,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1434,6 +1459,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1461,6 +1487,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=
@@ -1488,6 +1515,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-overflow: ellipsis;
             white-space: nowrap;
           }
+      dir="auto"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -147,6 +147,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -177,6 +178,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -204,6 +206,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -231,6 +234,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -391,6 +395,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -421,6 +426,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -448,6 +454,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -475,6 +482,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -659,6 +667,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -689,6 +698,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -716,6 +726,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -743,6 +754,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -283,6 +283,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -310,6 +311,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -337,6 +339,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -364,6 +367,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -512,6 +516,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -539,6 +544,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -566,6 +572,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -593,6 +600,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -801,6 +809,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -828,6 +837,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -855,6 +865,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -882,6 +893,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1090,6 +1102,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1117,6 +1130,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1144,6 +1158,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1171,6 +1186,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1379,6 +1395,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1406,6 +1423,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1433,6 +1451,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1460,6 +1479,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1695,6 +1715,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1721,6 +1742,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1748,6 +1770,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1775,6 +1798,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2002,6 +2026,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2028,6 +2053,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2055,6 +2081,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2082,6 +2109,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2315,6 +2343,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2341,6 +2370,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2368,6 +2398,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2395,6 +2426,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2655,6 +2687,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2681,6 +2714,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2708,6 +2742,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2735,6 +2770,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -178,6 +178,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -204,6 +205,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -231,6 +233,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       />
       <div
         className=
@@ -244,6 +247,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -190,6 +190,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -216,6 +217,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div>
           <i
@@ -250,6 +252,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -277,6 +280,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -117,6 +117,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -143,6 +144,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -170,6 +172,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -197,6 +200,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -327,6 +331,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -353,6 +358,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -380,6 +386,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -407,6 +414,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -537,6 +545,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -563,6 +572,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -590,6 +600,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -617,6 +628,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -747,6 +759,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -773,6 +786,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -800,6 +814,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -827,6 +842,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -957,6 +973,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -983,6 +1000,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1010,6 +1028,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1037,6 +1056,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1181,6 +1201,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1207,6 +1228,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1234,6 +1256,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1261,6 +1284,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1391,6 +1415,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1417,6 +1442,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1444,6 +1470,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1471,6 +1498,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1615,6 +1643,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1641,6 +1670,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1668,6 +1698,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1695,6 +1726,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1839,6 +1871,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1865,6 +1898,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1892,6 +1926,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -1919,6 +1954,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2063,6 +2099,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2089,6 +2126,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2116,6 +2154,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2143,6 +2182,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2273,6 +2313,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2299,6 +2340,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2326,6 +2368,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2353,6 +2396,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2483,6 +2527,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2509,6 +2554,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2536,6 +2582,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2563,6 +2610,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2711,6 +2759,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2737,6 +2786,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2764,6 +2814,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -2791,6 +2842,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
@@ -131,6 +131,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -157,6 +158,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -184,6 +186,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       />
       <div
         className=
@@ -197,6 +200,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       />
     </div>
   </div>
@@ -327,6 +331,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -353,6 +358,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -380,6 +386,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       >
         <div
           className=
@@ -407,6 +414,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+        dir="auto"
       />
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -1076,6 +1076,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
+            dir="auto"
           />
           <div
             className=
@@ -1088,6 +1089,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
+            dir="auto"
           />
           <div
             className=
@@ -1101,6 +1103,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
+            dir="auto"
           />
           <div
             className=
@@ -1114,6 +1117,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   text-overflow: ellipsis;
                   white-space: nowrap;
                 }
+            dir="auto"
           />
         </div>
       </div>

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -362,6 +362,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           text-overflow: ellipsis;
                           white-space: nowrap;
                         }
+                    dir="auto"
                   >
                     <div
                       className=
@@ -389,6 +390,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           text-overflow: ellipsis;
                           white-space: nowrap;
                         }
+                    dir="auto"
                   >
                     <div
                       className=
@@ -416,6 +418,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           text-overflow: ellipsis;
                           white-space: nowrap;
                         }
+                    dir="auto"
                   >
                     <div
                       className=
@@ -443,6 +446,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           text-overflow: ellipsis;
                           white-space: nowrap;
                         }
+                    dir="auto"
                   >
                     <div
                       className=


### PR DESCRIPTION
When truncating latin characters in RTL, the truncating was occuring on the left hand side, which isn't expected. By using `dir=auto` on these scenarios, the browser can truncate on the correct side.

Before:

![image](https://user-images.githubusercontent.com/1110944/55642958-c262cd80-5786-11e9-8142-c90ac039c1e8.png)

After:

![image](https://user-images.githubusercontent.com/1110944/55642889-921b2f00-5786-11e9-84ca-89e075d40943.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8621)