### PR TITLE
Publish codepen-loader

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -437,7 +437,7 @@
     {
       "packageName": "@uifabric/codepen-loader",
       "projectFolder": "packages/codepen-loader",
-      "shouldPublish": false
+      "shouldPublish": true
     },
     {
       "packageName": "@uifabric/migration",


### PR DESCRIPTION
For the HIG site to pull in the latest Fabric, it needs the codepen-loader to be published (because it's referenced in OUFR's doc files). 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8811)