### PR TITLE
Panel onOpen and onOpened

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-onopen_2019-04-05-18-59.json
+++ b/common/changes/office-ui-fabric-react/panel-onopen_2019-04-05-18-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: add onOpen and onOpened properties",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5434,6 +5434,8 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     onDismiss?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
     onDismissed?: () => void;
     onLightDismissClick?: () => void;
+    onOpen?: () => void;
+    onOpened?: () => void;
     onOuterClick?: () => void;
     onRenderBody?: IRenderFunction<IPanelProps>;
     onRenderFooter?: IRenderFunction<IPanelProps>;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -200,6 +200,10 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
           this._async.setTimeout(this._onTransitionComplete, 200);
         }
       );
+
+      if (this.props.onOpen) {
+        this.props.onOpen();
+      }
     }
   }
 
@@ -349,6 +353,10 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     this.setState({
       isAnimating: false
     });
+
+    if (this.state.isOpen && this.props.onOpened) {
+      this.props.onOpened();
+    }
 
     if (!this.state.isOpen && this.props.onDismissed) {
       this.props.onDismissed();

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
@@ -8,6 +8,10 @@ let div: HTMLElement;
 const ReactDOM = require('react-dom');
 
 describe('Panel', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('renders Panel correctly', () => {
     // Mock createPortal to capture its component hierarchy in snapshot output.
     ReactDOM.createPortal = jest.fn(element => {
@@ -34,7 +38,7 @@ describe('Panel', () => {
       ReactDOM.unmountComponentAtNode(div);
     });
 
-    it('fires the correct events when opening', done => {
+    it('fires the correct events when opening', () => {
       let openedCalled = false;
       let openCalled = false;
       const setOpenTrue = (): void => {
@@ -44,6 +48,8 @@ describe('Panel', () => {
         openedCalled = true;
       };
 
+      jest.useFakeTimers();
+
       const panel: PanelBase = ReactDOM.render(<PanelBase isOpen={false} onOpen={setOpenTrue} onOpened={setOpenedTrue} />, div) as any;
 
       panel.open();
@@ -51,14 +57,9 @@ describe('Panel', () => {
       expect(openCalled).toEqual(true);
       expect(openedCalled).toEqual(false);
 
-      setTimeout(() => {
-        try {
-          expect(openedCalled).toEqual(true);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      }, 250);
+      jest.runOnlyPendingTimers();
+
+      expect(openedCalled).toEqual(true);
     });
   });
 
@@ -71,7 +72,7 @@ describe('Panel', () => {
       ReactDOM.unmountComponentAtNode(div);
     });
 
-    it('fires the correct events when closing', done => {
+    it('fires the correct events when closing', () => {
       let dismissedCalled = false;
       let dismissCalled = false;
       const setDismissTrue = (): void => {
@@ -80,6 +81,8 @@ describe('Panel', () => {
       const setDismissedTrue = (): void => {
         dismissedCalled = true;
       };
+
+      jest.useFakeTimers();
 
       const panel: PanelBase = ReactDOM.render(
         <PanelBase isOpen={true} onDismiss={setDismissTrue} onDismissed={setDismissedTrue} />,
@@ -91,14 +94,9 @@ describe('Panel', () => {
       expect(dismissCalled).toEqual(true);
       expect(dismissedCalled).toEqual(false);
 
-      setTimeout(() => {
-        try {
-          expect(dismissedCalled).toEqual(true);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      }, 250);
+      jest.runOnlyPendingTimers();
+
+      expect(dismissedCalled).toEqual(true);
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
@@ -25,6 +25,43 @@ describe('Panel', () => {
     ReactDOM.createPortal.mockClear();
   });
 
+  describe('open', () => {
+    beforeEach(() => {
+      div = document.createElement('div');
+    });
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(div);
+    });
+
+    it('fires the correct events when opening', done => {
+      let openedCalled = false;
+      let openCalled = false;
+      const setOpenTrue = (): void => {
+        openCalled = true;
+      };
+      const setOpenedTrue = (): void => {
+        openedCalled = true;
+      };
+
+      const panel: PanelBase = ReactDOM.render(<PanelBase isOpen={false} onOpen={setOpenTrue} onOpened={setOpenedTrue} />, div) as any;
+
+      panel.open();
+
+      expect(openCalled).toEqual(true);
+      expect(openedCalled).toEqual(false);
+
+      setTimeout(() => {
+        try {
+          expect(openedCalled).toEqual(true);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, 250);
+    });
+  });
+
   describe('onClose', () => {
     beforeEach(() => {
       div = document.createElement('div');

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -67,6 +67,16 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   headerText?: string;
 
   /**
+   * A callback function for when the Panel is opened, before the animation completes.
+   */
+  onOpen?: () => void;
+
+  /**
+   * A callback function for when the Panel is opened, after the animation completes.
+   */
+  onOpened?: () => void;
+
+  /**
    * A callback function for when the panel is closed, before the animation completes.
    * If the panel should NOT be dismissed based on some keyboard event, then simply call ev.preventDefault() on it
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8562 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `onOpen` (called when the Panel opens, before animation completes) and `onOpened` (called when the Panel opens, after animation completes) callback properties to Panel, analogous to the existing `onDismiss` and `onDismissed`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8623)