### PR TITLE
Fix SwatchColorPicker flicker issue on circle border hover. Fixes #8681

### DIFF
--- a/common/changes/office-ui-fabric-react/dahajek-color-picker_2019-04-10-22-30.json
+++ b/common/changes/office-ui-fabric-react/dahajek-color-picker_2019-04-10-22-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix color picker flicker on hover",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dahajek@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -42,6 +42,7 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
       // In focus state for circle we want a round border which is not possible with outline.
       circle && {
         borderRadius: '50%',
+        overflow: 'hidden',
         selectors: {
           [`.${IsFocusVisibleClassName} &:focus::after`]: {
             outline: 'none',

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -236,6 +237,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -399,6 +401,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -562,6 +565,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -729,6 +733,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -892,6 +897,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1055,6 +1061,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1218,6 +1225,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1385,6 +1393,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1548,6 +1557,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;
@@ -1711,6 +1721,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 1px;
                   padding-left: 1px;
                   padding-right: 1px;
@@ -1874,6 +1885,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   font-weight: 400;
                   height: 20px;
                   outline: transparent;
+                  overflow: hidden;
                   padding-bottom: 0px;
                   padding-left: 0px;
                   padding-right: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -77,6 +77,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 20px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -240,6 +241,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 20px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -403,6 +405,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 20px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -566,6 +569,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 20px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -729,6 +733,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 20px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 1px;
                     padding-left: 1px;
                     padding-right: 1px;
@@ -2560,6 +2565,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -2723,6 +2729,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -2886,6 +2893,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3049,6 +3057,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3216,6 +3225,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3379,6 +3389,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3542,6 +3553,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3705,6 +3717,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -3872,6 +3885,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4035,6 +4049,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4198,6 +4213,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4361,6 +4377,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     font-weight: 400;
                     height: 35px;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4574,6 +4591,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     height: 20px;
                     opacity: 0.3;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4741,6 +4759,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     height: 20px;
                     opacity: 0.3;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -4908,6 +4927,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     height: 20px;
                     opacity: 0.3;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -5075,6 +5095,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     height: 20px;
                     opacity: 0.3;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 0px;
                     padding-left: 0px;
                     padding-right: 0px;
@@ -5242,6 +5263,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     height: 20px;
                     opacity: 0.3;
                     outline: transparent;
+                    overflow: hidden;
                     padding-bottom: 1px;
                     padding-left: 1px;
                     padding-right: 1px;


### PR DESCRIPTION
#### Pull request checklist
- [x] Addresses an existing issue: Fixes #8681
- [x] Include a change request file using `$ npm run change`

Fix an issue in the current SwatchColorPicker where hovering over the exact border between the color and the background makes it flicker between selected/unselected states very fast.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8682)