### PR TITLE
Refactors DetailsRowBase componentWillReceiveProps to getDerivedStateFromProps

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-detailsrow-willreceiveprops_2019-04-18-04-19.json
+++ b/common/changes/office-ui-fabric-react/keco-detailsrow-willreceiveprops_2019-04-18-04-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsRow: Refactor componentWillReceiveProps to getDerivedStateFromProps\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -893,11 +893,16 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
     // (undocumented)
     componentDidUpdate(previousProps: IDetailsRowBaseProps): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IDetailsRowBaseProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     focus(forceIntoFirstElement?: boolean): boolean;
+    // (undocumented)
+    static getDerivedStateFromProps(newProps: IDetailsRowBaseProps, state: IDetailsRowState): {
+        selectionState: IDetailsRowSelectionState;
+        groupNestingDepth: number | undefined;
+    };
+    // (undocumented)
+    static getSelectionState(props: IDetailsRowBaseProps): IDetailsRowSelectionState;
     measureCell(index: number, onMeasureDone: (width: number) => void): void;
     // (undocumented)
     protected _onRenderCheck(props: IDetailsRowCheckProps): JSX.Element;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -44,11 +44,27 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
   private _hasMounted: boolean;
   private _dragDropSubscription: IDisposable;
 
+  public static getSelectionState(props: IDetailsRowBaseProps): IDetailsRowSelectionState {
+    const { itemIndex, selection } = props;
+
+    return {
+      isSelected: !!selection && selection.isIndexSelected(itemIndex),
+      isSelectionModal: !!selection && !!selection.isModal && selection.isModal()
+    };
+  }
+
+  public static getDerivedStateFromProps(newProps: IDetailsRowBaseProps, state: IDetailsRowState) {
+    return {
+      selectionState: DetailsRowBase.getSelectionState(newProps),
+      groupNestingDepth: newProps.groupNestingDepth
+    };
+  }
+
   constructor(props: IDetailsRowBaseProps) {
     super(props);
 
     this.state = {
-      selectionState: this._getSelectionState(props),
+      selectionState: DetailsRowBase.getSelectionState(props),
       columnMeasureInfo: undefined,
       isDropping: false,
       groupNestingDepth: props.groupNestingDepth
@@ -130,17 +146,10 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
     }
   }
 
-  public componentWillReceiveProps(newProps: IDetailsRowBaseProps): void {
-    this.setState({
-      selectionState: this._getSelectionState(newProps),
-      groupNestingDepth: newProps.groupNestingDepth
-    });
-  }
-
   public shouldComponentUpdate(nextProps: IDetailsRowBaseProps, nextState: IDetailsRowState): boolean {
     if (this.props.useReducedRowRenderer) {
       if (this.state.selectionState) {
-        const newSelectionState = this._getSelectionState(nextProps);
+        const newSelectionState = DetailsRowBase.getSelectionState(nextProps);
         if (this.state.selectionState.isSelected !== newSelectionState.isSelected) {
           return true;
         }
@@ -312,17 +321,8 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
     return <DetailsRowCheck {...props} />;
   }
 
-  private _getSelectionState(props: IDetailsRowBaseProps): IDetailsRowSelectionState {
-    const { itemIndex, selection } = props;
-
-    return {
-      isSelected: !!selection && selection.isIndexSelected(itemIndex),
-      isSelectionModal: !!selection && !!selection.isModal && selection.isModal()
-    };
-  }
-
   private _onSelectionChanged(): void {
-    const selectionState = this._getSelectionState(this.props);
+    const selectionState = DetailsRowBase.getSelectionState(this.props);
 
     if (!shallowCompare(selectionState, this.state.selectionState)) {
       this.setState({


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

Related: #8743

#### Description of changes

Part of removing the usage of deprecated React life-cycle methods for Fabric 7. This time in `DetailsRowBase`.

#### Focus areas to test

- Tests should pass
- Rows should render on the DetailsList examples

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8758)