### PR TITLE
Slots: Move slot options to new 'slots' prop

### DIFF
--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -121,7 +121,7 @@ export class Nav extends React.Component<INavProps, INavState> {
       return (
         <li key={page.title + '-heading'} className={css(styles.category, _hasActiveChild(page) && styles.hasActiveChild)}>
           <CollapsibleSection
-            title={{ props: { text: page.title, styles: getTitleStyles } }}
+            title={{ text: page.title, styles: getTitleStyles }}
             styles={{ body: [{ marginLeft: '28px' }] }}
             defaultCollapsed={!_hasActiveChild(page)}
           >

--- a/common/changes/@uifabric/experiments/jg-move-slot-options_2019-04-28-22-24.json
+++ b/common/changes/@uifabric/experiments/jg-move-slot-options_2019-04-28-22-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Support slots API changes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/jg-move-slot-options_2019-04-28-22-24.json
+++ b/common/changes/@uifabric/fabric-website/jg-move-slot-options_2019-04-28-22-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Support slots API changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/jg-move-slot-options_2019-04-28-22-24.json
+++ b/common/changes/@uifabric/foundation/jg-move-slot-options_2019-04-28-22-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/foundation",
+      "comment": "Slots: Move slot options from individual props to new slots prop object.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-move-slot-options_2019-04-28-22-24.json
+++ b/common/changes/office-ui-fabric-react/jg-move-slot-options_2019-04-28-22-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Support slots API changes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/ActionButton.tsx
+++ b/packages/experiments/src/components/Button/ActionButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from './Button';
-import { IButtonComponent, IButtonTokenReturnType } from './Button.types';
+import { IButtonComponent, IButtonProps, IButtonTokenReturnType } from './Button.types';
 import { ButtonVariantsType } from './ButtonVariants.types';
 import { FontWeights } from '../../Styling';
 
@@ -42,16 +42,12 @@ export const ActionButtonTokens: IButtonComponent['tokens'] = (props, theme): IB
   props.disabled && disabledTokens
 ];
 
+const ActionButtonStackProps: IButtonProps['stack'] = {
+  horizontalAlign: 'start'
+};
+
 export const ActionButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return (
-    <Button
-      stack={{ props: { horizontalAlign: 'start' } }}
-      content={text}
-      icon={{ props: iconProps }}
-      tokens={ActionButtonTokens}
-      {...rest}
-    />
-  );
+  return <Button stack={ActionButtonStackProps} content={text} icon={iconProps} tokens={ActionButtonTokens} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/BaseButton.tsx
+++ b/packages/experiments/src/components/Button/BaseButton.tsx
@@ -57,5 +57,5 @@ const BaseButtonStyles: IButtonComponent['styles'] = (props, theme, tokens): IBu
 export const BaseButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return <Button content={text} icon={{ props: iconProps }} tokens={BaseButtonTokens} styles={BaseButtonStyles} {...rest} />;
+  return <Button content={text} icon={iconProps} tokens={BaseButtonTokens} styles={BaseButtonStyles} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -1,4 +1,4 @@
-import { IComponent, IComponentStyles, IHTMLElementSlot, ISlotProp, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLElementSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
 import { IFontWeight, IStackSlot, ITextSlot } from 'office-ui-fabric-react';
 import { IIconSlot } from '../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../Utilities';
@@ -46,7 +46,7 @@ export interface IButton {
 }
 
 export interface IButtonProps
-  extends IButtonSlots,
+  extends ISlottableProps<IButtonSlots>,
     IStyleableComponentProps<IButtonProps, IButtonTokens, IButtonStyles>,
     IBaseProps<IButton> {
   /**

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -41,8 +41,8 @@ export const ButtonView: IButtonComponent['view'] = props => {
       ref={buttonRef}
     >
       <Slots.stack horizontal as="span" tokens={{ childrenGap: 8 }} verticalAlign="center" horizontalAlign="center" verticalFill>
-        {icon && <Slots.icon />}
-        {content && <Slots.content />}
+        <Slots.icon />
+        <Slots.content />
         {children}
       </Slots.stack>
     </Slots.root>

--- a/packages/experiments/src/components/Button/CommandBarButton.tsx
+++ b/packages/experiments/src/components/Button/CommandBarButton.tsx
@@ -49,5 +49,5 @@ export const CommandBarButtonTokens: IButtonComponent['tokens'] = (props, theme)
 export const CommandBarButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return <Button content={text} icon={{ props: iconProps }} tokens={CommandBarButtonTokens} {...rest} />;
+  return <Button content={text} icon={iconProps} tokens={CommandBarButtonTokens} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/CompoundButton.tsx
+++ b/packages/experiments/src/components/Button/CompoundButton.tsx
@@ -103,9 +103,9 @@ export const CompoundButton: CompoundButtonType = props => {
 
   return (
     <Button
-      stack={{ props: { as: 'span', horizontal: false, horizontalAlign: 'start', tokens: stackTokens } }}
+      stack={{ as: 'span', horizontal: false, horizontalAlign: 'start', tokens: stackTokens }}
       content={text}
-      icon={{ props: iconProps }}
+      icon={iconProps}
       styles={CompoundButtonStyles}
       tokens={CompoundButtonTokens}
       {...rest}

--- a/packages/experiments/src/components/Button/DefaultButton.tsx
+++ b/packages/experiments/src/components/Button/DefaultButton.tsx
@@ -5,5 +5,5 @@ import { ButtonVariantsType } from './ButtonVariants.types';
 export const DefaultButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return <Button content={text} icon={{ props: iconProps }} {...rest} />;
+  return <Button content={text} icon={iconProps} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/IconButton.tsx
+++ b/packages/experiments/src/components/Button/IconButton.tsx
@@ -42,5 +42,5 @@ export const IconButtonTokens: IButtonComponent['tokens'] = (props, theme): IBut
 export const IconButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return <Button circular icon={{ props: iconProps }} tokens={IconButtonTokens} {...rest} />;
+  return <Button circular icon={iconProps} tokens={IconButtonTokens} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.test.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.test.tsx
@@ -6,18 +6,16 @@ import { MenuButton } from './MenuButton';
 import { IMenuButtonProps } from './MenuButton.types';
 
 const menuProps: IMenuButtonProps['menu'] = {
-  props: {
-    items: [
-      {
-        key: 'a',
-        name: 'Item a'
-      },
-      {
-        key: 'b',
-        name: 'Item b'
-      }
-    ]
-  }
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
 };
 
 describe('MenuButton view', () => {

--- a/packages/experiments/src/components/Button/MenuButton/examples/MenuButton.Example.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/examples/MenuButton.Example.tsx
@@ -3,18 +3,16 @@ import { MenuButton, IMenuButtonProps } from '@uifabric/experiments';
 import { Stack, Text } from 'office-ui-fabric-react';
 
 const menuProps: IMenuButtonProps['menu'] = {
-  props: {
-    items: [
-      {
-        key: 'a',
-        name: 'Item a'
-      },
-      {
-        key: 'b',
-        name: 'Item b'
-      }
-    ]
-  }
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
 };
 
 const tokens = {

--- a/packages/experiments/src/components/Button/MessageBarButton.tsx
+++ b/packages/experiments/src/components/Button/MessageBarButton.tsx
@@ -43,5 +43,5 @@ export const MessageBarButtonTokens: IButtonComponent['tokens'] = (props, theme)
 export const MessageBarButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return <Button content={text} icon={{ props: iconProps }} tokens={MessageBarButtonTokens} {...rest} />;
+  return <Button content={text} icon={iconProps} tokens={MessageBarButtonTokens} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/PrimaryButton.tsx
+++ b/packages/experiments/src/components/Button/PrimaryButton.tsx
@@ -5,5 +5,5 @@ import { ButtonVariantsType } from './ButtonVariants.types';
 export const PrimaryButton: ButtonVariantsType = props => {
   const { text, iconProps, ...rest } = props;
 
-  return <Button primary content={text} icon={{ props: iconProps }} {...rest} />;
+  return <Button primary content={text} icon={iconProps} {...rest} />;
 };

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.test.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.test.tsx
@@ -5,18 +5,16 @@ import { SplitButton } from './SplitButton';
 import { ISplitButtonProps } from './SplitButton.types';
 
 const menuProps: ISplitButtonProps['menu'] = {
-  props: {
-    items: [
-      {
-        key: 'a',
-        name: 'Item a'
-      },
-      {
-        key: 'b',
-        name: 'Item b'
-      }
-    ]
-  }
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
 };
 
 describe('SplitButton view', () => {

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -1,5 +1,5 @@
 import { IStackSlot } from 'office-ui-fabric-react';
-import { IComponent, IComponentStyles, IHTMLSlot, ISlotProp, IStyleableComponentProps } from '../../../Foundation';
+import { IComponent, IComponentStyles, IHTMLSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../../Foundation';
 import { IBaseProps } from '../../../Utilities';
 import {
   IMenuButtonProps,
@@ -44,7 +44,7 @@ export interface ISplitButton {
 }
 
 export interface ISplitButtonProps
-  extends ISplitButtonSlots,
+  extends ISlottableProps<ISplitButtonSlots>,
     Pick<IMenuButtonProps, 'href' | 'primary' | 'disabled' | 'onClick' | 'ariaLabel' | 'defaultExpanded' | 'expanded' | 'onKeyDown'>,
     IStyleableComponentProps<ISplitButtonProps, ISplitButtonTokens, ISplitButtonStyles>,
     IBaseProps<ISplitButton> {

--- a/packages/experiments/src/components/Button/SplitButton/examples/SplitButton.Example.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/examples/SplitButton.Example.tsx
@@ -3,18 +3,16 @@ import { SplitButton, ISplitButtonProps } from '@uifabric/experiments';
 import { Stack } from 'office-ui-fabric-react';
 
 const menuProps: ISplitButtonProps['menu'] = {
-  props: {
-    items: [
-      {
-        key: 'a',
-        name: 'Item a'
-      },
-      {
-        key: 'b',
-        name: 'Item b'
-      }
-    ]
-  }
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
 };
 
 const tokens = {

--- a/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -214,16 +214,16 @@ exports[`Button view renders a disabled primary Button with content correctly 1`
         border-color: GrayText;
         color: GrayText;
       }
-      &:hover .ms-Icon-57 {
+      &:hover .ms-Icon-60 {
         color: #a19f9d;
       }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-57 {
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-60 {
         color: GrayText;
       }
-      &:active .ms-Icon-57 {
+      &:active .ms-Icon-60 {
         color: #a19f9d;
       }
-      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-57 {
+      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-60 {
         color: GrayText;
       }
   disabled={true}
@@ -357,16 +357,16 @@ exports[`Button view renders a primary Button with content correctly 1`] = `
         border-color: Highlight;
         color: Window;
       }
-      &:hover .ms-Icon-55 {
+      &:hover .ms-Icon-57 {
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-55 {
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-57 {
         color: Window;
       }
-      &:active .ms-Icon-55 {
+      &:active .ms-Icon-57 {
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-55 {
+      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-57 {
         color: Window;
       }
   onClick={[Function]}

--- a/packages/experiments/src/components/Button/examples/Button.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Example.tsx
@@ -32,7 +32,7 @@ export class ButtonExample extends React.Component<{}, {}> {
         <Stack tokens={tokens.headingStack} padding={8}>
           <Stack tokens={tokens.buttonStack}>
             <ButtonStack>
-              <Button content="Default button" onClick={alertClicked} />
+              <Button content="Default button" onClick={alertClicked} slots={{ content: { render: () => <div>I'm new</div> } }} />
               <Button disabled content="Disabled default button" onClick={alertClicked} />
               <Button primary content="Primary button" onClick={alertClicked} />
               <Button primary disabled content="Disabled primary button" onClick={alertClicked} />
@@ -45,8 +45,8 @@ export class ButtonExample extends React.Component<{}, {}> {
             </ButtonStack>
             <ButtonStack>
               <Button icon="Upload" content="Button with string icon" />
-              <Button icon={{ props: { iconName: 'Share' } }} content="Button with iconProps" />
-              <Button icon={{ render: () => <Icon iconName="Download" /> }} content="Button with icon render function" />
+              <Button icon={{ iconName: 'Share' }} content="Button with iconProps" />
+              <Button content="Button with icon render function" slots={{ icon: { render: () => <Icon iconName="Download" /> } }} />
             </ButtonStack>
             <ButtonStack>
               <Button>

--- a/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { Stack, Text } from 'office-ui-fabric-react';
-import { IMenuButtonProps, ISplitButtonProps, MenuButton, SplitButton } from '@uifabric/experiments';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Text } from 'office-ui-fabric-react/lib/Text';
+import { IMenuButtonProps, MenuButton } from '@uifabric/experiments/lib/MenuButton';
+import { ISplitButtonProps, SplitButton } from '@uifabric/experiments/lib/SplitButton';
 
 export interface IRibbonMenuButtonProps extends IMenuButtonProps {
   vertical?: boolean;
@@ -11,18 +13,16 @@ export interface ISplitRibbonMenuButtonProps extends ISplitButtonProps {
 }
 
 const menuProps: ISplitButtonProps['menu'] = {
-  props: {
-    items: [
-      {
-        key: 'a',
-        name: 'Item a'
-      },
-      {
-        key: 'b',
-        name: 'Item b'
-      }
-    ]
-  }
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
 };
 
 const RibbonMenuButtonTokens = { backgroundColorHovered: '#C8C6C4', backgroundColorPressed: '#C8C6C4' };
@@ -54,7 +54,7 @@ export const RibbonMenuButton: React.SFC<IRibbonMenuButtonProps> = props => {
   const mergedProps: IMenuButtonProps = props.vertical
     ? {
         ...props,
-        stack: { props: { horizontal: false, tokens: { childrenGap: 0 }, verticalFill: true } },
+        stack: { horizontal: false, tokens: { childrenGap: 0 }, verticalFill: true },
         menuIcon: 'ChevronDownSmall',
         styles: RibbonMenuButtonVerticalStyles,
         tokens: RibbonMenuButtonVerticalTokens
@@ -89,7 +89,12 @@ const SplitMenuButtonVerticalStyles = {
   }
 };
 
-const SplitMenuButtonVerticalDivider: ISplitRibbonMenuButtonProps['splitDivider'] = { render: () => null };
+const SplitMenuButtonVerticalSlots: ISplitRibbonMenuButtonProps['slots'] = {
+  menuButton: {
+    component: RibbonMenuButton
+  },
+  splitDivider: { render: () => null }
+};
 
 export const RibbonSplitMenuButton: React.SFC<ISplitRibbonMenuButtonProps> = props => {
   const { content, vertical, ...rest } = props;
@@ -103,14 +108,11 @@ export const RibbonSplitMenuButton: React.SFC<ISplitRibbonMenuButtonProps> = pro
   const mergedProps: ISplitRibbonMenuButtonProps = vertical
     ? {
         ...rest,
-        root: { props: { horizontal: false, horizontalAlign: 'center' } },
-        menuButton: {
-          component: RibbonMenuButton,
-          props: verticalMenuButtonProps
-        },
-        splitDivider: SplitMenuButtonVerticalDivider,
+        root: { horizontal: false, horizontalAlign: 'center' },
+        menuButton: verticalMenuButtonProps,
         styles: SplitMenuButtonVerticalStyles,
-        tokens: SplitMenuButtonVerticalTokens
+        tokens: SplitMenuButtonVerticalTokens,
+        slots: SplitMenuButtonVerticalSlots
       }
     : { ...rest, content, tokens: RibbonMenuButtonTokens };
 

--- a/packages/experiments/src/components/Button/examples/Button.Styles.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Styles.Example.tsx
@@ -26,18 +26,16 @@ const tokens = {
 };
 
 const menuProps: IMenuButtonProps['menu'] = {
-  props: {
-    items: [
-      {
-        key: 'a',
-        name: 'Item a'
-      },
-      {
-        key: 'b',
-        name: 'Item b'
-      }
-    ]
-  }
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
 };
 
 const ButtonStack = (props: { children: JSX.Element[] | JSX.Element }) => (
@@ -58,25 +56,18 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
             <Stack tokens={tokens.buttonStack}>
               <ButtonStack>
                 <Button icon="PeopleAdd" content="Button Theme: Red Icon and Text" theme={testTheme} />
-                <Button icon="PeopleAdd" content={{ props: { children: 'Slot Theme: Purple Text', theme: testTheme } }} />
+                <Button icon="PeopleAdd" content={{ children: 'Slot Theme: Purple Text', theme: testTheme }} />
               </ButtonStack>
               <ButtonStack>
                 <Button icon="PeopleAdd" content="Button Styles Object: Red Text (root)" styles={{ root: { color: '#E20000' } }} />
                 <Button icon="PeopleAdd" content="Button Styles Object: Red Text (stack)" styles={{ stack: { color: '#E20000' } }} />
               </ButtonStack>
               <ButtonStack>
-                <Button
-                  icon="PeopleAdd"
-                  content="Stack Styles Object: Red Text"
-                  stack={{ props: { styles: { root: { color: '#E20000' } } } }}
-                />
+                <Button icon="PeopleAdd" content="Stack Styles Object: Red Text" stack={{ styles: { root: { color: '#E20000' } } }} />
               </ButtonStack>
               <ButtonStack>
                 <Button icon="PeopleAdd" content="Button Styles Object: Pink Icon" styles={{ icon: { color: 'pink ' } }} />
-                <Button
-                  icon={{ props: { iconName: 'PeopleAdd', styles: { root: { color: 'pink ' } } } }}
-                  content="Icon Styles Object: Pink Icon"
-                />
+                <Button icon={{ iconName: 'PeopleAdd', styles: { root: { color: 'pink ' } } }} content="Icon Styles Object: Pink Icon" />
               </ButtonStack>
               <ButtonStack>
                 <Button
@@ -97,10 +88,8 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
                 <Button
                   icon="PeopleAdd"
                   content={{
-                    props: {
-                      children: 'Content Styles Function: Golden Brown Text',
-                      styles: (props, theme) => ({ root: { color: '#8F6800' } })
-                    }
+                    children: 'Content Styles Function: Golden Brown Text',
+                    styles: (props, theme) => ({ root: { color: '#8F6800' } })
                   }}
                 />
               </ButtonStack>
@@ -108,21 +97,17 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
                 <Button
                   icon="PeopleAdd"
                   content={{
-                    props: {
-                      children: 'Content Styles Function: Red Text via Content Theme',
-                      styles: (props, theme) => ({ root: { color: theme.semanticColors.buttonText } }),
-                      theme: testTheme
-                    }
+                    children: 'Content Styles Function: Red Text via Content Theme',
+                    styles: (props, theme) => ({ root: { color: theme.semanticColors.buttonText } }),
+                    theme: testTheme
                   }}
                 />
               </ButtonStack>
               <ButtonStack>
                 <Button
                   icon={{
-                    props: {
-                      iconName: 'PeopleAdd',
-                      styles: props => ({ root: { color: '#8F6800' } })
-                    }
+                    iconName: 'PeopleAdd',
+                    styles: () => ({ root: { color: '#8F6800' } })
                   }}
                   content="Icon Styles Function: Golden Brown Icon"
                 />
@@ -130,11 +115,9 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
               <ButtonStack>
                 <Button
                   icon={{
-                    props: {
-                      iconName: 'PeopleAdd',
-                      styles: props => ({ root: { color: props.theme!.semanticColors.buttonText } }),
-                      theme: testTheme
-                    }
+                    iconName: 'PeopleAdd',
+                    styles: props => ({ root: { color: props.theme!.semanticColors.buttonText } }),
+                    theme: testTheme
                   }}
                   content="Icon Styles Function: Red Icon via Icon Theme"
                 />
@@ -144,18 +127,14 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
                 <Button
                   content="Icon Classname"
                   icon={{
-                    props: {
-                      iconName: 'PeopleAdd',
-                      className: 'icon-classname'
-                    }
+                    iconName: 'PeopleAdd',
+                    className: 'icon-classname'
                   }}
                 />
                 <Button
                   content={{
-                    props: {
-                      children: 'Content Classname',
-                      className: 'content-classname'
-                    }
+                    children: 'Content Classname',
+                    className: 'content-classname'
                   }}
                 />
                 <MenuButton
@@ -181,10 +160,8 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
                     }
                   }}
                   icon={{
-                    props: {
-                      iconName: 'PeopleAdd',
-                      className: testClassName
-                    }
+                    iconName: 'PeopleAdd',
+                    className: testClassName
                   }}
                 />
               </ButtonStack>
@@ -192,20 +169,16 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
                 <Button
                   icon="PeopleAdd"
                   content={{
-                    props: {
-                      children: 'Text ClassName: Blue Text',
-                      className: testClassName
-                    }
+                    children: 'Text ClassName: Blue Text',
+                    className: testClassName
                   }}
                 />
                 <Button
                   icon="PeopleAdd"
                   content={{
-                    props: {
-                      children: 'Text Styles Overrides ClassName: Red Text',
-                      styles: { root: { color: '#E20000' } },
-                      className: testClassName
-                    }
+                    children: 'Text Styles Overrides ClassName: Red Text',
+                    styles: { root: { color: '#E20000' } },
+                    className: testClassName
                   }}
                 />
               </ButtonStack>
@@ -213,20 +186,16 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
                 <Button
                   content="Icon ClassName: Blue Icon"
                   icon={{
-                    props: {
-                      iconName: 'PeopleAdd',
-                      className: testClassName
-                    }
+                    iconName: 'PeopleAdd',
+                    className: testClassName
                   }}
                 />
                 <Button
                   content="Icon Styles Overrides ClassName: Red Icon"
                   icon={{
-                    props: {
-                      iconName: 'PeopleAdd',
-                      styles: { root: { color: '#E20000' } },
-                      className: testClassName
-                    }
+                    iconName: 'PeopleAdd',
+                    styles: { root: { color: '#E20000' } },
+                    className: testClassName
                   }}
                 />
               </ButtonStack>

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IComponent, IComponentStyles, IHTMLSlot, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLSlot, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
 import { IBaseProps, IRefObject } from '../../Utilities';
 import { ICollapsibleSectionTitleSlot } from './CollapsibleSectionTitle.types';
 
@@ -25,7 +25,7 @@ export interface ICollapsibleSectionSlots {
 export interface ICollapsibleSection {}
 
 export interface ICollapsibleSectionProps
-  extends ICollapsibleSectionSlots,
+  extends ISlottableProps<ICollapsibleSectionSlots>,
     IStyleableComponentProps<ICollapsibleSectionViewProps, ICollapsibleSectionStyles, ICollapsibleSectionTokens>,
     IBaseProps<ICollapsibleSection> {
   /**

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -1,5 +1,5 @@
 import { IRefObject } from '../../Utilities';
-import { IComponent, IComponentStyles, IHTMLElementSlot, ISlotProp, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLElementSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
 import { ITextSlot } from 'office-ui-fabric-react';
 import { IIconSlot } from '../../utilities/factoryComponents.types';
 
@@ -25,7 +25,7 @@ export interface ICollapsibleSectionTitleSlots {
 }
 
 export interface ICollapsibleSectionTitleProps
-  extends ICollapsibleSectionTitleSlots,
+  extends ISlottableProps<ICollapsibleSectionTitleSlots>,
     IStyleableComponentProps<ICollapsibleSectionTitleProps, ICollapsibleSectionTitleTokens, ICollapsibleSectionTitleStyles>,
     React.ButtonHTMLAttributes<HTMLButtonElement> {
   focusElementRef?: IRefObject<HTMLButtonElement>;

--- a/packages/experiments/src/components/CollapsibleSection/examples/CollapsibleSection.Controlled.Example.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/examples/CollapsibleSection.Controlled.Example.tsx
@@ -40,11 +40,9 @@ export class CollapsibleSectionControlledExample extends React.Component<{}, ICo
           <CollapsibleSection
             collapsed={this.state.collapsed}
             title={{
-              props: {
-                text: `Title 1`,
-                onClick: () => {
-                  this.setState((state: ICollapsibleSectionControlledExampleState) => ({ clicks: state.clicks + 1 }));
-                }
+              text: `Title 1`,
+              onClick: () => {
+                this.setState((state: ICollapsibleSectionControlledExampleState) => ({ clicks: state.clicks + 1 }));
               }
             }}
           >
@@ -53,11 +51,9 @@ export class CollapsibleSectionControlledExample extends React.Component<{}, ICo
           <CollapsibleSection
             collapsed={this.state.collapsed}
             title={{
-              props: {
-                text: `Title 2`,
-                onClick: () => {
-                  this.setState((state: ICollapsibleSectionControlledExampleState) => ({ clicks: state.clicks + 1 }));
-                }
+              text: `Title 2`,
+              onClick: () => {
+                this.setState((state: ICollapsibleSectionControlledExampleState) => ({ clicks: state.clicks + 1 }));
               }
             }}
           >

--- a/packages/experiments/src/components/CollapsibleSection/examples/CollapsibleSection.Slots.Example.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/examples/CollapsibleSection.Slots.Example.tsx
@@ -2,23 +2,27 @@ import * as React from 'react';
 import { Icon, Stack, TooltipHost } from 'office-ui-fabric-react';
 import { CollapsibleSection, CollapsibleSectionTitle, ICollapsibleSectionTitleProps } from '@uifabric/experiments/lib/CollapsibleSection';
 
+// TODO: convert this example to use extendComponent
+
 // This is our customized component making use of default CollapsibleSectionTitle while using slots
 // to add the tooltip and icon. This would also have to be modified to add a prop for tooltip content (not done here)
 const CustomizedCollapsibleSectionTitle: React.FunctionComponent<ICollapsibleSectionTitleProps> = props => {
-  const titleText: ICollapsibleSectionTitleProps['text'] = {
-    render: (renderProps, DefaultComponent) => (
-      // Supplement the default title content with an icon. Wrap in a Stack for proper placement.
-      <Stack grow horizontal horizontalAlign="space-between">
-        <DefaultComponent {...renderProps}>{props.text}</DefaultComponent>
-        <Icon iconName="warning" styles={{ root: { color: 'red' } }} />
-      </Stack>
-    )
+  const titleText: ICollapsibleSectionTitleProps['slots'] = {
+    text: {
+      render: (renderProps, DefaultComponent) => (
+        // Supplement the default title text with an icon. Wrap in a Stack for proper placement.
+        <Stack grow horizontal horizontalAlign="space-between">
+          <DefaultComponent {...renderProps}>{props.text}</DefaultComponent>
+          <Icon iconName="warning" styles={{ root: { color: 'red' } }} />
+        </Stack>
+      )
+    }
   };
 
   // Wrap the entire title in a Tooltip
   return (
     <TooltipHost content="This is the tooltip">
-      <CollapsibleSectionTitle {...props} text={titleText} />
+      <CollapsibleSectionTitle {...props} slots={titleText} />
     </TooltipHost>
   );
 };
@@ -32,7 +36,12 @@ export class CollapsibleSectionSlotsExample extends React.Component<{}, {}> {
           <CollapsibleSection
             key={1}
             defaultCollapsed={true}
-            title={{ props: { text: 'Shorthand Title Text' }, component: CustomizedCollapsibleSectionTitle }}
+            title="Shorthand Title Text"
+            slots={{
+              title: {
+                component: CustomizedCollapsibleSectionTitle
+              }
+            }}
           >
             Content 1
           </CollapsibleSection>

--- a/packages/experiments/src/components/CollapsibleSection/examples/CollapsibleSection.Styled.Example.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/examples/CollapsibleSection.Styled.Example.tsx
@@ -81,10 +81,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
             key={2}
             defaultCollapsed={false}
             title={{
-              props: {
-                text: 'Prop Styles',
-                styles: getPropTitleStyles
-              }
+              text: 'Prop Styles',
+              styles: getPropTitleStyles
             }}
             styles={getPropStyles}
           >
@@ -101,10 +99,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
               key={3}
               defaultCollapsed={false}
               title={{
-                props: {
-                  text: 'Prop Styles + Customizer Styles',
-                  styles: getPropTitleStyles
-                }
+                text: 'Prop Styles + Customizer Styles',
+                styles: getPropTitleStyles
               }}
               styles={getPropStyles}
             >
@@ -117,10 +113,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
               key={4}
               defaultCollapsed={false}
               title={{
-                props: {
-                  text: 'Prop Styles + Customizer Theme',
-                  styles: getPropTitleStyles
-                }
+                text: 'Prop Styles + Customizer Theme',
+                styles: getPropTitleStyles
               }}
               styles={getPropStyles}
             >
@@ -132,10 +126,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
             key={5}
             defaultCollapsed={false}
             title={{
-              props: {
-                text: 'Prop Styles + Prop Theme',
-                styles: getPropTitleStyles
-              }
+              text: 'Prop Styles + Prop Theme',
+              styles: getPropTitleStyles
             }}
             styles={getPropStyles}
             theme={csPropTheme}
@@ -148,10 +140,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
               key={6}
               defaultCollapsed={false}
               title={{
-                props: {
-                  text: 'Prop Styles + Customizer Theme + Prop Theme',
-                  styles: getPropTitleStyles
-                }
+                text: 'Prop Styles + Customizer Theme + Prop Theme',
+                styles: getPropTitleStyles
               }}
               styles={getPropStyles}
               theme={csPropTheme}
@@ -170,10 +160,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
             key={8}
             collapsed={false}
             title={{
-              props: {
-                text: 'Prop Styles',
-                styles: getPropTitleStyles
-              }
+              text: 'Prop Styles',
+              styles: getPropTitleStyles
             }}
             styles={getPropStyles}
           >
@@ -190,10 +178,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
               key={9}
               collapsed={false}
               title={{
-                props: {
-                  text: 'Prop Styles + Customizer Styles',
-                  styles: getPropTitleStyles
-                }
+                text: 'Prop Styles + Customizer Styles',
+                styles: getPropTitleStyles
               }}
               styles={getPropStyles}
             >
@@ -206,10 +192,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
               key={10}
               collapsed={false}
               title={{
-                props: {
-                  text: 'Prop Styles + Customizer Theme',
-                  styles: getPropTitleStyles
-                }
+                text: 'Prop Styles + Customizer Theme',
+                styles: getPropTitleStyles
               }}
               styles={getPropStyles}
             >
@@ -221,10 +205,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
             key={11}
             collapsed={false}
             title={{
-              props: {
-                text: 'Prop Styles + Prop Theme',
-                styles: getPropTitleStyles
-              }
+              text: 'Prop Styles + Prop Theme',
+              styles: getPropTitleStyles
             }}
             styles={getPropStyles}
             theme={csPropTheme}
@@ -237,10 +219,8 @@ export class CollapsibleSectionStyledExample extends React.Component<{}, {}> {
               key={12}
               collapsed={false}
               title={{
-                props: {
-                  text: 'Prop Styles + Customizer Theme + Prop Theme',
-                  styles: getPropTitleStyles
-                }
+                text: 'Prop Styles + Customizer Theme + Prop Theme',
+                styles: getPropTitleStyles
               }}
               styles={getPropStyles}
               theme={csPropTheme}

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.test.tsx
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.test.tsx
@@ -46,7 +46,7 @@ describe('VerticalPersona', () => {
           text="James Bond"
           secondaryText="Super secret agent"
           styles={testVerticalPersonaStyles}
-          coin={{ props: { initials: 'MI6', coinColor: 'red' } }}
+          coin={{ initials: 'MI6', coinColor: 'red' }}
         />
       )
       .toJSON();

--- a/packages/experiments/src/components/Persona/examples/VerticalPersona.Example.tsx
+++ b/packages/experiments/src/components/Persona/examples/VerticalPersona.Example.tsx
@@ -34,22 +34,22 @@ export class VerticalPersonaExample extends React.Component<{}, {}> {
               <Persona
                 vertical
                 text="Hubert Blaine Wolfeschlegelsteinhausenbergerdorff Sr."
-                coin={{ props: { imageUrl: PersonaTestImages.personMale } }}
+                coin={{ imageUrl: PersonaTestImages.personMale }}
               />
               <Persona
                 vertical
                 text="Christian Duncan Claude Sandra Alvin Matilde Eriksson"
                 secondaryText="Director of global strategy management for the entire worldwide organization"
-                coin={{ props: { imageUrl: PersonaTestImages.personMale } }}
+                coin={{ imageUrl: PersonaTestImages.personMale }}
               />
             </VerticalPersonaStack>
           </Stack>
           <Stack tokens={tokens.personaCoinStack}>
             <Text>When passing coinProps</Text>
             <VerticalPersonaStack>
-              <Persona vertical text="Eline Page" secondaryText="eSports commentator" coin={{ props: { presence: 4 } }} />
-              <Persona vertical text="赵丽颖" coin={{ props: { imageUrl: PersonaTestImages.personFemale } }} />
-              <Persona vertical text="Kevin Jameson" coin={{ props: { imageUrl: PersonaTestImages.personMale } }} />
+              <Persona vertical text="Eline Page" secondaryText="eSports commentator" coin={{ presence: 4 }} />
+              <Persona vertical text="赵丽颖" coin={{ imageUrl: PersonaTestImages.personFemale }} />
+              <Persona vertical text="Kevin Jameson" coin={{ imageUrl: PersonaTestImages.personMale }} />
             </VerticalPersonaStack>
           </Stack>
           <Stack tokens={tokens.personaCoinStack}>

--- a/packages/experiments/src/components/Toggle/Toggle.types.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IComponent, IComponentStyles, IHTMLElementSlot, IHTMLSlot, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, IHTMLElementSlot, IHTMLSlot, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
 import { IKeytipProps } from 'office-ui-fabric-react/lib/Keytip';
 import { IBaseProps, IComponentAs } from '../../Utilities';
 import { IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';
@@ -50,7 +50,7 @@ export interface IToggle {
 }
 
 export interface IToggleProps
-  extends IToggleSlots,
+  extends ISlottableProps<IToggleSlots>,
     IStyleableComponentProps<IToggleViewProps, IToggleTokens, IToggleStyles>,
     IBaseProps<IToggle> {
   /**

--- a/packages/experiments/src/components/Toggle/examples/Toggle.Example.tsx
+++ b/packages/experiments/src/components/Toggle/examples/Toggle.Example.tsx
@@ -28,8 +28,10 @@ export class ToggleExample extends React.Component<{}, IToggleExampleState> {
           defaultChecked={true}
           label="Custom On/Off render functions"
           onChange={this._onCustomRenderChange}
-          text={{
-            render: props => <Label {...props}>{checked ? <Spinner /> : 'Spinner Off'}</Label>
+          slots={{
+            text: {
+              render: props => <Label {...props}>{checked ? <Spinner /> : 'Spinner Off'}</Label>
+            }
           }}
         />
       </div>

--- a/packages/experiments/src/slots/examples/Slots.Async.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Async.Example.tsx
@@ -36,12 +36,7 @@ const titleTextStyles: ICollapsibleSectionTitleProps['styles'] = (props, theme):
   ]
 });
 
-// TODO: is there any way to do lookup types here? like:
-// const titleTextRender: ICollapsibleSectionTitleProps['text']['render'] = {
-// which fails since 'render' may not exist due to union.
-// A helper version of this?
-// const titleTextRender: Exclude<ICollapsibleSectionTitleProps['text'], string | undefined>['render'] = (props, DefaultComponent) => (
-
+// TODO: use extendsComponent to create variants and clean up these examples
 const titleTextRender: ISlotRender<ITextProps> = (props, DefaultComponent) => (
   <AsyncData
     data="done"
@@ -50,7 +45,7 @@ const titleTextRender: ISlotRender<ITextProps> = (props, DefaultComponent) => (
   />
 );
 
-const bodyRender: ISlotRender<IHTMLSlot['props']> = (props, DefaultComponent) => (
+const bodyRender: ISlotRender<IHTMLSlot> = (props, DefaultComponent) => (
   <AsyncData
     data="done"
     // tslint:disable-next-line:jsx-no-lambda
@@ -72,15 +67,19 @@ export class SlotsAsyncExample extends React.Component<{}, {}> {
           key={1}
           defaultCollapsed={true}
           title={{
-            props: {
-              styles: titleTextStyles,
+            styles: titleTextStyles,
+            text: { children: 'Title Text' },
+            slots: {
               text: {
-                props: { children: 'Title Text' },
                 render: titleTextRender
               }
             }
           }}
-          body={{ render: bodyRender }}
+          slots={{
+            body: {
+              render: bodyRender
+            }
+          }}
         >
           Data loaded
         </CollapsibleSection>

--- a/packages/experiments/src/slots/examples/Slots.Content.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Content.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@uifabric/experiments';
-import { Spinner, Stack, Text } from 'office-ui-fabric-react';
+import { Spinner, Stack } from 'office-ui-fabric-react';
 import { stackProps } from './SlotExampleUtils';
 
 // tslint:disable:jsx-no-lambda
@@ -9,28 +9,31 @@ export class SlotsContentExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack {...stackProps}>
-        <Button content={{ props: { children: 1 } }}>
+        <Button content={{ children: 1 }}>
           <p>Content: Integer</p>
         </Button>
         <Button content="Content: String" />
-        <Button content={{ props: { weight: 'bold', children: 'Content: Props, weight: bold' } }} />
-        <Button content={{ render: () => <Spinner /> }}>
+        <Button content={{ weight: 'bold', children: 'Content: Props, weight: bold' }} />
+        <Button slots={{ content: { render: () => <Spinner /> } }}>
           <p>Content: Function, Spinner</p>
         </Button>
         <Button
-          content={{
-            render: (contentProps, DefaultComponent) => (
-              <b>
-                Wrapper Content Text: <DefaultComponent {...contentProps}>TextType</DefaultComponent>
-              </b>
-            )
+          slots={{
+            content: {
+              render: (contentProps, DefaultComponent) => (
+                <b>
+                  Wrapper Content Text: <DefaultComponent {...contentProps}>TextType</DefaultComponent>
+                </b>
+              )
+            }
           }}
         >
           <p>Content: Function, Text + ContentType</p>
         </Button>
-        <Button content={{ props: { children: 'Content: Child String' } }} />
-        <Button content={{ props: { children: ['Content: Child 1,', ' Child 2'] } }} />
-        <Button content={<Text>Content: JSX Element</Text>} />
+        <Button content={{ children: 'Content: Child String' }} />
+        <Button content={{ children: ['Content: Child 1,', ' Child 2'] }} />
+        {/* // TODO: add 'element' option with JSX? */}
+        {/* <Button content={<Text>Content: JSX Element</Text>} /> */}
         <Button content="Content: With Children">
           <p>Button Child 1</p>
           <p>Button Child 2</p>

--- a/packages/experiments/src/slots/examples/Slots.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Example.tsx
@@ -10,19 +10,24 @@ export class SlotsExample extends React.Component<{}, {}> {
       <Stack {...stackProps} maxWidth={400}>
         <Button
           // Render function usage, wrapping default content
-          root={{
-            render: (rootProps, DefaultComponent) => (
-              <TooltipHost content="This is the tooltip">
-                <DefaultComponent {...rootProps} />
-              </TooltipHost>
-            )
+          slots={{
+            root: {
+              render: (rootProps, DefaultComponent) => (
+                <TooltipHost content="This is the tooltip">
+                  <DefaultComponent {...rootProps} />
+                </TooltipHost>
+              )
+            },
+            content: {
+              // TODO: add 'element' option with JSX?
+              // element: <Spinner />
+              component: Spinner as any
+            }
           }}
           // Subcomponent props usage
-          stack={{ props: { styles: { root: { background: 'lightblue' } } } }}
+          stack={{ styles: { root: { background: 'lightblue' } } }}
           // Shorthand prop usage
           icon="share"
-          // JSX usage
-          content={<Spinner />}
         >
           Just a button with a spinner as its content.
         </Button>

--- a/packages/experiments/src/slots/examples/Slots.Icon.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Icon.Example.tsx
@@ -8,19 +8,21 @@ export class SlotsIconExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack {...stackProps}>
-        <Button icon="share" content="Icon: String" />
-        <Button icon={{ props: { iconName: 'share' } }} content="Icon: Props, iconName: 'share'" />
+        <Button icon={{ iconName: 'share' }} content="Icon: Props, iconName: 'share'" />
         <Button
-          icon={{
-            render: (iconProps, DefaultComponent) => (
-              <b>
-                Icon: <DefaultComponent {...iconProps} iconName="upload" />
-              </b>
-            )
+          icon="upload"
+          slots={{
+            icon: {
+              render: (iconProps, DefaultComponent) => (
+                <b>
+                  Icon: <DefaultComponent {...iconProps} />
+                </b>
+              )
+            }
           }}
           content="Icon: Function, Text + Icon"
         />
-        <Button icon={{ render: () => <Spinner /> }} content="Icon: Function, Spinner" />
+        <Button slots={{ icon: { render: () => <Spinner /> } }} content="Icon: Function, Spinner" />
       </Stack>
     );
   }

--- a/packages/experiments/src/slots/examples/Slots.Icon.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Icon.Example.tsx
@@ -8,6 +8,7 @@ export class SlotsIconExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack {...stackProps}>
+        <Button icon="share" content="Icon: String" />
         <Button icon={{ iconName: 'share' }} content="Icon: Props, iconName: 'share'" />
         <Button
           icon="upload"

--- a/packages/experiments/src/slots/examples/Slots.Root.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Root.Example.tsx
@@ -11,8 +11,8 @@ export class SlotsRootExample extends React.Component<{}, {}> {
         <Button icon="share" href="https://developer.microsoft.com/en-us/fabric" content="Root: Implicit 'a' via href prop" />
         <Button
           icon="share"
-          root={{ render: (rootProps, DefaultComponent) => <DefaultComponent {...rootProps} /> }}
           content="Root: Function"
+          slots={{ root: { render: (rootProps, DefaultComponent) => <DefaultComponent {...rootProps} /> } }}
         />
       </Stack>
     );

--- a/packages/experiments/src/slots/examples/Slots.Stack.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Stack.Example.tsx
@@ -19,21 +19,21 @@ export class SlotsStackExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack {...stackProps}>
-        <Button icon="share" content="Stack: Props, as: 'AsComponent'" stack={{ props: { as: AsComponent } }} />
-        <Button icon="share" content="Stack: Props, as: 'AsComponentSFC'" stack={{ props: { as: AsComponentSFC } }} />
-        <Button icon="share" content="Stack: Props, as: 'div'" stack={{ props: { as: 'div' } }} />
-        <Button icon="share" content="Stack: Props, as: 'span'" stack={{ props: { as: 'span' } }} />
-        <Button icon="share" stack={{ props: { horizontalAlign: 'start' } }} content="Stack: Object, horizontalAlign: left" />
+        <Button icon="share" content="Stack: Props, as: 'AsComponent'" stack={{ as: AsComponent }} />
+        <Button icon="share" content="Stack: Props, as: 'AsComponentSFC'" stack={{ as: AsComponentSFC }} />
+        <Button icon="share" content="Stack: Props, as: 'div'" stack={{ as: 'div' }} />
+        <Button icon="share" content="Stack: Props, as: 'span'" stack={{ as: 'span' }} />
+        <Button icon="share" stack={{ horizontalAlign: 'start' }} content="Stack: Object, horizontalAlign: left" />
         <Button
           icon="share"
-          stack={{ render: (props, DefaultComponent) => <DefaultComponent {...props} /> }}
           content="Stack: Render Function"
+          slots={{ stack: { render: (props, DefaultComponent) => <DefaultComponent {...props} /> } }}
         />
         <Button
           icon="share"
           content="Stack: Function, VerticalStack"
           // Have to override component's default horizontal prop value
-          stack={{ render: props => <Stack {...props as any} horizontal={false} /> }}
+          slots={{ stack: { render: props => <Stack {...props as any} horizontal={false} /> } }}
         />
       </Stack>
     );

--- a/packages/experiments/src/slots/examples/Slots.Styled.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Styled.Example.tsx
@@ -43,19 +43,9 @@ export class SlotsStyledExample extends React.Component<{}, {}> {
     return (
       <Stack>
         <Stack {...stackProps}>
-          <Button
-            icon={{ props: { iconName: 'share', styles: ButtonTheme.scopedSettings.Icon.styles } }}
-            content="Icon as IIconProps with styles"
-          />
-          <Button
-            icon="share"
-            content={{ props: { children: 'Text as ITextProps with styles', styles: ButtonTheme.scopedSettings.Text.styles } }}
-          />
-          <Button
-            icon={{ props: { iconName: 'share', styles: { root: { color: 'red' } } } }}
-            styles={getButtonStyles}
-            content="Button styles prop"
-          />
+          <Button icon={{ iconName: 'share', styles: ButtonTheme.scopedSettings.Icon.styles }} content="Icon as IIconProps with styles" />
+          <Button icon="share" content={{ children: 'Text as ITextProps with styles', styles: ButtonTheme.scopedSettings.Text.styles }} />
+          <Button icon={{ iconName: 'share', styles: { root: { color: 'red' } } }} styles={getButtonStyles} content="Button styles prop" />
           <Customizer {...ButtonTheme}>
             <Button icon="share" content="Button scopedSettings" />
           </Customizer>

--- a/packages/foundation/etc/foundation.api.md
+++ b/packages/foundation/etc/foundation.api.md
@@ -26,7 +26,7 @@ export type ExtractProps<TUnion> = TUnion extends ISlotProp<infer TProps> ? TPro
 export type ExtractShorthand<TUnion> = TUnion extends boolean ? boolean : TUnion extends number ? number : TUnion extends string ? string : never;
 
 // @public
-export function getSlots<TComponentProps extends TComponentSlots, TComponentSlots extends ISlotProps<TComponentSlots>>(userProps: TComponentProps, slots: ISlotDefinition<Required<TComponentSlots>>): ISlots<Required<TComponentSlots>>;
+export function getSlots<TComponentProps extends ISlottableProps<TComponentSlots>, TComponentSlots>(userProps: TComponentProps, slots: ISlotDefinition<Required<TComponentSlots>>): ISlots<Required<TComponentSlots>>;
 
 // @public
 export interface IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
@@ -98,25 +98,18 @@ export type ISlotDefinition<TSlots> = {
 };
 
 // @public
-export type ISlotFactory<TProps extends ValidProps, TShorthandProp extends ValidShorthand> = (componentProps: TProps & IProcessedSlotProps, userProps: ISlotProp<TProps, TShorthandProp>, defaultStyles: IStyle) => ReturnType<React.FunctionComponent<TProps>>;
+export type ISlotFactory<TProps extends ValidProps, TShorthandProp extends ValidShorthand> = (componentProps: TProps & IProcessedSlotProps, userProps: ISlotProp<TProps, TShorthandProp>, slotOptions: ISlotOptions<TProps> | undefined, defaultStyles: IStyle) => ReturnType<React.FunctionComponent<TProps>>;
 
 // @public
 export interface ISlotOptions<TProps> {
     // (undocumented)
     component?: React.ReactType<TProps>;
     // (undocumented)
-    props?: TProps;
-    // (undocumented)
     render?: ISlotRender<TProps>;
 }
 
 // @public
-export type ISlotProp<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never> = TShorthandProp | ISlotOptions<TProps>;
-
-// @public
-export type ISlotProps<TSlots> = {
-    [key in keyof TSlots]: ISlotProp<ExtractProps<TSlots[key]>, ExtractShorthand<TSlots[key]>>;
-};
+export type ISlotProp<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never> = TShorthandProp | TProps;
 
 // @public
 export type ISlotRender<TProps> = (props: IPropsWithChildren<TProps>, defaultComponent: React.ComponentType<TProps>) => ReturnType<React.FunctionComponent<TProps>>;
@@ -128,6 +121,13 @@ export type ISlots<TSlots> = {
 
 // @public
 export type ISlottableComponentType<TProps extends ValidProps, TShorthandProp extends ValidShorthand> = React.ComponentType<TProps> & ISlotCreator<TProps, TShorthandProp>;
+
+// @public
+export type ISlottableProps<TSlots> = TSlots & {
+    slots?: {
+        [key in keyof TSlots]+?: ISlotOptions<ExtractProps<TSlots[key]>>;
+    };
+};
 
 // @public
 export type ISlottableReactType<TProps extends ValidProps, TShorthandProp extends ValidShorthand> = React.ReactType<TProps> & ISlotCreator<TProps, TShorthandProp>;

--- a/packages/foundation/src/ISlots.ts
+++ b/packages/foundation/src/ISlots.ts
@@ -46,6 +46,7 @@ export interface ISlot<TProps> {
 export type ISlotFactory<TProps extends ValidProps, TShorthandProp extends ValidShorthand> = (
   componentProps: TProps & IProcessedSlotProps,
   userProps: ISlotProp<TProps, TShorthandProp>,
+  slotOptions: ISlotOptions<TProps> | undefined,
   defaultStyles: IStyle
 ) => ReturnType<React.FunctionComponent<TProps>>;
 
@@ -84,9 +85,11 @@ export type ExtractShorthand<TUnion> = TUnion extends boolean
 export type ISlots<TSlots> = { [slot in keyof TSlots]: ISlot<ExtractProps<TSlots[slot]>> };
 
 /**
- * Defines component slots props interface. Requires each slot prop to point to an ISlotProp value.
+ * Automatically defines 'slots' prop based on TSlots props.
  */
-export type ISlotProps<TSlots> = { [key in keyof TSlots]: ISlotProp<ExtractProps<TSlots[key]>, ExtractShorthand<TSlots[key]>> };
+export type ISlottableProps<TSlots> = TSlots & {
+  slots?: { [key in keyof TSlots]+?: ISlotOptions<ExtractProps<TSlots[key]>> };
+};
 
 /**
  * Defines user properties that are automatically applied by Slot utilities using slot name.
@@ -100,21 +103,16 @@ export interface IDefaultSlotProps<TSlots> {
  */
 // TODO: Constrain TProps more clearly (notably also exclude Functions) once this TS PR is merged:
 // https://github.com/Microsoft/TypeScript/pull/29317
-export type ISlotProp<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never> = TShorthandProp | ISlotOptions<TProps>;
+export type ISlotProp<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never> = TShorthandProp | TProps;
 
 /**
  * Defines the slot options object for all slot props:
- *    1. TProps object
- *    2. ISlotRender function.
- *    3. React component with TProps interface.
+ *    1. ISlotRender function.
+ *    2. React component with TProps interface.
  */
 
 // TODO: create mutually exclusive type for component & render, but only if it's a readable error for users.
 export interface ISlotOptions<TProps> {
-  // TODO: Really want this to work but it completely breaks TS's ability to infer TProps.
-  //       Infer ends up resolving to {} | TProps, which allows anything. May be a TS bug that should be isolated.
-  // props?: TProps | TShorthandProp;
-  props?: TProps;
   component?: React.ReactType<TProps>;
   render?: ISlotRender<TProps>;
 }

--- a/packages/foundation/src/slots.test.tsx
+++ b/packages/foundation/src/slots.test.tsx
@@ -3,13 +3,22 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { withSlots, createFactory, getSlots } from './slots';
 import { IHTMLElementSlot, IHTMLSlot } from './IHTMLSlots';
-import { ExtractProps, ExtractShorthand, IProcessedSlotProps, ISlot, ISlotDefinition, ISlotProp } from './ISlots';
+import {
+  ExtractProps,
+  ExtractShorthand,
+  IProcessedSlotProps,
+  ISlot,
+  ISlotDefinition,
+  ISlotOptions,
+  ISlotProp,
+  ISlottableProps,
+  ISlotRender
+} from './ISlots';
 
 describe('typings', () => {
   type ITestProps = { testProp?: number };
   const TestProps = { testProp: 42 };
-  const TestOptions = { props: TestProps };
-  const TestRender = (props: ITestProps, defaultComponent: React.ComponentType<ITestProps>) => null;
+  const TestRender: ISlotRender<ITestProps> = (props: ITestProps, defaultComponent: React.ComponentType<ITestProps>) => null;
   const TestComponent: React.FunctionComponent<ITestProps> = () => null;
 
   it('do not generate TS compile errors on getSlots usage', () => {
@@ -20,7 +29,7 @@ describe('typings', () => {
       testSlotNoShorthand?: ISlotProp<ITestProps>;
     }
 
-    interface IComponentProps extends IComponentSlots {
+    interface IComponentProps extends ISlottableProps<IComponentSlots> {
       someProp?: number;
     }
 
@@ -36,50 +45,64 @@ describe('typings', () => {
   });
 
   it('do not generate TS compile error on valid ISlotProp assignments', () => {
-    const p00: ISlotProp<ITestProps> = TestOptions;
-    const p01: ISlotProp<ITestProps, string> = TestOptions;
-    const p02: ISlotProp<ITestProps, number> = TestOptions;
-    const p03: ISlotProp<ITestProps, boolean> = TestOptions;
+    const p00: ISlotProp<ITestProps> = TestProps;
+    const p01: ISlotProp<ITestProps, string> = TestProps;
+    const p02: ISlotProp<ITestProps, number> = TestProps;
+    const p03: ISlotProp<ITestProps, boolean> = TestProps;
     const p10: ISlotProp<ITestProps> = {};
     const p11: ISlotProp<ITestProps, string> = {};
     const p12: ISlotProp<ITestProps, number> = {};
     const p13: ISlotProp<ITestProps, boolean> = {};
-    const p20: ISlotProp<ITestProps> = { component: TestComponent };
-    const p21: ISlotProp<ITestProps, string> = { component: TestComponent };
-    const p22: ISlotProp<ITestProps, number> = { component: TestComponent };
-    const p23: ISlotProp<ITestProps, boolean> = { component: TestComponent };
-    const p30: ISlotProp<ITestProps> = { render: TestRender };
-    const p31: ISlotProp<ITestProps, string> = { render: TestRender };
-    const p32: ISlotProp<ITestProps, number> = { render: TestRender };
-    const p33: ISlotProp<ITestProps, boolean> = { render: TestRender };
-    const p40: ISlotProp<ITestProps, string> = 'test';
-    const p41: ISlotProp<ITestProps, number> = 42;
-    const p42: ISlotProp<ITestProps, boolean> = false;
+    const p20: ISlotProp<ITestProps, string> = 'test';
+    const p21: ISlotProp<ITestProps, number> = 42;
+    const p22: ISlotProp<ITestProps, boolean> = false;
 
     // TODO: it'd be great to use ts-ignore to only ignore unused variables, but that's not currently possible:
     // https://github.com/Microsoft/TypeScript/issues/19139
     // Until then, pretend they're used:
-    const [] = [p00, p01, p02, p03, p10, p11, p12, p13, p20, p21, p22, p23, p30, p31, p32, p33, p40, p41, p42];
+    const [] = [p00, p01, p02, p03, p10, p11, p12, p13, p20, p21, p22];
   });
 
-  it('do not generate TS compile error on valid IHTMLSlot assignments', () => {
-    // IHTMLSlot should accept both generic and specialized elements.
-    let tHtml: IHTMLSlot = { component: 'b' };
-    tHtml = { component: 'div' };
-    tHtml = { component: 'button' };
-
-    // IHTMLElementSlot should accept its specified element and elements sharing the same shared subset of its attributes.
-    let tDiv: IHTMLElementSlot<'div'> = { component: 'div' };
-    tDiv = { component: 'b' };
-
-    let tButton: IHTMLElementSlot<'button'> = { component: 'button' };
-    tButton = { component: 'b' };
+  it('do not generate TS compile error on valid ISlotOption assignments', () => {
+    // TODO: assigning TestRender to component and TestComponent to render does not cause errors. why? because context is any?
+    const p00: ISlotOptions<ITestProps> = {};
+    const p01: ISlotOptions<ITestProps> = {};
+    const p02: ISlotOptions<ITestProps> = {};
+    const p03: ISlotOptions<ITestProps> = {};
+    const p10: ISlotOptions<ITestProps> = { component: TestComponent };
+    const p11: ISlotOptions<ITestProps> = { component: TestComponent };
+    const p12: ISlotOptions<ITestProps> = { component: TestComponent };
+    const p13: ISlotOptions<ITestProps> = { component: TestComponent };
+    const p20: ISlotOptions<ITestProps> = { render: TestRender };
+    const p21: ISlotOptions<ITestProps> = { render: TestRender };
+    const p22: ISlotOptions<ITestProps> = { render: TestRender };
+    const p23: ISlotOptions<ITestProps> = { render: TestRender };
 
     // TODO: it'd be great to use ts-ignore to only ignore unused variables, but that's not currently possible:
     // https://github.com/Microsoft/TypeScript/issues/19139
     // Until then, pretend they're used:
-    const [] = [tHtml, tDiv, tButton];
+    const [] = [p00, p01, p02, p03, p10, p11, p12, p13, p20, p21, p22, p23];
   });
+
+  // TODO: what will happen with HTML slots?
+  // it('do not generate TS compile error on valid IHTMLSlot assignments', () => {
+  //   // IHTMLSlot should accept both generic and specialized elements.
+  //   let tHtml: IHTMLSlot = { component: 'b' };
+  //   tHtml = { component: 'div' };
+  //   tHtml = { component: 'button' };
+
+  //   // IHTMLElementSlot should accept its specified element and elements sharing the same shared subset of its attributes.
+  //   let tDiv: IHTMLElementSlot<'div'> = { component: 'div' };
+  //   tDiv = { component: 'b' };
+
+  //   let tButton: IHTMLElementSlot<'button'> = { component: 'button' };
+  //   tButton = { component: 'b' };
+
+  //   // TODO: it'd be great to use ts-ignore to only ignore unused variables, but that's not currently possible:
+  //   // https://github.com/Microsoft/TypeScript/issues/19139
+  //   // Until then, pretend they're used:
+  //   const [] = [tHtml, tDiv, tButton];
+  // });
 
   it('do not generate TS compile error on valid ExtractProp assignments', () => {
     const p0: ExtractProps<ISlotProp<ITestProps>> = { testProp: 42 };
@@ -161,7 +184,9 @@ describe('withSlots', () => {
 describe('createFactory', () => {
   const componentProps = { component: 'componentValue', id: 'componentIdValue', children: ['Component Child 1', 'Component Child 2'] };
   const userProps: ISlotProp<any, any> = {
-    props: { user: 'userValue', id: 'userIdValue', children: ['User Child 1', 'User Child 2'] }
+    user: 'userValue',
+    id: 'userIdValue',
+    children: ['User Child 1', 'User Child 2']
   };
   const renderProps = { render: 'renderValue', id: 'renderIdValue', children: ['Render Child 1', 'Render Child 2'] };
   const userPropString = 'userPropString';
@@ -177,17 +202,22 @@ describe('createFactory', () => {
   };
 
   it(`passes componentProps without userProps`, () => {
-    const component = mount(createFactory<TComponentProps, any>(TestDiv)(componentProps, undefined, undefined) as JSX.Element);
+    const component = mount(createFactory<TComponentProps, any>(TestDiv)(componentProps, undefined, undefined, undefined) as JSX.Element);
     expect(component.props()).toEqual({ ...componentProps, ...emptyClassName });
   });
 
   it(`passes userProp string as child`, () => {
-    const component = mount(createFactory<TComponentProps, string>(TestDiv)(componentProps, userPropString, undefined) as JSX.Element);
+    const component = mount(createFactory<TComponentProps, string>(TestDiv)(
+      componentProps,
+      userPropString,
+      undefined,
+      undefined
+    ) as JSX.Element);
     expect(component.props()).toEqual({ ...componentProps, children: userPropString, ...emptyClassName });
   });
 
   it(`passes userProp integer as child`, () => {
-    const component = mount(createFactory<TComponentProps, number>(TestDiv)(componentProps, 42, undefined) as JSX.Element);
+    const component = mount(createFactory<TComponentProps, number>(TestDiv)(componentProps, 42, undefined, undefined) as JSX.Element);
     expect(component.props()).toEqual({ ...componentProps, children: 42, ...emptyClassName });
   });
 
@@ -195,23 +225,39 @@ describe('createFactory', () => {
     const component = mount(createFactory<TComponentProps, string>(TestDiv, factoryOptions)(
       componentProps,
       userPropString,
+      undefined,
       undefined
     ) as JSX.Element);
     expect(component.props()).toEqual({ ...componentProps, [defaultProp]: userPropString, ...emptyClassName });
   });
 
   it(`passes userProp integer as defaultProp`, () => {
-    const component = mount(createFactory<TComponentProps, number>(TestDiv, factoryOptions)(componentProps, 42, undefined) as JSX.Element);
+    const component = mount(createFactory<TComponentProps, number>(TestDiv, factoryOptions)(
+      componentProps,
+      42,
+      undefined,
+      undefined
+    ) as JSX.Element);
     expect(component.props()).toEqual({ ...componentProps, [defaultProp]: 42, ...emptyClassName });
   });
 
   it('merges userProps over componentProps', () => {
-    const component = mount(createFactory<TComponentProps>(TestDiv, factoryOptions)(componentProps, userProps, undefined) as JSX.Element);
-    expect(component.props()).toEqual({ ...componentProps, ...userProps.props, ...emptyClassName });
+    const component = mount(createFactory<TComponentProps>(TestDiv, factoryOptions)(
+      componentProps,
+      userProps,
+      undefined,
+      undefined
+    ) as JSX.Element);
+    expect(component.props()).toEqual({ ...componentProps, ...userProps, ...emptyClassName });
   });
 
   it('renders div and userProp integer as children', () => {
-    const component = renderer.create(createFactory<TComponentProps, number>(TestDiv)(componentProps, 42, undefined) as JSX.Element);
+    const component = renderer.create(createFactory<TComponentProps, number>(TestDiv)(
+      componentProps,
+      42,
+      undefined,
+      undefined
+    ) as JSX.Element);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -220,6 +266,7 @@ describe('createFactory', () => {
     const component = renderer.create(createFactory<TComponentProps, string>(TestDiv)(
       componentProps,
       userPropString,
+      undefined,
       undefined
     ) as JSX.Element);
     const tree = component.toJSON();
@@ -230,6 +277,7 @@ describe('createFactory', () => {
     const component = renderer.create(createFactory(TestDiv)(
       componentProps,
       <span id="I should be the only prop in the output" />,
+      undefined,
       undefined
     ) as JSX.Element);
     const tree = component.toJSON();
@@ -239,6 +287,7 @@ describe('createFactory', () => {
   it('renders userProp span function without component props', () => {
     const component = renderer.create(createFactory(TestDiv)(
       componentProps,
+      undefined,
       {
         render: () => <span id="I should be the only prop in the output" />
       },
@@ -251,6 +300,7 @@ describe('createFactory', () => {
   it('renders userProp span function with component props', () => {
     const component = renderer.create(createFactory(TestDiv)(
       componentProps,
+      undefined,
       {
         render: props => <span {...props} id="I should be present alongside componentProps" />
       },
@@ -263,7 +313,8 @@ describe('createFactory', () => {
   it('renders userProp span component with component props', () => {
     const component = renderer.create(createFactory(TestDiv)(
       componentProps,
-      { component: 'span', props: { id: 'I should be present alongside componentProps' } },
+      { id: 'I should be present alongside componentProps' },
+      { component: 'span' },
       undefined
     ) as JSX.Element);
     const tree = component.toJSON();
@@ -271,8 +322,7 @@ describe('createFactory', () => {
   });
 
   it(`passes props and type arguments to userProp function`, done => {
-    const slotProp: ISlotProp<typeof userProps.props | typeof renderProps> = {
-      props: renderProps,
+    const slotOptions: ISlotOptions<typeof userProps.props | typeof renderProps> = {
       render: (props, DefaultComponent) => {
         expect(props).toEqual({ ...componentProps, ...renderProps, ...emptyClassName });
         expect(DefaultComponent).toEqual(TestDiv);
@@ -281,7 +331,7 @@ describe('createFactory', () => {
       }
     };
 
-    createFactory(TestDiv, factoryOptions)(componentProps, slotProp, undefined);
+    createFactory(TestDiv, factoryOptions)(componentProps, renderProps, slotOptions, undefined);
   });
 });
 
@@ -302,15 +352,11 @@ describe('getSlots', () => {
   it(`creates slots and passes merged props to them`, done => {
     const testUserProps = {
       testSlot1: {
-        props: {
-          className: 'testSlot1Classname',
-          testSlot1Prop: 'userProp1'
-        }
+        className: 'testSlot1Classname',
+        testSlot1Prop: 'userProp1'
       },
       testSlot2: {
-        props: {
-          className: 'testSlot2Classname'
-        }
+        className: 'testSlot2Classname'
       }
     };
 
@@ -325,8 +371,8 @@ describe('getSlots', () => {
       testSlot1: props => {
         // User props should override slot props
         expect(props).toEqual({
-          ...testUserProps.testSlot1.props,
-          className: testUserProps.testSlot1.props.className
+          ...testUserProps.testSlot1,
+          className: testUserProps.testSlot1.className
         });
         return null;
       },
@@ -334,7 +380,7 @@ describe('getSlots', () => {
         // No user prop for slot in this case, so slot props should be present
         expect(props).toEqual({
           ...testSlot2Props,
-          className: testUserProps.testSlot2.props.className
+          className: testUserProps.testSlot2.className
         });
         done();
         return null;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -22,6 +22,7 @@ import { IRefObject } from '@uifabric/utilities';
 import { IRenderComponent } from '@uifabric/utilities';
 import { IRenderFunction } from '@uifabric/utilities';
 import { ISlotProp } from '@uifabric/foundation';
+import { ISlottableProps } from '@uifabric/foundation';
 import { IStyle } from '@uifabric/styling';
 import { IStyleableComponentProps } from '@uifabric/foundation';
 import { IStyleFunction } from '@uifabric/utilities';
@@ -50,7 +51,7 @@ export class ActivityItem extends React.Component<IActivityItemProps, {}> {
 export type Alignment = 'start' | 'end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'baseline' | 'stretch';
 
 // Warning: (ae-forgotten-export) The symbol "React" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export const Announced: React_2.StatelessComponent<IAnnouncedProps>;
 
@@ -485,7 +486,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalloutState" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export class Callout extends React.Component<ICalloutProps, ICalloutState> {
     // (undocumented)
@@ -648,7 +649,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     static defaultProps: IComboBoxProps;
     dismissMenu: () => void;
     // Warning: (ae-unresolved-inheritdoc-base) The `@inheritDoc` tag needs a TSDoc declaration reference; signature matching is not supported yet
-    // 
+    //
     // (undocumented)
     focus: (shouldOpenOnFocus?: boolean | undefined, useFocusAsync?: boolean | undefined) => void;
     // (undocumented)
@@ -2762,7 +2763,7 @@ export interface IContextualMenuItem {
     data?: any;
     disabled?: boolean;
     // Warning: (ae-forgotten-export) The symbol "IMenuItemClassNames" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @deprecated
     getItemClassNames?: (theme: ITheme, disabled: boolean, expanded: boolean, checked: boolean, isAnchorLink: boolean, knownIcon: boolean, itemClassName?: string, dividerClassName?: string, iconClassName?: string, subMenuClassName?: string, primaryDisabled?: boolean) => IMenuItemClassNames;
     getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
@@ -2862,7 +2863,7 @@ export interface IContextualMenuListProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -2882,7 +2883,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // Warning: (ae-forgotten-export) The symbol "IContextualMenuClassNames" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @deprecated
     getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
     hidden?: boolean;
@@ -3110,7 +3111,7 @@ export interface IDetailsGroupRenderProps extends IGroupRenderProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DetailsHeaderBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDetailsHeaderBaseProps extends React.ClassAttributes<DetailsHeaderBase>, IDetailsItemProps {
     ariaLabel?: string;
@@ -3175,7 +3176,7 @@ export interface IDetailsListCheckboxProps extends IDetailsCheckboxProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWithViewportProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps {
     ariaLabel?: string;
@@ -3520,7 +3521,7 @@ export interface IDialogFooterStyles {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IAccessiblePopupProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiveModeState, IAccessiblePopupProps {
     // @deprecated
@@ -3615,7 +3616,7 @@ export interface IDocumentCardActions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActionsBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardActionsProps extends React_2.ClassAttributes<DocumentCardActionsBase> {
     actions: IButtonProps[];
@@ -3658,7 +3659,7 @@ export interface IDocumentCardActivityPerson {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActivityBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardActivityProps extends React_2.ClassAttributes<DocumentCardActivityBase> {
     activity: string;
@@ -3697,7 +3698,7 @@ export interface IDocumentCardDetails {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardDetailsBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardDetailsProps extends React_2.Props<DocumentCardDetailsBase> {
     className?: string;
@@ -3756,7 +3757,7 @@ export interface IDocumentCardLocation {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLocationBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardLocationProps extends React_2.ClassAttributes<DocumentCardLocationBase> {
     ariaLabel?: string;
@@ -3786,7 +3787,7 @@ export interface IDocumentCardLogo {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLogoBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardLogoProps extends React_2.ClassAttributes<DocumentCardLogoBase> {
     className?: string;
@@ -3886,7 +3887,7 @@ export interface IDocumentCardStatus {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardStatusBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardStatusProps extends React_2.Props<DocumentCardStatusBase> {
     className?: string;
@@ -3928,7 +3929,7 @@ export interface IDocumentCardTitle {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardTitleBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardTitleProps extends React_2.ClassAttributes<DocumentCardTitleBase> {
     className?: string;
@@ -4060,7 +4061,7 @@ export interface IExpandingCard {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExpandingCardStyles, IExpandingCardStyleProps> {
     compactCardHeight?: number;
@@ -4079,7 +4080,7 @@ export interface IExpandingCardState {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyleProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
     compactCardHeight?: number;
@@ -4089,7 +4090,7 @@ export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyles" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IExpandingCardStyles extends IBaseCardStyles {
     compactCard?: IStyle;
@@ -5295,7 +5296,7 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     className?: string;
@@ -6287,7 +6288,7 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
     shimmerLines?: number;
     // Warning: (ae-forgotten-export) The symbol "IShimmeredDetailsListStyleProps" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "IShimmeredDetailsListStyles" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @deprecated
     styles?: IStyleFunctionOrObject<IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>;
 }
@@ -6523,7 +6524,7 @@ export interface ISpinButtonProps {
     keytipProps?: IKeytipProps;
     label?: string;
     // Warning: (ae-forgotten-export) The symbol "Position" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     labelPosition?: Position;
     max?: number;
@@ -6647,7 +6648,7 @@ export interface IStackItemTokens {
 }
 
 // @public (undocumented)
-export interface IStackProps extends IStackSlots, IStyleableComponentProps<IStackProps, IStackTokens, IStackStyles>, React_2.HTMLAttributes<HTMLElement> {
+export interface IStackProps extends ISlottableProps<IStackSlots>, IStyleableComponentProps<IStackProps, IStackTokens, IStackStyles>, React_2.HTMLAttributes<HTMLElement> {
     as?: React_2.ReactType<React_2.HTMLAttributes<HTMLElement>>;
     disableShrink?: boolean;
     gap?: number | string;
@@ -7170,7 +7171,7 @@ export interface ITextFieldSubComponentStyles {
 }
 
 // @public
-export interface ITextProps extends ITextSlots, IStyleableComponentProps<ITextProps, ITextTokens, ITextStyles>, React_2.HTMLAttributes<HTMLElement> {
+export interface ITextProps extends ISlottableProps<ITextSlots>, IStyleableComponentProps<ITextProps, ITextTokens, ITextStyles>, React_2.HTMLAttributes<HTMLElement> {
     as?: React_2.ReactType<React_2.HTMLAttributes<HTMLElement>>;
     block?: boolean;
     nowrap?: boolean;
@@ -7397,7 +7398,7 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IKeytipDataProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class KeytipData extends React.Component<IKeytipDataProps & IRenderComponent<{}>, {}> {
     // (undocumented)
@@ -7425,7 +7426,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
     // (undocumented)
     getCurrentSequence(): string;
     // Warning: (ae-forgotten-export) The symbol "KeytipTree" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     getKeytipTree(): KeytipTree;
     processInput(key: string, ev?: React.KeyboardEvent<HTMLElement>): void;
@@ -7467,7 +7468,7 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     }
 
 // Warning: (ae-forgotten-export) The symbol "ILayerHostProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export class LayerHost extends React.Component<ILayerHostProps> {
     // (undocumented)
@@ -9025,7 +9026,7 @@ export * from "@uifabric/styling";
 export * from "@uifabric/utilities";
 
 // Warnings were encountered during analysis:
-// 
+//
 // lib/components/DetailsList/DetailsList.types.d.ts:110:9 - (ae-forgotten-export) The symbol "IDragDropContext" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.LazyLoading.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.LazyLoading.Example.tsx
@@ -45,7 +45,7 @@ export interface IAnnouncedLazyLoadingExampleState {
   timeSinceLastAnnounce: number;
 }
 
-export interface IAnnouncedLazyLoadingExampleProps { }
+export interface IAnnouncedLazyLoadingExampleProps {}
 
 export class AnnouncedLazyLoadingExample extends React.Component<IAnnouncedLazyLoadingExampleProps, IAnnouncedLazyLoadingExampleState> {
   private _photos: IPhoto[];
@@ -119,9 +119,9 @@ export class AnnouncedLazyLoadingExample extends React.Component<IAnnouncedLazyL
             wrap
             // Render the inner content as a ul (there's not currently a less-verbose way to do this)
             // tslint:disable-next-line:jsx-no-lambda
-            inner={{ component: 'ul' }}
             tokens={photoStackTokens}
             styles={photoStackStyles}
+            slots={{ inner: { component: 'ul' } }}
           >
             {this._renderPhotos()}
           </Stack>

--- a/packages/office-ui-fabric-react/src/components/Stack/Stack.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/Stack.types.ts
@@ -1,4 +1,4 @@
-import { IComponentStyles, IHTMLSlot, ISlotProp, IComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponentStyles, IHTMLSlot, ISlotProp, IComponent, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
 
 /**
  * Defines a type made by the union of the different values that the align-items and justify-content flexbox
@@ -51,7 +51,7 @@ export interface IStackSlots {
  * {@docCategory Stack}
  */
 export interface IStackProps
-  extends IStackSlots,
+  extends ISlottableProps<IStackSlots>,
     IStyleableComponentProps<IStackProps, IStackTokens, IStackStyles>,
     React.HTMLAttributes<HTMLElement> {
   /**

--- a/packages/office-ui-fabric-react/src/components/Text/Text.types.tsx
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.types.tsx
@@ -1,4 +1,4 @@
-import { IComponentStyles, IHTMLSlot, ISlotProp, IComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponentStyles, IHTMLSlot, ISlotProp, IComponent, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
 import { IFontStyles } from '../../Styling';
 
 /**
@@ -37,7 +37,7 @@ export interface ITextSlots {
  * {@docCategory Text}
  */
 export interface ITextProps
-  extends ITextSlots,
+  extends ISlottableProps<ITextSlots>,
     IStyleableComponentProps<ITextProps, ITextTokens, ITextStyles>,
     React.HTMLAttributes<HTMLElement> {
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #8334, #8335
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Due to some thoughts I had while implementing #8754 reinforced by further discussion on said PR, I've decided to make some changes regarding slot options.

Fundamentally slot props are overloaded allowing both "what to render" and "how to render" to coexist in the same props object. However, this approach creates additional friction by merging "what" and "how" into the same complex object. It also prevents devs from using shorthand when providing any slot implementation.

This PR creates a new `slots` prop that is automatically added to components through a helper interface. This `slots` prop now contains the slot options for all of the slot props identified for the component.

This change will also make it a bit harder to impact perf negatively when using props and slots by minimizing need to instantiate complex objects and more easily allowing use of constant objects.

### Slots API

#### Before:

Slots interface before:
```tsx
{
  root: {
    props: rootProps,
    render: { },
    component: { }
  },
  content: {
    props: contentProps,
    render: { },
    component: { }
  }
}
```

#### After:

```tsx
{
  root: rootProps,  // (also supports shorthand, such as strings)
  content: contentProps,  // (also supports shorthand, such as strings)
  slots: {
    root: {
      render: { },
      component: { }
    },
    content: {
      render: { },
      component: { }
    },
  }
}
```

### Practical Examples

#### Before:

```tsx
<Button
  // This object is combining dynamic content (`iconName`) with static render values (`render`).
  // Devs may find themselves unnecessarily creating new objects for otherwise static content.
  icon: {
    props: { iconProps },
    render: (iconProps, DefaultComponent) => (
      <b>
        Icon: <DefaultComponent {...iconProps} />
      </b>
    )
  }
/>
```

#### After:

```tsx
<Button
  // Dynamic content separated out.
  icon={ iconProps }
  // Static content that can be defined as a const externally, 
  // or even as a component variant with default `slots` props.
  slots={{
    icon: {
      render: (iconProps, DefaultComponent) => (
        <b>
          Icon: <DefaultComponent {...iconProps} />
        </b>
      )
    }
  }}
/>
```

#### Before

```tsx
// New object! Gross.
<Button icon={{ props: iconProps }} />
```

#### After

```tsx
// Back to passthrough.
<Button icon={ iconProps } />
```

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8868)