### PR TITLE
Fabric 7.0: remove gray40 from automatic assignment in PersonaInitialColors

### DIFF
--- a/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
+++ b/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`VerticalPersona renders correctly with a text and secondary text 1`] = 
 
         {
           align-items: center;
-          background-color: #0B6A0B;
+          background-color: #750B1C;
           border-radius: 50%;
           color: white;
           display: flex;
@@ -122,7 +122,7 @@ exports[`VerticalPersona renders correctly with only a text 1`] = `
 
         {
           align-items: center;
-          background-color: #0B6A0B;
+          background-color: #750B1C;
           border-radius: 50%;
           color: white;
           display: flex;

--- a/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`PersonaCoin renders a coin with a contact icon for a Chinese name 1`] =
       test-cn-root
       {
         align-items: center;
-        background-color: #C239B3;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -116,7 +116,7 @@ exports[`PersonaCoin renders a correct persona 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #0B6A0B;
+        background-color: #750B1C;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -188,7 +188,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
       test-cn-root
       {
         align-items: center;
-        background-color: #C239B3;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -285,7 +285,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #C239B3;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -382,7 +382,7 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #986F0B;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7766,7 +7766,6 @@ export enum PersonaInitialsColor {
     gray20 = 45,
     // (undocumented)
     gray30 = 43,
-    // (undocumented)
     gray40 = 44,
     // @deprecated (undocumented)
     green = 5,

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #986F0B;
+                  background-color: #498205;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -379,7 +379,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #986F0B;
+                  background-color: #498205;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -541,7 +541,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #986F0B;
+                  background-color: #498205;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -699,7 +699,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #8E562E;
+                  background-color: #E3008C;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -824,7 +824,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #986F0B;
+                  background-color: #498205;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 14px;
@@ -1065,7 +1065,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #986F0B;
+                  background-color: #498205;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -1201,7 +1201,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #8E562E;
+                  background-color: #E3008C;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -413,7 +413,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #E3008C;
+                        background-color: #7A7574;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -568,6 +568,9 @@ export enum PersonaInitialsColor {
   orange30 = 41,
   orangeYellow20 = 42,
   gray30 = 43,
+  /**
+   * gray40 is a color that can result in offensive persona coins with some initials combinations, so it can only be set with overrides
+   */
   gray40 = 44,
   gray20 = 45
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -239,7 +239,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #5C2E91;
+            background-color: #4F6BED;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5C2E91;
+              background-color: #4F6BED;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -640,7 +640,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5C2E91;
+              background-color: #4F6BED;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -997,7 +997,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #D13438;
+              background-color: #7A7574;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;
@@ -1813,7 +1813,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #D13438;
+            background-color: #7A7574;
             border-radius: 50%;
             color: #ffffff;
             font-size: 42px;
@@ -1927,7 +1927,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #5C2E91;
+            background-color: #4F6BED;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -1984,7 +1984,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #5C2E91;
+            background-color: #4F6BED;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,10 +4,10 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#5C2E91');
+    expect(colorCode).toEqual('#4F6BED');
 
     const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
-    expect(colorCode2).toEqual('#C239B3');
+    expect(colorCode2).toEqual('#005B70');
   });
 
   it('uses provided enum initialsColor if one was specified', () => {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -26,7 +26,6 @@ const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [
   PersonaInitialsColor.orange30,
   PersonaInitialsColor.orangeYellow20,
   PersonaInitialsColor.gray30,
-  PersonaInitialsColor.gray40,
   PersonaInitialsColor.gray20
 ];
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -2,8 +2,8 @@ import { PersonaInitialsColor, IPersonaProps } from './Persona.types';
 
 /**
  * These colors are considered reserved colors and can only be set with overrides:
- * - Red is a color that often has a special meaning.
- * - Transparent is not intended to be used with typical initials due to accessibility issues,
+ * - `gray40` is a color that can result in offensive persona coins with some initials combinations, so it can only be set with overrides
+ * - `Transparent` is not intended to be used with typical initials due to accessibility issues,
  *   its primary use is for Facepile overflow buttons.
  */
 const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -267,7 +267,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5C2E91;
+              background-color: #4F6BED;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5C2E91;
+              background-color: #4F6BED;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -640,7 +640,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5C2E91;
+              background-color: #4F6BED;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -997,7 +997,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #D13438;
+              background-color: #7A7574;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -295,7 +295,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #C239B3;
+                    background-color: #881798;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -453,7 +453,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #498205;
+                    background-color: #0078D4;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -306,7 +306,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #D13438;
+                    background-color: #8764B8;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -696,7 +696,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #C239B3;
+                    background-color: #881798;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -1106,7 +1106,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #4F6BED;
+                    background-color: #498205;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -1242,7 +1242,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #C239B3;
+                    background-color: #005B70;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-482:hover + .headerDividerBar-483 {
+      & .headerDivider-483:hover + .headerDividerBar-484 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -275,7 +275,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #038387;
+                        background-color: #0078D4;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;
@@ -1426,7 +1426,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #D13438;
+                        background-color: #750B1C;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -245,7 +245,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #038387;
+                      background-color: #0078D4;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -772,7 +772,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #D13438;
+                      background-color: #750B1C;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -1153,7 +1153,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #5C2E91;
+                      background-color: #986F0B;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -236,7 +236,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #038387;
+                      background-color: #0078D4;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -611,7 +611,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #D13438;
+                      background-color: #750B1C;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -438,7 +438,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #E3008C;
+                          background-color: #7A7574;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -438,7 +438,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #E3008C;
+                          background-color: #7A7574;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;
@@ -539,7 +539,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #038387;
+                        background-color: #0078D4;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #5C2E91;
+                background-color: #4F6BED;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 10px;
@@ -286,7 +286,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #C239B3;
+                background-color: #0B6A0B;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 10px;
@@ -504,7 +504,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #004E8C;
+                background-color: #4F6BED;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 14px;
@@ -722,7 +722,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #8E562E;
+                background-color: #8764B8;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 14px;
@@ -940,7 +940,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #D13438;
+                background-color: #0B6A0B;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1157,7 +1157,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #CA5010;
+                background-color: #8764B8;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1388,7 +1388,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #881798;
+                background-color: #004E8C;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1605,7 +1605,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #7A7574;
+                background-color: #A4262C;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1836,7 +1836,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #750B1C;
+                background-color: #5C2E91;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 20px;
@@ -2067,7 +2067,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #4F6BED;
+                background-color: #E3008C;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 20px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -380,7 +380,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                       className=
                           ms-Persona-initials
                           {
-                            background-color: #A4262C;
+                            background-color: #8764B8;
                             border-radius: 50%;
                             color: #ffffff;
                             font-size: 14px;


### PR DESCRIPTION

#### Description of changes

Removing the `gray40` color from the array of colors participating in the automatic assignment to the PersonaCoin depending on the name of the person.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8852)