### PR TITLE
Fix Pivot item to not change width on (un)selection

### DIFF
--- a/common/changes/office-ui-fabric-react/fixPivotItemNotChangingWidthOnSelection_2019-04-08-14-07.json
+++ b/common/changes/office-ui-fabric-react/fixPivotItemNotChangingWidthOnSelection_2019-04-08-14-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Bugfix to set the correct width of the Pivot item's :after element, so Pivot items don't move on (un)selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "utschieh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -142,6 +142,11 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
       linkContent = this._renderLinkContent(link);
     }
 
+    let contentString = link.headerText || '';
+    contentString += link.itemCount ? ' (' + link.itemCount + ')' : '';
+    // Adding space supplementary for icon
+    contentString += link.itemIcon ? ' xx' : '';
+
     return (
       <CommandButton
         {...headerButtonProps}
@@ -155,6 +160,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
         aria-selected={isSelected}
         name={link.headerText}
         keytipProps={link.keytipProps}
+        data-content={contentString}
       >
         {linkContent}
       </CommandButton>

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -68,6 +68,11 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
         },
         [`.${IsFocusVisibleClassName} &:focus`]: {
           outline: `1px solid ${semanticColors.focusBorder}`
+        },
+        [`.${IsFocusVisibleClassName} &:focus:after`]: {
+          content: 'attr(name)',
+          position: 'relative',
+          border: 0
         }
       }
     },

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -1,14 +1,5 @@
 import { IPivotStyleProps, IPivotStyles } from './Pivot.types';
