### PR TITLE
Add es2015.promise to experiments build

### DIFF
--- a/common/changes/@uifabric/experiments/upp-experiments-espromise_2019-04-09-23-53.json
+++ b/common/changes/@uifabric/experiments/upp-experiments-espromise_2019-04-09-23-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add es6 promises to experiments",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/experiments/tsconfig.json
+++ b/packages/experiments/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "skipLibCheck": true,
-    "lib": ["es5", "dom"],
+    "lib": ["es5", "dom", "es2015.promise"],
     "typeRoots": ["node_modules/@types", "../../typings"],
     "types": ["jest", "webpack-env", "custom-global"],
     "paths": {


### PR DESCRIPTION
#### Pull request checklist

- ~~[ ] Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This is in office-ui-fabric-react build but not experiments.

Without it you can't construct promises or refer to promise as a concrete class in experiments

Some of the Extended Picker work I'm doing depends on this



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8667)