### PR TITLE
VerticalDivider: Convert into a styled component

### DIFF
--- a/common/changes/office-ui-fabric-react/style-verticaldivider_2019-04-19-18-53.json
+++ b/common/changes/office-ui-fabric-react/style-verticaldivider_2019-04-19-18-53.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "VerticalDivider: Make into a styled component",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/style-verticaldivider_2019-04-19-18-53.json
+++ b/common/changes/office-ui-fabric-react/style-verticaldivider_2019-04-19-18-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "VerticalDivider: Make into a styled component",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7448,7 +7448,7 @@ export interface ITooltipStyles {
     subText: IStyle;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface IVerticalDividerClassNames {
     // (undocumented)
     divider: string;
@@ -7456,9 +7456,24 @@ export interface IVerticalDividerClassNames {
     wrapper: string;
 }
 
-// @public (undocumented)
+// @public
 export interface IVerticalDividerProps {
+    className?: string;
+    // @deprecated (undocumented)
     getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
+    styles?: IStyleFunctionOrObject<IVerticalDividerPropsStyles, IVerticalDividerStyles>;
+    theme?: ITheme;
+}
+
+// @public
+export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 'getClassNames' | 'className'>;
+
+// @public
+export interface IVerticalDividerStyles {
+    // (undocumented)
+    divider: IStyle;
+    // (undocumented)
+    wrapper: IStyle;
 }
 
 // @public (undocumented)
@@ -9053,7 +9068,7 @@ export enum ValuePosition {
 }
 
 // @public (undocumented)
-export const VerticalDivider: (props: IVerticalDividerProps) => JSX.Element;
+export const VerticalDivider: React_2.StatelessComponent<IVerticalDividerProps>;
 
 // @public (undocumented)
 export class VirtualizedComboBox extends BaseComponent<IComboBoxProps, {}> implements IComboBox {

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7450,9 +7450,7 @@ export interface ITooltipStyles {
 
 // @public @deprecated (undocumented)
 export interface IVerticalDividerClassNames {
-    // (undocumented)
     divider: string;
-    // (undocumented)
     wrapper: string;
 }
 
@@ -7470,9 +7468,7 @@ export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 
 
 // @public
 export interface IVerticalDividerStyles {
-    // (undocumented)
     divider: IStyle;
-    // (undocumented)
     wrapper: IStyle;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
@@ -4,8 +4,8 @@ import { classNamesFunction } from '../../Utilities';
 const getClassNames = classNamesFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles>();
 
 export const VerticalDividerBase = (props: IVerticalDividerProps) => {
-  const { styles } = props;
-  const classNames = getClassNames(styles, { theme: props.theme, getClassNames: props.getClassNames });
+  const { styles, theme, getClassNames: deprecatedGetClassNames } = props;
+  const classNames = getClassNames(styles, { theme: theme, getClassNames: deprecatedGetClassNames });
   return (
     <span className={classNames.wrapper}>
       <span className={classNames.divider} />

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { IVerticalDividerProps, IVerticalDividerPropsStyles, IVerticalDividerStyles } from './VerticalDivider.types';
+import { classNamesFunction } from '../../Utilities';
+const getClassNames = classNamesFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles>();
+
+export const VerticalDividerBase = (props: IVerticalDividerProps) => {
+  const { styles } = props;
+  const classNames = getClassNames(styles, { theme: props.theme, getClassNames: props.getClassNames });
+  return (
+    <span className={classNames.wrapper}>
+      <span className={classNames.divider} />
+    </span>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
@@ -4,8 +4,8 @@ import { classNamesFunction } from '../../Utilities';
 const getClassNames = classNamesFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles>();
 
 export const VerticalDividerBase = (props: IVerticalDividerProps) => {
-  const { styles, theme, getClassNames: deprecatedGetClassNames } = props;
-  const classNames = getClassNames(styles, { theme: theme, getClassNames: deprecatedGetClassNames });
+  const { styles, theme, getClassNames: deprecatedGetClassNames, className } = props;
+  const classNames = getClassNames(styles, { theme: theme, getClassNames: deprecatedGetClassNames, className });
   return (
     <span className={classNames.wrapper}>
       <span className={classNames.divider} />

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.classNames.ts
@@ -2,6 +2,9 @@ import { memoizeFunction } from '../../Utilities';
 import { mergeStyleSets, ITheme } from '../../Styling';
 import { IVerticalDividerClassNames } from './VerticalDivider.types';
 
+/**
+ * @deprecated use getStyles exported from VerticalDivider.styles.ts
+ */
 export const getDividerClassNames = memoizeFunction(
   (theme: ITheme): IVerticalDividerClassNames => {
     return mergeStyleSets({

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.styles.ts
@@ -4,7 +4,7 @@ import { IStyleFunction } from '../../Utilities';
 export const getStyles: IStyleFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles> = (
   props: IVerticalDividerPropsStyles
 ): IVerticalDividerStyles => {
-  const { theme, getClassNames } = props;
+  const { theme, getClassNames, className } = props;
 
   if (!theme) {
     return {
@@ -22,15 +22,20 @@ export const getStyles: IStyleFunction<IVerticalDividerPropsStyles, IVerticalDiv
   }
 
   return {
-    wrapper: {
-      display: 'inline-flex',
-      height: '100%',
-      alignItems: 'center'
-    },
-    divider: {
-      width: 1,
-      height: '100%',
-      backgroundColor: theme.palette.neutralTertiaryAlt
-    }
+    wrapper: [
+      {
+        display: 'inline-flex',
+        height: '100%',
+        alignItems: 'center'
+      },
+      className
+    ],
+    divider: [
+      {
+        width: 1,
+        height: '100%',
+        backgroundColor: theme.palette.neutralTertiaryAlt
+      }
+    ]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.styles.ts
@@ -1,0 +1,36 @@
+import { IVerticalDividerPropsStyles, IVerticalDividerStyles } from './VerticalDivider.types';
+import { IStyleFunction } from '../../Utilities';
+
+export const getStyles: IStyleFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles> = (
+  props: IVerticalDividerPropsStyles
+): IVerticalDividerStyles => {
+  const { theme, getClassNames } = props;
+
+  if (!theme) {
+    return {
+      wrapper: {},
+      divider: {}
+    };
+  }
+
+  if (getClassNames) {
+    const names = getClassNames(theme);
+    return {
+      wrapper: [names.wrapper],
+      divider: [names.divider]
+    };
+  }
+
+  return {
+    wrapper: {
+      display: 'inline-flex',
+      height: '100%',
+      alignItems: 'center'
+    },
+    divider: {
+      width: 1,
+      height: '100%',
+      backgroundColor: theme.palette.neutralTertiaryAlt
+    }
+  };
+};

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.styles.ts
@@ -7,10 +7,7 @@ export const getStyles: IStyleFunction<IVerticalDividerPropsStyles, IVerticalDiv
   const { theme, getClassNames, className } = props;
 
   if (!theme) {
-    return {
-      wrapper: {},
-      divider: {}
-    };
+    throw new Error('Theme is undefined or null.');
   }
 
   if (getClassNames) {

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.tsx
@@ -1,15 +1,12 @@
-import * as React from 'react';
-import { getDividerClassNames } from './VerticalDivider.classNames';
-import { IVerticalDividerProps } from './VerticalDivider.types';
-import { getTheme } from '../../Styling';
+import { IVerticalDividerProps, IVerticalDividerStyles, IVerticalDividerPropsStyles } from './VerticalDivider.types';
+import { getStyles } from './VerticalDivider.styles';
+import { VerticalDividerBase } from './VerticalDivider.base';
+import { styled } from '../../Utilities';
 
-export const VerticalDivider = (props: IVerticalDividerProps) => {
-  const theme = getTheme();
-  const classNames = props.getClassNames ? props.getClassNames(theme) : getDividerClassNames(theme);
-
-  return (
-    <span className={classNames.wrapper}>
-      <span className={classNames.divider} />
-    </span>
-  );
-};
+export const VerticalDivider: React.StatelessComponent<IVerticalDividerProps> = styled<
+  IVerticalDividerProps,
+  IVerticalDividerPropsStyles,
+  IVerticalDividerStyles
+>(VerticalDividerBase, getStyles, undefined, {
+  scope: 'VerticalDivider'
+});

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
@@ -3,13 +3,15 @@ import { IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IVerticalDividerProps {
   /**
+   * @deprecated Use styles instead.
    * Optional function to generate the class names for the divider for custom styling
    */
   getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
   theme?: ITheme;
   styles?: IStyleFunctionOrObject<IVerticalDividerPropsStyles, IVerticalDividerStyles>;
+  className?: string;
 }
-export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 'getClassNames'>;
+export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 'getClassNames' | 'className'>;
 
 export interface IVerticalDividerStyles {
   wrapper: IStyle;

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
@@ -1,12 +1,20 @@
-import { ITheme } from '../../Styling';
+import { ITheme, IStyle } from '../../Styling';
+import { IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IVerticalDividerProps {
   /**
    * Optional function to generate the class names for the divider for custom styling
    */
   getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
+  theme?: ITheme;
+  styles?: IStyleFunctionOrObject<IVerticalDividerPropsStyles, IVerticalDividerStyles>;
 }
+export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 'getClassNames'>;
 
+export interface IVerticalDividerStyles {
+  wrapper: IStyle;
+  divider: IStyle;
+}
 export interface IVerticalDividerClassNames {
   wrapper: string;
   divider: string;

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
@@ -1,22 +1,50 @@
 import { ITheme, IStyle } from '../../Styling';
 import { IStyleFunctionOrObject } from '../../Utilities';
 
+/**
+ * {@docCategory VerticalDivider}
+ * Props for the Vertical Divider
+ */
 export interface IVerticalDividerProps {
   /**
    * @deprecated Use styles instead.
    * Optional function to generate the class names for the divider for custom styling
    */
   getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
+  /**
+   * The theme that should be used to render the vertical divider.
+   */
   theme?: ITheme;
+  /**
+   * Optional override stylings that will get merged with the dividers styles.
+   */
   styles?: IStyleFunctionOrObject<IVerticalDividerPropsStyles, IVerticalDividerStyles>;
+  /**
+   * className that will be placed on the divider wrapper div
+   */
   className?: string;
 }
+
+/**
+ * {@docCategory VerticalDivider}
+ * Props that will get passed to the styling function to style the Vertical Divider
+ */
 export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 'getClassNames' | 'className'>;
 
+/**
+ * {@docCategory VerticalDivider}
+ * Style interface that defines the different areas that styles can be customized on the Vertical Divider
+ */
 export interface IVerticalDividerStyles {
   wrapper: IStyle;
   divider: IStyle;
 }
+
+/**
+ * {@docCategory VerticalDivider}
+ * @deprecated
+ * Deprecated class names, used to be used to provider customizations, use IVerticalDividerStyles instead
+ */
 export interface IVerticalDividerClassNames {
   wrapper: string;
   divider: string;

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
@@ -36,7 +36,13 @@ export type IVerticalDividerPropsStyles = Pick<IVerticalDividerProps, 'theme' | 
  * Style interface that defines the different areas that styles can be customized on the Vertical Divider
  */
 export interface IVerticalDividerStyles {
+  /**
+   * Styling for the div that wraps the actual divider
+   */
   wrapper: IStyle;
+  /**
+   * Styling for the divider.
+   */
   divider: IStyle;
 }
 
@@ -46,6 +52,13 @@ export interface IVerticalDividerStyles {
  * Deprecated class names, used to be used to provider customizations, use IVerticalDividerStyles instead
  */
 export interface IVerticalDividerClassNames {
+  /**
+   * Styling for the div that wraps the actual divider
+   */
   wrapper: string;
+
+  /**
+   * Styling for the divider.
+   */
   divider: string;
 }

--- a/packages/office-ui-fabric-react/src/components/Divider/examples/VerticalDivider.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/examples/VerticalDivider.Custom.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { VerticalDivider, IVerticalDividerClassNames } from 'office-ui-fabric-react/lib/Divider';
-import { getDividerClassNames } from 'office-ui-fabric-react/lib/components/Divider/VerticalDivider.classNames';
-import { mergeStyleSets, ITheme } from 'office-ui-fabric-react/lib/Styling';
-import { memoizeFunction, Customizer } from 'office-ui-fabric-react/lib/Utilities';
+import { VerticalDivider } from 'office-ui-fabric-react/lib/Divider';
+import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
 
 interface ICustomDividerExampleClassNames {
   wrapper: string;
@@ -44,7 +43,7 @@ export class VerticalDividerCustomExample extends React.Component<any, any> {
               padding: 0
             },
             divider: {
-              height: '28',
+              height: 28,
               backgroundColor: 'pink'
             }
           }}

--- a/packages/office-ui-fabric-react/src/components/Divider/examples/VerticalDivider.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/examples/VerticalDivider.Custom.Example.tsx
@@ -30,27 +30,26 @@ const getExampleClassNames = memoizeFunction(
   }
 );
 
-const getVerticalDividerClassNames = memoizeFunction(
-  (theme: ITheme): IVerticalDividerClassNames => {
-    return mergeStyleSets(getDividerClassNames(theme), {
-      divider: {
-        height: 28,
-        backgroundColor: theme.palette.themePrimary
-      }
-    });
-  }
-);
-
 export class VerticalDividerCustomExample extends React.Component<any, any> {
   public render(): JSX.Element {
     const exampleClassNames = getExampleClassNames();
     return (
       <div className={exampleClassNames.wrapper}>
-        <Customizer settings={{ theme: { palette: { themePrimary: 'pink' } } }}>
-          <p className={exampleClassNames.text}> Some text before the divider. </p>
-          <VerticalDivider getClassNames={getVerticalDividerClassNames} />
-          <p className={exampleClassNames.text}>Some text after the divider. </p>
-        </Customizer>
+        <p className={exampleClassNames.text}> Some text before the divider. </p>
+        <VerticalDivider
+          styles={{
+            wrapper: {
+              height: 40,
+              backgroundColor: '#F4F4F4',
+              padding: 0
+            },
+            divider: {
+              height: '28',
+              backgroundColor: 'pink'
+            }
+          }}
+        />
+        <p className={exampleClassNames.text}>Some text after the divider. </p>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Divider/examples/VerticalDivider.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/examples/VerticalDivider.Custom.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { VerticalDivider, IVerticalDividerClassNames } from 'office-ui-fabric-react/lib/Divider';
 import { getDividerClassNames } from 'office-ui-fabric-react/lib/components/Divider/VerticalDivider.classNames';
 import { mergeStyleSets, ITheme } from 'office-ui-fabric-react/lib/Styling';
-import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { memoizeFunction, Customizer } from 'office-ui-fabric-react/lib/Utilities';
 
 interface ICustomDividerExampleClassNames {
   wrapper: string;
@@ -34,7 +34,8 @@ const getVerticalDividerClassNames = memoizeFunction(
   (theme: ITheme): IVerticalDividerClassNames => {
     return mergeStyleSets(getDividerClassNames(theme), {
       divider: {
-        height: 28
+        height: 28,
+        backgroundColor: theme.palette.themePrimary
       }
     });
   }
@@ -45,9 +46,11 @@ export class VerticalDividerCustomExample extends React.Component<any, any> {
     const exampleClassNames = getExampleClassNames();
     return (
       <div className={exampleClassNames.wrapper}>
-        <p className={exampleClassNames.text}> Some text before the divider. </p>
-        <VerticalDivider getClassNames={getVerticalDividerClassNames} />
-        <p className={exampleClassNames.text}>Some text after the divider. </p>
+        <Customizer settings={{ theme: { palette: { themePrimary: 'pink' } } }}>
+          <p className={exampleClassNames.text}> Some text before the divider. </p>
+          <VerticalDivider getClassNames={getVerticalDividerClassNames} />
+          <p className={exampleClassNames.text}>Some text after the divider. </p>
+        </Customizer>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/VerticalDivider.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/VerticalDivider.Custom.Example.tsx.shot
@@ -38,15 +38,20 @@ exports[`Component Examples renders VerticalDivider.Custom.Example.tsx correctly
 
         {
           align-items: center;
+          background-color: #F4F4F4;
           display: inline-flex;
-          height: 100%;
+          height: 40px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
         }
   >
     <span
       className=
 
           {
-            background-color: #c8c8c8;
+            background-color: pink;
             height: 28px;
             width: 1px;
           }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #8702
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Make VerticalDivider a styled component

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8785)