### PR TITLE
Fix panel twodismiss

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-panel-twodismiss_2019-04-12-05-48.json
+++ b/common/changes/office-ui-fabric-react/fix-panel-twodismiss_2019-04-12-05-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Fix double dismiss",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -21,7 +21,6 @@ const getClassNames = classNamesFunction<IPanelStyleProps, IPanelStyles>();
 
 export interface IPanelState {
   isFooterSticky?: boolean;
-  isOpen?: boolean;
   isAnimating?: boolean;
   id?: string;
 }
@@ -38,6 +37,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   private _panel = React.createRef<HTMLDivElement>();
   private _classNames: IProcessedStyleSet<IPanelStyles>;
   private _scrollableContent: HTMLDivElement | null;
+  private _isOpen: boolean;
 
   constructor(props: IPanelProps) {
     super(props);
@@ -47,10 +47,10 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       forceFocusInsideTrap: 'focusTrapZoneProps',
       firstFocusableSelector: 'focusTrapZoneProps'
     });
+    this._isOpen = !!props.isOpen;
 
     this.state = {
       isFooterSticky: false,
-      isOpen: false,
       isAnimating: false,
       id: getId('Panel')
     };
@@ -80,7 +80,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   }
 
   public componentWillReceiveProps(newProps: IPanelProps): void {
-    if (newProps.isOpen !== this.state.isOpen) {
+    if (newProps.isOpen !== this._isOpen) {
       if (newProps.isOpen) {
         this.open();
       } else {
@@ -115,13 +115,15 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       onRenderBody = this._onRenderBody,
       onRenderFooter = this._onRenderFooter
     } = this.props;
-    const { isFooterSticky, isOpen, isAnimating, id } = this.state;
+    const { isFooterSticky, isAnimating, id } = this.state;
     const isLeft = type === PanelType.smallFixedNear || type === PanelType.customNear ? true : false;
     const isRTL = getRTL();
     const isOnRightSide = isRTL ? isLeft : !isLeft;
     const headerTextId = headerText && id + '-headerText';
     const customWidthStyles = type === PanelType.custom || type === PanelType.customNear ? { width: customWidth } : {};
     const nativeProps = getNativeProps(this.props, divProperties);
+
+    const isOpen = this._isOpen;
 
     if (!isOpen && !isAnimating && !isHiddenOnDismiss) {
       return null;
@@ -190,10 +192,10 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   }
 
   public open() {
-    if (!this.state.isOpen) {
+    if (!this._isOpen) {
+      this._isOpen = true;
       this.setState(
         {
-          isOpen: true,
           isAnimating: true
         },
         () => {
@@ -208,7 +210,8 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   }
 
   public dismiss = (ev?: React.SyntheticEvent<HTMLElement>): void => {
-    if (this.state.isOpen) {
+    if (this._isOpen) {
+      this._isOpen = false;
       if (this.props.onDismiss) {
         this.props.onDismiss(ev);
       }
@@ -216,7 +219,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       if (!ev || (ev && !ev.defaultPrevented)) {
         this.setState(
           {
-            isOpen: false,
             isAnimating: true
           },
           () => {
@@ -332,7 +334,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
 
   private _dismissOnOuterClick(ev: any): void {
     const panel = this._panel.current;
-    if (this.state.isOpen && panel) {
+    if (this._isOpen && panel) {
       if (!elementContains(panel, ev.target)) {
         if (this.props.onOuterClick) {
           this.props.onOuterClick();
@@ -354,11 +356,11 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       isAnimating: false
     });
 
-    if (this.state.isOpen && this.props.onOpened) {
+    if (this._isOpen && this.props.onOpened) {
       this.props.onOpened();
     }
 
-    if (!this.state.isOpen && this.props.onDismissed) {
+    if (!this._isOpen && this.props.onDismissed) {
       this.props.onDismissed();
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
@@ -75,8 +75,10 @@ describe('Panel', () => {
     it('fires the correct events when closing', () => {
       let dismissedCalled = false;
       let dismissCalled = false;
+      let dismissCount = 0;
       const setDismissTrue = (): void => {
         dismissCalled = true;
+        dismissCount++;
       };
       const setDismissedTrue = (): void => {
         dismissedCalled = true;
@@ -93,6 +95,9 @@ describe('Panel', () => {
 
       expect(dismissCalled).toEqual(true);
       expect(dismissedCalled).toEqual(false);
+
+      // Dismiss should only be called once per dismiss.
+      expect(dismissCount).toEqual(1);
 
       jest.runOnlyPendingTimers();
 

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -102,10 +102,6 @@ exports[`Panel renders Panel correctly 1`] = `
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                animation-duration: 0.167s;
-                animation-fill-mode: both;
-                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
                 background-color: rgba(255,255,255,.4);
                 bottom: 0px;
                 cursor: pointer;
@@ -128,10 +124,6 @@ exports[`Panel renders Panel correctly 1`] = `
               ms-Panel-main
               {
                 -webkit-overflow-scrolling: touch;
-                animation-duration: 0.367s;
-                animation-fill-mode: both;
-                animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                animation-timing-function: cubic-bezier(.1,.9,.2,1);
                 background-color: #ffffff;
                 bottom: 0px;
                 box-shadow: 0px 0px 30px 0px rgba(0,0,0,0.2);


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8701
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Currently the panel will call on dismiss twice when it is closed. I believe that this fix is one of the only ways to get it working without breaking existing functionality. As a possible other fix we could change the comment so that it explicitly states that ondismiss will get called twice. This code change doesn't quite seem right but I can't think of any other way of fixing this bug. Suggestions are welcome.
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8710)