### PR TITLE
Add tooltip for cancel button in panel

### DIFF
--- a/common/changes/office-ui-fabric-react/AddTooltipForCancelButonInPanel_2019-04-25-12-33.json
+++ b/common/changes/office-ui-fabric-react/AddTooltipForCancelButonInPanel_2019-04-25-12-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "added the title attribute for the cancel icon in the panel which is same as aira-label",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "saishiva99@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -277,6 +277,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
           className={this._classNames.closeButton}
           onClick={this._onPanelClick}
           ariaLabel={closeButtonAriaLabel}
+          title={closeButtonAriaLabel}
           data-is-visible={true}
           iconProps={{ iconName: 'Cancel' }}
         />


### PR DESCRIPTION


#### Description of changes

added the title attribute for the cancel icon in the panel which is same as aira-label

**after fix**
![tooltip](https://user-images.githubusercontent.com/33802398/56736454-caaa9900-6785-11e9-95ef-5c1ca877bb48.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8842)