### PR TITLE
Spinner: aria-live message should not be injected just because a label exists.

### DIFF
--- a/common/changes/office-ui-fabric-react/spinner-aria_2019-04-05-20-36.json
+++ b/common/changes/office-ui-fabric-react/spinner-aria_2019-04-05-20-36.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Spinner: only render an aria-live polite message when ariaLabel is provided.",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/spinner-aria_2019-04-05-20-36.json
+++ b/common/changes/office-ui-fabric-react/spinner-aria_2019-04-05-20-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Spinner: only render an aria-live polite message when ariaLabel is provided.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
@@ -13,7 +13,7 @@ export class SpinnerBase extends BaseComponent<ISpinnerProps, any> {
 
   public render() {
     const { type, size, ariaLabel, ariaLive, styles, label, theme, className, labelPosition } = this.props;
-    const statusMessage = ariaLabel || label;
+    const statusMessage = ariaLabel;
     const nativeProps = getNativeProps(this.props, divProperties, ['size']);
 
     // SpinnerType is deprecated. If someone is still using this property, rather than putting the SpinnerType into the ISpinnerStyleProps,

--- a/packages/office-ui-fabric-react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -45,9 +45,5 @@ exports[`Spinner renders Spinner correctly 1`] = `
   >
     Standard spinner
   </div>
-  <div
-    aria-live="polite"
-    role="status"
-  />
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Labeled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Labeled.Example.tsx.shot
@@ -95,10 +95,6 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
       >
         I am definitely loading...
       </div>
-      <div
-        aria-live="polite"
-        role="status"
-      />
     </div>
   </div>
   <div>
@@ -173,10 +169,6 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
       >
         Seriously, still loading...
       </div>
-      <div
-        aria-live="assertive"
-        role="status"
-      />
     </div>
   </div>
   <div>
@@ -251,10 +243,6 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
       >
         Wait, wait...
       </div>
-      <div
-        aria-live="assertive"
-        role="status"
-      />
     </div>
   </div>
   <div>
@@ -329,10 +317,6 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
       >
         Nope, still loading...
       </div>
-      <div
-        aria-live="assertive"
-        role="status"
-      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8534
- [X] Include a change request file using `$ npm run change`

#### Description of changes

The `Spinner` will render a hidden span with aria-live messaging if you ever add a `label` prop. This seems to make accessibility worse as the screen reader will read both the aria-live message and the actual label when you go over it in scan mode.

I am tempted to completely remove the aria-live message support here, as it doesn't make sense to me. It is not the role of the atomic Spinner component to inject this; rather it should be the page coordinating the right aria-live messaging.

I am trying to keep this as minimal as possible which is to only add the messaging when ariaLabel is provided. This should at least give the caller an opportunity to have non redundant text read.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8629)