### PR TITLE
Reset input state on option click for ComboBox

### DIFF
--- a/common/changes/office-ui-fabric-react/combobox_2019-04-25-21-27.json
+++ b/common/changes/office-ui-fabric-react/combobox_2019-04-25-21-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Always reset pending info on option click.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anpablo@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -885,11 +885,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       if (onChanged) {
         onChanged(option, index, undefined, submitPendingValueEvent);
       }
-
-      // if we have a new selected index,
-      // clear all of the pending info
-      this._clearPendingInfo();
     }
+
+    // clear all of the pending info
+    this._clearPendingInfo();
   }
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8840
- [x] Include a change request file using `$ npm run change`

#### Description of changes
The state of input is not reset on option click.

#### Focus areas to test
Make sure the selected option is reflected in the input box after typed input that has not been confirmed.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8845)