### PR TITLE
Button: Creating ActionButton variant and cleaning styling

### DIFF
--- a/common/changes/@uifabric/experiments/actionButton_2019-04-08-21-50.json
+++ b/common/changes/@uifabric/experiments/actionButton_2019-04-08-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Creating ActionButton variant and cleaning styling.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/ActionButton.tsx
+++ b/packages/experiments/src/components/Button/ActionButton.tsx
@@ -15,7 +15,7 @@ const baseTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenRetur
     color: palette.neutralPrimary,
     colorHovered: palette.themePrimary,
     colorPressed: palette.black,
-    contentPadding: '0px 4px',
+    contentPadding: '0px 8px',
     height: '40px',
     iconColor: palette.neutralPrimary,
     iconColorHovered: palette.themePrimary,

--- a/packages/experiments/src/components/Button/ActionButton.tsx
+++ b/packages/experiments/src/components/Button/ActionButton.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Button } from './Button';
+import { IButtonComponent, IButtonTokenReturnType } from './Button.types';
+import { ButtonVariantsType } from './ButtonVariants.types';
+import { FontWeights } from '../../Styling';
+
+const baseTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
+  const { palette } = theme;
+
+  return {
+    backgroundColor: 'transparent',
+    backgroundColorHovered: 'transparent',
+    backgroundColorPressed: 'transparent',
+    borderColor: 'transparent',
+    color: palette.neutralPrimary,
+    colorHovered: palette.themePrimary,
+    colorPressed: palette.black,
+    contentPadding: '0px 4px',
+    height: '40px',
+    iconColor: palette.neutralPrimary,
+    iconColorHovered: palette.themePrimary,
+    iconColorPressed: palette.black,
+    textWeight: FontWeights.regular
+  };
+};
+
+const disabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => {
+  const { palette } = theme;
+
+  return {
+    color: palette.neutralTertiary,
+    colorHovered: palette.neutralTertiary,
+    colorPressed: palette.neutralTertiary,
+    iconColor: palette.neutralTertiary,
+    iconColorHovered: palette.neutralTertiary,
+    iconColorPressed: palette.neutralTertiary
+  };
+};
+
+export const ActionButtonTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenReturnType => [
+  baseTokens,
+  props.disabled && disabledTokens
+];
+
+export const ActionButton: ButtonVariantsType = props => {
+  const { text, iconProps, ...rest } = props;
+
+  return <Button stack={{ horizontalAlign: 'start' }} content={text} icon={iconProps} tokens={ActionButtonTokens} {...rest} />;
+};

--- a/packages/experiments/src/components/Button/Button.styles.ts
+++ b/packages/experiments/src/components/Button/Button.styles.ts
@@ -5,6 +5,7 @@ import { IsFocusVisibleClassName } from '../../Utilities';
 const baseTokens: IButtonComponent['tokens'] = {
   borderRadius: 0,
   borderWidth: 1,
+  cursor: 'pointer',
   minWidth: 100,
   minHeight: 32,
   lineHeight: 1,
@@ -96,7 +97,9 @@ const disabledTokens: IButtonComponent['tokens'] = (props, theme): IButtonTokenR
 
     highContrastBorderColor: 'GrayText',
     highContrastBorderColorHovered: 'GrayText',
-    highContrastBorderColorPressed: 'GrayText'
+    highContrastBorderColorPressed: 'GrayText',
+
+    cursor: 'default'
   };
 };
 
@@ -165,7 +168,7 @@ export const ButtonStyles: IButtonComponent['styles'] = (props, theme, tokens): 
         borderWidth: tokens.borderWidth,
         boxSizing: 'border-box',
         color: tokens.color,
