### PR TITLE
Inject nonce to style tag if specified in CSP settings in FabricConfig.

### DIFF
--- a/common/changes/@uifabric/merge-styles/cspnonce_2019-04-12-22-26.json
+++ b/common/changes/@uifabric/merge-styles/cspnonce_2019-04-12-22-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Inject nonce to style tag if specified in csp settings in FabricConfig.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "anpablo@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/cspnonce_2019-04-12-22-26.json
+++ b/common/changes/@uifabric/styling/cspnonce_2019-04-12-22-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Export ICSPSettings from MergeStyles.ts",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "anpablo@microsoft.com"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -40,6 +40,11 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
     };
 };
 
+// @public
+export interface ICSPSettings {
+    nonce?: string;
+}
+
 // @public (undocumented)
 export type ICSSRule = 'initial' | 'inherit' | 'unset';
 
@@ -396,6 +401,7 @@ export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
 
 // @public
 export interface IStyleSheetConfig {
+    cspSettings?: ICSPSettings;
     defaultPrefix?: string;
     injectionMode?: InjectionMode;
     namespace?: string;
@@ -426,7 +432,7 @@ export function mergeStyleSets<TStyleSet1 extends IStyleSet<TStyleSet1>, TStyleS
 export function mergeStyleSets(...styleSets: Array<IStyleSet<any> | undefined | false | null>): IProcessedStyleSet<any>;
 
 // Warning: (ae-forgotten-export) The symbol "Diff" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
@@ -453,7 +459,7 @@ export class Stylesheet {
 
 
 // Warnings were encountered during analysis:
-// 
+//
 // lib/IStyleSet.d.ts:48:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -20,6 +20,16 @@ export const InjectionMode = {
 export type InjectionMode = typeof InjectionMode[keyof typeof InjectionMode];
 
 /**
+ * CSP settings for the stylesheet
+ */
+export interface ICSPSettings {
+  /**
+   * Nonce to inject into script tag
+   */
+  nonce?: string;
+}
+
+/**
  * Stylesheet config.
  *
  * @public
@@ -40,6 +50,11 @@ export interface IStyleSheetConfig {
    * Default 'namespace' to attach before the className.
    */
   namespace?: string;
+
+  /**
+   * CSP settings
+   */
+  cspSettings?: ICSPSettings;
 
   /**
    * Callback executed when a rule is inserted.
@@ -97,6 +112,7 @@ export class Stylesheet {
       injectionMode: InjectionMode.insertNode,
       defaultPrefix: 'css',
       namespace: undefined,
+      cspSettings: undefined,
       ...config
     };
   }
@@ -256,6 +272,12 @@ export class Stylesheet {
     styleElement.setAttribute('data-merge-styles', 'true');
     styleElement.type = 'text/css';
 
+    const { cspSettings } = this._config;
+    if (cspSettings) {
+      if (cspSettings.nonce) {
+        styleElement.setAttribute('nonce', cspSettings.nonce);
+      }
+    }
     if (this._lastStyleElement && this._lastStyleElement.nextElementSibling) {
       document.head!.insertBefore(styleElement, this._lastStyleElement.nextElementSibling);
     } else {

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -16,7 +16,7 @@ export { fontFace } from './fontFace';
 
 export { keyframes } from './keyframes';
 
-export { IStyleSheetConfig, InjectionMode, Stylesheet } from './Stylesheet';
+export { IStyleSheetConfig, ICSPSettings, InjectionMode, Stylesheet } from './Stylesheet';
 
 export { setRTL } from './transforms/rtlifyRules';
 

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -6,6 +6,7 @@
 
 import { concatStyleSets } from '@uifabric/merge-styles';
 import { fontFace } from '@uifabric/merge-styles';
+import { ICSPSettings } from '@uifabric/merge-styles';
 import { ICustomizerContext } from '@uifabric/utilities';
 import { IFontFace } from '@uifabric/merge-styles';
 import { IFontWeight } from '@uifabric/merge-styles';
@@ -37,7 +38,7 @@ export function buildClassMap<T>(styles: T): {
 };
 
 // Warning: (ae-forgotten-export) The symbol "IColorClassNames" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export const ColorClassNames: IColorClassNames;
 
@@ -129,7 +130,7 @@ export function getScreenSelector(min: number, max: number): string;
 export function getTheme(depComments?: boolean): ITheme;
 
 // Warning: (ae-internal-missing-underscore) The name getThemedContext should be prefixed with an underscore because the declaration is marked as "@internal"
-// 
+//
 // @internal
 export function getThemedContext(context: ICustomizerContext, scheme?: ISchemeNames, theme?: ITheme): ICustomizerContext;
 
@@ -256,8 +257,10 @@ export namespace IconFontSizes {
     large: string;
 }
 
+export { ICSPSettings }
+
 // Warning: (ae-internal-missing-underscore) The name IEffects should be prefixed with an underscore because the declaration is marked as "@internal"
-// 
+//
 // @internal
 export interface IEffects {
     elevation16: string;
@@ -309,7 +312,7 @@ export interface IIconRecord {
     // (undocumented)
     code: string | undefined;
     // Warning: (ae-forgotten-export) The symbol "IIconSubsetRecord" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     subset: IIconSubsetRecord;
 }
@@ -405,7 +408,7 @@ export { IRawStyle }
 export interface IScheme {
     disableGlobalClassNames: boolean;
     // Warning: (ae-incompatible-release-tags) The symbol "effects" is marked as @public, but its signature references "IEffects" which is marked as @internal
-    // 
+    //
     // (undocumented)
     effects: IEffects;
     // (undocumented)
@@ -421,7 +424,7 @@ export interface IScheme {
 }
 
 // Warning: (ae-internal-missing-underscore) The name ISchemeNames should be prefixed with an underscore because the declaration is marked as "@internal"
-// 
+//
 // @internal
 export type ISchemeNames = 'default' | 'neutral' | 'soft' | 'strong';
 
@@ -518,7 +521,7 @@ export interface ISemanticTextColors {
 }
 
 // Warning: (ae-internal-missing-underscore) The name ISpacing should be prefixed with an underscore because the declaration is marked as "@internal"
-// 
+//
 // @internal
 export interface ISpacing {
     // (undocumented)
@@ -649,7 +652,7 @@ export namespace ZIndexes {
 
 
 // Warnings were encountered during analysis:
-// 
+//
 // lib/interfaces/ITheme.d.ts:68:5 - (ae-incompatible-release-tags) The symbol "spacing" is marked as @public, but its signature references "ISpacing" which is marked as @internal
 // lib/interfaces/ITheme.d.ts:69:5 - (ae-incompatible-release-tags) The symbol "effects" is marked as @public, but its signature references "IEffects" which is marked as @internal
 // lib/interfaces/ITheme.d.ts:70:5 - (ae-incompatible-release-tags) The symbol "schemes" is marked as @public, but its signature references "ISchemeNames" which is marked as @internal

--- a/packages/styling/src/MergeStyles.ts
+++ b/packages/styling/src/MergeStyles.ts
@@ -6,6 +6,7 @@ export {
   IStyleSet,
   IProcessedStyleSet,
   IStyleSheetConfig,
+  ICSPSettings,
   InjectionMode,
   Stylesheet,
   concatStyleSets,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: https://stackoverflow.com/questions/55599944/content-security-policy-and-office-ui-fabric
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Allow clients to specify nonce in CSP Settings.

#### Focus areas to test

See 'nonce' attribute added to script tags if passed from FabricConfig. This does not address csp hashes and will be address later.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8719)