### PR TITLE
Lists: Remove unnecessary css concat helper usage

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-rm-unnecessary-css-merge_2019-04-22-20-41.json
+++ b/common/changes/office-ui-fabric-react/keco-rm-unnecessary-css-merge_2019-04-22-20-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Lists: Remove unnecessary usages of css concat helper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -229,7 +229,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
               >
                 {onRenderColumnHeaderTooltip(
                   {
-                    hostClassName: css(classNames.checkTooltip),
+                    hostClassName: classNames.checkTooltip,
                     id: `${this._id}-checkTooltip`,
                     setAriaDescribedBy: false,
                     content: ariaLabelForSelectAllCheckbox,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -228,7 +228,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
         role="row"
         aria-label={ariaLabel}
         ariaDescribedBy={ariaDescribedBy}
-        className={css(classNames.root)}
+        className={classNames.root}
         data-is-focusable={true}
         data-selection-index={itemIndex}
         data-item-index={itemIndex}
@@ -275,7 +275,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
           </span>
         )}
 
-        <span role="checkbox" className={css(classNames.checkCover)} aria-checked={isSelected} data-selection-toggle={true} />
+        <span role="checkbox" className={classNames.checkCover} aria-checked={isSelected} data-selection-toggle={true} />
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -370,7 +370,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
 
     return (
       <div ref={this._root} {...divProps} role={pageElements.length > 0 ? role : undefined} className={css('ms-List', className)}>
-        <div ref={this._surface} className={css('ms-List-surface')} role="presentation">
+        <div ref={this._surface} className={'ms-List-surface'} role="presentation">
           {pageElements}
         </div>
       </div>
@@ -407,7 +407,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
     const pageElement = onRenderPage(
       {
         page: page,
-        className: css('ms-List-page'),
+        className: 'ms-List-page',
         key: page.key,
         ref: page.key,
         style: pageStyle,
@@ -466,7 +466,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
       }
 
       cells.push(
-        <div role={cellRole} className={css('ms-List-cell')} key={itemKey} data-list-index={index} data-automationid="ListCell">
+        <div role={cellRole} className={'ms-List-cell'} key={itemKey} data-list-index={index} data-automationid="ListCell">
           {onRenderCell && onRenderCell(item, index, this.state.isScrolling)}
         </div>
       );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

These calls to our css concat helper method in Lists code are unnecessary. There is only one value and therefore nothing to concatenate!

See `css` helper definition: https://github.com/OfficeDev/office-ui-fabric-react/blob/9e9159e8c887f52ca0cc2ad2b9575708839c63bc/packages/utilities/src/css.ts#L31

#### Focus areas to test

None.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8803)