### PR TITLE
Add pointer events to baseElementProperties

### DIFF
--- a/common/changes/@uifabric/utilities/pointer-events_2019-04-25-23-30.json
+++ b/common/changes/@uifabric/utilities/pointer-events_2019-04-25-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Adds pointer events to baseElementProperties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "lotacket@microsoft.com"
+}

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -74,7 +74,17 @@ export const baseElementEvents = [
   'onTouchMove',
   'onTouchStart',
   'onScroll',
-  'onWheel'
+  'onWheel',
+  'onPointerCancel',
+  'onPointerDown',
+  'onPointerEnter',
+  'onPointerLeave',
+  'onPointerMove',
+  'onPointerOut',
+  'onPointerOver',
+  'onPointerUp',
+  'onGotPointerCapture',
+  'onLostPointerCapture'
 ];
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8822
- [x] Include a change request file using `$ npm run change`

#### Description of changes

[Pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) were not being passed from UI Fabric components to their native DOM elements. This PR adds the pointer events to the `baseElementProperties`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8850)