### PR TITLE
SplitButton: Improving screenreader narration for secondary action and fixing styling in fabric 7 branch

### DIFF
--- a/common/changes/@uifabric/experiments/splitButtonAriaLabel_2019-04-19-22-43.json
+++ b/common/changes/@uifabric/experiments/splitButtonAriaLabel_2019-04-19-22-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "SplitButton: Improving screenreader narration for secondary action and fixing styling in fabric 7 branch.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -5,6 +5,8 @@ const baseTokens: ISplitButtonComponent['tokens'] = (props, theme): ISplitButton
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.buttonBackground,
+    borderColor: semanticColors.buttonBorder,
+    borderWidth: 1,
     color: semanticColors.buttonText,
     contentPadding: '0px 10px',
     minWidth: 0
@@ -15,6 +17,9 @@ const primaryTokens: ISplitButtonComponent['tokens'] = (props, theme): ISplitBut
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.primaryButtonBackground,
+    borderColor: semanticColors.primaryButtonBorder,
+    borderColorHovered: semanticColors.buttonBorder,
+    borderColorPressed: semanticColors.buttonBorder,
     color: semanticColors.primaryButtonText,
     highContrastColor: 'Window'
   };
@@ -24,31 +29,68 @@ const disabledTokens: ISplitButtonComponent['tokens'] = (props, theme): ISplitBu
   const { semanticColors } = theme;
   return {
     backgroundColor: semanticColors.buttonBackgroundDisabled,
+    borderColor: semanticColors.buttonBorderDisabled,
+    borderColorHovered: semanticColors.buttonBorderDisabled,
+    borderColorPressed: semanticColors.buttonBorderDisabled,
     color: semanticColors.disabledText,
     highContrastColor: 'GrayText'
+  };
+};
+
+const primaryActionDisabledTokens: ISplitButtonComponent['tokens'] = (props, theme): ISplitButtonTokenReturnType => {
+  const { semanticColors } = theme;
+  return {
+    borderColorHovered: semanticColors.buttonBorder,
+    borderColorPressed: semanticColors.buttonBorder
   };
 };
 
 export const SplitButtonTokens: ISplitButtonComponent['tokens'] = (props, theme): ISplitButtonTokenReturnType => [
   baseTokens,
   props.primary && primaryTokens,
-  (props.primaryActionDisabled || props.disabled) && disabledTokens
+  (props.primaryActionDisabled || props.disabled) && disabledTokens,
+  props.primaryActionDisabled && primaryActionDisabledTokens
 ];
 
 export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme, tokens): ISplitButtonStylesReturnType => {
   return {
     root: [
+      {
+        borderColor: tokens.borderColor,
+        borderStyle: 'solid',
+        borderWidth: tokens.borderWidth,
+        boxSizing: 'border-box',
+
+        selectors: {
+          ':hover': {
+            borderColor: props.primaryActionDisabled ? 'transparent' : tokens.borderColorHovered
+          },
+          ':active': {
+            borderColor: props.primaryActionDisabled ? 'transparent' : tokens.borderColorPressed
+          },
+          [HighContrastSelector]: {
+            borderColor: 'transparent'
+          }
+        }
+      },
       getFocusStyle(theme),
       {
         backgroundColor: tokens.backgroundColor
       }
     ],
     button: {
+      borderColor: 'transparent',
       minWidth: tokens.minWidth,
 
       selectors: {
         '> *': {
           padding: tokens.contentPadding
+        },
+        ':hover': {
+          borderColor: 'transparent'
+        },
+        ':active': {
+          borderColor: 'transparent'
         }
       }
     },
@@ -62,6 +104,21 @@ export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme,
       selectors: {
         [HighContrastSelector]: {
           borderColor: tokens.highContrastColor
+        }
+      }
+    },
+    menuButton: {
+      borderColor: 'transparent',
+
+      selectors: {
+        '> *': {
+          padding: tokens.contentPadding
+        },
+        ':hover': {
+          borderColor: props.primaryActionDisabled ? tokens.borderColorHovered : 'transparent'
+        },
+        ':active': {
+          borderColor: props.primaryActionDisabled ? tokens.borderColorPressed : 'transparent'
         }
       }
     }

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -53,6 +53,11 @@ export interface ISplitButtonProps
    * @defaultvalue false
    */
   primaryActionDisabled?: boolean;
+
+  /**
+   * Defines the aria label that the screen readers use when focus goes on the second focus stop of the SplitButton.
+   */
+  secondaryAriaLabel?: string;
 }
 
 export interface ISplitButtonViewProps extends Pick<IMenuButtonViewProps, 'buttonRef' | 'onMenuDismiss' | 'menuTarget'>, ISplitButtonProps {

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -11,6 +11,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
   const {
     styles,
     children,
+    content,
     primary,
     disabled,
     onClick,
@@ -18,6 +19,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     expanded,
     menu: Menu,
     primaryActionDisabled,
+    secondaryAriaLabel,
     buttonRef,
     onMenuDismiss,
     menuTarget,
@@ -37,15 +39,17 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     splitDivider: 'span'
   });
 
+  const menuButtonAriaLabel = secondaryAriaLabel ? secondaryAriaLabel : ariaLabel ? ariaLabel : (content as string);
+
   return (
     <Slots.root horizontal as="span" verticalAlign="stretch">
       <Slots.button
         primary={primary}
         disabled={primaryActionDisabled || disabled}
-        aria-disabled={primaryActionDisabled || disabled}
-        aria-label={ariaLabel}
+        ariaLabel={ariaLabel}
         onClick={onClick}
         componentRef={buttonRef}
+        content={content}
         {...rest}
       >
         {children}
@@ -57,8 +61,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
         primary={primary}
         disabled={disabled}
         expanded={expanded}
-        aria-disabled={disabled}
-        aria-label={ariaLabel}
+        ariaLabel={menuButtonAriaLabel}
         onClick={onSecondaryActionClick}
         menu={Menu}
       />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds a `secondaryAriaLabel` prop to `SplitButton` to allow for more customizability for screen reader support while also leveraging the current `ariaLabel` and `content` props in case the new `secondaryAriaLabel` prop is not provided.

This PR also fixes styling issues with `SplitButton` that arose when starting work on the fabric 7 branch. The changes were also visually checked in the master branch to verify that nothing is broken by this change. Below are images of the `SplitButton` example before and after the change:

__Before:__

![image](https://user-images.githubusercontent.com/7798177/56447168-99c8f080-62bb-11e9-8028-4adf204ca203.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/56447080-28893d80-62bb-11e9-9979-d0ec9e72f13f.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8791)