### PR TITLE
DetailsList: Fix focus high contrast color

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-detailslist-highcontrast_2019-04-12-17-55.json
+++ b/common/changes/office-ui-fabric-react/fix-detailslist-highcontrast_2019-04-12-17-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Fix high contrast focus color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -154,11 +154,13 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
             // Selected State hover meta cell
             $cell: {
               color: colors.focusMetaTextColor,
-              [HighContrastSelector]: {
-                color: 'HighlightText',
-                selectors: {
-                  '> a': {
-                    color: 'HighlightText'
+              selectors: {
+                [HighContrastSelector]: {
+                  color: 'HighlightText',
+                  selectors: {
+                    '> a': {
+                      color: 'HighlightText'
+                    }
                   }
                 }
               },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #8634
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Details list had an incorrect selector so the highcontrast color was not properly applied when a row was focused.

Before:

![image](https://user-images.githubusercontent.com/20801176/56056848-3286cb80-5d12-11e9-986b-dc6325faefc9.png)

After: 

![image](https://user-images.githubusercontent.com/20801176/56056869-403c5100-5d12-11e9-880a-ebf6cfe20dc5.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8714)