### PR TITLE
Add more focus style helpers

### DIFF
--- a/common/changes/@uifabric/azure-themes/focus-helpers_2019-04-26-20-46.json
+++ b/common/changes/@uifabric/azure-themes/focus-helpers_2019-04-26-20-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/azure-themes",
+      "comment": "Use new getFocusStyle helper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/azure-themes",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/date-time/focus-helpers_2019-04-26-20-46.json
+++ b/common/changes/@uifabric/date-time/focus-helpers_2019-04-26-20-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "Use new getFocusStyle helper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/example-app-base/focus-helpers_2019-04-29-17-43.json
+++ b/common/changes/@uifabric/example-app-base/focus-helpers_2019-04-29-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": " Use new getFocusStyle signature",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/focus-helpers_2019-04-29-17-43.json
+++ b/common/changes/@uifabric/experiments/focus-helpers_2019-04-29-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": " Use new getFocusStyle signature",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fluent-theme/focus-helpers_2019-04-29-17-43.json
+++ b/common/changes/@uifabric/fluent-theme/focus-helpers_2019-04-29-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": " Use new getFocusStyle signature",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/focus-helpers_2019-04-25-04-54.json
+++ b/common/changes/@uifabric/styling/focus-helpers_2019-04-25-04-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add more focus style helpers",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/focus-helpers_2019-04-29-17-43.json
+++ b/common/changes/office-ui-fabric-react/focus-helpers_2019-04-29-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Use new getFocusStyle signature",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/CommandBarButton.styles.ts
@@ -14,7 +14,7 @@ export const CommandBarButtonStyles = (theme: ITheme): Partial<IButtonStyles> =>
       color: semanticColors.bodyText
     },
     root: {
-      ...getFocusStyle(theme, 2),
+      ...getFocusStyle(theme, { inset: 2 }),
       fontSize: FontSizes.size12,
       backgroundColor: semanticColors.bodyBackground,
       color: semanticColors.bodyText

--- a/packages/date-time/src/components/Calendar/Calendar.styles.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.styles.ts
@@ -34,7 +34,7 @@ export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
       }
     ],
     goTodayButton: [
-      getFocusStyle(theme, -1, 'relative'),
+      getFocusStyle(theme, { inset: -1 }),
       {
         bottom: 0,
         color: palette.neutralPrimary,

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -43,7 +43,7 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
       width: '100%'
     },
     monthAndYear: [
-      getFocusStyle(theme, -1, 'relative'),
+      getFocusStyle(theme, { inset: -1 }),
       {
         alignItems: 'center',
         fontSize: FontSizes.medium,
@@ -85,7 +85,7 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
       alignSelf: 'flex-end'
     },
     headerIconButton: [
-      getFocusStyle(theme, -1, 'relative'),
+      getFocusStyle(theme, { inset: -1 }),
       {
         width: 28,
         height: 28,
@@ -160,7 +160,7 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
       fontWeight: FontWeights.regular
     },
     dayButton: [
-      getFocusStyle(theme, -2, 'relative'),
+      getFocusStyle(theme, { inset: -2 }),
       {
         width: 24,
         height: 24,

--- a/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
@@ -19,7 +19,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
       display: 'flex'
     },
     currentItemButton: [
-      getFocusStyle(theme, -1, 'relative'),
+      getFocusStyle(theme, { inset: -1 }),
       {
         fontSize: FontSizes.medium,
         fontWeight: FontWeights.semibold,
@@ -45,7 +45,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
       alignItems: 'center'
     },
     navigationButton: [
-      getFocusStyle(theme, -1, 'relative'),
+      getFocusStyle(theme, { inset: -1 }),
       {
         width: 28,
         minWidth: 28,
@@ -75,7 +75,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
       marginTop: 4
     },
     itemButton: [
-      getFocusStyle(theme, -1, 'relative'),
+      getFocusStyle(theme, { inset: -1 }),
       {
         width: 40,
         height: 40,

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.styles.ts
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.styles.ts
@@ -37,7 +37,7 @@ export const getStyles: IStyleFunction<IFeedbackListStyleProps, IFeedbackListSty
       globalClassNames.button
     ],
     itemCell: [
-      getFocusStyle(theme, -1),
+      getFocusStyle(theme, { inset: -1 }),
       {
         minHeight: 54,
         padding: 10,

--- a/packages/example-app-base/src/components/Header/Header.styles.ts
+++ b/packages/example-app-base/src/components/Header/Header.styles.ts
@@ -46,7 +46,7 @@ export const getStyles: IStyleFunction<IHeaderStyleProps, IHeaderStyles> = props
     ],
     button: [
       commonStyles,
-      getFocusStyle(theme, 1, 'relative', undefined, theme.palette.themeLight, 'transparent'),
+      getFocusStyle(theme, { inset: 1, borderColor: theme.palette.themeLight, outlineColor: 'transparent' }),
       {
         position: 'relative',
         textDecoration: 'none',

--- a/packages/experiments/src/components/Toggle/Toggle.styles.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.styles.ts
@@ -128,7 +128,7 @@ export const ToggleStyles: IToggleComponent['styles'] = (props, theme, tokens): 
     ],
     pill: [
       classNames.pill,
-      getFocusStyle(theme, -3),
+      getFocusStyle(theme, { inset: -3 }),
       {
         fontSize: '20px',
         boxSizing: 'border-box',

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -12,7 +12,7 @@ export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyl
 
   return {
     root: [
-      { ...getFocusStyle(theme, 2) },
+      { ...getFocusStyle(theme, { inset: 2 }) },
       {
         backgroundColor: palette.white
       }

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -10,7 +10,7 @@ export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles
 
   return {
     root: {
-      ...getFocusStyle(theme, 2),
+      ...getFocusStyle(theme, { inset: 2 }),
       backgroundColor: palette.white,
       border: `1px solid ${palette.neutralSecondaryAlt}`,
       borderRadius: effects.roundedCorner2,

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -13,7 +13,7 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
       borderRadius: effects.roundedCorner2,
       backgroundColor: palette.white,
       border: `1px solid ${palette.neutralSecondaryAlt}`,
-      ...getFocusStyle(theme, 1)
+      ...getFocusStyle(theme, { inset: 1 })
     },
     rootHovered: {
       backgroundColor: palette.neutralLighter,

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
@@ -39,7 +39,7 @@ export const getStyles = memoizeFunction(
 
     return {
       root: [
-        getFocusStyle(theme, -1, 'relative', buttonHighContrastFocus),
+        getFocusStyle(theme, { inset: -1, highContrastStyle: buttonHighContrastFocus }),
         theme.fonts.medium,
         {
           boxSizing: 'border-box',
@@ -65,7 +65,7 @@ export const getStyles = memoizeFunction(
       ],
 
       rootDisabled: [
-        getFocusStyle(theme, -1, 'relative', buttonHighContrastFocus),
+        getFocusStyle(theme, { inset: -1, highContrastStyle: buttonHighContrastFocus }),
         {
           backgroundColor: disabledBackground,
           color: disabledText,

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -18,7 +18,7 @@ export const getStyles = memoizeFunction(
 
     const commandButtonStyles: IButtonStyles = {
       root: [
-        getFocusStyle(theme, -1, 'relative', commandButtonHighContrastFocus),
+        getFocusStyle(theme, { inset: -1, highContrastStyle: commandButtonHighContrastFocus }),
         theme.fonts.medium,
         {
           minWidth: '40px',

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -14,7 +14,7 @@ export const getStyles = memoizeFunction(
 
     const splitButtonStyles: IButtonStyles = {
       splitButtonContainer: [
-        getFocusStyle(theme, 0, 'relative', buttonHighContrastFocus),
+        getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus }),
         {
           display: 'inline-flex'
         }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -97,7 +97,7 @@ export const getOptionStyles = memoizeFunction(
           backgroundColor: ComboBoxOptionBackgroundHovered,
           color: ComboBoxOptionTextColorSelected
         },
-        getFocusStyle(theme, undefined, undefined, undefined, undefined, undefined, false),
+        getFocusStyle(theme, { isFocusedOnly: false }),
         getListOptionHighContrastStyles(theme)
       ],
       rootDisabled: {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -95,7 +95,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
   const shimmerRightBorderStyle = `${cellStyleProps.cellRightPadding * 4}px solid ${colors.defaultBackgroundColor}`;
   const shimmerLeftBorderStyle = `${cellStyleProps.cellLeftPadding}px solid ${colors.defaultBackgroundColor}`;
   const selectedStyles: IStyle = [
-    getFocusStyle(theme, -1, undefined, undefined, focusBorder, white),
+    getFocusStyle(theme, { inset: -1, borderColor: focusBorder, outlineColor: white }),
     classNames.isSelected,
     {
       color: colors.selectedMetaTextColor,
@@ -230,7 +230,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
   };
 
   const defaultCellStyles: IStyle = [
-    getFocusStyle(theme, -1),
+    getFocusStyle(theme, { inset: -1 }),
     classNames.cell,
     {
       display: 'inline-block',
@@ -249,7 +249,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
           maxWidth: '100%'
         },
 
-        [classNames.isFocusable!]: getFocusStyle(theme, -1, undefined, undefined, neutralSecondary, white),
+        [classNames.isFocusable!]: getFocusStyle(theme, { inset: -1, borderColor: neutralSecondary, outlineColor: white }),
 
         '&$shimmer': {
           padding: 0,
@@ -277,7 +277,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       droppingClassName,
       theme.fonts.small,
       isCheckVisible && classNames.isCheckVisible,
-      getFocusStyle(theme, 0, undefined, undefined, focusBorder, white),
+      getFocusStyle(theme, { borderColor: focusBorder, outlineColor: white }),
       {
         borderBottom: `1px solid ${neutralLighter}`,
         background: colors.defaultBackgroundColor,

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.styles.ts
@@ -48,7 +48,7 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
 
     addButton: [
       classNames.addButton,
-      getFocusStyle(theme, -1),
+      getFocusStyle(theme, { inset: -1 }),
       ItemButtonStyles,
       {
         fontSize: fonts.medium.fontSize,
@@ -74,7 +74,7 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
 
     descriptiveOverflowButton: [
       classNames.descriptiveOverflowButton,
-      getFocusStyle(theme, -1),
+      getFocusStyle(theme, { inset: -1 }),
       ItemButtonStyles,
       {
         fontSize: fonts.small.fontSize,
@@ -115,7 +115,7 @@ export const styles = (props: IFacepileStyleProps): IFacepileStyles => {
 
     overflowButton: [
       classNames.overflowButton,
-      getFocusStyle(theme, -1),
+      getFocusStyle(theme, { inset: -1 }),
       ItemButtonStyles,
       {
         fontSize: fonts.medium.fontSize,

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
@@ -17,7 +17,7 @@ const classNames = mergeStyleSets({
     maxHeight: 500
   },
   itemCell: [
-    getFocusStyle(theme, -1),
+    getFocusStyle(theme, { inset: -1 }),
     {
       minHeight: 54,
       padding: 10,

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -104,7 +104,7 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
     }
   };
 
-  const focusStyle = getFocusStyle(theme, 0, 'relative', undefined, palette.black);
+  const focusStyle = getFocusStyle(theme, { borderColor: palette.black });
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
@@ -103,7 +103,7 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
       _getColorWithHighContrast(ratingStarCheckedColor, 'Highlight')
     ],
     ratingButton: [
-      getFocusStyle(theme, 0),
+      getFocusStyle(theme),
       classNames.ratingButton,
       {
         backgroundColor: 'transparent',

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -65,7 +65,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
 
     pill: [
       'ms-Toggle-background',
-      getFocusStyle(theme, -3),
+      getFocusStyle(theme, { inset: -3 }),
       {
         fontSize: '20px',
         boxSizing: 'border-box',

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -64,7 +64,7 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
   return {
     root: [
       classNames.root,
-      getFocusStyle(theme, -2),
+      getFocusStyle(theme, { inset: -2 }),
       {
         borderRadius: 15,
         display: 'inline-flex',

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -112,6 +112,12 @@ export namespace FontWeights {
 export function getFadedOverflowStyle(theme: ITheme, color?: keyof ISemanticColors | keyof IPalette, direction?: 'horizontal' | 'vertical', width?: string | number, height?: string | number): IRawStyle;
 
 // @public
+export function getFocusOutlineStyle(theme: ITheme, inset?: number, width?: number, color?: string): IRawStyle;
+
+// @public
+export function getFocusStyle(theme: ITheme, options?: IGetFocusStylesOptions): IRawStyle;
+
+// @public @deprecated
 export function getFocusStyle(theme: ITheme, inset?: number, position?: 'relative' | 'absolute', highContrastStyle?: IRawStyle | undefined, borderColor?: string, outlineColor?: string, isFocusedOnly?: boolean): IRawStyle;
 
 // @public
@@ -299,6 +305,17 @@ export interface IFontStyles {
 }
 
 export { IFontWeight }
+
+// @public (undocumented)
+export interface IGetFocusStylesOptions {
+    borderColor?: string;
+    highContrastStyle?: IRawStyle;
+    inset?: number;
+    isFocusedOnly?: boolean;
+    outlineColor?: string;
+    position?: 'relative' | 'absolute';
+    width?: number;
+}
 
 // @public (undocumented)
 export interface IIconOptions {

--- a/packages/styling/src/interfaces/IGetFocusStyles.ts
+++ b/packages/styling/src/interfaces/IGetFocusStyles.ts
@@ -1,0 +1,65 @@
+import { IRawStyle } from '@uifabric/merge-styles';
+
+export interface IGetFocusStylesOptions {
+  /**
+   * The number of pixels to inset the border.
+   * @defaultvalue 0
+   */
+  inset?: number;
+
+  /**
+   * The width of the border in pixels.
+   * @defaultvalue 1
+   */
+  width?: number;
+
+  /**
+   * The positioning applied to the container.
+   * Must be 'relative' or 'absolute' so that the focus border can live around it.
+   * @defaultvalue 'relative'
+   */
+  position?: 'relative' | 'absolute';
+
+  /**
+   * Style for high contrast mode.
+   */
+  highContrastStyle?: IRawStyle;
+
+  /**
+   * Color of the border.
+   * @defaultvalue theme.palette.white
+   */
+  borderColor?: string;
+
+  /**
+   * Color of the outline.
+   * @defaultvalue theme.palette.neutralSecondary
+   */
+  outlineColor?: string;
+
+  /**
+   * If the styles should apply on `:focus` pseudo element.
+   * @defaultvalue true
+   */
+  isFocusedOnly?: boolean;
+}
+
+export interface IGetFocusOutlineOptions {
+  /**
+   * The number of pixels to inset the border.
+   * @defaultvalue 0
+   */
+  inset?: number;
+
+  /**
+   * The border width.
+   * @defaultvalue 1
+   */
+  width?: number;
+
+  /**
+   * Color of the outline.
+   * @defaultvalue theme.palette.neutralSecondary
+   */
+  color?: string;
+}

--- a/packages/styling/src/interfaces/IGetFocusStyles.ts
+++ b/packages/styling/src/interfaces/IGetFocusStyles.ts
@@ -43,23 +43,3 @@ export interface IGetFocusStylesOptions {
    */
   isFocusedOnly?: boolean;
 }
-
-export interface IGetFocusOutlineOptions {
-  /**
-   * The number of pixels to inset the border.
-   * @defaultvalue 0
-   */
-  inset?: number;
-
-  /**
-   * The border width.
-   * @defaultvalue 1
-   */
-  width?: number;
-
-  /**
-   * Color of the outline.
-   * @defaultvalue theme.palette.neutralSecondary
-   */
-  color?: string;
-}

--- a/packages/styling/src/interfaces/index.ts
+++ b/packages/styling/src/interfaces/index.ts
@@ -1,4 +1,5 @@
 export { IAnimationStyles, IAnimationVariables } from './IAnimationStyles';
+export { IGetFocusStylesOptions } from './IGetFocusStyles';
 export { IFontStyles } from './IFontStyles';
 export { IPalette } from './IPalette';
 export { ISemanticColors } from './ISemanticColors';

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -1,9 +1,17 @@
 import { IRawStyle } from '@uifabric/merge-styles';
-import { ITheme } from '../interfaces/index';
+import { IGetFocusStylesOptions, ITheme } from '../interfaces/index';
 import { HighContrastSelector } from './CommonStyles';
 import { IsFocusVisibleClassName } from '@uifabric/utilities';
 import { ZIndexes } from './zIndexes';
 
+/**
+ * Generates a focus style which can be used to define an :after focus border.
+ *
+ * @param theme - The theme object to use.
+ * @param options - Options to customize the focus border.
+ * @returns The style object.
+ */
+export function getFocusStyle(theme: ITheme, options?: IGetFocusStylesOptions): IRawStyle;
 /**
  * Generates a focus style which can be used to define an :after focus border.
  *
@@ -16,25 +24,59 @@ import { ZIndexes } from './zIndexes';
  * @param outlineColor - Color of the outline.
  * @param isFocusedOnly - If the styles should apply on focus or not.
  * @returns The style object.
+ * @deprecated Use the object parameter version instead.
  */
 export function getFocusStyle(
   theme: ITheme,
-  inset: number = 0,
-  position: 'relative' | 'absolute' = 'relative',
-  highContrastStyle: IRawStyle | undefined = undefined,
-  borderColor: string = theme.palette.white,
-  outlineColor: string = theme.palette.neutralSecondary,
-  isFocusedOnly: boolean = true
+  inset?: number,
+  position?: 'relative' | 'absolute',
+  highContrastStyle?: IRawStyle | undefined,
+  borderColor?: string,
+  outlineColor?: string,
+  isFocusedOnly?: boolean
+): IRawStyle;
+export function getFocusStyle(
+  theme: ITheme,
+  insetOrOptions?: number | IGetFocusStylesOptions,
+  position?: 'relative' | 'absolute',
+  highContrastStyle?: IRawStyle,
+  borderColor?: string,
+  outlineColor?: string,
+  isFocusedOnly?: boolean
 ): IRawStyle {
+  if (typeof insetOrOptions === 'number' || !insetOrOptions) {
+    return _getFocusStyleInternal(theme, { inset: insetOrOptions, position, highContrastStyle, borderColor, outlineColor, isFocusedOnly });
+  } else {
+    return _getFocusStyleInternal(theme, insetOrOptions);
+  }
+}
+
+function _getFocusStyleInternal(theme: ITheme, options: IGetFocusStylesOptions = {}): IRawStyle {
+  const {
+    inset = 0,
+    width = 1,
+    position = 'relative',
+    highContrastStyle,
+    borderColor = theme.palette.white,
+    outlineColor = theme.palette.neutralSecondary,
+    isFocusedOnly = true
+  } = options;
+
   return {
+    // Clear browser-specific focus styles and use 'transparent' as placeholder for focus style.
     outline: 'transparent',
+    // Requirement because pseudo-element is absolutely positioned.
     position,
 
     selectors: {
+      // Clear the focus border in Firefox.
+      // Reference: http://stackoverflow.com/a/199319/1436671
       '::-moz-focus-inner': {
         border: '0'
       },
 
+      // When the element that uses this mixin is in a :focus state, add a pseudo-element to
+      // create a border.
       [`.${IsFocusVisibleClassName} &${isFocusedOnly ? ':focus' : ''}:after`]: {
         content: '""',
         position: 'absolute',
@@ -42,8 +84,8 @@ export function getFocusStyle(
         top: inset + 1,
         bottom: inset + 1,
         right: inset + 1,
-        border: '1px solid ' + borderColor,
-        outline: '1px solid ' + outlineColor,
+        border: `${width}px solid ${borderColor}`,
+        outline: `${width}px solid ${outlineColor}`,
         zIndex: ZIndexes.FocusStyle,
         selectors: {
           [HighContrastSelector]: highContrastStyle
@@ -66,6 +108,24 @@ export function focusClear(): IRawStyle {
       '&': {
         // Clear browser specific focus styles and use transparent as placeholder for focus style
         outline: 'transparent'
+      }
+    }
+  };
+}
+
+/**
+ * Generates a style which can be used to set a border on focus.
+ *
+ * @param theme - The theme object to use.
+ * @param options - Options to customize the focus border.
+ * @returns The style object.
+ */
+export function getFocusOutlineStyle(theme: ITheme, inset: number = 0, width: number = 1, color?: string): IRawStyle {
+  return {
+    selectors: {
+      [`:global(${IsFocusVisibleClassName}) &:focus`]: {
+        outline: `${width} solid ${color || theme.palette.neutralSecondary}`,
+        outlineOffset: `${-inset}px`
       }
     }
   };

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -117,7 +117,9 @@ export function focusClear(): IRawStyle {
  * Generates a style which can be used to set a border on focus.
  *
  * @param theme - The theme object to use.
- * @param options - Options to customize the focus border.
+ * @param inset - The number of pixels to inset the border (default 0)
+ * @param width - The border width in pixels (default 1)
+ * @param color - Color of the outline (default `theme.palette.neutralSecondary`)
  * @returns The style object.
  */
 export function getFocusOutlineStyle(theme: ITheme, inset: number = 0, width: number = 1, color?: string): IRawStyle {

--- a/packages/styling/src/styles/index.ts
+++ b/packages/styling/src/styles/index.ts
@@ -2,7 +2,7 @@ export { AnimationStyles, AnimationVariables } from './AnimationStyles';
 export { DefaultPalette } from './DefaultPalette';
 export { DefaultFontStyles, registerDefaultFontFaces } from './DefaultFontStyles';
 export { FontSizes, FontWeights, IconFontSizes, createFontStyles } from './fonts';
-export { getFocusStyle, focusClear } from './getFocusStyle';
+export * from './getFocusStyle';
 export { hiddenContentStyle } from './hiddenContentStyle';
 export { PulsingBeaconAnimationStyles } from './PulsingBeaconAnimationStyles';
 export { getGlobalClassNames, GlobalClassNames } from './getGlobalClassNames';


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Copy the object param version of `getFocusStyle` from the fabric 7 branch (with a new parameter `width`) and add a new helper `getFocusOutlineStyle`. Both `width` and `getFocusOutlineStyle` are used by some new components which will be coming into example-app-base soon.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8839)