### PR TITLE
Add deprecation message to dashboard readme

### DIFF
--- a/common/changes/@uifabric/dashboard/dashboard_2019-04-09-18-20.json
+++ b/common/changes/@uifabric/dashboard/dashboard_2019-04-09-18-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/dashboard",
+      "comment": "Deprecate dashboard package",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/dashboard",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,3 +1,3 @@
 # dashboard
 
-This component is a wrapper for intended for use with [fabric dashboard cards](https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/dashboard/src/components/Card). Please follow the example to see usage and guidelines.
+We've moved the Dashboard code to a new dedicated repo and have deprecated this experimental package. Please contact m365admincomponents@microsoft.com for information about using and contributing to these controls.


### PR DESCRIPTION
The dashboard package is deprecated and will be deleted from OUFR shortly. Before doing that, we're adding a deprecation message to the readme (shown when someone views the npm package) and publishing one last version. (Apparently the actual deprecation is done using `npm deprecate`, not a package.json setting, so that will be done once the new version is published.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8657)