### PR TITLE
Detailslist fix initialfocusedindex

### DIFF
--- a/common/changes/office-ui-fabric-react/detailslist-fix-initialfocusedindex_2019-04-16-00-19.json
+++ b/common/changes/office-ui-fabric-react/detailslist-fix-initialfocusedindex_2019-04-16-00-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: fix a bug where the initialfocusedindex wouldn't be focused",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -845,6 +845,8 @@ export const DetailsList: React_2.StatelessComponent<IDetailsListProps>;
 export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsListState> implements IDetailsList {
     constructor(props: IDetailsListProps);
     // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
     componentDidUpdate(prevProps: IDetailsListProps, prevState: IDetailsListState): void;
     // (undocumented)
     componentWillReceiveProps(newProps: IDetailsListProps): void;
@@ -7597,6 +7599,8 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
     // (undocumented)
     render(): JSX.Element;
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
+    // (undocumented)
+    scrollToIndexAsync(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     shouldComponentUpdate(newProps: IListProps<T>, newState: IListState<T>): boolean;
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -104,7 +104,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     this._onColumnDragEnd = this._onColumnDragEnd.bind(this);
 
     this.state = {
-      focusedItemIndex: -1,
+      focusedItemIndex: this.props.initialFocusedIndex || -1,
       lastWidth: 0,
       adjustedColumns: this._getAdjustedColumns(props),
       isSizing: false,
@@ -164,6 +164,25 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     if (this._dragDropHelper) {
       // TODO If the DragDropHelper was passed via props, this will dispose it, which is incorrect behavior.
       this._dragDropHelper.dispose();
+    }
+  }
+
+  public componentDidMount() {
+    // Only attempt to focus/scroll to a new item if the user has set an index
+    // and if we have items
+    if (
+      this._initialFocusedIndex !== undefined &&
+      this.props.items &&
+      this.props.items.length > 0 &&
+      this.state.focusedItemIndex !== -1 &&
+      !elementContains(this._root.current, document.activeElement as HTMLElement, false)
+    ) {
+      // Set focus to the item that has the highest index possible. If the index exceeds the list length then
+      // focus to the last item.
+      const index = this.state.focusedItemIndex < this.props.items.length ? this.state.focusedItemIndex : this.props.items.length - 1;
+      if (this._list.current) {
+        this._list.current.scrollToIndexAsync(index);
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -265,6 +265,10 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
     }
   }
 
+  public scrollToIndexAsync(index: number, measureItem?: (itemIndex: number) => number, scrollToMode: ScrollToMode = ScrollToMode.auto) {
+    this._async.setTimeout(() => this.scrollToIndex(index, measureItem, scrollToMode), 0);
+  }
+
   public getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number {
     const pages = this.state.pages || [];
     for (const page of pages) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #8722
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adds in a scrollToIndex call for the details list so that it will actually scroll to the given initialfocusedIndex. It also adds an async scrollToIndex function for list since the list itself does not render it's children immediately, it will only load some of them after the initial render which means that we have no good way of knowing when we should scroll and when we shouldn't.

This feels like a bad idea but I'm not sure how else to accomplish this without a different list component. Suggestions welcome.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8733)