### PR TITLE
Ensure all tsconfigs have lib setting

### DIFF
--- a/apps/fabric-website/tsconfig.json
+++ b/apps/fabric-website/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
+    "lib": ["es5", "dom"],
     "types": ["node", "webpack-env"],
     "paths": {
       "office-ui-fabric-react/lib/*": ["node_modules/office-ui-fabric-react/lib/*"]

--- a/apps/server-rendered-app/tsconfig.json
+++ b/apps/server-rendered-app/tsconfig.json
@@ -12,12 +12,9 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": false,
-    "types": [
-      "webpack-env"
-    ],
+    "lib": ["es5", "dom"],
+    "types": ["webpack-env"],
     "paths": {}
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/apps/test-bundles/tsconfig.json
+++ b/apps/test-bundles/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": false,
+    "lib": ["es5", "dom"],
     "types": ["webpack-env"],
     "paths": {}
   },

--- a/apps/vr-tests/tsconfig.json
+++ b/apps/vr-tests/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
+    "lib": ["es5", "dom"],
     "types": ["webpack-env", "screener-storybook"]
   },
   "include": ["src"]

--- a/common/changes/@uifabric/fabric-website/tsconfig_2019-04-16-21-22.json
+++ b/common/changes/@uifabric/fabric-website/tsconfig_2019-04-16-21-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
The tsconfig.json files in some projects were missing the `lib` setting, which could allow IE 11 breaks like [the one called out here](https://github.com/OfficeDev/office-ui-fabric-react/pull/8737#discussion_r275937998) to sneak in. Adding `"lib": ["es5", "dom"]` prevents this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8739)