### PR TITLE
MessageBar: fixing transparency background issue

### DIFF
--- a/common/changes/office-ui-fabric-react/v-vibr-MessagebarBackground_2019-04-12-19-32.json
+++ b/common/changes/office-ui-fabric-react/v-vibr-MessagebarBackground_2019-04-12-19-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "MessageBar: fixes the transparency of the background issue when rendered on top of themed backgrounds.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "vitaliebraga@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
@@ -105,7 +105,8 @@ const classNameSelectors: { [key: string]: string } = {
   Nav: 'ms-Nav',
   Panel: 'ms-Panel',
   PlainCard: 'ms-Callout',
-  Tooltip: 'ms-Tooltip'
+  Tooltip: 'ms-Tooltip',
+  MessageBar: 'ms-MessageBar'
 };
 
 // NOTE: Please consider modifying your component to work with this test instead

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -106,27 +106,33 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderMultiLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
+    const { theme } = this.props;
     return (
-      <div className={this._classNames.root}>
-        <div className={this._classNames.content}>
-          {this._getIconSpan()}
-          {this._renderInnerText()}
-          {this._getDismissDiv()}
+      <div style={{ background: theme!.semanticColors.bodyBackground }}>
+        <div className={this._classNames.root}>
+          <div className={this._classNames.content}>
+            {this._getIconSpan()}
+            {this._renderInnerText()}
+            {this._getDismissDiv()}
+          </div>
+          {this._getActionsDiv()}
         </div>
-        {this._getActionsDiv()}
       </div>
     );
   }
 
   private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
+    const { theme } = this.props;
     return (
-      <div className={this._classNames.root}>
-        <div className={this._classNames.content}>
-          {this._getIconSpan()}
-          {this._renderInnerText()}
-          {this._getExpandSingleLine()}
-          {this._getActionsDiv()}
-          {this._getDismissSingleLine()}
+      <div style={{ background: theme!.semanticColors.bodyBackground }}>
+        <div className={this._classNames.root}>
+          <div className={this._classNames.content}>
+            {this._getIconSpan()}
+            {this._renderInnerText()}
+            {this._getExpandSingleLine()}
+            {this._getActionsDiv()}
+            {this._getDismissSingleLine()}
+          </div>
         </div>
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -175,7 +175,7 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
               [HighContrastSelector]: {
                 background: 'WindowText',
                 color: 'Window',
-                content: ' '
+                content: '""'
               }
             }
           }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -125,7 +125,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         width: '100%',
         boxSizing: 'border-box',
         display: 'flex',
-        position: 'relative',
         wordBreak: 'break-word',
         selectors: {
           '& .ms-Link': {
@@ -133,7 +132,8 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
             ...fonts.small
           },
           [HighContrastSelector]: {
-            background: 'windowText'
+            background: 'windowText',
+            color: 'Window'
           }
         }
       },
@@ -161,25 +161,7 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         display: 'flex',
         lineHeight: 'normal',
         width: '100%',
-        boxSizing: 'border-box',
-        selectors: {
-          '&:before': {
-            pointerEvents: 'none',
-            position: 'absolute',
-            right: 0,
-            bottom: 0,
-            left: 0,
-            top: 0,
-            margin: 0,
-            selectors: {
-              [HighContrastSelector]: {
-                background: 'WindowText',
-                color: 'Window',
-                content: '""'
-              }
-            }
-          }
-        }
+        boxSizing: 'border-box'
       },
       !isMultiline && {
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
           font-size: 14px;
           font-weight: 400;
           min-height: 32px;
-          position: relative;
           width: 100%;
           word-break: break-word;
         }
