### PR TITLE
Fix layer and modal codepen links

### DIFF
--- a/common/changes/office-ui-fabric-react/example-fixes_2019-04-05-20-33.json
+++ b/common/changes/office-ui-fabric-react/example-fixes_2019-04-05-20-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix layer and modal codepen links",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.doc.tsx
@@ -10,9 +10,9 @@ import { LayerStatus } from './Layer.checklist';
 const LayerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Basic.Example.tsx') as string;
 const LayerHostedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Hosted.Example.tsx') as string;
 const LayerCustomizedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx') as string;
-const LayerCustomizedExampleCodepen = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx') as string;
+const LayerCustomizedExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx') as string;
 const LayerNestedLayersExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.NestedLayers.Example.tsx') as string;
-const LayerNestedLayersExampleCodepen = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.NestedLayers.Example.tsx') as string;
+const LayerNestedLayersExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.NestedLayers.Example.tsx') as string;
 
 export const LayerPageProps: IDocPageProps = {
   title: 'Layer',

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.doc.tsx
@@ -6,7 +6,6 @@ import { IDocPageProps } from '../../common/DocPage.types';
 import { ModalStatus } from './Modal.checklist';
 
 const ModalBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Modal/examples/Modal.Basic.Example.tsx') as string;
-const ModalBasicExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Modal/examples/Modal.Basic.Example.tsx') as string;
 const ModalModelessExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Modal/examples/Modal.Modeless.Example.tsx') as string;
 
 export const ModalPageProps: IDocPageProps = {
@@ -18,8 +17,7 @@ export const ModalPageProps: IDocPageProps = {
     {
       title: 'Modal',
       code: ModalBasicExampleCode,
-      view: <ModalBasicExample />,
-      codepenJS: ModalBasicExampleCodepen
+      view: <ModalBasicExample />
     },
     {
       title: 'Modeless Modal',


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

#8601 had a couple mistakes in the doc pages:
- Layer codepens should be loaded with codepen-loader not raw-loader
- Modal example doesn't actually work in codepen

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8628)