### PR TITLE
Add direction prop for ResizeGroup which allows for both vertical and horizontal

### DIFF
--- a/common/changes/office-ui-fabric-react/keyou-vertical-resize-group-2_2019-04-19-22-07.json
+++ b/common/changes/office-ui-fabric-react/keyou-vertical-resize-group-2_2019-04-19-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Introduce vertical option for ResizeGroup",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "keyou@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1254,7 +1254,7 @@ export const getNextResizeGroupStateProvider: (measurementCache?: {
     getCachedMeasurement: (data: any) => number | undefined;
     addMeasurementToCache: (data: any, measurement: number) => void;
 }) => {
-    getNextState: (props: IResizeGroupProps, currentState: IResizeGroupState, getElementToMeasureWidth: () => number, newContainerWidth?: number | undefined) => IResizeGroupState | undefined;
+    getNextState: (props: IResizeGroupProps, currentState: IResizeGroupState, getElementToMeasureDimension: () => number, newContainerDimension?: number | undefined) => IResizeGroupState | undefined;
     shouldRenderDataForMeasurement: (dataToMeasure: any) => boolean;
     getInitialResizeGroupState: (data: any) => IResizeGroupState;
 };
@@ -5993,6 +5993,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
     componentRef?: IRefObject<IResizeGroup>;
     data: any;
     dataDidRender?: (renderedData: any) => void;
+    direction?: ResizeGroupDirection;
     onGrowData?: (prevData: any) => any;
     onReduceData: (prevData: any) => any;
     onRenderData: (data: any) => JSX.Element;
@@ -8151,6 +8152,14 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     // (undocumented)
     render(): JSX.Element;
     }
