### PR TITLE
Selection: initialize count

### DIFF
--- a/common/changes/office-ui-fabric-react/selection_2019-04-19-22-12.json
+++ b/common/changes/office-ui-fabric-react/selection_2019-04-19-22-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Selection: initialize count",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selection/Selection.ts
@@ -48,6 +48,8 @@ export class Selection implements ISelection {
     this._isModal = false;
 
     this.setItems([], true);
+
+    this.count = this.getSelectedCount();
   }
 
   public canSelectItem(item: IObjectWithKey, index?: number): boolean {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8747
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Selection wasn't initializing its `count` property when constructed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8788)