### PR TITLE
Updating the styled helper to allow for a "pure" option.

### DIFF
--- a/common/changes/@uifabric/utilities/pure-styled_2019-04-25-17-43.json
+++ b/common/changes/@uifabric/utilities/pure-styled_2019-04-25-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "The `styled` helper can now take in a pure flag to create pure components. Note that in a future release we'd like to match the `styled` contracts of other libraries which can take in a View and an options property bag, but for now to make this non-breaking we'll add another arugument.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/pure-styled_2019-04-25-17-43.json
+++ b/common/changes/@uifabric/utilities/pure-styled_2019-04-25-17-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/utilities",
-      "comment": "The `styled` helper can now take in a pure flag to create pure components. Note that in a future release we'd like to match the `styled` contracts of other libraries which can take in a View and an options property bag, but for now to make this non-breaking we'll add another arugument.",
+      "comment": "The `styled` helper can now take in a pure flag to create pure components. Note that in a future release we'd like to match the `styled` contracts of other libraries which can take in a View and an options property bag, but for now to make this non-breaking we'll add another argument.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/pure-styled_2019-04-25-17-43.json
+++ b/common/changes/office-ui-fabric-react/pure-styled_2019-04-25-17-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updating Icon, Checkbox, and Image to be pure components (correctly.)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -501,7 +501,7 @@ export function canAnyMenuItemsCheck(items: IContextualMenuItem[]): boolean;
 export const Check: React_2.StatelessComponent<ICheckProps>;
 
 // @public (undocumented)
