### PR TITLE
Checkbox: Move onhover event to label only where it is actionable.

### DIFF
--- a/common/changes/office-ui-fabric-react/checkbox-fixhover_2019-04-24-00-09.json
+++ b/common/changes/office-ui-fabric-react/checkbox-fixhover_2019-04-24-00-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Concentrate onhover style ui changes to label element for Checkbox",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anpablo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -35,6 +35,42 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       checked && 'is-checked',
       !disabled && 'is-enabled',
       disabled && 'is-disabled',
+      className
+    ],
+    input: [
+      {
+        position: 'absolute',
+        background: 'none',
+
+        opacity: 0,
+        selectors: {
+          [`.${IsFocusVisibleClassName} &:focus + label::before`]: {
+            outline: '1px solid ' + theme.palette.neutralSecondary,
+            outlineOffset: '2px',
+            selectors: {
+              [HighContrastSelector]: {
+                outline: '1px solid ActiveBorder'
+              }
+            }
+          }
+        }
+      }
+    ],
+    label: [
+      'ms-Checkbox-label',
+      theme.fonts.medium,
+      {
+        display: 'flex',
+        alignItems: isUsingCustomLabelRender ? 'center' : 'flex-start',
+        cursor: disabled ? 'default' : 'pointer',
+        position: 'relative',
+        userSelect: 'none',
+        textAlign: 'left'
+      },
+      reversed && {
+        flexDirection: 'row-reverse',
+        justifyContent: 'flex-end'
+      },
       !disabled && [
         !checked && {
           selectors: {
@@ -96,56 +132,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
             ':focus .ms-Checkbox-text': { color: checkboxHoveredTextColor }
           }
         }
-      ],
-      className
-    ],
-    input: [
-      {
-        position: 'absolute',
-        background: 'none',
-
-        opacity: 0,
-        selectors: {
-          [`.${IsFocusVisibleClassName} &:focus + label::before`]: {
-            outline: '1px solid ' + theme.palette.neutralSecondary,
-            outlineOffset: '2px',
-            selectors: {
-              [HighContrastSelector]: {
-                outline: '1px solid ActiveBorder'
-              }
-            }
-          }
-        }
-      }
-    ],
-    label: [
-      'ms-Checkbox-label',
-      theme.fonts.medium,
-      {
-        display: 'flex',
-        alignItems: isUsingCustomLabelRender ? 'center' : 'flex-start',
-        cursor: disabled ? 'default' : 'pointer',
-        position: 'relative',
-        userSelect: 'none',
-        textAlign: 'left'
-      },
-      reversed && {
-        flexDirection: 'row-reverse',
-        justifyContent: 'flex-end'
-      },
-      {
-        selectors: {
-          '&::before': {
-            position: 'absolute',
-            left: 0,
-            right: 0,
-            top: 0,
-            bottom: 0,
-            content: '""',
-            pointerEvents: 'none'
-          }
-        }
-      }
+      ]
     ],
     checkbox: [
       'ms-Checkbox-checkbox',

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -9,28 +9,6 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
         display: flex;
         position: relative;
       }
-      &:hover .ms-Checkbox-checkbox {
-        border-color: #333333;
-      }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-        border-color: Highlight;
-      }
-      &:focus .ms-Checkbox-checkbox {
-        border-color: #333333;
-      }
-      &:hover .ms-Checkbox-checkmark {
-        color: #a6a6a6;
-        opacity: 1;
-      }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-        color: Highlight;
-      }
-      &:hover .ms-Checkbox-text {
-        color: #333333;
-      }
-      &:focus .ms-Checkbox-text {
-        color: #333333;
-      }
 >
   <input
     className=
@@ -69,14 +47,27 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
           text-align: left;
           user-select: none;
         }
-        &::before {
-          bottom: 0px;
-          content: "";
-          left: 0px;
-          pointer-events: none;
-          position: absolute;
-          right: 0px;
-          top: 0px;
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #333333;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #333333;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #a6a6a6;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #333333;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #333333;
         }
     htmlFor="checkbox-0"
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -16,36 +16,6 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            background: #106ebe;
-            border-color: #106ebe;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            background: #106ebe;
-            border-color: #106ebe;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            background: Window;
-            border-color: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
-            background: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
-            background: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
-            color: Window;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={true}
@@ -85,14 +55,35 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              background: #106ebe;
+              border-color: #106ebe;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              background: #106ebe;
+              border-color: #106ebe;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              background: Window;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+              background: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
+              background: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
+              color: Window;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -10,28 +10,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
           display: flex;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       className=
