### PR TITLE
CommandBarButton: Fix selector for ms-Button-icon

### DIFF
--- a/common/changes/@uifabric/fluent-theme/edwl-2019-04-fixFluentCommandBarButton_2019-04-22-20-03.json
+++ b/common/changes/@uifabric/fluent-theme/edwl-2019-04-fixFluentCommandBarButton_2019-04-22-20-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Fix selector for ms-Button-icon in CommandBarButton",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -8,7 +8,7 @@ export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyl
   }
   const { palette, semanticColors } = theme;
 
-  const BUTTON_ICON_CLASSNAME = '.ms-Button-Icon';
+  const BUTTON_ICON_CLASSNAME = '.ms-Button-icon';
 
   return {
     root: [


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix faulty selector `.ms-Button-Icon` --> `.ms-Button-icon`

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8800)