### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ gulp-cache
 npm-debug.log.*
 
 package-lock.json
+yarn.lock
 
 *.swp
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adds `yarn.lock` to the repo's `.gitignore` as brought up in https://github.com/OfficeDev/office-ui-fabric-react/pull/8397/files/480fd8ecdf0cfe812cdd79164c796430f08242e7#r272407866.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8665)