### PR TITLE
removed flickering split button tests

### DIFF
--- a/apps/vr-tests/src/stories/Button.stories.tsx
+++ b/apps/vr-tests/src/stories/Button.stories.tsx
@@ -149,15 +149,15 @@ storiesOf('Button Split', module)
         .snapshot('hover main', { cropTo: '.testWrapper' })
         .hover('.ms-Button:nth-child(2)')
         .snapshot('hover split', { cropTo: '.testWrapper' })
-        .mouseDown('.ms-Button:nth-child(1)')
-        .snapshot('pressed main', { cropTo: '.testWrapper' })
-        .hover('.ms-Button') // reset mouseDown
-        .mouseUp('.ms-Button:nth-child(2)')
-        .mouseDown('.ms-Button:nth-child(2)')
-        .snapshot('pressed split', { cropTo: '.testWrapper' })
-        .click('.ms-Button:nth-child(2)')
-        .hover('.ms-Button') // move mouse to make click work
-        .snapshot('open', { cropTo: '.testWrapper' })
+        // .mouseDown('.ms-Button:nth-child(1)')
+        // .snapshot('pressed main', { cropTo: '.testWrapper' })
+        // .hover('.ms-Button') // reset mouseDown
+        // .mouseUp('.ms-Button:nth-child(2)')
+        // .mouseDown('.ms-Button:nth-child(2)')
+        // .snapshot('pressed split', { cropTo: '.testWrapper' })
+        // .click('.ms-Button:nth-child(2)')
+        // .hover('.ms-Button') // move mouse to make click work
+        // .snapshot('open', { cropTo: '.testWrapper' })
         .end()}
     >
       {story()}


### PR DESCRIPTION
Some of the split button tests are flickering and randomly failing. I've commented out the problematic tests and we can try to reintroduce them once Screener team has a chance to see what changed.  For context, screener did update recently to use the newest version of chrome, so it could be a small change based on that. Not sure yet. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8689)