### PR TITLE
Remove usage of assign helper across Lists code

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-rm-assign-helper-usage_2019-04-18-05-53.json
+++ b/common/changes/office-ui-fabric-react/keco-rm-assign-helper-usage_2019-04-18-05-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove usage of assign helper in favor of Object.spread across Lists",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -47,7 +47,7 @@ describe('DetailsColumn', () => {
   });
 
   it('invokes IColumn#onColumnClick when columnActionMode is ColumnActionsMode.clickable', () => {
-    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.clickable });
+    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.clickable } };
     const columns = [column];
     let component: any;
 
@@ -74,7 +74,7 @@ describe('DetailsColumn', () => {
   });
 
   it('invokes IColumn#onColumnClick when columnActionMode is ColumnActionsMode.hasDropdown', () => {
-    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.hasDropdown });
+    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.hasDropdown } };
     const columns = [column];
     let component: any;
 
@@ -101,7 +101,7 @@ describe('DetailsColumn', () => {
   });
 
   it('does not invoke IColumn#onColumnClick when columnActionMode is ColumnActionMode.disabled', () => {
-    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.disabled });
+    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.disabled } };
     const columns = [column];
     let component: any;
 
@@ -128,7 +128,7 @@ describe('DetailsColumn', () => {
   });
 
   it('by default, has aria-describedby set for columns which provide an ariaLabel value', () => {
-    const column = assign({}, baseColumn, { ariaLabel: 'Foo' });
+    const column: IColumn = { ...baseColumn, ...{ ariaLabel: 'Foo' } };
     let component: any;
     const columns = [column];
 
@@ -150,7 +150,7 @@ describe('DetailsColumn', () => {
   });
 
   it("by default, has a node present in the DOM referenced by the column's aria-describedby attribute", () => {
-    const column = assign({}, baseColumn, { ariaLabel: 'Foo' });
+    const column: IColumn = { ...baseColumn, ...{ ariaLabel: 'Foo' } };
     let component: any;
     const columns = [column];
 
@@ -178,7 +178,7 @@ describe('DetailsColumn', () => {
   });
 
   it('if custom DetailsHeader has optional onRenderColumnHeaderTooltip, do not render invalid aria-describedby attribute', () => {
-    const column = assign({}, baseColumn, { ariaLabel: 'Foo' });
+    const column: IColumn = { ...baseColumn, ...{ ariaLabel: 'Foo' } };
     let component: any;
     const columns = [column];
 
@@ -209,7 +209,7 @@ describe('DetailsColumn', () => {
   });
 
   it('Examine aria-expanded value when columnActionMode is not hasDropDown', () => {
-    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.clickable, isMenuOpen: true });
+    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.clickable, isMenuOpen: true } };
     const columns = [column];
     let component: any;
 
@@ -234,7 +234,7 @@ describe('DetailsColumn', () => {
   });
 
   it('Examine aria-expanded value when columnActionMode is hasDropDown with isMenuOpen property set', () => {
-    const column = assign({}, baseColumn, { columnActionsMode: ColumnActionsMode.hasDropdown, isMenuOpen: true });
+    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.hasDropdown, isMenuOpen: true } };
     const columns = [column];
     let component: any;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -74,7 +74,7 @@ describe('DetailsColumn', () => {
   });
 
   it('invokes IColumn#onColumnClick when columnActionMode is ColumnActionsMode.hasDropdown', () => {
-    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.hasDropdown } };
+    const column: IColumn = { ...baseColumn, columnActionsMode: ColumnActionsMode.hasDropdown };
     const columns = [column];
     let component: any;
 
@@ -101,7 +101,7 @@ describe('DetailsColumn', () => {
   });
 
   it('does not invoke IColumn#onColumnClick when columnActionMode is ColumnActionMode.disabled', () => {
-    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.disabled } };
+    const column: IColumn = { ...baseColumn, columnActionsMode: ColumnActionsMode.disabled };
     const columns = [column];
     let component: any;
 
@@ -128,7 +128,7 @@ describe('DetailsColumn', () => {
   });
 
   it('by default, has aria-describedby set for columns which provide an ariaLabel value', () => {
-    const column: IColumn = { ...baseColumn, ...{ ariaLabel: 'Foo' } };
+    const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 
@@ -150,7 +150,7 @@ describe('DetailsColumn', () => {
   });
 
   it("by default, has a node present in the DOM referenced by the column's aria-describedby attribute", () => {
-    const column: IColumn = { ...baseColumn, ...{ ariaLabel: 'Foo' } };
+    const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 
@@ -178,7 +178,7 @@ describe('DetailsColumn', () => {
   });
 
   it('if custom DetailsHeader has optional onRenderColumnHeaderTooltip, do not render invalid aria-describedby attribute', () => {
-    const column: IColumn = { ...baseColumn, ...{ ariaLabel: 'Foo' } };
+    const column: IColumn = { ...baseColumn, ariaLabel: 'Foo' };
     let component: any;
     const columns = [column];
 
@@ -209,7 +209,7 @@ describe('DetailsColumn', () => {
   });
 
   it('Examine aria-expanded value when columnActionMode is not hasDropDown', () => {
-    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.clickable, isMenuOpen: true } };
+    const column: IColumn = { ...baseColumn, columnActionsMode: ColumnActionsMode.clickable, isMenuOpen: true };
     const columns = [column];
     let component: any;
 
@@ -234,7 +234,7 @@ describe('DetailsColumn', () => {
   });
 
   it('Examine aria-expanded value when columnActionMode is hasDropDown with isMenuOpen property set', () => {
-    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.hasDropdown, isMenuOpen: true } };
+    const column: IColumn = { ...baseColumn, columnActionsMode: ColumnActionsMode.hasDropdown, isMenuOpen: true };
     const columns = [column];
     let component: any;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -47,7 +47,7 @@ describe('DetailsColumn', () => {
   });
 
   it('invokes IColumn#onColumnClick when columnActionMode is ColumnActionsMode.clickable', () => {
-    const column: IColumn = { ...baseColumn, ...{ columnActionsMode: ColumnActionsMode.clickable } };
+    const column: IColumn = { ...baseColumn, columnActionsMode: ColumnActionsMode.clickable };
     const columns = [column];
     let component: any;
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.test.tsx
@@ -3,7 +3,7 @@ import { DetailsColumn } from 'office-ui-fabric-react/lib/components/DetailsList
 import { IColumn, ColumnActionsMode, IDetailsHeaderProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList.types';
 import { mount } from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsList';
-import { assign, IRenderFunction } from '@uifabric/utilities';
+import { IRenderFunction } from '@uifabric/utilities';
 import { ITooltipHostProps, TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 
 let mockOnColumnClick: jest.Mock<{}>;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { BaseComponent, KeyCodes, assign, elementContains, getRTLSafeKeyCode, IRenderFunction, classNamesFunction } from '../../Utilities';
+import { BaseComponent, KeyCodes, elementContains, getRTLSafeKeyCode, IRenderFunction, classNamesFunction } from '../../Utilities';
 import {
   CheckboxVisibility,
   ColumnActionsMode,
@@ -768,7 +768,7 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
   /** Builds a set of columns based on the given columns mixed with the current overrides. */
   private _getFixedColumns(newColumns: IColumn[]): IColumn[] {
     return newColumns.map(column => {
-      const newColumn: IColumn = assign({}, column, this._columnOverrides[column.key]);
+      const newColumn: IColumn = { ...column, ...this._columnOverrides[column.key] };
 
       if (!newColumn.calculatedWidth) {
         newColumn.calculatedWidth = newColumn.maxWidth || newColumn.minWidth || MIN_COLUMN_WIDTH;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { BaseComponent, IDisposable, assign, css, shallowCompare, getNativeProps, divProperties } from '../../Utilities';
+import { BaseComponent, IDisposable, css, shallowCompare, getNativeProps, divProperties } from '../../Utilities';
 import { IColumn, CheckboxVisibility } from './DetailsList.types';
 import { DetailsRowCheck } from './DetailsRowCheck';
 import { GroupSpacer } from '../GroupedList/GroupSpacer';
@@ -288,7 +288,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
    */
   public measureCell(index: number, onMeasureDone: (width: number) => void): void {
     const { columns = NO_COLUMNS } = this.props;
-    const column = assign({}, columns[index]) as IColumn;
+    const column: IColumn = { ...columns[index] };
 
     column.minWidth = 0;
     column.maxWidth = 999999;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
-import { BaseComponent, IRectangle, assign, classNamesFunction, IClassNames } from '../../Utilities';
+import { BaseComponent, IRectangle, classNamesFunction, IClassNames } from '../../Utilities';
 import { IGroupedList, IGroupedListProps, IGroup, IGroupedListStyleProps, IGroupedListStyles } from './GroupedList.types';
 import { GroupedListSection } from './GroupedListSection';
 import { List, ScrollToMode, IListProps } from '../../List';
 import { SelectionMode } from '../../utilities/selection/index';
 import { DEFAULT_ROW_HEIGHTS } from '../DetailsList/DetailsRow.styles';
+import { IGroupHeaderProps } from './GroupHeader';
+import { IGroupShowAllProps } from './GroupShowAll.styles';
+import { IGroupFooterProps } from './GroupFooter.types';
 
 const getClassNames = classNamesFunction<IGroupedListStyleProps, IGroupedListStyles>();
 const { rowHeight: ROW_HEIGHT, compactRowHeight: COMPACT_ROW_HEIGHT } = DEFAULT_ROW_HEIGHTS;
@@ -163,9 +166,9 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
       onToggleSummarize: this._onToggleSummarize
     };
 
-    const headerProps = assign({}, groupProps!.headerProps, dividerProps);
-    const showAllProps = assign({}, groupProps!.showAllProps, dividerProps);
-    const footerProps = assign({}, groupProps!.footerProps, dividerProps);
+    const headerProps: IGroupHeaderProps = { ...groupProps!.headerProps, ...dividerProps };
+    const showAllProps: IGroupShowAllProps = { ...groupProps!.showAllProps, ...dividerProps };
+    const footerProps: IGroupFooterProps = { ...groupProps!.footerProps, ...dividerProps };
     const groupNestingDepth = this._getGroupNestingDepth();
 
     if (!groupProps!.showEmptyGroups && group && group.count === 0) {
@@ -313,8 +316,7 @@ export class GroupedListBase extends BaseComponent<IGroupedListProps, IGroupedLi
   };
 
   private _getPageSpecification = (
-    itemIndex: number,
-    visibleRect: IRectangle
+    itemIndex: number
   ): {
     key?: string;
   } => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, IRectangle, classNamesFunction, IClassNames } from '../../Utilities';
+import { BaseComponent, classNamesFunction, IClassNames } from '../../Utilities';
 import { IGroupedList, IGroupedListProps, IGroup, IGroupedListStyleProps, IGroupedListStyles } from './GroupedList.types';
 import { GroupedListSection } from './GroupedListSection';
 import { List, ScrollToMode, IListProps } from '../../List';

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -16,7 +16,7 @@ import { GroupFooter } from './GroupFooter';
 
 import { List } from '../../List';
 import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
-import { assign, css, getId } from '../../Utilities';
+import { css, getId } from '../../Utilities';
 import { IViewport } from '../../utilities/decorators/withViewport';
 import { IListProps } from '../List/index';
 
@@ -205,9 +205,9 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
       groupedListId: this._id
     };
 
-    const groupHeaderProps: IGroupHeaderProps = assign({}, headerProps, dividerProps, ariaControlsProps);
-    const groupShowAllProps: IGroupShowAllProps = assign({}, showAllProps, dividerProps);
-    const groupFooterProps: IGroupFooterProps = assign({}, footerProps, dividerProps);
+    const groupHeaderProps: IGroupHeaderProps = { ...headerProps, ...dividerProps, ...ariaControlsProps };
+    const groupShowAllProps: IGroupShowAllProps = { ...showAllProps, ...dividerProps };
+    const groupFooterProps: IGroupFooterProps = { ...footerProps, ...dividerProps };
 
     return (
       <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Small "clean-up" PR...

Removes usage of `assign` helper in favor of native `Object.spread` across the List components. Also removes an unused param in a private method `_getPageSpecification` that my IDE picked-up.

I'm mostly curious if size-auditor reports any delta. **Update:** It did, https://github.com/OfficeDev/office-ui-fabric-react/pull/8762#issuecomment-484385319

Separately, I wonder if we should modify `assign`'s signature to be type-safe:

```ts
export function assign<T = any>(target: T, ...args: T[]): T {
```

And perhaps additionally use `Object.spread` under the hood... cc: @JasonGore for thoughts. If we plan to keep it around, of course.

#### Focus areas to test

- CI passes
- Lists render


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8762)