@@ -38,6 +37,7 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
         }
         @media screen and (-ms-high-contrast: active){& {
           background: windowText;
+          color: Window;
         }
   >
     <div
@@ -49,23 +49,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
             flex-direction: row;
             line-height: normal;
             width: 100%;
-          }
-          &:before {
-            bottom: 0px;
-            left: 0px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-          }
-          @media screen and (-ms-high-contrast: active){&:before {
-            background: WindowText;
-            color: Window;
-            content: "";
           }
     >
       <div

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -2,151 +2,159 @@
 
 exports[`MessageBar renders MessageBar correctly 1`] = `
 <div
-  className=
-      ms-MessageBar
-      ms-MessageBar-multiline
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background: #f4f4f4;
-        box-sizing: border-box;
-        color: #333333;
-        display: flex;
-        flex-direction: column;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        min-height: 32px;
-        position: relative;
-        width: 100%;
-        word-break: break-word;
-      }
-      & .ms-Link {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #005a9e;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 12px;
-        font-weight: 400;
-      }
-      @media screen and (-ms-high-contrast: active){& {
-        background: windowText;
-      }
+  style={
+    Object {
+      "background": "#ffffff",
+    }
+  }
 >
   <div
     className=
-        ms-MessageBar-content
+        ms-MessageBar
+        ms-MessageBar-multiline
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: #f4f4f4;
           box-sizing: border-box;
+          color: #333333;
           display: flex;
-          flex-direction: row;
-          line-height: normal;
+          flex-direction: column;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          min-height: 32px;
+          position: relative;
           width: 100%;
+          word-break: break-word;
         }
-        &:before {
-          bottom: 0px;
-          left: 0px;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          pointer-events: none;
-          position: absolute;
-          right: 0px;
-          top: 0px;
+        & .ms-Link {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #005a9e;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
         }
-        @media screen and (-ms-high-contrast: active){&:before {
-          background: WindowText;
-          color: Window;
-          content:  ;
+        @media screen and (-ms-high-contrast: active){& {
+          background: windowText;
         }
   >
     <div
       className=
-          ms-MessageBar-icon
+          ms-MessageBar-content
           {
-            color: #666666;
+            box-sizing: border-box;
             display: flex;
-            flex-shrink: 0;
-            font-size: 16px;
-            margin-bottom: 16px;
-            margin-left: 16px;
-            margin-right: 0px;
-            margin-top: 16px;
-            min-height: 16px;
-            min-width: 16px;
+            flex-direction: row;
+            line-height: normal;
+            width: 100%;
           }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            margin-bottom: 8px;
-            margin-left: 8px;
+          &:before {
+            bottom: 0px;
+            left: 0px;
+            margin-bottom: 0px;
+            margin-left: 0px;
             margin-right: 0px;
-            margin-top: 8px;
+            margin-top: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background: WindowText;
+            color: Window;
+            content: "";
           }
     >
-      <i
+      <div
         className=
+            ms-MessageBar-icon
+            {
+              color: #666666;
+              display: flex;
+              flex-shrink: 0;
+              font-size: 16px;
+              margin-bottom: 16px;
+              margin-left: 16px;
+              margin-right: 0px;
+              margin-top: 16px;
+              min-height: 16px;
+              min-width: 16px;
+            }
+            @media only screen and (min-width: 0px) and (max-width: 479px){& {
+              margin-bottom: 8px;
+              margin-left: 8px;
+              margin-right: 0px;
+              margin-top: 8px;
+            }
+      >
+        <i
+          className=
 
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #666666;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: window;
+              }
+          data-icon-name="Info"
+          role="presentation"
+        >
+          
+        </i>
+      </div>
+      <div
+        className=
+            ms-MessageBar-text
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: #666666;
-              display: inline-block;
-              font-family: "FabricMDL2Icons";
-              font-style: normal;
-              font-weight: normal;
-              speak: none;
+              display: flex;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              margin-bottom: 16px;
+              margin-left: 8px;
+              margin-right: 16px;
+              margin-top: 16px;
+              min-width: 0px;
+            }
+            @media only screen and (min-width: 0px) and (max-width: 479px){& {
+              margin-bottom: 8px;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 8px;
             }
             @media screen and (-ms-high-contrast: active){& {
               -ms-high-contrast-adjust: none;
               color: window;
             }
-        data-icon-name="Info"
-        role="presentation"
+        id="MessageBar0"
       >
-        
-      </i>
-    </div>
-    <div
-      className=
-          ms-MessageBar-text
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            display: flex;
-            flex-grow: 1;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-            margin-bottom: 16px;
-            margin-left: 8px;
-            margin-right: 16px;
-            margin-top: 16px;
-            min-width: 0px;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            margin-bottom: 8px;
-            margin-left: 8px;
-            margin-right: 8px;
-            margin-top: 8px;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            -ms-high-contrast-adjust: none;
-            color: window;
-          }
-      id="MessageBar0"
-    >
-      <span
-        aria-live="polite"
-        className=
-            ms-MessageBar-innerText
-            {
-              line-height: 16px;
-            }
-            & a {
-              padding-left: 4px;
-            }
-        role="status"
-      />
+        <span
+          aria-live="polite"
+          className=
+              ms-MessageBar-innerText
+              {
+                line-height: 16px;
+              }
+              & a {
+                padding-left: 4px;
+              }
+          role="status"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -64,151 +64,159 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       Info/Default MessageBar
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar-multiline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: #f4f4f4;
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar-multiline
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: #f4f4f4;
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              flex-direction: row;
-              line-height: normal;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
               }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 8px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #666666;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Info"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #666666;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 16px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="Info"
-            role="presentation"
+            id="MessageBar0"
           >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 16px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar0"
-        >
-          <span
-            aria-live="polite"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -255,255 +263,177 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       Error MessageBar - single line, with dismiss button
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--error
-          ms-MessageBar-singleline
-          ms-MessageBar-dismissalSingleLine
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(232, 17, 35, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar--error
+            ms-MessageBar-singleline
+            ms-MessageBar-dismissalSingleLine
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(232, 17, 35, .2);
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              line-height: normal;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
+              flex-direction: column;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
+                flex-direction: row;
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a80000;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-3";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="ErrorBadge"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a80000;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-3";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="ErrorBadge"
-            role="presentation"
+            id="MessageBar1"
           >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar1"
-        >
-          <span
-            aria-live="assertive"
+            <span
+              aria-live="assertive"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                  }
+              role="status"
+            />
+          </div>
+          <div
             className=
-                ms-MessageBar-innerText
+                ms-MessageBar-dismissSingleLine
                 {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  overflow: visible;
-                  white-space: pre-wrap;
-                }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-dismissSingleLine
-              {
-                display: flex;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-        >
-          <button
-            aria-label="Close"
-            className=
-                ms-Button
-                ms-Button--icon
-                ms-MessageBar-dismissal
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  flex-shrink: 0;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  margin-bottom: 8px;
-                  margin-left: 0px;
-                  margin-right: 8px;
-                  margin-top: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                  width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #000000;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  color: #0078d4;
+                  display: flex;
                 }
                 & .ms-Button-icon {
                   color: #333333;
@@ -515,61 +445,147 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  margin-bottom: 0px;
-                  margin-left: 8px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
           >
-            <div
+            <button
+              aria-label="Close"
               className=
-                  ms-Button-flexContainer
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-dismissal
                   {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #333333;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              <i
+              <div
                 className=
-                    ms-Button-icon
+                    ms-Button-flexContainer
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      flex-shrink: 0;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 16px;
-                      font-style: normal;
-                      font-weight: normal;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
-                      speak: none;
-                      text-align: center;
-                      vertical-align: middle;
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
                     }
-                data-icon-name="Clear"
-                role="presentation"
               >
-                
-              </i>
-            </div>
-          </button>
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="Clear"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -616,266 +632,186 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       Blocked MessageBar - single line, with dismiss button and truncated text. Truncation is not available if you use action buttons or multiline and should be used sparingly.
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--blocked
-          ms-MessageBar-singleline
-          ms-MessageBar-dismissalSingleLine
-          ms-MessageBar-expandingSingleLine
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(232, 17, 35, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
-          & .ms-Button-icon {
-            color: #333333;
-            font-size: 12px;
-            height: 12px;
-            line-height: 12px;
-          }
-          @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-            -ms-high-contrast-adjust: none;
-            color: window;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar--blocked
+            ms-MessageBar-singleline
+            ms-MessageBar-dismissalSingleLine
+            ms-MessageBar-expandingSingleLine
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(232, 17, 35, .2);
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              flex-direction: row;
-              line-height: normal;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
+              flex-direction: column;
+            }
+            & .ms-Button-icon {
+              color: #333333;
+              font-size: 12px;
+              height: 12px;
+              line-height: 12px;
+            }
+            @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+              -ms-high-contrast-adjust: none;
+              color: window;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
+                flex-direction: row;
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a80000;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-5";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Blocked2"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a80000;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-5";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="Blocked2"
-            role="presentation"
+            id="MessageBar5"
           >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar5"
-        >
-          <span
-            aria-live="assertive"
+            <span
+              aria-live="assertive"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
+          <div
             className=
-                ms-MessageBar-innerText
+                ms-MessageBar-expandSingleLine
                 {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-expandSingleLine
-              {
-                display: flex;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-        >
-          <button
-            aria-controls="MessageBar5"
-            aria-expanded={false}
-            aria-label="See more"
-            className=
-                ms-Button
-                ms-Button--icon
-                ms-MessageBar-expand
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  flex-shrink: 0;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  margin-bottom: 8px;
-                  margin-left: 0px;
-                  margin-right: 8px;
-                  margin-top: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                  width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #000000;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  color: #0078d4;
+                  display: flex;
                 }
                 & .ms-Button-icon {
                   color: #333333;
@@ -887,152 +823,154 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  margin-bottom: 0px;
-                  margin-left: 8px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
           >
-            <div
+            <button
+              aria-controls="MessageBar5"
+              aria-expanded={false}
+              aria-label="See more"
               className=
-                  ms-Button-flexContainer
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-expand
                   {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #333333;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              <i
+              <div
                 className=
-                    ms-Button-icon
+                    ms-Button-flexContainer
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      flex-shrink: 0;
-                      font-family: "FabricMDL2Icons-6";
-                      font-size: 16px;
-                      font-style: normal;
-                      font-weight: normal;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
-                      speak: none;
-                      text-align: center;
-                      vertical-align: middle;
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
                     }
-                data-icon-name="DoubleChevronDown"
-                role="presentation"
               >
-                
-              </i>
-            </div>
-          </button>
-        </div>
-        <div
-          className=
-              ms-MessageBar-dismissSingleLine
-              {
-                display: flex;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-        >
-          <button
-            aria-label="Close"
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons-6";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="DoubleChevronDown"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
+          <div
             className=
-                ms-Button
-                ms-Button--icon
-                ms-MessageBar-dismissal
+                ms-MessageBar-dismissSingleLine
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  flex-shrink: 0;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  margin-bottom: 8px;
-                  margin-left: 0px;
-                  margin-right: 8px;
-                  margin-top: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                  width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #000000;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  color: #0078d4;
+                  display: flex;
                 }
                 & .ms-Button-icon {
                   color: #333333;
@@ -1044,61 +982,147 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  margin-bottom: 0px;
-                  margin-left: 8px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
           >
-            <div
+            <button
+              aria-label="Close"
               className=
-                  ms-Button-flexContainer
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-dismissal
                   {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #333333;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              <i
+              <div
                 className=
-                    ms-Button-icon
+                    ms-Button-flexContainer
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      flex-shrink: 0;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 16px;
-                      font-style: normal;
-                      font-weight: normal;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
-                      speak: none;
-                      text-align: center;
-                      vertical-align: middle;
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
                     }
-                data-icon-name="Clear"
-                role="presentation"
               >
-                
-              </i>
-            </div>
-          </button>
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="Clear"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1145,609 +1169,164 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
       SevereWarning MessageBar - defaults to multiline, with action buttons
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--severeWarning
-          ms-MessageBar-multiline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(234, 67, 0, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-    >
-      <div
-        className=
-            ms-MessageBar-content
-            {
-              box-sizing: border-box;
-              display: flex;
-              flex-direction: row;
-              line-height: normal;
-              width: 100%;
-            }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-      >
-        <div
-          className=
-              ms-MessageBar-icon
-              {
-                color: #666666;
-                display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a80000;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-0";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Warning"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 16px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar12"
-        >
-          <span
-            aria-live="assertive"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
-        </div>
-      </div>
-      <div
-        className=
-            ms-MessageBar-actions
-            {
-              align-items: center;
-              display: flex;
-              flex-basis: auto;
-              flex-direction: row-reverse;
-              flex-grow: 0;
-              flex-shrink: 0;
-              margin-bottom: 12px;
-              margin-left: 0;
-              margin-right: 12px;
-              margin-top: 0px;
-            }
-            & button:nth-child(n+2) {
-              margin-left: 12px;
-            }
-      >
-        <div>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__13"
-                >
-                  Yes
-                </div>
-              </div>
-            </div>
-          </button>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__16"
-                >
-                  No
-                </div>
-              </div>
-            </div>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-StackItem
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          flex-shrink: 1;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          width: auto;
+      style={
+        Object {
+          "background": "#ffffff",
         }
-  >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-    >
-      Success MessageBar - single line, with action buttons
-    </label>
-    <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--success
-          ms-MessageBar-singleline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(186, 216, 10, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar--severeWarning
+            ms-MessageBar-multiline
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(234, 67, 0, .2);
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              line-height: normal;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-            @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
               }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #107c10;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-2";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Completed"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 16px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
+              &:before {
+                bottom: 0px;
+                left: 0px;
                 margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 8px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
               }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
-          id="MessageBar19"
         >
-          <span
-            aria-live="polite"
+          <div
             className=
-                ms-MessageBar-innerText
+                ms-MessageBar-icon
                 {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
                 }
                 @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  overflow: visible;
-                  white-space: pre-wrap;
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
                 }
-            role="status"
-          />
+          >
+            <i
+              className=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a80000;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-0";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Warning"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 16px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar12"
+          >
+            <span
+              aria-live="assertive"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
         </div>
         <div
           className=
-              ms-MessageBar-actionsSingleLine
+              ms-MessageBar-actions
               {
                 align-items: center;
                 display: flex;
@@ -1755,13 +1334,13 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 flex-direction: row-reverse;
                 flex-grow: 0;
                 flex-shrink: 0;
-                margin-bottom: 8px;
+                margin-bottom: 12px;
                 margin-left: 0;
-                margin-right: 8px;
-                margin-top: 8px;
+                margin-right: 12px;
+                margin-top: 0px;
               }
               & button:nth-child(n+2) {
-                margin-left: 8px;
+                margin-left: 12px;
               }
         >
           <div>
@@ -1872,7 +1451,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                         }
-                    id="id__20"
+                    id="id__13"
                   >
                     Yes
                   </div>
@@ -1986,7 +1565,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                         }
-                    id="id__23"
+                    id="id__16"
                   >
                     No
                   </div>
@@ -2037,230 +1616,838 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             word-wrap: break-word;
           }
     >
-      Warning MessageBar - single line, with dismiss and action buttons
+      Success MessageBar - single line, with action buttons
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--warning
-          ms-MessageBar-singleline
-          ms-MessageBar-dismissalSingleLine
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(255, 185, 0, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar--success
+            ms-MessageBar-singleline
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(186, 216, 10, .2);
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              line-height: normal;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
+              flex-direction: column;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
+                flex-direction: row;
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #107c10;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-2";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Completed"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #333333;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 16px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="Info"
-            role="presentation"
+            id="MessageBar19"
           >
-            
-          </i>
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                  }
+              role="status"
+            />
+          </div>
+          <div
+            className=
+                ms-MessageBar-actionsSingleLine
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-basis: auto;
+                  flex-direction: row-reverse;
+                  flex-grow: 0;
+                  flex-shrink: 0;
+                  margin-bottom: 8px;
+                  margin-left: 0;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                & button:nth-child(n+2) {
+                  margin-left: 8px;
+                }
+          >
+            <div>
+              <button
+                className=
+                    ms-Button
+                    ms-Button--default
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #dadada;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      min-width: 80px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #a6a6a6;
+                      color: #212121;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-textContainer
+                        {
+                          flex-grow: 1;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Button-label
+                          {
+                            font-weight: 600;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                          }
+                      id="id__20"
+                    >
+                      Yes
+                    </div>
+                  </div>
+                </div>
+              </button>
+              <button
+                className=
+                    ms-Button
+                    ms-Button--default
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #dadada;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      min-width: 80px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #a6a6a6;
+                      color: #212121;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-textContainer
+                        {
+                          flex-grow: 1;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Button-label
+                          {
+                            font-weight: 600;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                          }
+                      id="id__23"
+                    >
+                      No
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-StackItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          flex-shrink: 1;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          width: auto;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Warning MessageBar - single line, with dismiss and action buttons
+    </label>
+    <div
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
+    >
+      <div
+        className=
+            ms-MessageBar
+            ms-MessageBar--warning
+            ms-MessageBar-singleline
+            ms-MessageBar-dismissalSingleLine
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(255, 185, 0, .2);
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
+              width: 100%;
+              word-break: break-word;
+            }
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
+            }
+            @media only screen and (min-width: 0px) and (max-width: 479px){& {
+              flex-direction: column;
+            }
+      >
         <div
           className=
-              ms-MessageBar-text
+              ms-MessageBar-content
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
+                box-sizing: border-box;
                 display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
+                flex-direction: row;
               }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar26"
         >
-          <span
-            aria-live="polite"
+          <div
             className=
-                ms-MessageBar-innerText
+                ms-MessageBar-icon
                 {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
                 }
                 @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  overflow: visible;
-                  white-space: pre-wrap;
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
                 }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-actionsSingleLine
-              {
-                align-items: center;
-                display: flex;
-                flex-basis: auto;
-                flex-direction: row-reverse;
-                flex-grow: 0;
-                flex-shrink: 0;
-                margin-bottom: 8px;
-                margin-left: 0;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              & button:nth-child(n+2) {
-                margin-left: 8px;
-              }
-        >
-          <div>
-            <button
+          >
+            <i
               className=
-                  ms-Button
-                  ms-Button--default
+
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background-color: #dadada;
+                    color: #333333;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Info"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar26"
+          >
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                  }
+              role="status"
+            />
+          </div>
+          <div
+            className=
+                ms-MessageBar-actionsSingleLine
+                {
+                  align-items: center;
+                  display: flex;
+                  flex-basis: auto;
+                  flex-direction: row-reverse;
+                  flex-grow: 0;
+                  flex-shrink: 0;
+                  margin-bottom: 8px;
+                  margin-left: 0;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                & button:nth-child(n+2) {
+                  margin-left: 8px;
+                }
+          >
+            <div>
+              <button
+                className=
+                    ms-Button
+                    ms-Button--default
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #dadada;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      min-width: 80px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #a6a6a6;
+                      color: #212121;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-textContainer
+                        {
+                          flex-grow: 1;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Button-label
+                          {
+                            font-weight: 600;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                          }
+                      id="id__27"
+                    >
+                      Action
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            className=
+                ms-MessageBar-dismissSingleLine
+                {
+                  display: flex;
+                }
+                & .ms-Button-icon {
+                  color: #333333;
+                  font-size: 12px;
+                  height: 12px;
+                  line-height: 12px;
+                }
+                @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+          >
+            <button
+              aria-label="Close"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-dismissal
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
                     border-radius: 0px;
-                    border: 1px solid transparent;
+                    border: none;
                     box-sizing: border-box;
                     color: #333333;
                     cursor: pointer;
                     display: inline-block;
+                    flex-shrink: 0;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
                     height: 32px;
-                    min-width: 80px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
                     outline: transparent;
                     padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
+                    padding-left: 4px;
+                    padding-right: 4px;
                     padding-top: 0;
                     position: relative;
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
+                    width: 32px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid #000000;
+                    bottom: 1px;
                     content: "";
-                    left: 0px;
+                    left: 1px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 1px;
+                    top: 1px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -2277,7 +2464,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     top: 0px;
                   }
                   &:hover {
-                    background-color: #c8c8c8;
                     color: #212121;
                   }
                   @media screen and (-ms-high-contrast: active){&:hover {
@@ -2285,8 +2471,23 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     color: Highlight;
                   }
                   &:active {
-                    background-color: #a6a6a6;
-                    color: #212121;
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #333333;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
                   }
               data-is-focusable={true}
               onClick={[Function]}
@@ -2308,50 +2509,236 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       justify-content: center;
                     }
               >
-                <div
+                <i
                   className=
-                      ms-Button-textContainer
+                      ms-Button-icon
                       {
-                        flex-grow: 1;
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
                       }
+                  data-icon-name="Clear"
+                  role="presentation"
                 >
-                  <div
-                    className=
-                        ms-Button-label
-                        {
-                          font-weight: 600;
-                          line-height: 100%;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                        }
-                    id="id__27"
-                  >
-                    Action
-                  </div>
-                </div>
+                  
+                </i>
               </div>
             </button>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-StackItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          flex-shrink: 1;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          width: auto;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Warning MessageBar - defaults to multiline, with dismiss and action buttons
+    </label>
+    <div
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
+    >
+      <div
+        className=
+            ms-MessageBar
+            ms-MessageBar--warning
+            ms-MessageBar-multiline
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(255, 185, 0, .2);
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
+              width: 100%;
+              word-break: break-word;
+            }
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
+            }
+      >
         <div
           className=
-              ms-MessageBar-dismissSingleLine
+              ms-MessageBar-content
               {
+                box-sizing: border-box;
                 display: flex;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
               }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
               }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
         >
+          <div
+            className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #333333;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Info"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar33"
+          >
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
           <button
             aria-label="Close"
             className=
@@ -2492,586 +2879,255 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             </div>
           </button>
         </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-StackItem
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          flex-shrink: 1;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          width: auto;
-        }
-  >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-    >
-      Warning MessageBar - defaults to multiline, with dismiss and action buttons
-    </label>
-    <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--warning
-          ms-MessageBar-multiline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(255, 185, 0, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-    >
-      <div
-        className=
-            ms-MessageBar-content
-            {
-              box-sizing: border-box;
-              display: flex;
-              flex-direction: row;
-              line-height: normal;
-              width: 100%;
-            }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-      >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-actions
               {
-                color: #666666;
+                align-items: center;
                 display: flex;
+                flex-basis: auto;
+                flex-direction: row-reverse;
+                flex-grow: 0;
                 flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #333333;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Info"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar33"
-        >
-          <span
-            aria-live="polite"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
-        </div>
-        <button
-          aria-label="Close"
-          className=
-              ms-Button
-              ms-Button--icon
-              ms-MessageBar-dismissal
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: none;
-                box-sizing: border-box;
-                color: #333333;
-                cursor: pointer;
-                display: inline-block;
-                flex-shrink: 0;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 32px;
-                margin-bottom: 8px;
-                margin-left: 0px;
-                margin-right: 8px;
-                margin-top: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 4px;
-                padding-right: 4px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-                width: 32px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #000000;
-                bottom: 1px;
-                content: "";
-                left: 1px;
-                outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                color: #212121;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                color: #0078d4;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 0px;
+                margin-bottom: 12px;
+                margin-left: 0;
+                margin-right: 12px;
                 margin-top: 0px;
               }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
+              & button:nth-child(n+2) {
+                margin-left: 12px;
+              }
         >
-          <div
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-          >
-            <i
+          <div>
+            <button
               className=
-                  ms-Button-icon
+                  ms-Button
+                  ms-Button--default
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
+                    background-color: #dadada;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
                     display: inline-block;
-                    flex-shrink: 0;
-                    font-family: "FabricMDL2Icons";
-                    font-size: 16px;
-                    font-style: normal;
-                    font-weight: normal;
-                    height: 16px;
-                    line-height: 16px;
-                    margin-bottom: 0;
-                    margin-left: 4px;
-                    margin-right: 4px;
-                    margin-top: 0;
-                    speak: none;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    min-width: 80px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                    padding-top: 0;
+                    position: relative;
                     text-align: center;
-                    vertical-align: middle;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
                   }
-              data-icon-name="Clear"
-              role="presentation"
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #c8c8c8;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #a6a6a6;
+                    color: #212121;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              
-            </i>
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: 600;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
+                    id="id__37"
+                  >
+                    Yes
+                  </div>
+                </div>
+              </div>
+            </button>
+            <button
+              className=
+                  ms-Button
+                  ms-Button--default
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #dadada;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    min-width: 80px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #c8c8c8;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #a6a6a6;
+                    color: #212121;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: 600;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
+                    id="id__40"
+                  >
+                    No
+                  </div>
+                </div>
+              </div>
+            </button>
           </div>
-        </button>
-      </div>
-      <div
-        className=
-            ms-MessageBar-actions
-            {
-              align-items: center;
-              display: flex;
-              flex-basis: auto;
-              flex-direction: row-reverse;
-              flex-grow: 0;
-              flex-shrink: 0;
-              margin-bottom: 12px;
-              margin-left: 0;
-              margin-right: 12px;
-              margin-top: 0px;
-            }
-            & button:nth-child(n+2) {
-              margin-left: 12px;
-            }
-      >
-        <div>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__37"
-                >
-                  Yes
-                </div>
-              </div>
-            </div>
-          </button>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__40"
-                >
-                  No
-                </div>
-              </div>
-            </div>
-          </button>
         </div>
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -86,7 +86,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -100,6 +99,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
       >
         <div
@@ -111,23 +111,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
         >
           <div
@@ -286,7 +269,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -300,6 +282,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -313,23 +296,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 display: flex;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -657,7 +623,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -671,6 +636,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -695,23 +661,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -1192,7 +1141,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -1206,6 +1154,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
       >
         <div
@@ -1217,23 +1166,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
         >
           <div
@@ -1641,7 +1573,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -1655,6 +1586,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -1668,23 +1600,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 display: flex;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -2103,7 +2018,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -2117,6 +2031,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -2130,23 +2045,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 display: flex;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -2608,7 +2506,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -2622,6 +2519,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
       >
         <div
@@ -2633,23 +2531,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
         >
           <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
@@ -86,7 +86,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -100,6 +99,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
       >
         <div
@@ -111,23 +111,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
         >
           <div
@@ -286,7 +269,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -300,6 +282,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -314,23 +297,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 display: flex;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -659,7 +625,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -673,6 +638,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -697,23 +663,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -1197,7 +1146,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -1211,6 +1159,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
       >
         <div
@@ -1222,23 +1171,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
         >
           <div
@@ -1647,7 +1579,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -1661,6 +1592,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -1674,23 +1606,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 display: flex;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -2111,7 +2026,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -2125,6 +2039,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
               flex-direction: column;
@@ -2139,23 +2054,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 display: flex;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
                 flex-direction: row;
@@ -2619,7 +2517,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               min-height: 32px;
-              position: relative;
               width: 100%;
               word-break: break-word;
             }
@@ -2633,6 +2530,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){& {
               background: windowText;
+              color: Window;
             }
       >
         <div
@@ -2644,23 +2542,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                 flex-direction: row;
                 line-height: normal;
                 width: 100%;
-              }
-              &:before {
-                bottom: 0px;
-                left: 0px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background: WindowText;
-                color: Window;
-                content: "";
               }
         >
           <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
@@ -64,151 +64,159 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
       Info/Default MessageBar - custom styles
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar-multiline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(113, 175, 229, 0.2);
-            box-sizing: border-box;
-            color: #00188f;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar-multiline
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(113, 175, 229, 0.2);
               box-sizing: border-box;
+              color: #00188f;
               display: flex;
-              flex-direction: row;
-              line-height: normal;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
               }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 8px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #00188f;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Info"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #00188f;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 16px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="Info"
-            role="presentation"
+            id="MessageBar0"
           >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 16px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar0"
-        >
-          <span
-            aria-live="polite"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -255,260 +263,182 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
       Error, single line, with dismiss button - custom styles
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--error
-          ms-MessageBar-singleline
-          ms-MessageBar-dismissalSingleLine
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(232, 17, 35, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar--error
+            ms-MessageBar-singleline
+            ms-MessageBar-dismissalSingleLine
             {
-              background: rgba(50, 20, 90, 0.2);
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(232, 17, 35, .2);
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              line-height: normal;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
+              flex-direction: column;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                background: rgba(50, 20, 90, 0.2);
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
+                flex-direction: row;
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a80000;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-3";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="ErrorBadge"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a80000;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-3";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  background: rgba(166, 166, 166, 0.5);
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="ErrorBadge"
-            role="presentation"
+            id="MessageBar1"
           >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background: rgba(166, 166, 166, 0.5);
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar1"
-        >
-          <span
-            aria-live="assertive"
+            <span
+              aria-live="assertive"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                  }
+              role="status"
+            />
+          </div>
+          <div
             className=
-                ms-MessageBar-innerText
+                ms-MessageBar-dismissSingleLine
                 {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  overflow: visible;
-                  white-space: pre-wrap;
-                }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-dismissSingleLine
-              {
-                display: flex;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-        >
-          <button
-            aria-label="Close"
-            className=
-                ms-Button
-                ms-Button--icon
-                ms-MessageBar-dismissal
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  flex-shrink: 0;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  margin-bottom: 8px;
-                  margin-left: 0px;
-                  margin-right: 8px;
-                  margin-top: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                  width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #000000;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  color: #0078d4;
+                  display: flex;
                 }
                 & .ms-Button-icon {
-                  color: #107c10;
+                  color: #333333;
                   font-size: 12px;
                   height: 12px;
                   line-height: 12px;
@@ -517,61 +447,147 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  margin-bottom: 0px;
-                  margin-left: 8px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
           >
-            <div
+            <button
+              aria-label="Close"
               className=
-                  ms-Button-flexContainer
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-dismissal
                   {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #107c10;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              <i
+              <div
                 className=
-                    ms-Button-icon
+                    ms-Button-flexContainer
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      flex-shrink: 0;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 16px;
-                      font-style: normal;
-                      font-weight: normal;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
-                      speak: none;
-                      text-align: center;
-                      vertical-align: middle;
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
                     }
-                data-icon-name="Clear"
-                role="presentation"
               >
-                
-              </i>
-            </div>
-          </button>
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="Clear"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -618,271 +634,191 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
       Blocked, single line, with dismiss button and truncated text - custom styles
     </label>
     <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--blocked
-          ms-MessageBar-singleline
-          ms-MessageBar-dismissalSingleLine
-          ms-MessageBar-expandingSingleLine
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(0, 178, 148, 0.2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
-          & .ms-Button-icon {
-            color: #333333;
-            font-size: 12px;
-            height: 12px;
-            line-height: 12px;
-          }
-          @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-            -ms-high-contrast-adjust: none;
-            color: window;
-          }
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
     >
       <div
         className=
-            ms-MessageBar-content
+            ms-MessageBar
+            ms-MessageBar--blocked
+            ms-MessageBar-singleline
+            ms-MessageBar-dismissalSingleLine
+            ms-MessageBar-expandingSingleLine
             {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(0, 178, 148, 0.2);
               box-sizing: border-box;
+              color: #333333;
               display: flex;
-              flex-direction: row;
-              line-height: normal;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
               width: 100%;
+              word-break: break-word;
             }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
             }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
             }
             @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
+              flex-direction: column;
+            }
+            & .ms-Button-icon {
+              color: #333333;
+              font-size: 12px;
+              height: 12px;
+              line-height: 12px;
+            }
+            @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+              -ms-high-contrast-adjust: none;
+              color: window;
             }
       >
         <div
           className=
-              ms-MessageBar-icon
+              ms-MessageBar-content
               {
-                color: #666666;
+                box-sizing: border-box;
                 display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
                 margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
               @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
+                flex-direction: row;
               }
         >
-          <i
+          <div
             className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
 
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a80000;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-5";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Blocked2"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
-                  color: #a80000;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-5";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
-            data-icon-name="Blocked2"
-            role="presentation"
+            id="MessageBar5"
           >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar5"
-        >
-          <span
-            aria-live="assertive"
+            <span
+              aria-live="assertive"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-decoration: underline;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
+          <div
             className=
-                ms-MessageBar-innerText
+                ms-MessageBar-expandSingleLine
                 {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-decoration: underline;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-expandSingleLine
-              {
-                border: 1px solid #e3008c;
-                display: flex;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-        >
-          <button
-            aria-controls="MessageBar5"
-            aria-expanded={false}
-            aria-label="See more"
-            className=
-                ms-Button
-                ms-Button--icon
-                ms-MessageBar-expand
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  flex-shrink: 0;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  margin-bottom: 8px;
-                  margin-left: 0px;
-                  margin-right: 8px;
-                  margin-top: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                  width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #000000;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  color: #0078d4;
+                  border: 1px solid #e3008c;
+                  display: flex;
                 }
                 & .ms-Button-icon {
-                  color: #004b50;
+                  color: #333333;
                   font-size: 12px;
                   height: 12px;
                   line-height: 12px;
@@ -891,80 +827,1929 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                   -ms-high-contrast-adjust: none;
                   color: window;
                 }
+          >
+            <button
+              aria-controls="MessageBar5"
+              aria-expanded={false}
+              aria-label="See more"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-expand
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #004b50;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons-6";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="DoubleChevronDown"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
+          <div
+            className=
+                ms-MessageBar-dismissSingleLine
+                {
+                  border: 1px solid #5c2d91;
+                  display: flex;
+                }
+                & .ms-Button-icon {
+                  color: #333333;
+                  font-size: 12px;
+                  height: 12px;
+                  line-height: 12px;
+                }
+                @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+          >
+            <button
+              aria-label="Close"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-dismissal
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #004b50;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="Clear"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-StackItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          flex-shrink: 1;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          width: auto;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Severe warning, multiline, with action buttons - custom styles
+    </label>
+    <div
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
+    >
+      <div
+        className=
+            ms-MessageBar
+            ms-MessageBar--severeWarning
+            ms-MessageBar-multiline
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(227, 0, 140, 0.2);
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
+              width: 100%;
+              word-break: break-word;
+            }
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
+            }
+      >
+        <div
+          className=
+              ms-MessageBar-content
+              {
+                box-sizing: border-box;
+                display: flex;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
+              }
+        >
+          <div
+            className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #e3008c;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-0";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Warning"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 16px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar12"
+          >
+            <span
+              aria-live="assertive"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-MessageBar-actions
+              {
+                align-items: center;
+                background: rgba(180, 0, 158, 0.4);
+                display: flex;
+                flex-basis: auto;
+                flex-direction: row-reverse;
+                flex-grow: 0;
+                flex-shrink: 0;
+                margin-bottom: 12px;
+                margin-left: 0;
+                margin-right: 12px;
+                margin-top: 0px;
+              }
+              & button:nth-child(n+2) {
+                margin-left: 12px;
+              }
+        >
+          <div>
+            <button
+              className=
+                  ms-Button
+                  ms-Button--default
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #dadada;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #e3008c;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    min-width: 80px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #c8c8c8;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #a6a6a6;
+                    color: #212121;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: 600;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
+                    id="id__13"
+                  >
+                    Yes
+                  </div>
+                </div>
+              </div>
+            </button>
+            <button
+              className=
+                  ms-Button
+                  ms-Button--default
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #dadada;
+                    border-radius: 0px;
+                    border: 1px solid transparent;
+                    box-sizing: border-box;
+                    color: #e3008c;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    min-width: 80px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 16px;
+                    padding-right: 16px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 0px;
+                    content: "";
+                    left: 0px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #c8c8c8;
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #a6a6a6;
+                    color: #212121;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-textContainer
+                      {
+                        flex-grow: 1;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-label
+                        {
+                          font-weight: 600;
+                          line-height: 100%;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                        }
+                    id="id__16"
+                  >
+                    No
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-StackItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          flex-shrink: 1;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          width: auto;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Success, single line, with action buttons - custom styles
+    </label>
+    <div
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
+    >
+      <div
+        className=
+            ms-MessageBar
+            ms-MessageBar--success
+            ms-MessageBar-singleline
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(186, 216, 10, .2);
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
+              width: 100%;
+              word-break: break-word;
+            }
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
+            }
+            @media only screen and (min-width: 0px) and (max-width: 479px){& {
+              flex-direction: column;
+            }
+      >
+        <div
+          className=
+              ms-MessageBar-content
+              {
+                box-sizing: border-box;
+                display: flex;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
+              }
+              @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                flex-direction: row;
+              }
+        >
+          <div
+            className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #107c10;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-2";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Completed"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 16px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar19"
+          >
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                  }
+              role="status"
+            />
+          </div>
+          <div
+            className=
+                ms-MessageBar-actionsSingleLine
+                {
+                  align-items: center;
+                  background: #007d84;
+                  border: 1px solid #ffb900;
+                  display: flex;
+                  flex-basis: auto;
+                  flex-direction: row-reverse;
+                  flex-grow: 0;
+                  flex-shrink: 0;
+                  margin-bottom: 8px;
+                  margin-left: 0;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                & button:nth-child(n+2) {
+                  margin-left: 8px;
+                }
+          >
+            <div>
+              <button
+                className=
+                    ms-Button
+                    ms-Button--default
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #dadada;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      min-width: 80px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #a6a6a6;
+                      color: #212121;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-textContainer
+                        {
+                          flex-grow: 1;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Button-label
+                          {
+                            font-weight: 600;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                          }
+                      id="id__20"
+                    >
+                      Yes
+                    </div>
+                  </div>
+                </div>
+              </button>
+              <button
+                className=
+                    ms-Button
+                    ms-Button--default
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #dadada;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      min-width: 80px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #a6a6a6;
+                      color: #212121;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
+              >
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-textContainer
+                        {
+                          flex-grow: 1;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Button-label
+                          {
+                            font-weight: 600;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                          }
+                      id="id__23"
+                    >
+                      No
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-StackItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          flex-shrink: 1;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          width: auto;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Warning, single line, with dismiss and action buttons - custom styles
+    </label>
+    <div
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
+    >
+      <div
+        className=
+            ms-MessageBar
+            ms-MessageBar--warning
+            ms-MessageBar-singleline
+            ms-MessageBar-dismissalSingleLine
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(255, 185, 0, .2);
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
+              width: 100%;
+              word-break: break-word;
+            }
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
+            }
+            @media only screen and (min-width: 0px) and (max-width: 479px){& {
+              flex-direction: column;
+            }
+      >
+        <div
+          className=
+              ms-MessageBar-content
+              {
+                background: rgba(234, 67, 0, 0.2);
+                box-sizing: border-box;
+                display: flex;
+                line-height: normal;
+                width: 100%;
+              }
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
+              }
+              @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                flex-direction: row;
+              }
+        >
+          <div
+            className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #333333;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Info"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 16px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
                 @media only screen and (min-width: 0px) and (max-width: 479px){& {
                   margin-bottom: 0px;
                   margin-left: 8px;
                   margin-right: 0px;
-                  margin-top: 0px;
+                  margin-top: 8px;
                 }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar26"
           >
-            <div
+            <span
+              aria-live="polite"
               className=
-                  ms-Button-flexContainer
+                  ms-MessageBar-innerText
                   {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
+                    line-height: 16px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                   }
-            >
-              <i
+                  & a {
+                    padding-left: 4px;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    overflow: visible;
+                    white-space: pre-wrap;
+                  }
+              role="status"
+            />
+          </div>
+          <div
+            className=
+                ms-MessageBar-actionsSingleLine
+                {
+                  align-items: center;
+                  border: 1px solid #ea4300;
+                  display: flex;
+                  flex-basis: auto;
+                  flex-direction: row-reverse;
+                  flex-grow: 0;
+                  flex-shrink: 0;
+                  margin-bottom: 8px;
+                  margin-left: 0;
+                  margin-right: 8px;
+                  margin-top: 8px;
+                }
+                & button:nth-child(n+2) {
+                  margin-left: 8px;
+                }
+          >
+            <div>
+              <button
                 className=
-                    ms-Button-icon
+                    ms-Button
+                    ms-Button--default
                     {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
+                      background-color: #dadada;
+                      border-radius: 0px;
+                      border: 1px solid transparent;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
                       display: inline-block;
-                      flex-shrink: 0;
-                      font-family: "FabricMDL2Icons-6";
-                      font-size: 16px;
-                      font-style: normal;
-                      font-weight: normal;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
-                      speak: none;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 32px;
+                      min-width: 80px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 16px;
+                      padding-right: 16px;
+                      padding-top: 0;
+                      position: relative;
                       text-align: center;
-                      vertical-align: middle;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
                     }
-                data-icon-name="DoubleChevronDown"
-                role="presentation"
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 0px;
+                      content: "";
+                      left: 0px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #c8c8c8;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #a6a6a6;
+                      color: #212121;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
-                
-              </i>
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <div
+                    className=
+                        ms-Button-textContainer
+                        {
+                          flex-grow: 1;
+                        }
+                  >
+                    <div
+                      className=
+                          ms-Button-label
+                          {
+                            font-weight: 600;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                          }
+                      id="id__27"
+                    >
+                      Action
+                    </div>
+                  </div>
+                </div>
+              </button>
             </div>
-          </button>
+          </div>
+          <div
+            className=
+                ms-MessageBar-dismissSingleLine
+                {
+                  border: 1px solid #ea4300;
+                  display: flex;
+                }
+                & .ms-Button-icon {
+                  color: #333333;
+                  font-size: 12px;
+                  height: 12px;
+                  line-height: 12px;
+                }
+                @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+          >
+            <button
+              aria-label="Close"
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-MessageBar-dismissal
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #333333;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex-shrink: 0;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 32px;
+                    margin-bottom: 8px;
+                    margin-left: 0px;
+                    margin-right: 8px;
+                    margin-top: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 32px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #000000;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #666666;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    color: #212121;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    color: #0078d4;
+                  }
+                  & .ms-Button-icon {
+                    color: #333333;
+                    font-size: 12px;
+                    height: 12px;
+                    line-height: 12px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+                  @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                    margin-bottom: 0px;
+                    margin-left: 8px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <div
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+              >
+                <i
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 16px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="Clear"
+                  role="presentation"
+                >
+                  
+                </i>
+              </div>
+            </button>
+          </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className=
+        ms-StackItem
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          flex-shrink: 1;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: auto;
+          width: auto;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+    >
+      Warning, multiline, with dismiss and action buttons - custom styles
+    </label>
+    <div
+      style={
+        Object {
+          "background": "#ffffff",
+        }
+      }
+    >
+      <div
+        className=
+            ms-MessageBar
+            ms-MessageBar--warning
+            ms-MessageBar-multiline
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background: rgba(0, 188, 242, 0.4);
+              box-sizing: border-box;
+              color: #333333;
+              display: flex;
+              flex-direction: column;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              min-height: 32px;
+              position: relative;
+              width: 100%;
+              word-break: break-word;
+            }
+            & .ms-Link {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #005a9e;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: windowText;
+            }
+      >
         <div
           className=
-              ms-MessageBar-dismissSingleLine
+              ms-MessageBar-content
               {
-                border: 1px solid #5c2d91;
+                box-sizing: border-box;
                 display: flex;
+                flex-direction: row;
+                line-height: normal;
+                width: 100%;
               }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
+              &:before {
+                bottom: 0px;
+                left: 0px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
               }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
+              @media screen and (-ms-high-contrast: active){&:before {
+                background: WindowText;
+                color: Window;
+                content: "";
               }
         >
+          <div
+            className=
+                ms-MessageBar-icon
+                {
+                  color: #666666;
+                  display: flex;
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  margin-bottom: 16px;
+                  margin-left: 16px;
+                  margin-right: 0px;
+                  margin-top: 16px;
+                  min-height: 16px;
+                  min-width: 16px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+          >
+            <i
+              className=
+
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #333333;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: window;
+                  }
+              data-icon-name="Info"
+              role="presentation"
+            >
+              
+            </i>
+          </div>
+          <div
+            className=
+                ms-MessageBar-text
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: flex;
+                  flex-grow: 1;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  margin-bottom: 8px;
+                  margin-left: 8px;
+                  margin-right: 8px;
+                  margin-top: 16px;
+                  min-width: 0px;
+                }
+                @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                  margin-bottom: 0px;
+                  margin-left: 8px;
+                  margin-right: 0px;
+                  margin-top: 8px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: window;
+                }
+            id="MessageBar33"
+          >
+            <span
+              aria-live="polite"
+              className=
+                  ms-MessageBar-innerText
+                  {
+                    line-height: 16px;
+                  }
+                  & a {
+                    padding-left: 4px;
+                  }
+              role="status"
+            />
+          </div>
           <button
             aria-label="Close"
             className=
@@ -976,7 +2761,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                   -webkit-font-smoothing: antialiased;
                   background-color: transparent;
                   border-radius: 0px;
-                  border: none;
+                  border: 1px solid #00188f;
                   box-sizing: border-box;
                   color: #333333;
                   cursor: pointer;
@@ -1040,7 +2825,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                   color: #0078d4;
                 }
                 & .ms-Button-icon {
-                  color: #004b50;
+                  color: #333333;
                   font-size: 12px;
                   height: 12px;
                   line-height: 12px;
@@ -1105,671 +2890,24 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
             </div>
           </button>
         </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-StackItem
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          flex-shrink: 1;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          width: auto;
-        }
-  >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-    >
-      Severe warning, multiline, with action buttons - custom styles
-    </label>
-    <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--severeWarning
-          ms-MessageBar-multiline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(227, 0, 140, 0.2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-    >
-      <div
-        className=
-            ms-MessageBar-content
-            {
-              box-sizing: border-box;
-              display: flex;
-              flex-direction: row;
-              line-height: normal;
-              width: 100%;
-            }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-      >
         <div
           className=
-              ms-MessageBar-icon
-              {
-                color: #666666;
-                display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #e3008c;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-0";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Warning"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 16px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar12"
-        >
-          <span
-            aria-live="assertive"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
-        </div>
-      </div>
-      <div
-        className=
-            ms-MessageBar-actions
-            {
-              align-items: center;
-              background: rgba(180, 0, 158, 0.4);
-              display: flex;
-              flex-basis: auto;
-              flex-direction: row-reverse;
-              flex-grow: 0;
-              flex-shrink: 0;
-              margin-bottom: 12px;
-              margin-left: 0;
-              margin-right: 12px;
-              margin-top: 0px;
-            }
-            & button:nth-child(n+2) {
-              margin-left: 12px;
-            }
-      >
-        <div>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #e3008c;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__13"
-                >
-                  Yes
-                </div>
-              </div>
-            </div>
-          </button>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #e3008c;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__16"
-                >
-                  No
-                </div>
-              </div>
-            </div>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-StackItem
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          flex-shrink: 1;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          width: auto;
-        }
-  >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-    >
-      Success, single line, with action buttons - custom styles
-    </label>
-    <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--success
-          ms-MessageBar-singleline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(186, 216, 10, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
-    >
-      <div
-        className=
-            ms-MessageBar-content
-            {
-              box-sizing: border-box;
-              display: flex;
-              line-height: normal;
-              width: 100%;
-            }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-            @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
-            }
-      >
-        <div
-          className=
-              ms-MessageBar-icon
-              {
-                color: #666666;
-                display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #107c10;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-2";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Completed"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 16px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar19"
-        >
-          <span
-            aria-live="polite"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  overflow: visible;
-                  white-space: pre-wrap;
-                }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-actionsSingleLine
+              ms-MessageBar-actions
               {
                 align-items: center;
-                background: #007d84;
-                border: 1px solid #ffb900;
+                border: 1px solid #0078d4;
                 display: flex;
                 flex-basis: auto;
-                flex-direction: row-reverse;
+                flex-direction: row;
                 flex-grow: 0;
                 flex-shrink: 0;
-                margin-bottom: 8px;
+                margin-bottom: 12px;
                 margin-left: 0;
-                margin-right: 8px;
-                margin-top: 8px;
+                margin-right: 12px;
+                margin-top: 0px;
               }
               & button:nth-child(n+2) {
-                margin-left: 8px;
+                margin-left: 12px;
               }
         >
           <div>
@@ -1880,7 +3018,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                           margin-right: 4px;
                           margin-top: 0;
                         }
-                    id="id__20"
+                    id="id__37"
                   >
                     Yes
                   </div>
@@ -1994,7 +3132,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                           margin-right: 4px;
                           margin-top: 0;
                         }
-                    id="id__23"
+                    id="id__40"
                   >
                     No
                   </div>
@@ -2002,1088 +3140,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               </div>
             </button>
           </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-StackItem
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          flex-shrink: 1;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          width: auto;
-        }
-  >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-    >
-      Warning, single line, with dismiss and action buttons - custom styles
-    </label>
-    <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--warning
-          ms-MessageBar-singleline
-          ms-MessageBar-dismissalSingleLine
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(255, 185, 0, .2);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-          @media only screen and (min-width: 0px) and (max-width: 479px){& {
-            flex-direction: column;
-          }
-    >
-      <div
-        className=
-            ms-MessageBar-content
-            {
-              background: rgba(234, 67, 0, 0.2);
-              box-sizing: border-box;
-              display: flex;
-              line-height: normal;
-              width: 100%;
-            }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-            @media only screen and (min-width: 0px) and (max-width: 479px){& {
-              flex-direction: row;
-            }
-      >
-        <div
-          className=
-              ms-MessageBar-icon
-              {
-                color: #666666;
-                display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #333333;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Info"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 16px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar26"
-        >
-          <span
-            aria-live="polite"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                  overflow: hidden;
-                  text-overflow: ellipsis;
-                  white-space: nowrap;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  overflow: visible;
-                  white-space: pre-wrap;
-                }
-            role="status"
-          />
-        </div>
-        <div
-          className=
-              ms-MessageBar-actionsSingleLine
-              {
-                align-items: center;
-                border: 1px solid #ea4300;
-                display: flex;
-                flex-basis: auto;
-                flex-direction: row-reverse;
-                flex-grow: 0;
-                flex-shrink: 0;
-                margin-bottom: 8px;
-                margin-left: 0;
-                margin-right: 8px;
-                margin-top: 8px;
-              }
-              & button:nth-child(n+2) {
-                margin-left: 8px;
-              }
-        >
-          <div>
-            <button
-              className=
-                  ms-Button
-                  ms-Button--default
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    background-color: #dadada;
-                    border-radius: 0px;
-                    border: 1px solid transparent;
-                    box-sizing: border-box;
-                    color: #333333;
-                    cursor: pointer;
-                    display: inline-block;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    height: 32px;
-                    min-width: 80px;
-                    outline: transparent;
-                    padding-bottom: 0;
-                    padding-left: 16px;
-                    padding-right: 16px;
-                    padding-top: 0;
-                    position: relative;
-                    text-align: center;
-                    text-decoration: none;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &::-moz-focus-inner {
-                    border: 0;
-                  }
-                  .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    outline: 1px solid #666666;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    z-index: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                    border: none;
-                    bottom: -2px;
-                    left: -2px;
-                    outline-color: ButtonText;
-                    right: -2px;
-                    top: -2px;
-                  }
-                  &:active > * {
-                    left: 0px;
-                    position: relative;
-                    top: 0px;
-                  }
-                  &:hover {
-                    background-color: #c8c8c8;
-                    color: #212121;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:hover {
-                    border-color: Highlight;
-                    color: Highlight;
-                  }
-                  &:active {
-                    background-color: #a6a6a6;
-                    color: #212121;
-                  }
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <div
-                className=
-                    ms-Button-flexContainer
-                    {
-                      align-items: center;
-                      display: flex;
-                      flex-wrap: nowrap;
-                      height: 100%;
-                      justify-content: center;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-textContainer
-                      {
-                        flex-grow: 1;
-                      }
-                >
-                  <div
-                    className=
-                        ms-Button-label
-                        {
-                          font-weight: 600;
-                          line-height: 100%;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                        }
-                    id="id__27"
-                  >
-                    Action
-                  </div>
-                </div>
-              </div>
-            </button>
-          </div>
-        </div>
-        <div
-          className=
-              ms-MessageBar-dismissSingleLine
-              {
-                border: 1px solid #ea4300;
-                display: flex;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-        >
-          <button
-            aria-label="Close"
-            className=
-                ms-Button
-                ms-Button--icon
-                ms-MessageBar-dismissal
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: none;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  flex-shrink: 0;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  margin-bottom: 8px;
-                  margin-left: 0px;
-                  margin-right: 8px;
-                  margin-top: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 4px;
-                  padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                  width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #000000;
-                  bottom: 1px;
-                  content: "";
-                  left: 1px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 1px;
-                  top: 1px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  color: #0078d4;
-                }
-                & .ms-Button-icon {
-                  color: #333333;
-                  font-size: 12px;
-                  height: 12px;
-                  line-height: 12px;
-                }
-                @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-                @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                  margin-bottom: 0px;
-                  margin-left: 8px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <i
-                className=
-                    ms-Button-icon
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      flex-shrink: 0;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 16px;
-                      font-style: normal;
-                      font-weight: normal;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
-                      speak: none;
-                      text-align: center;
-                      vertical-align: middle;
-                    }
-                data-icon-name="Clear"
-                role="presentation"
-              >
-                
-              </i>
-            </div>
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className=
-        ms-StackItem
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          flex-shrink: 1;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: auto;
-          width: auto;
-        }
-  >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #333333;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-    >
-      Warning, multiline, with dismiss and action buttons - custom styles
-    </label>
-    <div
-      className=
-          ms-MessageBar
-          ms-MessageBar--warning
-          ms-MessageBar-multiline
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            background: rgba(0, 188, 242, 0.4);
-            box-sizing: border-box;
-            color: #333333;
-            display: flex;
-            flex-direction: column;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            min-height: 32px;
-            position: relative;
-            width: 100%;
-            word-break: break-word;
-          }
-          & .ms-Link {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            color: #005a9e;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 12px;
-            font-weight: 400;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            background: windowText;
-          }
-    >
-      <div
-        className=
-            ms-MessageBar-content
-            {
-              box-sizing: border-box;
-              display: flex;
-              flex-direction: row;
-              line-height: normal;
-              width: 100%;
-            }
-            &:before {
-              bottom: 0px;
-              left: 0px;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background: WindowText;
-              color: Window;
-              content:  ;
-            }
-      >
-        <div
-          className=
-              ms-MessageBar-icon
-              {
-                color: #666666;
-                display: flex;
-                flex-shrink: 0;
-                font-size: 16px;
-                margin-bottom: 16px;
-                margin-left: 16px;
-                margin-right: 0px;
-                margin-top: 16px;
-                min-height: 16px;
-                min-width: 16px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-        >
-          <i
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #333333;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-style: normal;
-                  font-weight: normal;
-                  speak: none;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  -ms-high-contrast-adjust: none;
-                  color: window;
-                }
-            data-icon-name="Info"
-            role="presentation"
-          >
-            
-          </i>
-        </div>
-        <div
-          className=
-              ms-MessageBar-text
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: flex;
-                flex-grow: 1;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 12px;
-                font-weight: 400;
-                margin-bottom: 8px;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-top: 16px;
-                min-width: 0px;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 8px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-          id="MessageBar33"
-        >
-          <span
-            aria-live="polite"
-            className=
-                ms-MessageBar-innerText
-                {
-                  line-height: 16px;
-                }
-                & a {
-                  padding-left: 4px;
-                }
-            role="status"
-          />
-        </div>
-        <button
-          aria-label="Close"
-          className=
-              ms-Button
-              ms-Button--icon
-              ms-MessageBar-dismissal
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 1px solid #00188f;
-                box-sizing: border-box;
-                color: #333333;
-                cursor: pointer;
-                display: inline-block;
-                flex-shrink: 0;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 32px;
-                margin-bottom: 8px;
-                margin-left: 0px;
-                margin-right: 8px;
-                margin-top: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 4px;
-                padding-right: 4px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-                width: 32px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #000000;
-                bottom: 1px;
-                content: "";
-                left: 1px;
-                outline: 1px solid #666666;
-                position: absolute;
-                right: 1px;
-                top: 1px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                color: #212121;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                color: #0078d4;
-              }
-              & .ms-Button-icon {
-                color: #333333;
-                font-size: 12px;
-                height: 12px;
-                line-height: 12px;
-              }
-              @media screen and (-ms-high-contrast: active){& .ms-Button-icon {
-                -ms-high-contrast-adjust: none;
-                color: window;
-              }
-              @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                margin-bottom: 0px;
-                margin-left: 8px;
-                margin-right: 0px;
-                margin-top: 0px;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
-        >
-          <div
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-          >
-            <i
-              className=
-                  ms-Button-icon
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    display: inline-block;
-                    flex-shrink: 0;
-                    font-family: "FabricMDL2Icons";
-                    font-size: 16px;
-                    font-style: normal;
-                    font-weight: normal;
-                    height: 16px;
-                    line-height: 16px;
-                    margin-bottom: 0;
-                    margin-left: 4px;
-                    margin-right: 4px;
-                    margin-top: 0;
-                    speak: none;
-                    text-align: center;
-                    vertical-align: middle;
-                  }
-              data-icon-name="Clear"
-              role="presentation"
-            >
-              
-            </i>
-          </div>
-        </button>
-      </div>
-      <div
-        className=
-            ms-MessageBar-actions
-            {
-              align-items: center;
-              border: 1px solid #0078d4;
-              display: flex;
-              flex-basis: auto;
-              flex-direction: row;
-              flex-grow: 0;
-              flex-shrink: 0;
-              margin-bottom: 12px;
-              margin-left: 0;
-              margin-right: 12px;
-              margin-top: 0px;
-            }
-            & button:nth-child(n+2) {
-              margin-left: 12px;
-            }
-      >
-        <div>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__37"
-                >
-                  Yes
-                </div>
-              </div>
-            </div>
-          </button>
-          <button
-            className=
-                ms-Button
-                ms-Button--default
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: #dadada;
-                  border-radius: 0px;
-                  border: 1px solid transparent;
-                  box-sizing: border-box;
-                  color: #333333;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 32px;
-                  min-width: 80px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 16px;
-                  padding-right: 16px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid #ffffff;
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  outline: 1px solid #666666;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #c8c8c8;
-                  color: #212121;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:active {
-                  background-color: #a6a6a6;
-                  color: #212121;
-                }
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <div
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: center;
-                  }
-            >
-              <div
-                className=
-                    ms-Button-textContainer
-                    {
-                      flex-grow: 1;
-                    }
-              >
-                <div
-                  className=
-                      ms-Button-label
-                      {
-                        font-weight: 600;
-                        line-height: 100%;
-                        margin-bottom: 0;
-                        margin-left: 4px;
-                        margin-right: 4px;
-                        margin-top: 0;
-                      }
-                  id="id__40"
-                >
-                  No
-                </div>
-              </div>
-            </div>
-          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7939 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Fixing the issue where `MessageBar` background rendered over some elements with themed backgrounds was getting washed out due to the semi-transparent colors it uses (see the pictures before and after below). A couple of other fixes were considered but after investigating the breaking effect of them this one seemed the least invasive.
1. The transparency was added here for reasons that these semantic slots are used for column formatting within lists in ODSP. One solution is to add new semantic slots for `MessageBar` separately and assign to them some solid colors, but we try to limit the addition of already too many slots which can bring confusion for devs over which one to use.
https://github.com/OfficeDev/office-ui-fabric-react/blob/ba042b688838610ca60cb746cec7afdd5566c777/packages/styling/src/styles/theme.ts#L201-L205
2. The other solution was to add a pseudo element like `:before` on the root element but in order for that to work it required a very careful hacky manipulation of `z-index` which apparently it's not behaving equally in all browsers.
3. I ended up adding a new `div` wrapper element around the `root` element of the `MessageBar` (thanks @phkuo for the idea 👍 ) and decided not to add a new style area mainly because we don't really intend for anyone to change the styles for it, so I styled it inline and gave it a `bodyBackground` color. If anyone thinks of any reason I should still make it as a style area I am happy to change my opinion :)


## Before:
![Screen Shot 2019-04-12 at 12 07 35 PM](https://user-images.githubusercontent.com/29514833/56063874-5c95b900-5d25-11e9-91a9-874ba325aaa8.png)
## After:
![Screen Shot 2019-04-12 at 12 06 40 PM](https://user-images.githubusercontent.com/29514833/56063881-61f30380-5d25-11e9-965a-aa262f5220d3.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8717)