@@ -70,14 +48,27 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-0"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -11,28 +11,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           margin-top: 10px;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       className=
@@ -71,14 +49,27 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-0"
     >
@@ -151,36 +142,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           margin-top: 10px;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          background: #106ebe;
-          border-color: #106ebe;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          background: #106ebe;
-          border-color: #106ebe;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          background: Window;
-          border-color: Highlight;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
-          background: Highlight;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
-          background: Highlight;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
-          color: Window;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       className=
@@ -220,14 +181,35 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            background: Window;
+            border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+            background: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
+            background: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
+            color: Window;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-1"
     >
@@ -343,15 +325,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             position: relative;
             text-align: left;
             user-select: none;
-          }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
           }
       htmlFor="checkbox-2"
     >
@@ -471,15 +444,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
-          }
       htmlFor="checkbox-3"
     >
       <div
@@ -557,28 +521,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           margin-top: 10px;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       checked={false}
@@ -618,14 +560,27 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-4"
     >
@@ -698,28 +653,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           margin-top: 10px;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       className=
@@ -760,14 +693,27 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-5"
     >
@@ -839,28 +785,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           margin-top: 10px;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       className=
@@ -899,14 +823,27 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-6"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -15,28 +15,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            border-color: Highlight;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          &:hover .ms-Checkbox-checkmark {
-            color: #a6a6a6;
-            opacity: 1;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={false}
@@ -76,14 +54,27 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              border-color: Highlight;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            &:hover .ms-Checkbox-checkmark {
+              color: #a6a6a6;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-479:hover + .headerDividerBar-480 {
+      & .headerDivider-477:hover + .headerDividerBar-478 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -933,36 +933,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            background: #106ebe;
-            border-color: #106ebe;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            background: #106ebe;
-            border-color: #106ebe;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            background: Window;
-            border-color: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
-            background: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
-            background: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
-            color: Window;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={true}
@@ -1002,14 +972,35 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              background: #106ebe;
+              border-color: #106ebe;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              background: #106ebe;
+              border-color: #106ebe;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              background: Window;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+              background: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
+              background: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
+              color: Window;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-6"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -18,36 +18,6 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
           display: flex;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          background: #106ebe;
-          border-color: #106ebe;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          background: #106ebe;
-          border-color: #106ebe;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          background: Window;
-          border-color: Highlight;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
-          background: Highlight;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
-          background: Highlight;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
-          color: Window;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       className=
@@ -87,14 +57,35 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            background: #106ebe;
+            border-color: #106ebe;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            background: Window;
+            border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+            background: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
+            background: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
+            color: Window;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-0"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -312,28 +312,6 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
             margin-top: 10px;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            border-color: Highlight;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          &:hover .ms-Checkbox-checkmark {
-            color: #a6a6a6;
-            opacity: 1;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={false}
@@ -373,14 +351,27 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              border-color: Highlight;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            &:hover .ms-Checkbox-checkmark {
+              color: #a6a6a6;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-3"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -12,36 +12,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            background: #106ebe;
-            border-color: #106ebe;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            background: #106ebe;
-            border-color: #106ebe;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            background: Window;
-            border-color: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
-            background: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
-            background: Highlight;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
-            color: Window;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={true}
@@ -81,14 +51,35 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              background: #106ebe;
+              border-color: #106ebe;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              background: #106ebe;
+              border-color: #106ebe;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              background: Window;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+              background: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
+              background: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
+              color: Window;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3113,28 +3113,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            border-color: Highlight;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          &:hover .ms-Checkbox-checkmark {
-            color: #a6a6a6;
-            opacity: 1;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={false}
@@ -3174,14 +3152,27 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              border-color: Highlight;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            &:hover .ms-Checkbox-checkmark {
+              color: #a6a6a6;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-61"
       >
@@ -3252,28 +3243,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            border-color: Highlight;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          &:hover .ms-Checkbox-checkmark {
-            color: #a6a6a6;
-            opacity: 1;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={false}
@@ -3313,14 +3282,27 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              border-color: Highlight;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            &:hover .ms-Checkbox-checkmark {
+              color: #a6a6a6;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-62"
       >
@@ -3391,28 +3373,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             display: flex;
             position: relative;
           }
-          &:hover .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-            border-color: Highlight;
-          }
-          &:focus .ms-Checkbox-checkbox {
-            border-color: #333333;
-          }
-          &:hover .ms-Checkbox-checkmark {
-            color: #a6a6a6;
-            opacity: 1;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-            color: Highlight;
-          }
-          &:hover .ms-Checkbox-text {
-            color: #333333;
-          }
-          &:focus .ms-Checkbox-text {
-            color: #333333;
-          }
     >
       <input
         checked={false}
@@ -3452,14 +3412,27 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               text-align: left;
               user-select: none;
             }
-            &::before {
-              bottom: 0px;
-              content: "";
-              left: 0px;
-              pointer-events: none;
-              position: absolute;
-              right: 0px;
-              top: 0px;
+            &:hover .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              border-color: Highlight;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              border-color: #333333;
+            }
+            &:hover .ms-Checkbox-checkmark {
+              color: #a6a6a6;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #333333;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #333333;
             }
         htmlFor="checkbox-63"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -353,28 +353,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   margin-right: 10px;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -413,14 +391,27 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-1"
             >
@@ -491,28 +482,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   display: flex;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -551,14 +520,27 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-2"
             >
@@ -689,28 +671,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   margin-bottom: 10px;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -749,14 +709,27 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-3"
             >
@@ -827,28 +800,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   display: flex;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -887,14 +838,27 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-4"
             >
@@ -3320,28 +3284,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               display: flex;
               position: relative;
             }
-            &:hover .ms-Checkbox-checkbox {
-              border-color: #333333;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-              border-color: Highlight;
-            }
-            &:focus .ms-Checkbox-checkbox {
-              border-color: #333333;
-            }
-            &:hover .ms-Checkbox-checkmark {
-              color: #a6a6a6;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-              color: Highlight;
-            }
-            &:hover .ms-Checkbox-text {
-              color: #333333;
-            }
-            &:focus .ms-Checkbox-text {
-              color: #333333;
-            }
       >
         <input
           className=
@@ -3380,14 +3322,27 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 text-align: left;
                 user-select: none;
               }
-              &::before {
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                pointer-events: none;
-                position: absolute;
-                right: 0px;
-                top: 0px;
+              &:hover .ms-Checkbox-checkbox {
+                border-color: #333333;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                border-color: Highlight;
+              }
+              &:focus .ms-Checkbox-checkbox {
+                border-color: #333333;
+              }
+              &:hover .ms-Checkbox-checkmark {
+                color: #a6a6a6;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                color: Highlight;
+              }
+              &:hover .ms-Checkbox-text {
+                color: #333333;
+              }
+              &:focus .ms-Checkbox-text {
+                color: #333333;
               }
           htmlFor="checkbox-14"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -354,28 +354,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   margin-right: 10px;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -414,14 +392,27 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-1"
             >
@@ -493,28 +484,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   margin-right: 10px;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -553,14 +522,27 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-2"
             >
@@ -632,28 +614,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   margin-right: 10px;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -692,14 +652,27 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-3"
             >
@@ -770,28 +743,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   display: flex;
                   position: relative;
                 }
-                &:hover .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                  border-color: Highlight;
-                }
-                &:focus .ms-Checkbox-checkbox {
-                  border-color: #333333;
-                }
-                &:hover .ms-Checkbox-checkmark {
-                  color: #a6a6a6;
-                  opacity: 1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                  color: Highlight;
-                }
-                &:hover .ms-Checkbox-text {
-                  color: #333333;
-                }
-                &:focus .ms-Checkbox-text {
-                  color: #333333;
-                }
           >
             <input
               className=
@@ -830,14 +781,27 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     text-align: left;
                     user-select: none;
                   }
