### PR TITLE
Min height from ms list cell

### DIFF
--- a/common/changes/office-ui-fabric-react/min-height-from-ms-list-cell_2019-04-10-07-31.json
+++ b/common/changes/office-ui-fabric-react/min-height-from-ms-list-cell_2019-04-10-07-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removing min-height as it is applied using DetailsRow anyway",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "svaibhav@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.styles.ts
@@ -27,7 +27,6 @@ export const getStyles = (props: IDetailsListStyleProps): IDetailsListStyles => 
         color: semanticColors.listText,
         selectors: {
           [`& .${classNames.listCell}`]: {
-            minHeight: 38,
             wordBreak: 'break-word'
           }
         }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`DetailsList renders List correctly 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -609,7 +608,6 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -2360,7 +2358,6 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -3317,7 +3314,6 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -4500,7 +4496,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`DetailsRow renders details list row correctly 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -837,7 +836,6 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -2178,7 +2176,6 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"
@@ -2987,7 +2984,6 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
           position: relative;
         }
         & .ms-List-cell {
-          min-height: 38px;
           word-break: break-word;
         }
     data-automationid="DetailsList"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Since DetailsRow.Style.ts already have the minHeight attribute, it seems like we do not need this one.
minHeight was added in [DetailsList.scss](https://github.com/OfficeDev/office-ui-fabric-react/blob/78e462bc936350fee2806ee0e70d523e8deee9b5/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.scss) (first draft) so that the empty rows in the list also have a minimum height.
Now it seems that [DetailsRow.styles.ts](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts) already is taking care of the same.

#### Focus areas to test

Various lists, especially the ones with empty row(s).
This change will also fix the following issue:
https://github.com/SharePoint/sp-dev-docs/issues/3537

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8672)