### PR TITLE
Card: Changing import of Stack to import from office-ui-fabric-react/lib/Stack given partner requests

### DIFF
--- a/common/changes/@uifabric/react-cards/stackImports_2019-04-19-17-58.json
+++ b/common/changes/@uifabric/react-cards/stackImports_2019-04-19-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/react-cards",
+      "comment": "ard: Changing import of Stack to import from office-ui-fabric-react/lib/Stack given partner requests.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/common/changes/@uifabric/react-cards/stackImports_2019-04-19-17-58.json
+++ b/common/changes/@uifabric/react-cards/stackImports_2019-04-19-17-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/react-cards",
-      "comment": "ard: Changing import of Stack to import from office-ui-fabric-react/lib/Stack given partner requests.",
+      "comment": "Card: Changing import of Stack to import from office-ui-fabric-react/lib/Stack given partner requests.",
       "type": "patch"
     }
   ],

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import { withSlots, getSlots } from '@uifabric/foundation';
 import { getNativeProps, htmlElementProperties } from '@uifabric/utilities';
-import { Stack } from 'office-ui-fabric-react';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 
 import { ICardComponent, ICardProps, ICardSlots } from './Card.types';
 

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.tsx
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { StackItem, IStackItemProps } from 'office-ui-fabric-react';
+import { StackItem, IStackItemProps } from 'office-ui-fabric-react/lib/Stack';
 
 export const CardItem: React.StatelessComponent<IStackItemProps> = StackItem;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Partner teams are asking us to change the imports of `Stack` to import from `office-ui-fabric-react/lib/Stack` instead of from `office-ui-fabric-react` citing "webpack bugs int bundle mix which interferes with the correct importing of `office-ui-fabric-react` components". Given that the code still works the same with this change, I'm making it right now, with the intention to maintain communication and update later.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8784)