+
+// @public (undocumented)
+export enum ResizeGroupDirection {
+    // (undocumented)
+    horizontal = 0,
+    // (undocumented)
+    vertical = 1,
+}
 
 // @public
 export function rgb2hex(r: number, g: number, b: number): string;

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -396,10 +396,8 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     this._async.requestAnimationFrame(() => {
       let containerDimension = undefined;
       if (this.state.measureContainer && this._root.current) {
-        containerDimension =
-          direction && direction === ResizeGroupDirection.vertical
-            ? this._root.current.getBoundingClientRect().height
-            : this._root.current.getBoundingClientRect().width;
+        const boundingRect = this._root.current.getBoundingClientRect();
+        containerDimension = direction && direction === ResizeGroupDirection.vertical ? boundingRect.height : boundingRect.width;
       }
       const nextState = this._nextResizeGroupStateProvider.getNextState(
         this.props,

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { BaseComponent, divProperties, getNativeProps, provideContext } from '../../Utilities';
-import { IResizeGroupProps } from './ResizeGroup.types';
+import { IResizeGroupProps, ResizeGroupDirection } from './ResizeGroup.types';
 
 const RESIZE_DELAY = 16;
 
@@ -69,42 +69,42 @@ export const getMeasurementCache = () => {
  */
 export const getNextResizeGroupStateProvider = (measurementCache = getMeasurementCache()) => {
   const _measurementCache = measurementCache;
-  let _containerWidth: number | undefined;
+  let _containerDimension: number | undefined;
 
   /**
-   * Gets the width of the data rendered in a hidden div.
+   * Gets the width/height of the data rendered in a hidden div.
    * @param measuredData - The data corresponding to the measurement we wish to take.
-   * @param getElementToMeasureWidth - A function that returns the measurement of the rendered data. Only called when the measurement
+   * @param getElementToMeasureDimension - A function that returns the measurement of the rendered data. Only called when the measurement
    * is not in the cache.
    */
-  function _getMeasuredWidth(measuredData: any, getElementToMeasureWidth: () => number): number {
-    const cachedWidth = _measurementCache.getCachedMeasurement(measuredData);
-    if (cachedWidth !== undefined) {
-      return cachedWidth;
+  function _getMeasuredDimension(measuredData: any, getElementToMeasureDimension: () => number): number {
+    const cachedDimension = _measurementCache.getCachedMeasurement(measuredData);
+    if (cachedDimension !== undefined) {
+      return cachedDimension;
     }
 
-    const measuredWidth = getElementToMeasureWidth();
-    _measurementCache.addMeasurementToCache(measuredData, measuredWidth);
-    return measuredWidth;
+    const measuredDimension = getElementToMeasureDimension();
+    _measurementCache.addMeasurementToCache(measuredData, measuredDimension);
+    return measuredDimension;
   }
 
   /**
    * Will get the next IResizeGroupState based on the current data while trying to shrink contents
    * to fit in the container.
    * @param data - The initial data point to start measuring.
-   * @param onReduceData - Function that transforms the data into something that should render with less width.
-   * @param getElementToMeasureWidth - A function that returns the measurement of the rendered data. Only called when the measurement
+   * @param onReduceData - Function that transforms the data into something that should render with less width/height.
+   * @param getElementToMeasureDimension - A function that returns the measurement of the rendered data. Only called when the measurement
    * is not in the cache.
    */
   function _shrinkContentsUntilTheyFit(
     data: any,
     onReduceData: (prevData: any) => any,
-    getElementToMeasureWidth: () => number
+    getElementToMeasureDimension: () => number
   ): IResizeGroupState {
     let dataToMeasure = data;
-    let measuredWidth: number | undefined = _getMeasuredWidth(data, getElementToMeasureWidth);
+    let measuredDimension: number | undefined = _getMeasuredDimension(data, getElementToMeasureDimension);
 
-    while (measuredWidth > _containerWidth!) {
+    while (measuredDimension > _containerDimension!) {
       const nextMeasuredData = onReduceData(dataToMeasure);
 
       // We don't want to get stuck in an infinite render loop when there are no more
@@ -118,10 +118,10 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
         };
       }
 
-      measuredWidth = _measurementCache.getCachedMeasurement(nextMeasuredData);
+      measuredDimension = _measurementCache.getCachedMeasurement(nextMeasuredData);
 
       // If the measurement isn't in the cache, we need to rerender with some data in a hidden div
-      if (measuredWidth === undefined) {
+      if (measuredDimension === undefined) {
         return {
           dataToMeasure: nextMeasuredData,
           resizeDirection: 'shrink'
@@ -140,22 +140,22 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
 
   /**
    * This function should be called when the state changes in a manner that might allow for more content to fit
-   * on the screen, such as the window width growing.
+   * on the screen, such as the window width/height growing.
    * @param data - The initial data point to start measuring.
    * @param onGrowData - Function that transforms the data into something that may take up more space when rendering.
-   * @param getElementToMeasureWidth - A function that returns the measurement of the rendered data. Only called when the measurement
+   * @param getElementToMeasureDimension - A function that returns the measurement of the rendered data. Only called when the measurement
    * is not in the cache.
    */
   function _growDataUntilItDoesNotFit(
     data: any,
     onGrowData: (prevData: any) => any,
-    getElementToMeasureWidth: () => number,
+    getElementToMeasureDimension: () => number,
     onReduceData: (prevData: any) => any
   ): IResizeGroupState {
     let dataToMeasure = data;
-    let measuredWidth: number | undefined = _getMeasuredWidth(data, getElementToMeasureWidth);
+    let measuredDimension: number | undefined = _getMeasuredDimension(data, getElementToMeasureDimension);
 
-    while (measuredWidth < _containerWidth!) {
+    while (measuredDimension < _containerDimension!) {
       const nextMeasuredData = onGrowData(dataToMeasure);
 
       // We don't want to get stuck in an infinite render loop when there are no more
@@ -169,9 +169,9 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
         };
       }
 
-      measuredWidth = _measurementCache.getCachedMeasurement(nextMeasuredData);
+      measuredDimension = _measurementCache.getCachedMeasurement(nextMeasuredData);
       // If the measurement isn't in the cache, we need to rerender with some data in a hidden div
-      if (measuredWidth === undefined) {
+      if (measuredDimension === undefined) {
         return {
           dataToMeasure: nextMeasuredData
         };
@@ -183,25 +183,25 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
     // Once the loop is done, we should now shrink until the contents fit.
     return {
       resizeDirection: 'shrink',
-      ..._shrinkContentsUntilTheyFit(dataToMeasure, onReduceData, getElementToMeasureWidth)
+      ..._shrinkContentsUntilTheyFit(dataToMeasure, onReduceData, getElementToMeasureDimension)
     };
   }
 
   /**
-   * Handles an update to the container width. Should only be called when we knew the previous container width.
-   * @param newWidth - The new width of the container.
-   * @param fullWidthData - The initial data passed in as a prop to resizeGroup.
+   * Handles an update to the container width/eheight. Should only be called when we knew the previous container width/height.
+   * @param newDimension - The new width/height of the container.
+   * @param fullDimensionData - The initial data passed in as a prop to resizeGroup.
    * @param renderedData - The data that was rendered prior to the container size changing.
    * @param onGrowData - Set to true if the Resize group has an onGrowData function.
    */
-  function _updateContainerWidth(
-    newWidth: number,
-    fullWidthData: any,
+  function _updateContainerDimension(
+    newDimension: number,
+    fullDimensionData: any,
     renderedData: any,
     onGrowData?: (prevData: any) => any
   ): IResizeGroupState {
     let nextState: IResizeGroupState;
-    if (newWidth > _containerWidth!) {
+    if (newDimension > _containerDimension!) {
       if (onGrowData) {
         nextState = {
           resizeDirection: 'grow',
@@ -210,7 +210,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
       } else {
         nextState = {
           resizeDirection: 'shrink',
-          dataToMeasure: fullWidthData
+          dataToMeasure: fullDimensionData
         };
       }
     } else {
@@ -219,32 +219,32 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
         dataToMeasure: renderedData
       };
     }
-    _containerWidth = newWidth;
+    _containerDimension = newDimension;
     return { ...nextState, measureContainer: false };
   }
 
   function getNextState(
     props: IResizeGroupProps,
     currentState: IResizeGroupState,
-    getElementToMeasureWidth: () => number,
-    newContainerWidth?: number
+    getElementToMeasureDimension: () => number,
+    newContainerDimension?: number
   ): IResizeGroupState | undefined {
-    // If there is no new container width or data to measure, there is no need for a new state update
-    if (newContainerWidth === undefined && currentState.dataToMeasure === undefined) {
+    // If there is no new container width/height or data to measure, there is no need for a new state update
+    if (newContainerDimension === undefined && currentState.dataToMeasure === undefined) {
       return undefined;
     }
 
-    if (newContainerWidth) {
-      // If we know what the last container size was and we rendered data at that width, we can do an optimized render
-      if (_containerWidth && currentState.renderedData && !currentState.dataToMeasure) {
+    if (newContainerDimension) {
+      // If we know what the last container size was and we rendered data at that width/height, we can do an optimized render
+      if (_containerDimension && currentState.renderedData && !currentState.dataToMeasure) {
         return {
           ...currentState,
-          ..._updateContainerWidth(newContainerWidth, props.data, currentState.renderedData, props.onGrowData)
+          ..._updateContainerDimension(newContainerDimension, props.data, currentState.renderedData, props.onGrowData)
         };
       }
 
-      // If we are just setting the container width for the first time, we can't do any optimizations
-      _containerWidth = newContainerWidth;
+      // If we are just setting the container width/height for the first time, we can't do any optimizations
+      _containerDimension = newContainerDimension;
     }
 
     let nextState: IResizeGroupState = {
@@ -256,12 +256,12 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
       if (currentState.resizeDirection === 'grow' && props.onGrowData) {
         nextState = {
           ...nextState,
-          ..._growDataUntilItDoesNotFit(currentState.dataToMeasure, props.onGrowData, getElementToMeasureWidth, props.onReduceData)
+          ..._growDataUntilItDoesNotFit(currentState.dataToMeasure, props.onGrowData, getElementToMeasureDimension, props.onReduceData)
         };
       } else {
         nextState = {
           ...nextState,
-          ..._shrinkContentsUntilTheyFit(currentState.dataToMeasure, props.onReduceData, getElementToMeasureWidth)
+          ..._shrinkContentsUntilTheyFit(currentState.dataToMeasure, props.onReduceData, getElementToMeasureDimension)
         };
       }
     }
@@ -364,7 +364,7 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
   }
 
   public componentDidMount(): void {
-    this._afterComponentRendered();
+    this._afterComponentRendered(this.props.direction);
     this._events.on(window, 'resize', this._async.debounce(this._onResize, RESIZE_DELAY, { leading: true }));
   }
 
@@ -372,7 +372,7 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     this.setState({
       dataToMeasure: { ...nextProps.data },
       resizeDirection: 'grow',
-      measureContainer: true // Receiving new props means the parent might rerender and the root width might change
+      measureContainer: true // Receiving new props means the parent might rerender and the root width/height might change
     });
   }
 
@@ -383,7 +383,7 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
         this.props.dataDidRender(this.state.renderedData);
       }
     }
-    this._afterComponentRendered();
+    this._afterComponentRendered(this.props.direction);
   }
 
   public remeasure(): void {
@@ -392,20 +392,28 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     }
   }
 
-  private _afterComponentRendered(): void {
+  private _afterComponentRendered(direction?: ResizeGroupDirection): void {
     this._async.requestAnimationFrame(() => {
-      let containerWidth = undefined;
+      let containerDimension = undefined;
       if (this.state.measureContainer && this._root.current) {
-        containerWidth = this._root.current.getBoundingClientRect().width;
+        containerDimension =
+          direction && direction === ResizeGroupDirection.vertical
+            ? this._root.current.getBoundingClientRect().height
+            : this._root.current.getBoundingClientRect().width;
       }
       const nextState = this._nextResizeGroupStateProvider.getNextState(
         this.props,
         this.state,
         () => {
           const refToMeasure = !this._hasRenderedContent ? this._initialHiddenDiv : this._updateHiddenDiv;
-          return refToMeasure.current ? refToMeasure.current.scrollWidth : 0;
+          if (!refToMeasure.current) {
+            return 0;
+          }
+          return direction && direction === ResizeGroupDirection.vertical
+            ? refToMeasure.current.scrollHeight
+            : refToMeasure.current.scrollWidth;
         },
-        containerWidth
+        containerDimension
       );
 
       if (nextState) {

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.doc.tsx
@@ -4,8 +4,11 @@ import { ResizeGroupOverflowSetExample } from './examples/ResizeGroup.OverflowSe
 import { IDocPageProps } from '../../common/DocPage.types';
 import { FlexBoxResizeGroupExample } from './examples/ResizeGroup.FlexBox.Example';
 import { ResizeGroupStatus } from './ResizeGroup.checklist';
+import { ResizeGroupVerticalOverflowSetExample } from './examples/ResizeGroup.VerticalOverflowSet.Example';
 
 const ResizeGroupBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx') as string;
+
+const ResizeGroupVerticalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx') as string;
 
 const ResizeGroupFlexBoxExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.FlexBox.Example.tsx') as string;
 
@@ -20,6 +23,12 @@ export const ResizeGroupPageProps: IDocPageProps = {
       title: 'Use ResizeGroup to move commands into an overflow menu',
       code: ResizeGroupBasicExampleCode,
       view: <ResizeGroupOverflowSetExample />
+    },
+    {
+      title: 'Use a vertical ResizeGroup to move commands into an overflow menu',
+      code: ResizeGroupVerticalExampleCode,
+      view: <ResizeGroupVerticalOverflowSetExample />,
+      isScrollable: false
     },
     {
       title: 'Use ResizeGroup to prevent two groups of items from overlapping',

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -6,6 +6,14 @@ import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 /**
  * {@docCategory ResizeGroup}
  */
+export enum ResizeGroupDirection {
+  horizontal = 0,
+  vertical = 1
+}
+
+/**
+ * {@docCategory ResizeGroup}
+ */
 export interface IResizeGroup {
   /**
    * Remeasures the available space.
@@ -39,6 +47,12 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * @defaultvalue undefined
    */
   className?: string;
+
+  /**
+   * Direction of this resize group, vertical or horizontal
+   * @defaultvalue ResizeGroupDirection.horizontal
+   */
+  direction?: ResizeGroupDirection;
 
   /**
    * Initial data to be passed to the onRenderData function. When there is no onGrowData provided, this data should represent what should

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
-import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
+import { CommandBarButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
 import { OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { ResizeGroupDirection } from '../ResizeGroup.types';
-import { IButtonStyles } from '../../Button';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-import { DirectionalHint } from '../../Callout';
+import { DirectionalHint } from '../../../common/DirectionalHint';
 
 export interface IOverflowData {
   primary: IContextualMenuItem[];

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
+import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
+import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
+import { OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
+import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ResizeGroupDirection } from '../ResizeGroup.types';
+import { IButtonStyles } from '../../Button';
+import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { DirectionalHint } from '../../Callout';
+
+export interface IOverflowData {
+  primary: IContextualMenuItem[];
+  overflow: IContextualMenuItem[];
+  cacheKey?: string;
+}
+
+function generateData(count: number, cachingEnabled: boolean, checked: boolean): IOverflowData {
+  const icons = ['Add', 'Share', 'Upload'];
+  const dataItems = [];
+  let cacheKey = '';
+  for (let index = 0; index < count; index++) {
+    const item = {
+      key: `item${index}`,
+      name: `Item ${index}`,
+      icon: icons[index % icons.length],
+      checked: checked
+    };
+
+    cacheKey = cacheKey + item.key;
+    dataItems.push(item);
+  }
+
+  let result: IOverflowData = {
+    primary: dataItems,
+    overflow: [] as any[]
+  };
+
+  if (cachingEnabled) {
+    result = { ...result, cacheKey };
+  }
+
+  return result;
+}
+
+// Styles for the vertical buttons
+const buttonStyles: IButtonStyles = {
+  root: {
+    paddingBottom: 10,
+    paddingTop: 10,
+    width: 100
+  }
+};
+
+// Styles for the container of the ResizeGroup
+// This is only for the example to be constrained to a certain height to demonstrate the resizing
+const exampleHeight = '40vh';
+const resizeRootClassName = mergeStyles({ height: exampleHeight });
+
+export class ResizeGroupVerticalOverflowSetExample extends BaseComponent {
+  public render(): JSX.Element {
+    const dataToRender = generateData(20, false, false);
+    return (
+      <ResizeGroup
+        className={resizeRootClassName}
+        role="tabpanel"
+        aria-label="Vertical Resize Group with an Overflow Set"
+        direction={ResizeGroupDirection.vertical}
+        data={dataToRender}
+        onReduceData={this._onReduceData}
+        // tslint:disable-next-line:jsx-no-lambda
+        onRenderData={data => {
+          return (
+            <OverflowSet
+              vertical={true}
+              items={data.primary}
+              overflowItems={data.overflow.length ? data.overflow : null}
+              onRenderItem={item => {
+                return (
+                  <CommandBarButton
+                    text={item.name}
+                    iconProps={{ iconName: item.icon }}
+                    onClick={item.onClick}
+                    checked={item.checked}
+                    styles={buttonStyles}
+                  />
+                );
+              }}
+              onRenderOverflowButton={overflowItems => {
+                return (
+                  <CommandBarButton
+                    styles={buttonStyles}
+                    menuIconProps={{ iconName: 'ChevronRight' }}
+                    menuProps={{ items: overflowItems!, directionalHint: DirectionalHint.rightCenter }}
+                  />
+                );
+              }}
+            />
+          );
+        }}
+      />
+    );
+  }
+
+  private _onReduceData = (currentData: any): any => {
+    if (currentData.primary.length === 0) {
+      return undefined;
+    }
+
+    const overflow = [...currentData.primary.slice(-1), ...currentData.overflow];
+    const primary = currentData.primary.slice(0, -1);
+
+    return { primary, overflow, undefined };
+  };
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
@@ -1,0 +1,3129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx correctly 1`] = `
+<div
+  aria-label="Vertical Resize Group with an Overflow Set"
+  className=
+
+      {
+        height: 40vh;
+      }
+  role="tabpanel"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      data-automation-id="visibleContent"
+      style={
+        Object {
+          "position": "fixed",
+          "visibility": "hidden",
+        }
+      }
+    >
+      <div
+        className=
+            ms-FocusZone
+            ms-OverflowSet
+            {
+              display: flex;
+              flex-direction: column;
+              flex-wrap: nowrap;
+              position: relative;
+            }
+        data-focuszone-id="FocusZone0"
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onMouseDownCapture={[Function]}
+        role="menubar"
+      >
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__1"
+                >
+                  Item 0
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__4"
+                >
+                  Item 1
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Upload"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__7"
+                >
+                  Item 2
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__10"
+                >
+                  Item 3
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__13"
+                >
+                  Item 4
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Upload"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__16"
+                >
+                  Item 5
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__19"
+                >
+                  Item 6
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__22"
+                >
+                  Item 7
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Upload"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__25"
+                >
+                  Item 8
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__28"
+                >
+                  Item 9
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__31"
+                >
+                  Item 10
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Upload"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__34"
+                >
+                  Item 11
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__37"
+                >
+                  Item 12
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__40"
+                >
+                  Item 13
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Upload"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__43"
+                >
+                  Item 14
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__46"
+                >
+                  Item 15
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__49"
+                >
+                  Item 16
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Upload"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__52"
+                >
+                  Item 17
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Add"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__55"
+                >
+                  Item 18
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+        <div
+          className=
+              ms-OverflowSet-item
+              {
+                display: inherit;
+                flex-shrink: 0;
+              }
+        >
+          <button
+            checked={false}
+            className=
+                ms-Button
+                ms-Button--commandBar
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #f4f4f4;
+                  border-radius: 0px;
+                  border: 1px solid transparent;
+                  box-sizing: border-box;
+                  color: #333333;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  min-width: 40px;
+                  outline: transparent;
+                  padding-bottom: 10px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 10px;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  width: 100px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  outline: 1px solid #666666;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 4px;
+                  left: 4px;
+                  outline-color: ButtonText;
+                  right: 4px;
+                  top: 4px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: none;
+                }
+                &:hover {
+                  background-color: #eaeaea;
+                  color: #212121;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #dadada;
+                  color: #000000;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <div
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+            >
+              <i
+                className=
+                    ms-Button-icon
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #106ebe;
+                      display: inline-block;
+                      flex-shrink: 0;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      speak: none;
+                      text-align: center;
+                      vertical-align: middle;
+                    }
+                data-icon-name="Share"
+                role="presentation"
+              >
+                
+              </i>
+              <div
+                className=
+                    ms-Button-textContainer
+                    {
+                      flex-grow: 1;
+                    }
+              >
+                <div
+                  className=
+                      ms-Button-label
+                      {
+                        font-weight: normal;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__58"
+                >
+                  Item 19
+                </div>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

There are a large set of computation functions in ResizeGroup that take in two numbers; previously 'width' and 'scrollWidth' were hardcoded. I've added an optional boolean 'direction' prop, which if not provided defaults to 'horizontal', but also allows for 'vertical'. If vertical is set then we pass through 'height' and 'scrollHeight' to the computation functions

Renamed all usage of "width" in variable names to "dimension"

#### Focus areas to test

I looked at the current ResizeGroup tests and most of them test the computation functionality of the ResizeGroup, which just take in two numbers. I didn't see any way or value to test something explicitly for 'vertical'

A snapshot with 'vertical' provided was identical to one without it and so I didn't create one either

Tested manually with a new example, and also integrated it into code where it will be used in the future and it behaved as expected


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8789)