### PR TITLE
Temporarily disable a11y-tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,9 +79,5 @@ steps:
       SCREENER_API_KEY: $(screener.key)
 
   - script: |
-      npm run a11ytest
-    displayName: run a11y tests
-
-  - script: |
       npm run check-for-changed-files
     displayName: check for change file


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Generated (unstable) CSS class names are included as snippets in a11y-tests' snapshots, causing failures in CI. Temporarily disable it until we correctly scrub/stabilize them.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8767)