### PR TITLE
a11y-tests: Remove snippets and identifiers containing CSS classes and re-enable tests

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/Button.test.ts.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/Button.test.ts.snap
@@ -4,26 +4,10 @@ exports[`runs Axe on Button 1`] = `
 Array [
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"false\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-250\\" tabindex=\\"0\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(1) > .css-250[aria-roledescription=\\"split\\\\ button\\"][aria-haspopup=\\"true\\"]",
-      },
-    ],
     "message": Object {
       "richText": "Fix all of the following:
 - ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(1) > .css-250[aria-roledescription=\\"split\\\\ button\\"][aria-haspopup=\\"true\\"]",
-      "ruleId": "aria-allowed-attr",
     },
     "properties": Object {
       "tags": Array [
@@ -34,26 +18,10 @@ Array [
   },
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"false\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-250\\" tabindex=\\"0\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(2) > .css-250[aria-roledescription=\\"split\\\\ button\\"][aria-haspopup=\\"true\\"]",
-      },
-    ],
     "message": Object {
       "richText": "Fix all of the following:
 - ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(2) > .css-250[aria-roledescription=\\"split\\\\ button\\"][aria-haspopup=\\"true\\"]",
-      "ruleId": "aria-allowed-attr",
     },
     "properties": Object {
       "tags": Array [
@@ -64,26 +32,10 @@ Array [
   },
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"false\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-250\\" tabindex=\\"0\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(3) > .css-250[aria-roledescription=\\"split\\\\ button\\"][aria-haspopup=\\"true\\"]",
-      },
-    ],
     "message": Object {
       "richText": "Fix all of the following:
 - ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(3) > .css-250[aria-roledescription=\\"split\\\\ button\\"][aria-haspopup=\\"true\\"]",
-      "ruleId": "aria-allowed-attr",
     },
     "properties": Object {
       "tags": Array [
@@ -94,26 +46,10 @@ Array [
   },
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"true\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-275\\" tabindex=\\"0\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".css-275",
-      },
-    ],
     "message": Object {
       "richText": "Fix all of the following:
 - ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-275",
-      "ruleId": "aria-allowed-attr",
     },
     "properties": Object {
       "tags": Array [
@@ -124,26 +60,10 @@ Array [
   },
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"false\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-306\\" tabindex=\\"0\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".css-306",
-      },
-    ],
     "message": Object {
       "richText": "Fix all of the following:
 - ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-306",
-      "ruleId": "aria-allowed-attr",
     },
     "properties": Object {
       "tags": Array [

--- a/apps/a11y-tests/src/tests/__snapshots__/TextField.test.ts.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/TextField.test.ts.snap
@@ -4,26 +4,10 @@ exports[`runs Axe on TextField 1`] = `
 Array [
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<span style=\\"padding-bottom: 1px;\\">https://</span>",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".prefix-240 > span",
-      },
-    ],
     "message": Object {
       "richText": "Fix any of the following:
 - Element has insufficient color contrast of 2.21 (foreground color: #a6a6a6, background color: #f4f4f4, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
       "text": "Fix any of the following: Element has insufficient color contrast of 2.21 (foreground color: #a6a6a6, background color: #f4f4f4, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".prefix-240 > span",
-      "ruleId": "color-contrast",
     },
     "properties": Object {
       "tags": Array [
@@ -34,26 +18,10 @@ Array [
   },
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField111\\" class=\\"ms-TextField-field field-230\\" aria-describedby=\\"TextFieldDescription112\\" aria-invalid=\\"false\\" value=\\"\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField111",
-      },
-    ],
     "message": Object {
       "richText": "Fix all of the following:
 - Only title used to generate label for form element",
       "text": "Fix all of the following: Only title used to generate label for form element.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField111",
-      "ruleId": "label-title-only",
     },
     "properties": Object {
       "tags": Array [
@@ -64,18 +32,6 @@ Array [
   },
   Object {
     "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField111\\" class=\\"ms-TextField-field field-230\\" aria-describedby=\\"TextFieldDescription112\\" aria-invalid=\\"false\\" value=\\"\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField111",
-      },
-    ],
     "message": Object {
       "richText": "Fix any of the following:
 - aria-label attribute does not exist or is empty
@@ -84,10 +40,6 @@ Array [
 - Form element does not have an explicit &lt;label>
 - Element has no title attribute or the title attribute is empty",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField111",
-      "ruleId": "label",
     },
     "properties": Object {
       "tags": Array [

--- a/apps/a11y-tests/src/tests/testComponent.ts
+++ b/apps/a11y-tests/src/tests/testComponent.ts
@@ -5,7 +5,10 @@ import { Result } from 'axe-sarif-converter/dist/sarif/sarif-2.0.0';
 // Extract interesting info to reduce snapshot size
 function dehydrateSarifReport(report: SarifLog): Result[] {
   const results = report.runs[0]!.results!.filter(item => item.level === 'error');
-  results.forEach(item => item.locations!.forEach(location => delete location.physicalLocation));
+  results.forEach(item => {
+    delete item.locations;
+    delete item.partialFingerprints;
+  });
   return results;
 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,5 +79,9 @@ steps:
       SCREENER_API_KEY: $(screener.key)
 
   - script: |
+      npm run a11ytest
+    displayName: run a11y tests
+
+  - script: |
       npm run check-for-changed-files
     displayName: check for change file


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Scrub all snippets and element identifiers from a11y tests' snapshots, and re-enable a11y tests that were disabled by #8767.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8871)