### PR TITLE
Add perf-script and task

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "prettier": "node scripts/prettier.js",
     "generate-version-files": "node scripts/just.js generate-version-files",
     "codepen": "cd packages/office-ui-fabric-react && node ../../scripts/local-codepen.js",
-    "precommit": "node scripts/node_modules/lint-staged/index.js"
+    "precommit": "node scripts/node_modules/lint-staged/index.js",
+    "perf-test": "node scripts/just.js perf-test"
   },
   "license": "MIT",
   "lint-staged": {

--- a/scripts/just-task.js
+++ b/scripts/just-task.js
@@ -17,6 +17,7 @@ const prettier = require('./tasks/prettier');
 const bundleSizeCollect = require('./tasks/bundle-size-collect');
 const checkForModifiedFiles = require('./tasks/check-for-modified-files');
 const generateVersionFiles = require('./tasks/generate-version-files');
+const perfTest = require('./tasks/perf-test');
 
 let packageJson;
 
@@ -51,6 +52,7 @@ registerTask('prettier', prettier);
 registerTask('bundle-size-collect', bundleSizeCollect);
 registerTask('check-for-modified-files', checkForModifiedFiles);
 registerTask('generate-version-files', generateVersionFiles);
+registerTask('perf-test', perfTest);
 
 task('ts', parallel('ts:commonjs', 'ts:esm', condition('ts:amd', () => argv().production && !argv().min && !argv().prdeploy)));
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -53,6 +53,7 @@
     "postcss-loader": "^2.0.9",
     "postcss-modules": "^0.8.0",
     "prettier": "^1.12.1",
+    "puppeteer": "^1.13.0",
     "raf": "^3.4.0",
     "raw-loader": "^0.5.1",
     "recast": "~0.15.0",

--- a/scripts/tasks/perf-test.js
+++ b/scripts/tasks/perf-test.js
@@ -1,0 +1,88 @@
+const urlFromDeployJob = `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test/`;
+const urlForMaster = 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/';
+
+module.exports = async function getPerfRegressions() {
+  const browser = await require('puppeteer').launch({ headless: true });
+  let page = await browser.newPage();
+
+  // get perf numbers for existing code
+  await page.goto(urlForMaster);
+  const perfAveragesNow = await runAvailableScenarios(page, 1000, 100);
+  console.log(perfAveragesNow);
+
+  // get perf numbers for new code
+  await page.goto(urlFromDeployJob);
+  const perfAveragesNew = await runAvailableScenarios(page, 1000, 100);
+  console.log(perfAveragesNew);
+
+  // Clean up
+  await browser.close();
+
+  // Write results to json file
+  require('fs').writeFileSync(
+    require('path').join('apps/perf-test/dist', 'perfCounts.json'),
+    JSON.stringify({ now: perfAveragesNow, new: perfAveragesNew })
+  );
+};
+
+async function runAvailableScenarios(page, componentCount, iterations) {
+  // set up
+  await page.$eval(
+    '.iterations input',
+    (ifield, count) => {
+      ifield.value = count;
+    },
+    iterations
+  );
+  await page.$eval(
+    '.componentCount input',
+    (ccfield, count) => {
+      ccfield.value = count;
+    },
+    componentCount
+  );
+
+  const perfNumbers = {};
+
+  // Iterate through scenarios available
+  const scenarioDropdown = await page.$('.scenario');
+  let scenarioName = (await page.$eval('.scenario', dropdown => dropdown.textContent)).trim();
+  while (!perfNumbers[scenarioName]) {
+    // get numbers
+    perfNumbers[scenarioName] = await runScenarioNTimes(page, 10);
+
+    // go to next scenario
+    await scenarioDropdown.focus();
+    await page.keyboard.press('ArrowDown');
+    scenarioName = (await page.$eval('.scenario', dropdown => dropdown.textContent)).trim();
+  }
+
+  return perfNumbers;
+}
+
+async function runScenarioNTimes(page, times) {
+  let totalsum = 0;
+  let peritemsum = 0;
+  const runTestButton = await page.$('.runTest');
+
+  for (let i = 0; i < times; i++) {
+    // run scenario
+    await runTestButton.click();
+    await page.waitForSelector('.total', { visible: true });
+    let total = await page.$eval('.total', result => result.innerText);
+    let peritem = await page.$eval('.peritem', result => result.innerText);
+
+    // add perf numbers
+    totalsum += parseFloat(total.replace(/[a-zA-Z:]/g, ''));
+    peritemsum += parseFloat(peritem.replace(/[a-zA-Z:]/g, ''));
+
+    // reset
+    await runTestButton.click();
+  }
+
+  // average
+  return {
+    total: totalsum / times,
+    peritem: peritemsum / times
+  };
+}

--- a/scripts/tasks/perf-test.js
+++ b/scripts/tasks/perf-test.js
@@ -1,3 +1,4 @@
+// TODO: add the ability to run this perf-test against a non PR deployed site
 const urlFromDeployJob = `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test/`;
 const urlForMaster = 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/';
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Adding script that iterates through scenarios in perf-app programmatically.

#### Focus areas to test
The script produces json file with the perf numbers in format:
{
now: { <scenarioName>: { total: <number of ms>, peritem: <number of ms>},
new:  { <scenarioName>: { total: <number of ms>, peritem: <number of ms>}
}

Confirmed running locally.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8671)