### PR TITLE
Button: Fix issue where button would eat keydowns

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-button-eatingkeydowns_2019-04-16-21-50.json
+++ b/common/changes/office-ui-fabric-react/fix-button-eatingkeydowns_2019-04-16-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: Fix issue where button would eat keydown events",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -677,14 +677,19 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     if (!(ev.altKey || ev.metaKey) && (isUp || isDown)) {
-      const state = this.state;
+      this.setState(state => {
+        if (state.menuProps && !state.menuProps.shouldFocusOnMount) {
+          return { menuProps: { ...state.menuProps, shouldFocusOnMount: true } };
+        }
+        return state;
+      });
+
       // This should be done in the setStateCallback but because preventDefault
       // needs to be called, we have to evaluate the current state, even though
       // it might not be 100% accurate;
-      if (state.menuProps && !state.menuProps.shouldFocusOnMount) {
+      if (this.state.menuProps && !this.state.menuProps.shouldFocusOnMount) {
         ev.preventDefault();
         ev.stopPropagation();
-        this.setState({ menuProps: { ...state.menuProps, shouldFocusOnMount: true } });
       }
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -677,15 +677,15 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     if (!(ev.altKey || ev.metaKey) && (isUp || isDown)) {
-      this.setState(state => {
-        if (state.menuProps && !state.menuProps.shouldFocusOnMount) {
-          return { menuProps: { ...state.menuProps, shouldFocusOnMount: true } };
-        }
-        return state;
-      });
-
-      ev.preventDefault();
-      ev.stopPropagation();
+      const state = this.state;
+      // This should be done in the setStateCallback but because preventDefault
+      // needs to be called, we have to evaluate the current state, even though
+      // it might not be 100% accurate;
+      if (state.menuProps && !state.menuProps.shouldFocusOnMount) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        this.setState({ menuProps: { ...state.menuProps, shouldFocusOnMount: true } });
+      }
     }
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8706
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Buttons would prevent keyDown events from propagating when they had focus, they should only do that if they are in a state that has a menu that should be focused.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8741)