### PR TITLE
Fixing Persisted Split Buttons that show expanded state always

### DIFF
--- a/common/changes/office-ui-fabric-react/persistFlyoutAndSplitButtons_2019-04-16-22-13.json
+++ b/common/changes/office-ui-fabric-react/persistFlyoutAndSplitButtons_2019-04-16-22-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Split button displays an expanded state always with persistMenu:true - fixing that",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -115,7 +115,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           menuIconProps && menuIconProps.className,
           isPrimaryButtonDisabled!,
           checked!,
-          this._isMenuExpanded(),
+          this._isExpanded,
           this.props.split,
           !!allowDisabledFocus
         )
@@ -128,7 +128,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           menuIconProps && menuIconProps.className,
           isPrimaryButtonDisabled!,
           checked!,
-          this._isMenuExpanded(),
+          this._isExpanded,
           this.props.split
         );
 
@@ -362,11 +362,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     return this.props.text !== null && (this.props.text !== undefined || typeof this.props.children === 'string');
   }
 
-  private _isMenuExpanded(): boolean {
-    const { menuProps } = this.state;
-    return !!menuProps && !menuProps.hidden;
-  }
-
   private _onRenderChildren = (): JSX.Element | null => {
     const { children } = this.props;
 
@@ -473,8 +468,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     let { keytipProps } = this.props;
 
     const classNames = getSplitButtonClassNames
-      ? getSplitButtonClassNames(!!disabled, !!this.state.menuProps, !!checked, !!allowDisabledFocus)
-      : styles && getBaseSplitButtonClassNames(styles!, !!disabled, !!this.state.menuProps, !!checked);
+      ? getSplitButtonClassNames(!!disabled, this._isExpanded, !!checked, !!allowDisabledFocus)
+      : styles && getBaseSplitButtonClassNames(styles!, !!disabled, this._isExpanded, !!checked);
 
     assign(buttonProps, {
       onClick: undefined,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
When in persisted mode, we cannot rely on the menuProps being null to ascertain whether a menu is closed. We need to check for menuProps.hidden to be true. This change corrects this for persisted Split buttons.

We have two properties that do the same thing - isExpanded and isMenuExpanded. Removing one of them.

Checked that this does not break current flyout anchors etc. with persistedMenus.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8742)