### PR TITLE
add yarn.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ gulp-cache
 npm-debug.log.*
 
 package-lock.json
+yarn.lock
 
 *.swp
 


### PR DESCRIPTION
#### Pull request checklist

- ~[ ] Addresses an existing issue: Fixes #0000~
- ~[x] Include a change request file using `$ npm run change`~
 `npm run change` generated no changefile. 

#### Description of changes

adds yarn.lock to the `.gitignore`. Safety rails for those used to running `yarn` in their normal workflow as opposed to `npm`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8666)