### PR TITLE
Removing closure created in the styled render function to improve performance

### DIFF
--- a/common/changes/@uifabric/utilities/remove-closure_2019-04-18-23-02.json
+++ b/common/changes/@uifabric/utilities/remove-closure_2019-04-18-23-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Removing closure from `styled` helper to improve performance.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -61,20 +61,7 @@ export function styled<
     private _inCustomizerContext = false;
 
     public render(): JSX.Element {
-      return (
-        <CustomizerContext.Consumer>
-          {(context: ICustomizerContext) => {
-            this._inCustomizerContext = !!context.customizations.inCustomizerContext;
-
-            const settings = Customizations.getSettings(fields, scope, context.customizations);
-            const { styles: customizedStyles, ...rest } = settings;
-            const styles = (styleProps: TStyleProps) => _resolve(styleProps, baseStyles, customizedStyles, this.props.styles);
-
-            const additionalProps = getProps ? getProps(this.props) : undefined;
-            return <Component {...rest} {...additionalProps} {...this.props} styles={styles} />;
-          }}
-        </CustomizerContext.Consumer>
-      );
+      return <CustomizerContext.Consumer>{this._renderContent}</CustomizerContext.Consumer>;
     }
 
     public componentDidMount(): void {
@@ -88,6 +75,17 @@ export function styled<
         Customizations.unobserve(this._onSettingsChanged);
       }
     }
+
+    private _renderContent = (context: ICustomizerContext): JSX.Element => {
+      this._inCustomizerContext = !!context.customizations.inCustomizerContext;
+
+      const settings = Customizations.getSettings(fields, scope, context.customizations);
+      const { styles: customizedStyles, ...rest } = settings;
+      const styles = (styleProps: TStyleProps) => _resolve(styleProps, baseStyles, customizedStyles, this.props.styles);
+
+      const additionalProps = getProps ? getProps(this.props) : undefined;
+      return <Component {...rest} {...additionalProps} {...this.props} styles={styles} />;
+    };
 
     private _onSettingsChanged = () => this.forceUpdate();
   }
@@ -108,7 +106,9 @@ function _resolve<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
     }
   }
-  if (result.length) {
+  if (result.length === 1) {
+    return result[0] as IConcatenatedStyleSet<TStyleSet>;
+  } else if (result.length) {
     // cliffkoh: I cannot figure out how to avoid the cast to any here.
     // It is something to do with the use of Omit in IStyleSet.
     // It might not be necessary once  Omit becomes part of lib.d.ts (when we remove our own Omit and rely on


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8769
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Removing a closure created inside of the styled render function. Yay render components. Good food for thought. Not sure if this will make a measurable impact, but this is definitely a hotspot.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8775)