### PR TITLE
Add classNames to perf-app components

### DIFF
--- a/apps/perf-test/src/App.tsx
+++ b/apps/perf-test/src/App.tsx
@@ -26,6 +26,7 @@ export const App = () => {
         <Stack gap={20} style={{ width: 300 }}>
           <Dropdown
             label="Scenario"
+            className="scenario"
             options={Scenarios}
             selectedKey={scenario.key}
             onChange={(ev, option) => {
@@ -37,6 +38,7 @@ export const App = () => {
           />
           <TextField
             label="Component count"
+            className="componentCount"
             value={String(count)}
             type="number"
             onChange={(ev, value) => {
@@ -46,6 +48,7 @@ export const App = () => {
           />
           <TextField
             label="Iterations"
+            className="iterations"
             value={String(iterations)}
             type="number"
             onChange={(ev, value) => {
@@ -53,7 +56,7 @@ export const App = () => {
               setIterations(Number(value));
             }}
           />
-          <PrimaryButton text={itemsVisible ? 'Reset' : 'Run test'} onClick={() => setItemsVisible(!itemsVisible)} />
+          <PrimaryButton text={itemsVisible ? 'Reset' : 'Run test'} onClick={() => setItemsVisible(!itemsVisible)} className="runTest" />
         </Stack>
         {timingsVisible && <MeasurerTimings />}
       </Stack>

--- a/apps/perf-test/src/Measurer.tsx
+++ b/apps/perf-test/src/Measurer.tsx
@@ -56,8 +56,11 @@ export const MeasurerTimings = () => {
 
   return (
     <Stack gap={20}>
-      <Text>
-        <b>Total time:</b> {timings.totalTime}ms ({timings.individualTime}ms per item)
+      <Text className="total">
+        <b>Total time:</b> {timings.totalTime}ms
+      </Text>
+      <Text className="peritem">
+        <b>Per Item:</b> {timings.individualTime}ms
       </Text>
     </Stack>
   );


### PR DESCRIPTION
#### Description of changes
Add classNames to perf-app page for easier query in perf-test. The perf-test will use puppeteer to run scenarios programmatically and record results for regression analysis.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8664)