-                  &::before {
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    pointer-events: none;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
+                  &:hover .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                    border-color: Highlight;
+                  }
+                  &:focus .ms-Checkbox-checkbox {
+                    border-color: #333333;
+                  }
+                  &:hover .ms-Checkbox-checkmark {
+                    color: #a6a6a6;
+                    opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                    color: Highlight;
+                  }
+                  &:hover .ms-Checkbox-text {
+                    color: #333333;
+                  }
+                  &:focus .ms-Checkbox-text {
+                    color: #333333;
                   }
               htmlFor="checkbox-4"
             >
@@ -1159,36 +1123,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 display: flex;
                 position: relative;
               }
-              &:hover .ms-Checkbox-checkbox {
-                background: #106ebe;
-                border-color: #106ebe;
-              }
-              &:focus .ms-Checkbox-checkbox {
-                background: #106ebe;
-                border-color: #106ebe;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                background: Window;
-                border-color: Highlight;
-              }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
-                background: Highlight;
-              }
-              @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
-                background: Highlight;
-              }
-              @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
-                color: Window;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                color: Highlight;
-              }
-              &:hover .ms-Checkbox-text {
-                color: #333333;
-              }
-              &:focus .ms-Checkbox-text {
-                color: #333333;
-              }
         >
           <input
             className=