-export class CheckBase extends React.PureComponent<ICheckProps, {}> {
+export class CheckBase extends React.Component<ICheckProps, {}> {
     // (undocumented)
     static defaultProps: ICheckProps;
     // (undocumented)
@@ -2733,7 +2733,7 @@ export interface ICommandBarStyles {
 export const Icon: React_2.StatelessComponent<IIconProps>;
 
 // @public (undocumented)
-export class IconBase extends React.PureComponent<IIconProps, IIconState> {
+export class IconBase extends React.Component<IIconProps, IIconState> {
     constructor(props: IIconProps);
     // (undocumented)
     render(): JSX.Element;

--- a/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
@@ -6,7 +6,7 @@ import { ICheckStyleProps, ICheckStyles } from './Check.types';
 
 const getClassNames = classNamesFunction<ICheckStyleProps, ICheckStyles>();
 
-export class CheckBase extends React.PureComponent<ICheckProps, {}> {
+export class CheckBase extends React.Component<ICheckProps, {}> {
   public static defaultProps: ICheckProps = {
     checked: false
   };

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -9,5 +9,6 @@ export const Check: React.StatelessComponent<ICheckProps> = styled<ICheckProps, 
   undefined,
   {
     scope: 'Check'
-  }
+  },
+  true
 );

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -12,7 +12,7 @@ export interface IIconState {
 
 const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>();
 
-export class IconBase extends React.PureComponent<IIconProps, IIconState> {
+export class IconBase extends React.Component<IIconProps, IIconState> {
   constructor(props: IIconProps) {
     super(props);
     this.state = {

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.tsx
@@ -7,6 +7,12 @@ import { getStyles } from './Icon.styles';
  * Icons are used for rendering an individual's avatar, presence and details.
  * They are used within the PeoplePicker components.
  */
-export const Icon: React.StatelessComponent<IIconProps> = styled<IIconProps, IIconStyleProps, IIconStyles>(IconBase, getStyles, undefined, {
-  scope: 'Icon'
-});
+export const Icon: React.StatelessComponent<IIconProps> = styled<IIconProps, IIconStyleProps, IIconStyles>(
+  IconBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Icon'
+  },
+  true
+);

--- a/packages/office-ui-fabric-react/src/components/Image/Image.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.tsx
@@ -9,5 +9,6 @@ export const Image: React.StatelessComponent<IImageProps> = styled<IImageProps, 
   undefined,
   {
     scope: 'Image'
-  }
+  },
+  true
 );

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -125,7 +125,7 @@ export function createArray<T>(size: number, getItem: (index: number) => T): T[]
 export function createRef<T>(): RefObject<T>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "css" is marked as @public, but its signature references "ICssInput" which is marked as @internal
-//
+// 
 // @public
 export function css(...args: ICssInput[]): string;
 
@@ -168,7 +168,7 @@ export const DATA_IS_SCROLLABLE_ATTRIBUTE = "data-is-scrollable";
 export const DATA_PORTAL_ATTRIBUTE = "data-portal-element";
 
 // Warning: (ae-incompatible-release-tags) The symbol "DelayedRender" is marked as @public, but its signature references "IDelayedRenderState" which is marked as @internal
-//
+// 
 // @public
 export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayedRenderState> {
     constructor(props: IDelayedRenderProps);
@@ -224,7 +224,7 @@ export class EventGroup {
     }
 
 // Warning: (ae-forgotten-export) The symbol "React" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export function extendComponent<T extends React_2.Component>(parent: T, methods: {
     [key in keyof T]?: T[key];
@@ -238,7 +238,7 @@ export class FabricPerformance {
     // (undocumented)
     static setPeriodicReset(): void;
     // Warning: (ae-incompatible-release-tags) The symbol "summary" is marked as @public, but its signature references "IPerfSummary" which is marked as @internal
-    //
+    // 
     // (undocumented)
     static summary: IPerfSummary;
     }
@@ -429,7 +429,7 @@ export type IComponentAsProps<T> = T & {
 };
 
 // Warning: (ae-internal-missing-underscore) The name ICssInput should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export type ICssInput = string | ISerializableObject | IDictionary | null | undefined | boolean;
 
@@ -466,7 +466,7 @@ export type ICustomizerProps = IBaseProps & Partial<{
 };
 
 // Warning: (ae-internal-missing-underscore) The name IDeclaredEventsByName should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IDeclaredEventsByName {
     // (undocumented)
@@ -479,14 +479,14 @@ export interface IDelayedRenderProps extends React.Props<{}> {
 }
 
 // Warning: (ae-internal-missing-underscore) The name IDelayedRenderState should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IDelayedRenderState {
     isRendered: boolean;
 }
 
 // Warning: (ae-internal-missing-underscore) The name IDictionary should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IDictionary {
     // (undocumented)
@@ -500,7 +500,7 @@ export interface IDisposable {
 }
 
 // Warning: (ae-internal-missing-underscore) The name IEventRecord should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IEventRecord {
     // (undocumented)
@@ -520,7 +520,7 @@ export interface IEventRecord {
 }
 
 // Warning: (ae-internal-missing-underscore) The name IEventRecordList should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IEventRecordList {
     // (undocumented)
@@ -530,7 +530,7 @@ export interface IEventRecordList {
 }
 
 // Warning: (ae-internal-missing-underscore) The name IEventRecordsByName should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IEventRecordsByName {
     // (undocumented)
@@ -558,7 +558,7 @@ export function initializeFocusRects(window?: Window): void;
 export const inputProperties: string[];
 
 // Warning: (ae-internal-missing-underscore) The name IPerfData should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IPerfData {
     // (undocumented)
@@ -568,7 +568,7 @@ export interface IPerfData {
 }
 
 // Warning: (ae-internal-missing-underscore) The name IPerfMeasurement should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IPerfMeasurement {
     // (undocumented)
@@ -580,7 +580,7 @@ export interface IPerfMeasurement {
 }
 
 // Warning: (ae-internal-missing-underscore) The name IPerfSummary should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface IPerfSummary {
     // (undocumented)
@@ -647,7 +647,7 @@ export function isElementTabbable(element: HTMLElement, checkTabIndex?: boolean)
 export function isElementVisible(element: HTMLElement | undefined | null): boolean;
 
 // Warning: (ae-internal-missing-underscore) The name ISerializableObject should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export interface ISerializableObject {
     // (undocumented)
@@ -902,7 +902,7 @@ export function setFocusVisibility(enabled: boolean, target?: Element): void;
 export function setLanguage(language: string, avoidPersisting?: boolean): void;
 
 // Warning: (ae-internal-missing-underscore) The name setMemoizeWeakMap should be prefixed with an underscore because the declaration is marked as "@internal"
-//
+// 
 // @internal
 export function setMemoizeWeakMap(weakMap: any): void;
 
@@ -934,7 +934,7 @@ export function shallowCompare<TA, TB>(a: TA, b: TB): boolean;
 export function shouldWrapFocus(element: HTMLElement, noWrapDataAttribute: 'data-no-vertical-wrap' | 'data-no-horizontal-wrap'): boolean;
 
 // @public
-export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps): React.StatelessComponent<TComponentProps>;
+export function styled<TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>, TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>, baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>, getProps?: (props: TComponentProps) => Partial<TComponentProps>, customizable?: ICustomizableProps, pure?: boolean): React.StatelessComponent<TComponentProps>;
 
 // @public
 export const textAreaProperties: string[];

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -63,6 +63,34 @@ describe('styled', () => {
     Stylesheet.getInstance().reset();
   });
 
+  it('can create pure components', () => {
+    let renderCount = 0;
+    const render = () => {
+      renderCount++;
+      return <div />;
+    };
+    const styles = () => ({});
+    const Comp = styled(render, styles);
+    const PureComp = styled(render, styles, undefined, undefined, true);
+    const App = () => {
+      return (
+        <div>
+          <Comp />
+          <PureComp />
+        </div>
+      );
+    };
+    const appWrapper = mount(<App />);
+
+    try {
+      expect(renderCount).toEqual(2);
+      appWrapper.setProps({ 'data-foo': '1' });
+      expect(renderCount).toEqual(3);
+    } finally {
+      appWrapper.unmount();
+    }
+  });
+
   it('renders base styles (background red)', () => {
     safeCreate(<Test />, (component: renderer.ReactTestRenderer) => {
       // Test that defaults are the base styles (red).

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -37,6 +37,9 @@ const DefaultFields = ['theme', 'styles'];
  * @param baseStyles - The styles which should be curried with the component.
  * @param getProps - A helper which provides default props.
  * @param customizable - An object which defines which props can be customized using the Customizer.
+ * @param pure - A boolean indicating if the component should avoid re-rendering when props haven't changed.
+ * Note that pure should not be used on components which allow children, or take in complex objects or
+ * arrays as props which could mutate on every render.
  */
 export function styled<
   TComponentProps extends IPropsWithStyles<TStyleProps, TStyleSet>,
@@ -46,13 +49,15 @@ export function styled<
   Component: React.ComponentClass<TComponentProps> | React.StatelessComponent<TComponentProps>,
   baseStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>,
   getProps?: (props: TComponentProps) => Partial<TComponentProps>,
-  customizable?: ICustomizableProps
+  customizable?: ICustomizableProps,
+  pure?: boolean
 ): React.StatelessComponent<TComponentProps> {
   customizable = customizable || { scope: '', fields: undefined };
 
   const { scope, fields = DefaultFields } = customizable;
+  const ParentComponent = pure ? React.PureComponent : React.Component;
 
-  class Wrapped extends React.Component<TComponentProps, {}> {
+  class Wrapped extends ParentComponent<TComponentProps, {}> {
     // Function.prototype.name is an ES6 feature, so the cast to any is required until we're
     // able to drop IE 11 support and compile with ES6 libs
     // tslint:disable-next-line:no-any


### PR DESCRIPTION
Today, the `styled` helper always returns a `React.Component` instance. Inside of that wrapper component, it renders the given view passing in a `styles` prop that mixes default styles, customized styles, and user provided styles in the right order. We made a recent change to make sure that styled function prop would not mutate on each render.

This exposed an issue; if the view component itself was pure, it wouldn't re-render on new styles provided, because the function wouldn't change (which again is by design.)

The memoization or "pure" shallow check really needs to apply at the external component layer, not at the internal view layer. So we need `styled` to be able to return pure components, not the view to be pure.

Now, you can do that:

```tsx
styled(
  renderFunction,
  stylesFunction,
  propsTransform,
  scopeSettings,
  pure
)
```

Obviously this would be better suited for an options bag. We are planning this for a future release and working on cleaning up the `createComponent` helper to bring it more inline with styled-components or emotion `styled` helpers.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8843)