### PR TITLE
Deprecate implementation examples

### DIFF
--- a/apps/fabric-website/src/pages/Components/ButtonComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/ButtonComponentPage.tsx
@@ -26,10 +26,6 @@ export class ButtonComponentPage extends React.Component<any, any> {
                 location: 'Variants'
               },
               {
-                text: 'Implementation Examples',
-                location: 'ImplementationExamples'
-              },
-              {
                 text: 'Implementation',
                 location: 'Implementation'
               }

--- a/apps/fabric-website/src/pages/Components/TextFieldComponentPage.tsx
+++ b/apps/fabric-website/src/pages/Components/TextFieldComponentPage.tsx
@@ -26,10 +26,6 @@ export class TextFieldComponentPage extends React.Component<any, any> {
                 location: 'Variants'
               },
               {
-                text: 'Implementation Examples',
-                location: 'ImplementationExamples'
-              },
-              {
                 text: 'Implementation',
                 location: 'Implementation'
               }

--- a/common/changes/@uifabric/example-app-base/impl-examples_2019-04-23-21-27.json
+++ b/common/changes/@uifabric/example-app-base/impl-examples_2019-04-23-21-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Deprecate implementation examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/impl-examples_2019-04-23-21-27.json
+++ b/common/changes/@uifabric/fabric-website/impl-examples_2019-04-23-21-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Remove implementation examples sections",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/impl-examples_2019-04-23-21-27.json
+++ b/common/changes/office-ui-fabric-react/impl-examples_2019-04-23-21-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Deprecate implementation examples",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.types.ts
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.types.ts
@@ -15,7 +15,7 @@ export interface IComponentPageProps {
   componentName: string;
   /** Component examples **/
   exampleCards?: JSX.Element;
-  /** Array of implementation examples, displayed in the order defined */
+  /** @deprecated Use `exampleCards` */
   implementationExampleCards?: JSX.Element;
   /** Component properties table(s) **/
   propertiesTables?: JSX.Element;
@@ -123,6 +123,7 @@ export interface IComponentPageStyles {
   variantsTitle: IStyle;
   variantsList: IStyle;
   implementationSection: IStyle;
+  /** @deprecated */
   implementationExamplesSection: IStyle;
   feedbackSection: IStyle;
   /** Wrapper for best practices, dos, and don'ts */

--- a/packages/office-ui-fabric-react/src/common/DocPage.types.ts
+++ b/packages/office-ui-fabric-react/src/common/DocPage.types.ts
@@ -83,7 +83,7 @@ export interface IDocPageProps {
   /** Array of examples, displayed in the order defined */
   examples?: IExample[];
 
-  /** Array of implementation examples, displayed in the order defined */
+  /** @deprecated */
   implementationExamples?: {
     /** Title of the example */
     title: string;

--- a/packages/office-ui-fabric-react/src/components/Button/Button.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.doc.tsx
@@ -78,12 +78,9 @@ export const ButtonPageProps = (props: IButtonDocPageProps): IDocPageProps => ({
       title: 'Command Button',
       code: ButtonCommandExampleCode,
       view: <ButtonCommandExample disabled={props.areButtonsDisabled} checked={props.areButtonsChecked} />
-    }
-  ],
-
-  implementationExamples: [
+    },
     {
-      title: 'Button Like Anchor',
+      title: 'Button-like Anchor',
       code: ButtonAnchorExampleCode,
       view: <ButtonAnchorExample disabled={props.areButtonsDisabled} checked={props.areButtonsChecked} />
     },

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.doc.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { CheckboxBasicExample } from './examples/Checkbox.Basic.Example';
 
 import { IDocPageProps } from '../../common/DocPage.types';
-import { CheckboxImplementationExamples } from './examples/Checkbox.Other.Example';
+import { CheckboxOtherExamples } from './examples/Checkbox.Other.Example';
 
 const CheckboxBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Basic.Example.tsx') as string;
 const CheckboxBasicExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Basic.Example.tsx') as string;
-const CheckboxImplementationExamplesCode = require('!raw-loader!office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Other.Example.tsx') as string;
+const CheckboxOtherExamplesCode = require('!raw-loader!office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Other.Example.tsx') as string;
+const CheckboxOtherExamplesCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Other.Example.tsx') as string;
 
 export const CheckboxPageProps: IDocPageProps = {
   title: 'Checkbox',
@@ -21,8 +22,9 @@ export const CheckboxPageProps: IDocPageProps = {
     },
     {
       title: 'Implementation Examples',
-      code: CheckboxImplementationExamplesCode,
-      view: <CheckboxImplementationExamples />
+      code: CheckboxOtherExamplesCode,
+      view: <CheckboxOtherExamples />,
+      codepenJS: CheckboxOtherExamplesCodepen
     }
   ],
   propertiesTablesSources: [require<string>('!raw-loader!office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts')],

--- a/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Other.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/examples/Checkbox.Other.Example.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Checkbox, ICheckboxProps } from 'office-ui-fabric-react/lib/Checkbox';
+import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 
-export interface ICheckboxBasicExampleState {
+export interface ICheckboxOtherExamplesState {
   isChecked: boolean;
 }
 
-export class CheckboxImplementationExamples extends React.Component<{}, ICheckboxBasicExampleState> {
-  public state: ICheckboxBasicExampleState = {
+export class CheckboxOtherExamples extends React.Component<{}, ICheckboxOtherExamplesState> {
+  public state: ICheckboxOtherExamplesState = {
     isChecked: false
   };
 
@@ -71,7 +71,7 @@ export class CheckboxImplementationExamples extends React.Component<{}, ICheckbo
     this.setState({ isChecked: checked! });
   };
 
-  private _renderLabelWithLink = (props: ICheckboxProps) => {
+  private _renderLabelWithLink = () => {
     return (
       <span>
         This is a <a href="https://www.microsoft.com">link</a> inside a label.


### PR DESCRIPTION
"Implementation examples" (as opposed to standard examples) are very rarely used and make our component example API surface more confusing. This PR deprecates the related properties and merges the remaining implementation examples into normal examples.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8824)