### PR TITLE
fixing the keyboard callback for the OUFR calendar

### DIFF
--- a/common/changes/office-ui-fabric-react/lorejoh12-headerMonthViewCalendarKeyboardFix_2019-04-23-23-57.json
+++ b/common/changes/office-ui-fabric-react/lorejoh12-headerMonthViewCalendarKeyboardFix_2019-04-23-23-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fixing header keyboarding in CalendarMonth in OUFR",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -332,9 +332,8 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
   };
 
   private _onHeaderKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    const { onHeaderSelect } = this.props;
-    if (onHeaderSelect && (ev.which === KeyCodes.enter || ev.which === KeyCodes.space)) {
-      onHeaderSelect(true);
+    if (this._onHeaderSelect && (ev.which === KeyCodes.enter || ev.which === KeyCodes.space)) {
+      this._onHeaderSelect();
     }
   };
 }


### PR DESCRIPTION
…rying to call the pros.onHeaderSelect instead of the private _onHeaderSelect (which itself calls props.onHeaderSelect if necessary).

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8034
- [x] Include a change request file using `$ npm run change`

#### Description of changes

fixing the keyboard callback for the OUFR calendar. Was erroneously trying to call the pros.onHeaderSelect instead of the private _onHeaderSelect (which itself calls props.onHeaderSelect if necessary).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8827)