-        cursor: 'default',
+        cursor: tokens.cursor,
         display: 'inline-block',
         fontSize: tokens.textSize,
         fontWeight: tokens.textWeight,

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -111,6 +111,7 @@ export interface IButtonTokens {
   borderWidth?: number | string;
   contentPadding?: number | string;
   contentPaddingFocused?: number | string;
+  cursor?: string | undefined;
   textFamily?: string;
   textSize?: number | string;
   textWeight?: IFontWeight;

--- a/packages/experiments/src/components/Button/ButtonPage.tsx
+++ b/packages/experiments/src/components/Button/ButtonPage.tsx
@@ -6,12 +6,14 @@ import { MenuButtonExample } from './MenuButton/examples/MenuButton.Example';
 import { SplitButtonExample } from './SplitButton/examples/SplitButton.Example';
 import { ButtonStylesExample } from './examples/Button.Styles.Example';
 import { ButtonTokensExample } from './examples/Button.Tokens.Example';
+import { ButtonVariantsExample } from './examples/Button.Variants.Example';
 
 const ButtonExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Example.tsx') as string;
 const MenuButtonExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/MenuButton/examples/MenuButton.Example.tsx') as string;
 const SplitButtonExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/SplitButton/examples/SplitButton.Example.tsx') as string;
 const ButtonStylesExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Styles.Example.tsx') as string;
 const ButtonTokensExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Tokens.Example.tsx') as string;
+const ButtonVariantsExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Tokens.Example.tsx') as string;
 
 export class ButtonPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -30,6 +32,9 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, {}> {
             <ExampleCard title="Split Button with two focus stops" code={SplitButtonExampleCode}>
               <SplitButtonExample />
             </ExampleCard>
+            <ExampleCard title="Button Variants Examples" code={ButtonVariantsExampleCode}>
+              <ButtonVariantsExample />
+            </ExampleCard>
             <ExampleCard title="Button Styles" code={ButtonStylesExampleCode}>
               <ButtonStylesExample />
             </ExampleCard>
@@ -42,6 +47,7 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, {}> {
           <PropertiesTableSet
             sources={[
               require<string>('!raw-loader!@uifabric/experiments/src/components/Button/Button.types.tsx'),
+              require<string>('!raw-loader!@uifabric/experiments/src/components/Button/ButtonVariants.types.ts'),
               require<string>('!raw-loader!@uifabric/experiments/src/components/Button/MenuButton/MenuButton.types.tsx'),
               require<string>('!raw-loader!@uifabric/experiments/src/components/Button/SplitButton/SplitButton.types.tsx')
             ]}

--- a/packages/experiments/src/components/Button/ButtonVariants.types.ts
+++ b/packages/experiments/src/components/Button/ButtonVariants.types.ts
@@ -1,6 +1,8 @@
 import { IButtonProps } from './Button.types';
+import { IIconProps } from 'office-ui-fabric-react';
 
 export interface IButtonVariantProps extends IButtonProps {
+  iconProps?: IIconProps;
   text?: string;
 }
 

--- a/packages/experiments/src/components/Button/DefaultButton.tsx
+++ b/packages/experiments/src/components/Button/DefaultButton.tsx
@@ -3,7 +3,7 @@ import { Button } from './Button';
 import { ButtonVariantsType } from './ButtonVariants.types';
 
 export const DefaultButton: ButtonVariantsType = props => {
-  const { text, ...rest } = props;
+  const { text, iconProps, ...rest } = props;
 
-  return <Button content={text} {...rest} />;
+  return <Button content={text} icon={iconProps} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/PrimaryButton.tsx
+++ b/packages/experiments/src/components/Button/PrimaryButton.tsx
@@ -3,7 +3,7 @@ import { Button } from './Button';
 import { ButtonVariantsType } from './ButtonVariants.types';
 
 export const PrimaryButton: ButtonVariantsType = props => {
-  const { text, ...rest } = props;
+  const { text, iconProps, ...rest } = props;
 
-  return <Button primary content={text} {...rest} />;
+  return <Button primary content={text} icon={iconProps} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -50,11 +50,10 @@ export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme,
       }
     },
     splitDivider: {
-      borderRight: '1px solid',
-      borderColor: tokens.color,
+      backgroundColor: tokens.color,
       boxSizing: 'border-box',
-      height: 'calc(100% - 16px)',
-      margin: '8px 0px',
+      height: 'calc(100% - 14px)',
+      margin: '7px 0px',
       width: 1,
 
       selectors: {

--- a/packages/experiments/src/components/Button/__snapshots__/Button.view.test.tsx.snap
+++ b/packages/experiments/src/components/Button/__snapshots__/Button.view.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Button view renders a default Button with content correctly 1`] = `
         border-width: 1px;
         box-sizing: border-box;
         color: #333333;
-        cursor: default;
+        cursor: pointer;
         display: inline-block;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
@@ -293,7 +293,7 @@ exports[`Button view renders a primary Button with content correctly 1`] = `
         border-width: 1px;
         box-sizing: border-box;
         color: #ffffff;
-        cursor: default;
+        cursor: pointer;
         display: inline-block;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;

--- a/packages/experiments/src/components/Button/examples/Button.Variants.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Variants.Example.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { ActionButton, DefaultButton, PrimaryButton } from '../index';
+import { Stack } from 'office-ui-fabric-react';
+
+const tokens = {
+  sectionStack: {
+    childrenGap: 32
+  },
+  buttonStack: {
+    childrenGap: 12
+  }
+};
+
+const alertClicked = (): void => {
+  alert('Clicked');
+};
+
+const ButtonStack = (props: { children: JSX.Element[] | JSX.Element }) => (
+  <Stack horizontal disableShrink tokens={tokens.buttonStack}>
+    {props.children}
+  </Stack>
+);
+
+// tslint:disable:jsx-no-lambda
+export class ButtonVariantsExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    return (
+      <Stack tokens={tokens.sectionStack}>
+        <Stack tokens={tokens.buttonStack}>
+          <ButtonStack>
+            <DefaultButton text="Default button" onClick={alertClicked} />
+            <DefaultButton disabled text="Disabled default button" onClick={alertClicked} />
+            <PrimaryButton text="Primary button" onClick={alertClicked} />
+            <PrimaryButton disabled text="Disabled primary button" onClick={alertClicked} />
+          </ButtonStack>
+          <ButtonStack>
+            <ActionButton text="Action button" onClick={alertClicked} />
+            <ActionButton disabled text="Disabled action button" onClick={alertClicked} />
+          </ButtonStack>
+        </Stack>
+      </Stack>
+    );
+  }
+}

--- a/packages/experiments/src/components/Button/index.ts
+++ b/packages/experiments/src/components/Button/index.ts
@@ -1,5 +1,6 @@
 export * from './Button';
 export * from './Button.types';
 export * from './ButtonVariants.types';
+export * from './ActionButton';
 export * from './DefaultButton';
 export * from './PrimaryButton';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds an `ActionButton` variant to improve parity between new and old `Button` components while also making some styling fixes in general.

Below is a comparison, on the left using the `ActionButtons` in `office-ui-fabric-react` and on the right using the ones in `experiments`:

![image](https://user-images.githubusercontent.com/7798177/55759527-6a3dfc80-5a0e-11e9-9d76-54556960e23f.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8645)