-import {
-  AnimationVariables,
-  getFocusStyle,
-  getGlobalClassNames,
-  HighContrastSelector,
-  IStyle,
-  normalize,
-  FontSizes,
-  FontWeights
-} from '../../Styling';
+import { AnimationVariables, getGlobalClassNames, HighContrastSelector, IStyle, normalize, FontSizes, FontWeights } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 const globalClassNames = {
@@ -24,7 +15,7 @@ const globalClassNames = {
 };
 
 const linkStyles = (props: IPivotStyleProps): IStyle[] => {
-  const { rootIsLarge, rootIsTabs, theme } = props;
+  const { rootIsLarge, rootIsTabs } = props;
   const { palette, semanticColors } = props.theme;
   return [
     {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -52,7 +52,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
         },
         ':after': {
           color: 'transparent',
-          content: 'attr(title)',
+          content: 'attr(name)',
           display: 'block',
           fontWeight: FontWeights.bold,
           height: '1px',

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -52,7 +52,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
         },
         ':after': {
           color: 'transparent',
-          content: 'attr(name)',
+          content: 'attr(data-content)',
           display: 'block',
           fontWeight: FontWeights.bold,
           height: '1px',
@@ -70,7 +70,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
           outline: `1px solid ${semanticColors.focusBorder}`
         },
         [`.${IsFocusVisibleClassName} &:focus:after`]: {
-          content: 'attr(name)',
+          content: 'attr(data-content)',
           position: 'relative',
           border: 0
         }
@@ -80,7 +80,6 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
       fontSize: FontSizes.large
     },
     rootIsTabs && [
-      getFocusStyle(theme),
       {
         marginRight: 0,
         height: '40px',

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -74,12 +74,12 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -131,7 +131,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -147,6 +147,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -227,12 +228,12 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -282,7 +283,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -296,6 +297,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content=""
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name=""

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -74,12 +74,12 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -131,7 +131,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -147,6 +147,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content="test"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="test"
@@ -227,12 +228,12 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -282,7 +283,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -296,6 +297,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content="Test Link (20+)"
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name="Test Link"
@@ -438,12 +440,12 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -495,7 +497,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -511,6 +513,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -591,12 +594,12 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -646,7 +649,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -660,6 +663,7 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content="Test Link 2"
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name="Test Link 2"
@@ -789,12 +793,12 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -846,7 +850,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -862,6 +866,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content=" (12)"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         onClick={[Function]}
@@ -943,12 +948,12 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -998,7 +1003,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -1012,6 +1017,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content="Test Link (12)"
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name="Test Link"
@@ -1105,12 +1111,12 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -1160,7 +1166,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -1174,6 +1180,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content="Text with icon xx"
         data-is-focusable={true}
         id="Pivot0-Tab2"
         name="Text with icon"
@@ -1327,12 +1334,12 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -1384,7 +1391,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -1400,6 +1407,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -1480,12 +1488,12 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -1535,7 +1543,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -1549,6 +1557,7 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content=""
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name=""
@@ -1678,14 +1687,14 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
-              bottom: 1px;
-              content: "";
-              left: 1px;
+              border: 0px;
+              bottom: 0px;
+              content: attr(data-content);
+              left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
-              right: 1px;
-              top: 1px;
+              position: relative;
+              right: 0px;
+              top: 0px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -1737,7 +1746,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -1764,6 +1773,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             &:active, &:hover {
               color: #ffffff;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -1844,14 +1854,14 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
-              bottom: 1px;
-              content: "";
-              left: 1px;
+              border: 0px;
+              bottom: 0px;
+              content: attr(data-content);
+              left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
-              right: 1px;
-              top: 1px;
+              position: relative;
+              right: 0px;
+              top: 0px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -1901,7 +1911,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -1923,6 +1933,7 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             &:hover, &:focus {
               color: #000000;
             }
+        data-content=""
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name=""
@@ -2050,12 +2061,12 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -2107,7 +2118,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -2123,6 +2134,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -2203,12 +2215,12 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -2258,7 +2270,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -2272,6 +2284,7 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content=""
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name=""
@@ -2400,14 +2413,14 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
-              bottom: 1px;
-              content: "";
-              left: 1px;
+              border: 0px;
+              bottom: 0px;
+              content: attr(data-content);
+              left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
-              right: 1px;
-              top: 1px;
+              position: relative;
+              right: 0px;
+              top: 0px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -2459,7 +2472,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -2486,6 +2499,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             &:active, &:hover {
               color: #ffffff;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -2566,14 +2580,14 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
-              bottom: 1px;
-              content: "";
-              left: 1px;
+              border: 0px;
+              bottom: 0px;
+              content: attr(data-content);
+              left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
-              right: 1px;
-              top: 1px;
+              position: relative;
+              right: 0px;
+              top: 0px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -2623,7 +2637,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -2645,6 +2659,7 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             &:hover, &:focus {
               color: #000000;
             }
+        data-content=""
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name=""
@@ -2771,12 +2786,12 @@ exports[`Pivot supports JSX expressions 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -2826,7 +2841,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -2840,6 +2855,7 @@ exports[`Pivot supports JSX expressions 1`] = `
               border-bottom: 2px solid transparent;
               box-sizing: border-box;
             }
+        data-content="Test Link 1"
         data-is-focusable={true}
         id="Pivot0-Tab0"
         name="Test Link 1"
@@ -2921,12 +2937,12 @@ exports[`Pivot supports JSX expressions 1`] = `
               border: 0;
             }
             .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid #ffffff;
+              border: 0px;
               bottom: 0px;
-              content: "";
+              content: attr(data-content);
               left: 0px;
               outline: 1px solid #666666;
-              position: absolute;
+              position: relative;
               right: 0px;
               top: 0px;
               z-index: 1;
@@ -2978,7 +2994,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             }
             &:after {
               color: transparent;
-              content: attr(title);
+              content: attr(data-content);
               display: block;
               font-weight: 700;
               height: 1px;
@@ -2994,6 +3010,7 @@ exports[`Pivot supports JSX expressions 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
+        data-content="Test Link 3"
         data-is-focusable={true}
         id="Pivot0-Tab1"
         name="Test Link 3"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -79,12 +79,12 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -136,7 +136,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -152,6 +152,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="Pivot 1"
           data-is-focusable={true}
           data-ktp-execute-target="ktp-a"
           data-ktp-target="ktp-a"
@@ -235,12 +236,12 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -290,7 +291,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -304,6 +305,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Pivot 2"
           data-is-focusable={true}
           data-ktp-execute-target="ktp-b"
           data-ktp-target="ktp-b"
@@ -387,12 +389,12 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -442,7 +444,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -456,6 +458,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Pivot 3"
           data-is-focusable={true}
           data-ktp-execute-target="ktp-c"
           data-ktp-target="ktp-c"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -75,12 +75,12 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -132,7 +132,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -148,6 +148,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="My Files"
           data-is-focusable={true}
           data-order={1}
           data-title="My Files Title"
@@ -230,12 +231,12 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -285,7 +286,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -299,6 +300,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Recent"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Recent"
@@ -379,12 +381,12 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -434,7 +436,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -448,6 +450,7 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Shared with me"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Shared with me"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -75,12 +75,12 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -132,7 +132,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -148,6 +148,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="Callout"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="Callout"
@@ -228,12 +229,12 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -283,7 +284,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -297,6 +298,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Spinner"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Spinner"
@@ -377,12 +379,12 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -432,7 +434,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -446,6 +448,7 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Persona"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Persona"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -75,12 +75,12 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -132,7 +132,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -148,6 +148,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="My Files (42) xx"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="My Files"
@@ -266,12 +267,12 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -321,7 +322,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -335,6 +336,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content=" (23) xx"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           onClick={[Function]}
@@ -441,12 +443,12 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -496,7 +498,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -510,6 +512,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content=" xx"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           onClick={[Function]}
@@ -603,12 +606,12 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -658,7 +661,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -672,6 +675,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Shared with me (1) xx"
           data-is-focusable={true}
           id="Pivot0-Tab3"
           name="Shared with me"
@@ -790,12 +794,12 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -845,7 +849,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -859,6 +863,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Customized Rendering (10) xx"
           data-is-focusable={true}
           id="Pivot0-Tab4"
           name="Customized Rendering"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -76,12 +76,12 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -133,7 +133,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -149,6 +149,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="My Files"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="My Files"
@@ -229,12 +230,12 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -284,7 +285,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -298,6 +299,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Recent"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Recent"
@@ -378,12 +380,12 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -433,7 +435,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -447,6 +449,7 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Shared with me"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Shared with me"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -77,14 +77,14 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -136,7 +136,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -163,6 +163,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               &:active, &:hover {
                 color: #ffffff;
               }
+          data-content="Foo"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="Foo"
@@ -243,14 +244,14 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -300,7 +301,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -322,6 +323,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bar"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Bar"
@@ -402,14 +404,14 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -459,7 +461,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -481,6 +483,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bas"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Bas"
@@ -561,14 +564,14 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -618,7 +621,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -640,6 +643,7 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Biz"
           data-is-focusable={true}
           id="Pivot0-Tab3"
           name="Biz"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -75,12 +75,12 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -132,7 +132,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -148,6 +148,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="My Files"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="My Files"
@@ -228,12 +229,12 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -283,7 +284,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -297,6 +298,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Recent"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Recent"
@@ -377,12 +379,12 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -432,7 +434,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -446,6 +448,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Shared with me"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Shared with me"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -77,14 +77,14 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -136,7 +136,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -163,6 +163,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               &:active, &:hover {
                 color: #ffffff;
               }
+          data-content="Foo"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="Foo"
@@ -243,14 +244,14 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -300,7 +301,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -322,6 +323,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bar"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Bar"
@@ -402,14 +404,14 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -459,7 +461,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -481,6 +483,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bas"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Bas"
@@ -561,14 +564,14 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -618,7 +621,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -640,6 +643,7 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Biz"
           data-is-focusable={true}
           id="Pivot0-Tab3"
           name="Biz"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -87,12 +87,12 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -144,7 +144,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -160,6 +160,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 color: Highlight;
               }
+          data-content="Rectangle red"
           data-is-focusable={true}
           id="ShapeColorPivot_rectangleRed"
           name="Rectangle red"
@@ -240,12 +241,12 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -295,7 +296,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -309,6 +310,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Square red"
           data-is-focusable={true}
           id="ShapeColorPivot_squareRed"
           name="Square red"
@@ -389,12 +391,12 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
+                border: 0px;
                 bottom: 0px;
-                content: "";
+                content: attr(data-content);
                 left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
+                position: relative;
                 right: 0px;
                 top: 0px;
                 z-index: 1;
@@ -444,7 +446,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -458,6 +460,7 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 border-bottom: 2px solid transparent;
                 box-sizing: border-box;
               }
+          data-content="Rectangle green"
           data-is-focusable={true}
           id="ShapeColorPivot_rectangleGreen"
           name="Rectangle green"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -76,14 +76,14 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -135,7 +135,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -162,6 +162,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               &:active, &:hover {
                 color: #ffffff;
               }
+          data-content="Foo"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="Foo"
@@ -242,14 +243,14 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -299,7 +300,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -321,6 +322,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bar"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Bar"
@@ -401,14 +403,14 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -458,7 +460,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -480,6 +482,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bas"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Bas"
@@ -560,14 +563,14 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -617,7 +620,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -639,6 +642,7 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Biz"
           data-is-focusable={true}
           id="Pivot0-Tab3"
           name="Biz"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -77,14 +77,14 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -136,7 +136,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -163,6 +163,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               &:active, &:hover {
                 color: #ffffff;
               }
+          data-content="Foo"
           data-is-focusable={true}
           id="Pivot0-Tab0"
           name="Foo"
@@ -243,14 +244,14 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -300,7 +301,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -322,6 +323,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bar"
           data-is-focusable={true}
           id="Pivot0-Tab1"
           name="Bar"
@@ -402,14 +404,14 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -459,7 +461,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -481,6 +483,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Bas"
           data-is-focusable={true}
           id="Pivot0-Tab2"
           name="Bas"
@@ -561,14 +564,14 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 border: 0;
               }
               .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: 1px;
-                content: "";
-                left: 1px;
+                border: 0px;
+                bottom: 0px;
+                content: attr(data-content);
+                left: 0px;
                 outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
+                position: relative;
+                right: 0px;
+                top: 0px;
                 z-index: 1;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -618,7 +621,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               }
               &:after {
                 color: transparent;
-                content: attr(title);
+                content: attr(data-content);
                 display: block;
                 font-weight: 700;
                 height: 1px;
@@ -640,6 +643,7 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               &:hover, &:focus {
                 color: #000000;
               }
+          data-content="Biz"
           data-is-focusable={true}
           id="Pivot0-Tab3"
           name="Biz"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: 
- [x] Includes a change request file using `$ npm run change`

#### Description of changes

Bug: the Pivot item changes it's width on (un)selection, which shifts all items to the left/right.
Fix: 
1. Passing down the correct property of the pivot link item to the :after style element, including the content name of the button. Based on [this](https://github.com/OfficeDev/office-ui-fabric-core/pull/658) pull request.

2. Adapting the content to be passed down to not only include the display name, but also the item count and a placeholder for the item icon. Having a bit larger item width (by setting the item placeholder to ' xx') is chosen in favor of preventing any jiggling/movement of items.

3. Enabling keyboard navigation while keeping a stable item position, by overwriting some button related styles ( CommandBarButton and BaseButton).

Before:
![190408_fabricReactPivotFix_movingItems_2](https://user-images.githubusercontent.com/18209083/55732563-7df05f80-5a1c-11e9-96e5-8056103e0f0d.gif)

After:
![190408_fabricReactPivotFix_movingItems_fixed_2](https://user-images.githubusercontent.com/18209083/55732610-92ccf300-5a1c-11e9-825c-5fcc6cbccd70.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8638)