### PR TITLE
Fluent: CommandBarButton fix expanded background color and expanded hover bg color

### DIFF
--- a/common/changes/@uifabric/fluent-theme/edwl-2019-04-fixCommanBarButtonFluent_2019-04-22-23-45.json
+++ b/common/changes/@uifabric/fluent-theme/edwl-2019-04-fixCommanBarButtonFluent_2019-04-22-23-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "CommandBarButton: Update expanded and expanded hover color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -47,6 +47,11 @@ export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyl
       }
     },
 
+    rootCheckedHovered: {
+      backgroundColor: palette.neutralQuaternaryAlt,
+      color: palette.neutralDark
+    },
+
     rootExpanded: {
       color: palette.neutralDark,
       backgroundColor: palette.neutralLight,

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -49,11 +49,16 @@ export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyl
 
     rootExpanded: {
       color: palette.neutralDark,
+      backgroundColor: palette.neutralLight,
       selectors: {
         [BUTTON_ICON_CLASSNAME]: {
           color: palette.themeDark
         }
       }
+    },
+
+    rootExpandedHovered: {
+      background: palette.neutralQuaternaryAlt
     },
 
     rootDisabled: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix expanded bg color and expanded hover bg color

**Expanded**
`#edebe9`
![image](https://user-images.githubusercontent.com/1291968/56540458-a51b5680-651d-11e9-8170-9380b6102581.png)

**Expanded Hover**
`#e1dfdd`
![image](https://user-images.githubusercontent.com/1291968/56540420-887f1e80-651d-11e9-8fe4-7a3be88fe106.png)

**Design**
`#edebe9`
`#e1dfdd`
![image](https://user-images.githubusercontent.com/1291968/56540882-dc3e3780-651e-11e9-8c0f-83aa43bc1654.png)



#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8810)