### PR TITLE
TilesList: replacing the Shimmer imports

### DIFF
--- a/common/changes/@uifabric/experiments/v-vibr-ReplaceShimmerImports_2019-04-15-22-42.json
+++ b/common/changes/@uifabric/experiments/v-vibr-ReplaceShimmerImports_2019-04-15-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "TilesList: replaces the imports of Shimmer from experiments package with the one from OUFR.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "vitaliebraga@gmail.com"
+}

--- a/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.base.tsx
+++ b/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.base.tsx
@@ -3,9 +3,7 @@ import { BaseComponent, classNamesFunction } from '../../../Utilities';
 import { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
 import { TileSize } from '../Tile.types';
 import { TileLayoutSizes } from '../Tile';
-import { ShimmerGap } from '../../Shimmer/ShimmerGap/ShimmerGap';
-import { ShimmerElementsGroup } from '../../Shimmer/ShimmerElementsGroup/ShimmerElementsGroup';
-import { ShimmerElementType as ElemType } from '../../Shimmer/Shimmer.types';
+import { ShimmerGap, ShimmerElementsGroup, ShimmerElementType } from 'office-ui-fabric-react/lib/Shimmer';
 
 const ShimmerTileLayoutValues = {
   largeSquareWidth: 96,
@@ -89,51 +87,51 @@ export class ShimmerTileBase extends BaseComponent<IShimmerTileProps, {}> {
 
     return (
       <div className={this._classNames.root}>
-        <ShimmerGap widthInPixel={contentSize.width} height={contentSize.height - squareHeight - nameplateHeight} />
+        <ShimmerGap width={contentSize.width} height={contentSize.height - squareHeight - nameplateHeight} />
         <ShimmerElementsGroup
           shimmerElements={[
             {
-              type: ElemType.gap,
-              widthInPixel: (contentSize.width - squareWidth) / 2,
+              type: ShimmerElementType.gap,
+              width: (contentSize.width - squareWidth) / 2,
               height: squareHeight
             },
             itemThumbnail
               ? {
-                  type: ElemType.line,
-                  widthInPixel: squareWidth,
+                  type: ShimmerElementType.line,
+                  width: squareWidth,
                   height: squareHeight
                 }
               : {
-                  type: ElemType.gap,
-                  widthInPixel: squareWidth,
+                  type: ShimmerElementType.gap,
+                  width: squareWidth,
                   height: squareHeight
                 },
             {
-              type: ElemType.gap,
-              widthInPixel: (contentSize.width - squareWidth) / 2,
+              type: ShimmerElementType.gap,
+              width: (contentSize.width - squareWidth) / 2,
               height: squareHeight
             }
           ]}
         />
         {itemActivity || itemName ? (
           <div>
-            <ShimmerGap widthInPixel={contentSize.width} height={nameplatePadding} />
+            <ShimmerGap width={contentSize.width} height={nameplatePadding} />
             {itemName ? (
               <ShimmerElementsGroup
                 shimmerElements={[
                   {
-                    type: ElemType.gap,
-                    widthInPixel: (contentSize.width - nameWidth) / 2,
+                    type: ShimmerElementType.gap,
+                    width: (contentSize.width - nameWidth) / 2,
                     height: nameplateNameHeight
                   },
                   {
-                    type: ElemType.line,
-                    widthInPixel: nameWidth,
+                    type: ShimmerElementType.line,
+                    width: nameWidth,
                     height: nameHeight
                   },
                   {
-                    type: ElemType.gap,
-                    widthInPixel: (contentSize.width - nameWidth) / 2,
+                    type: ShimmerElementType.gap,
+                    width: (contentSize.width - nameWidth) / 2,
                     height: nameplateNameHeight
                   }
                 ]}
@@ -143,24 +141,24 @@ export class ShimmerTileBase extends BaseComponent<IShimmerTileProps, {}> {
               <ShimmerElementsGroup
                 shimmerElements={[
                   {
-                    type: ElemType.gap,
-                    widthInPixel: (contentSize.width - activityWidth) / 2,
+                    type: ShimmerElementType.gap,
+                    width: (contentSize.width - activityWidth) / 2,
                     height: nameplateActivityHeight
                   },
                   {
-                    type: ElemType.line,
-                    widthInPixel: activityWidth,
+                    type: ShimmerElementType.line,
+                    width: activityWidth,
                     height: activityHeight
                   },
                   {
-                    type: ElemType.gap,
-                    widthInPixel: (contentSize.width - activityWidth) / 2,
+                    type: ShimmerElementType.gap,
+                    width: (contentSize.width - activityWidth) / 2,
                     height: nameplateActivityHeight
                   }
                 ]}
               />
             ) : null}
-            <ShimmerGap widthInPixel={contentSize.width} height={nameplatePadding} />
+            <ShimmerGap width={contentSize.width} height={nameplatePadding} />
           </div>
         ) : null}
       </div>

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -4,7 +4,7 @@ import { List, IPageProps } from 'office-ui-fabric-react/lib/List';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import { css, IRenderFunction, IRectangle } from 'office-ui-fabric-react/lib/Utilities';
 import * as TilesListStylesModule from './TilesList.scss';
-import { Shimmer } from '../Shimmer/Shimmer';
+import { Shimmer } from 'office-ui-fabric-react/lib/Shimmer';
 
 // tslint:disable-next-line:no-any
 const TilesListStyles: any = TilesListStylesModule;
@@ -14,7 +14,7 @@ const CELLS_PER_PAGE = 100;
 const MIN_ASPECT_RATIO = 0.5;
 const MAX_ASPECT_RATIO = 3;
 
-const ROW_OF_PLACEHOLDER_CELLS = 3;
+const ROWS_OF_PLACEHOLDER_CELLS = 3;
 
 export interface ITilesListState<TItem> {
   cells: ITileCell<TItem>[];
@@ -263,7 +263,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
         if (cell.isPlaceholder && grid.mode !== TilesGridMode.none) {
           const cellsPerRow = Math.floor(width / (grid.spacing + finalSize.width));
-          const totalPlaceholderItems = cellsPerRow * ROW_OF_PLACEHOLDER_CELLS;
+          const totalPlaceholderItems = cellsPerRow * ROWS_OF_PLACEHOLDER_CELLS;
           shimmerWrapperWidth = cellsPerRow * finalSize.width + grid.spacing * (cellsPerRow - 1);
           for (let j = 0; j < totalPlaceholderItems; j++) {
             renderedCells.push(renderedCell(j));
@@ -304,7 +304,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
         </div>
       );
 
-      grids.push(isPlaceholder ? <Shimmer key={i} customElementsGroup={finalGrid} widthInPixel={shimmerWrapperWidth} /> : finalGrid);
+      grids.push(isPlaceholder ? <Shimmer key={i} customElementsGroup={finalGrid} width={shimmerWrapperWidth} /> : finalGrid);
     }
 
     return (

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
@@ -7,7 +7,7 @@ import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { AnimationClassNames } from 'office-ui-fabric-react/lib/Styling';
 import { IExampleGroup, IExampleItem, createGroup, createDocumentItems, getTileCells, createShimmerGroups } from './ExampleHelpers';
 import { ISize } from '@uifabric/experiments/lib/Utilities';
-import { ShimmerElementType as ElemType, ShimmerElementsGroup } from '@uifabric/experiments/lib/Shimmer';
+import { ShimmerElementType, ShimmerElementsGroup } from 'office-ui-fabric-react/lib/Shimmer';
 
 const HEADER_VERTICAL_PADDING = 13;
 const HEADER_FONT_SIZE = 18;
@@ -226,8 +226,8 @@ export class TilesListDocumentExample extends React.Component<ITilesListDocument
     return (
       <ShimmerElementsGroup
         shimmerElements={[
-          { type: ElemType.line, height: HEADER_FONT_SIZE, widthInPercentage: 100 }, // gap is given to maintain height
-          { type: ElemType.gap, height: HEADER_VERTICAL_PADDING * 2 + HEADER_FONT_SIZE, widthInPixel: 0 }
+          { type: ShimmerElementType.line, height: HEADER_FONT_SIZE, width: '100%' }, // gap is given to maintain height
+          { type: ShimmerElementType.gap, height: HEADER_VERTICAL_PADDING * 2 + HEADER_FONT_SIZE, width: 0 }
         ]}
       />
     );


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Replacing the Shimmer imports so that now they pull from OUFR Shimmer component. This is another step before proceeding with #8020 for Fabric 7.0. Nothing should change as the changes to the prop names are just that... different names for the same functionality which was introduced during the graduation of Shimmer.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8730)