@@ -1228,14 +1162,35 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   text-align: left;
                   user-select: none;
                 }
-                &::before {
-                  bottom: 0px;
-                  content: "";
-                  left: 0px;
-                  pointer-events: none;
-                  position: absolute;
-                  right: 0px;
-                  top: 0px;
+                &:hover .ms-Checkbox-checkbox {
+                  background: #106ebe;
+                  border-color: #106ebe;
+                }
+                &:focus .ms-Checkbox-checkbox {
+                  background: #106ebe;
+                  border-color: #106ebe;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                  background: Window;
+                  border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-checkbox {
+                  background: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkbox {
+                  background: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus:hover .ms-Checkbox-checkmark {
+                  color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                  color: Highlight;
+                }
+                &:hover .ms-Checkbox-text {
+                  color: #333333;
+                }
+                &:focus .ms-Checkbox-text {
+                  color: #333333;
                 }
             htmlFor="checkbox-6"
           >
@@ -2106,28 +2061,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     display: flex;
                     position: relative;
                   }
-                  &:hover .ms-Checkbox-checkbox {
-                    border-color: #333333;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-                    border-color: Highlight;
-                  }
-                  &:focus .ms-Checkbox-checkbox {
-                    border-color: #333333;
-                  }
-                  &:hover .ms-Checkbox-checkmark {
-                    color: #a6a6a6;
-                    opacity: 1;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-                    color: Highlight;
-                  }
-                  &:hover .ms-Checkbox-text {
-                    color: #333333;
-                  }
-                  &:focus .ms-Checkbox-text {
-                    color: #333333;
-                  }
             >
               <input
                 className=
@@ -2166,14 +2099,27 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       text-align: left;
                       user-select: none;
                     }
-                    &::before {
-                      bottom: 0px;
-                      content: "";
-                      left: 0px;
-                      pointer-events: none;
-                      position: absolute;
-                      right: 0px;
-                      top: 0px;
+                    &:hover .ms-Checkbox-checkbox {
+                      border-color: #333333;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                      border-color: Highlight;
+                    }
+                    &:focus .ms-Checkbox-checkbox {
+                      border-color: #333333;
+                    }
+                    &:hover .ms-Checkbox-checkmark {
+                      color: #a6a6a6;
+                      opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Checkbox-text {
+                      color: #333333;
+                    }
+                    &:focus .ms-Checkbox-text {
+                      color: #333333;
                     }
                 htmlFor="checkbox-10"
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -10,28 +10,6 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
           display: flex;
           position: relative;
         }
-        &:hover .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
-        }
-        &:focus .ms-Checkbox-checkbox {
-          border-color: #333333;
-        }
-        &:hover .ms-Checkbox-checkmark {
-          color: #a6a6a6;
-          opacity: 1;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
-          color: Highlight;
-        }
-        &:hover .ms-Checkbox-text {
-          color: #333333;
-        }
-        &:focus .ms-Checkbox-text {
-          color: #333333;
-        }
   >
     <input
       checked={false}
@@ -71,14 +49,27 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
             text-align: left;
             user-select: none;
           }
-          &::before {
-            bottom: 0px;
-            content: "";
-            left: 0px;
-            pointer-events: none;
-            position: absolute;
-            right: 0px;
-            top: 0px;
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #333333;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #a6a6a6;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #333333;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #333333;
           }
       htmlFor="checkbox-0"
     >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8818
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Hovering on checkbox outside of label element (checkbox + label) shows ghost checkmark but the box check is not available. Reduce onhover visible affects to label element.

#### Focus areas to test
Make sure ghost checkmark exists only when checkbox is 'checkable'.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8828)