### PR TITLE
Panel nonblocking forceFocusInsideTrap

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-nonblocking_2019-04-08-20-25.json
+++ b/common/changes/office-ui-fabric-react/panel-nonblocking_2019-04-08-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: set forceFocusInsideTrap to false for non-blocking Panels",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -164,7 +164,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
             {overlay}
             <FocusTrapZone
               ignoreExternalFocusing={ignoreExternalFocusing}
-              forceFocusInsideTrap={isHiddenOnDismiss && !isOpen ? false : forceFocusInsideTrap}
+              forceFocusInsideTrap={!isBlocking || (isHiddenOnDismiss && !isOpen) ? false : forceFocusInsideTrap}
               firstFocusableSelector={firstFocusableSelector}
               isClickableOutsideFocusTrap={true}
               {...focusTrapZoneProps}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8625 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This pull request sets the `forceFocusInsideTrap` property of the FocusTrapZone within Panel to false if the Panel is non-blocking, i.e. its `isBlocking` property is false or undefined.

Previously, users could not focus on input elements (TextField, SearchBox, Dropdown, etc.) outside of a non-blocking Panel since the FocusTrapZone was stealing the focus events.

Before (unable to focus):
![panel-nonblocking-before-2](https://user-images.githubusercontent.com/6687333/55754746-3b218e00-5a02-11e9-882e-f8c624173148.gif)

After (able to focus):
![panel-nonblocking-after-2](https://user-images.githubusercontent.com/6687333/55754756-4379c900-5a02-11e9-858b-b9e6458453e0.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8643)