### PR TITLE
Fix themeGenerator page so it looks right

### DIFF
--- a/apps/fabric-website-resources/src/components/pages/ColorsPage.global.scss
+++ b/apps/fabric-website-resources/src/components/pages/ColorsPage.global.scss
@@ -6,7 +6,9 @@
 
   .ms-themer {
     padding: 12px;
-    h2, h3, h4 {
+    h2,
+    h3,
+    h4 {
       color: $ms-color-black;
     }
   }
@@ -39,7 +41,6 @@
 
   .ms-themer-example {
     padding: 20px;
-    max-width: 40%;
   }
 
   .ms-themer-fabricPalette-root {

--- a/common/changes/@uifabric/fabric-website-resources/fix-themepage_2019-04-10-23-31.json
+++ b/common/changes/@uifabric/fabric-website-resources/fix-themepage_2019-04-10-23-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website-resources",
+      "comment": "ThemeGeneratorPage: fix it so it looks right",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "joschect@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fix-themepage_2019-04-10-23-21.json
+++ b/common/changes/office-ui-fabric-react/fix-themepage_2019-04-10-23-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ThemeGeneratorPage: fix it so it looks right",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.doc.tsx
@@ -172,7 +172,7 @@ export class ThemeGeneratorPage extends BaseComponent<{}, IThemeGeneratorPageSta
         <br />
 
         <h2 id="Samples">Samples</h2>
-        <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
           <div className="ms-themer-example">
             <TextFieldBasicExample />
           </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Theme Generator page currently has some weird overlap.

![image](https://user-images.githubusercontent.com/20801176/55920016-07369c00-5bad-11e9-9353-0be4bf482329.png)

This change fixes it so it now looks like this:

![image](https://user-images.githubusercontent.com/20801176/55920042-20d7e380-5bad-11e9-82d6-335da5df2ac7.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8686)