### PR TITLE
Refactors GroupHeaderBase componentWillReceiveProps to getDerivedStateFromProps

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-groupheader-willreceiveprops_2019-04-18-05-28.json
+++ b/common/changes/office-ui-fabric-react/keco-groupheader-willreceiveprops_2019-04-18-05-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupHeader: Refactor componentWillReceiveProps to getDerivedStateFromProps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -22,6 +22,21 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
 
   private _classNames: IClassNames<IGroupHeaderStyles>;
 
+  public static getDerivedStateFromProps(newProps: IGroupHeaderProps, state: IGroupHeaderState): IGroupHeaderState {
+    if (newProps.group) {
+      const { group, isGroupLoading } = newProps;
+      const { isCollapsed = false } = group;
+      const isLoadingVisible = Boolean(!isCollapsed && isGroupLoading && isGroupLoading(group));
+
+      return {
+        isCollapsed,
+        isLoadingVisible
+      };
+    }
+
+    return state;
+  }
+
   constructor(props: IGroupHeaderProps) {
     super(props);
 
@@ -29,19 +44,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       isCollapsed: (this.props.group && this.props.group.isCollapsed) as boolean,
       isLoadingVisible: false
     };
-  }
-
-  public componentWillReceiveProps(newProps: IGroupHeaderProps): void {
-    if (newProps.group) {
-      const newCollapsed = newProps.group.isCollapsed;
-      const isGroupLoading = newProps.isGroupLoading;
-      const newLoadingVisible = !newCollapsed && isGroupLoading && isGroupLoading(newProps.group);
-
-      this.setState({
-        isCollapsed: newCollapsed || false,
-        isLoadingVisible: newLoadingVisible || false
-      });
-    }
   }
 
   public render(): JSX.Element | null {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -26,7 +26,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     if (newProps.group) {
       const { group, isGroupLoading } = newProps;
       const { isCollapsed = false } = group;
-      const isLoadingVisible = Boolean(!isCollapsed && isGroupLoading && isGroupLoading(group));
+      const isLoadingVisible =!isCollapsed && !!isGroupLoading && isGroupLoading(group);
 
       return {
         isCollapsed,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

Related: #8743

#### Description of changes

Part of removing the usage of deprecated React life-cycle methods for Fabric 7. This time in GroupHeaderBase.

#### Focus areas to test

- Tests should pass
- Grouped DetailsList / GroupedList examples should expand / collapse via header interaction


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8760)