### PR TITLE
Fix Image.types.ts typo at componentRef

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-image-types-typo_2019-04-23-05-06.json
+++ b/common/changes/office-ui-fabric-react/fix-image-types-typo_2019-04-23-05-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove componentRef property for Image component at Image.types.ts.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "i91935058@gmail.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4664,7 +4664,6 @@ export interface IImage {
 // @public (undocumented)
 export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
     className?: string;
-    componentRef?: IRefObject<IImage>;
     coverStyle?: ImageCoverStyle;
     // @deprecated
     errorSrc?: string;

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IStyleFunctionOrObject } from '../../Utilities';
 
 /**
  * {@docCategory Image}
@@ -11,12 +11,6 @@ export interface IImage {}
  * {@docCategory Image}
  */
 export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
-  /**
-   * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
-   * the public methods and properties of the component.
-   */
-  componentRef?: IRefObject<IImage>;
-
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Since `Image` component extends `React.Component` not `BaseComponent`, so it does not accept `componentRef` property. Consider there is a typo in `Image.types.ts`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8815)