### PR TITLE
DetailsColumn: Use lambda to bind this and add type-safety to _root

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-details-column-cleanup_2019-04-29-18-26.json
+++ b/common/changes/office-ui-fabric-react/keco-details-column-cleanup_2019-04-29-18-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsColumn: Cleanup className vars, use lambdas for this binding, add type-safety to root ref",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -17,19 +17,9 @@ const TRANSITION_DURATION_DROP = 1500; // ms
 const CLASSNAME_ADD_INTERVAL = 20; // ms
 
 export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
-  private _root: any;
+  private _root = React.createRef<HTMLDivElement>();
   private _dragDropSubscription: IDisposable;
   private _classNames: IClassNames<IDetailsColumnStyles>;
-
-  constructor(props: IDetailsColumnProps) {
-    super(props);
-
-    this._root = React.createRef();
-    this._onDragStart = this._onDragStart.bind(this);
-    this._onDragEnd = this._onDragEnd.bind(this);
-    this._onRootMouseDown = this._onRootMouseDown.bind(this);
-    this._updateHeaderDragInfo = this._updateHeaderDragInfo.bind(this);
-  }
 
   public render(): JSX.Element {
     const { column, columnIndex, parentId, isDraggable, styles, theme, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = this.props;
@@ -256,36 +246,36 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     ) : null;
   }
 
-  private _onDragStart(item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent): void {
+  private _onDragStart = (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent): void => {
     const classNames = this._classNames;
     if (itemIndex) {
       this._updateHeaderDragInfo(itemIndex);
-      this._root.current.classList.add(classNames.borderWhileDragging);
+      (this._root.current as HTMLElement).classList.add(classNames.borderWhileDragging);
       this._async.setTimeout(() => {
         if (this._root.current) {
           this._root.current.classList.add(classNames.noBorderWhileDragging);
         }
       }, CLASSNAME_ADD_INTERVAL);
     }
-  }
+  };
 
-  private _onDragEnd(item?: any, event?: MouseEvent): void {
+  private _onDragEnd = (item?: any, event?: MouseEvent): void => {
     const classNames = this._classNames;
     if (event) {
       this._updateHeaderDragInfo(-1, event);
     }
-    this._root.current.classList.remove(classNames.borderWhileDragging);
-    this._root.current.classList.remove(classNames.noBorderWhileDragging);
-  }
+    (this._root.current as HTMLElement).classList.remove(classNames.borderWhileDragging);
+    (this._root.current as HTMLElement).classList.remove(classNames.noBorderWhileDragging);
+  };
 
-  private _updateHeaderDragInfo(itemIndex: number, event?: MouseEvent) {
+  private _updateHeaderDragInfo = (itemIndex: number, event?: MouseEvent) => {
     if (this.props.setDraggedItemIndex) {
       this.props.setDraggedItemIndex(itemIndex);
     }
     if (this.props.updateDragInfo) {
       this.props.updateDragInfo({ itemIndex }, event);
     }
-  }
+  };
 
   private _onColumnContextMenu(column: IColumn, ev: React.MouseEvent<HTMLElement>): void {
     const { onColumnContextMenu } = this.props;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -39,6 +39,8 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       transitionDurationDrop: TRANSITION_DURATION_DROP
     });
 
+    const classNames = this._classNames;
+
     return (
       <>
         <div
@@ -47,7 +49,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
           role={'columnheader'}
           aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
           aria-colindex={columnIndex}
-          className={this._classNames.root}
+          className={classNames.root}
           data-is-draggable={isDraggable}
           draggable={isDraggable}
           style={{
@@ -60,10 +62,10 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
           data-automationid={'ColumnsHeaderColumn'}
           data-item-key={column.key}
         >
-          {isDraggable && <Icon iconName="GripperBarVertical" className={this._classNames.gripperBarVerticalStyle} />}
+          {isDraggable && <Icon iconName="GripperBarVertical" className={classNames.gripperBarVerticalStyle} />}
           {onRenderColumnHeaderTooltip(
             {
-              hostClassName: this._classNames.cellTooltip,
+              hostClassName: classNames.cellTooltip,
               id: `${parentId}-${column.key}-tooltip`,
               setAriaDescribedBy: false,
               content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
@@ -72,7 +74,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                   id={`${parentId}-${column.key}`}
                   aria-label={column.isIconOnly ? column.name : undefined}
                   aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name`}
-                  className={this._classNames.cellTitle}
+                  className={classNames.cellTitle}
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
                   role={
                     column.columnActionsMode !== ColumnActionsMode.disabled &&
@@ -90,24 +92,20 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                     column.columnActionsMode === ColumnActionsMode.hasDropdown ? (column.isMenuOpen ? true : false) : undefined
                   }
                 >
-                  <span id={`${parentId}-${column.key}-name`} className={this._classNames.cellName}>
-                    {(column.iconName || column.iconClassName) && (
-                      <Icon className={this._classNames.iconClassName} iconName={column.iconName} />
-                    )}
+                  <span id={`${parentId}-${column.key}-name`} className={classNames.cellName}>
+                    {(column.iconName || column.iconClassName) && <Icon className={classNames.iconClassName} iconName={column.iconName} />}
 
-                    {column.isIconOnly ? <span className={this._classNames.accessibleLabel}>{column.name}</span> : column.name}
+                    {column.isIconOnly ? <span className={classNames.accessibleLabel}>{column.name}</span> : column.name}
                   </span>
 
-                  {column.isFiltered && <Icon className={this._classNames.nearIcon} iconName={'Filter'} />}
+                  {column.isFiltered && <Icon className={classNames.nearIcon} iconName={'Filter'} />}
 
-                  {column.isSorted && (
-                    <Icon className={this._classNames.sortIcon} iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'} />
-                  )}
+                  {column.isSorted && <Icon className={classNames.sortIcon} iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'} />}
 
-                  {column.isGrouped && <Icon className={this._classNames.nearIcon} iconName={'GroupedDescending'} />}
+                  {column.isGrouped && <Icon className={classNames.nearIcon} iconName={'GroupedDescending'} />}
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
-                    <Icon aria-hidden={true} className={this._classNames.filterChevron} iconName={'ChevronDown'} />
+                    <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />
                   )}
                 </span>
               )

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -39,8 +39,6 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       transitionDurationDrop: TRANSITION_DURATION_DROP
     });
 
-    const classNames = this._classNames;
-
     return (
       <>
         <div
@@ -49,7 +47,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
           role={'columnheader'}
           aria-sort={column.isSorted ? (column.isSortedDescending ? 'descending' : 'ascending') : 'none'}
           aria-colindex={columnIndex}
-          className={classNames.root}
+          className={this._classNames.root}
           data-is-draggable={isDraggable}
           draggable={isDraggable}
           style={{
@@ -62,10 +60,10 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
           data-automationid={'ColumnsHeaderColumn'}
           data-item-key={column.key}
         >
-          {isDraggable && <Icon iconName="GripperBarVertical" className={classNames.gripperBarVerticalStyle} />}
+          {isDraggable && <Icon iconName="GripperBarVertical" className={this._classNames.gripperBarVerticalStyle} />}
           {onRenderColumnHeaderTooltip(
             {
-              hostClassName: classNames.cellTooltip,
+              hostClassName: this._classNames.cellTooltip,
               id: `${parentId}-${column.key}-tooltip`,
               setAriaDescribedBy: false,
               content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
@@ -74,7 +72,7 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                   id={`${parentId}-${column.key}`}
                   aria-label={column.isIconOnly ? column.name : undefined}
                   aria-labelledby={column.isIconOnly ? undefined : `${parentId}-${column.key}-name`}
-                  className={classNames.cellTitle}
+                  className={this._classNames.cellTitle}
                   data-is-focusable={column.columnActionsMode !== ColumnActionsMode.disabled}
                   role={
                     column.columnActionsMode !== ColumnActionsMode.disabled &&
@@ -92,20 +90,24 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
                     column.columnActionsMode === ColumnActionsMode.hasDropdown ? (column.isMenuOpen ? true : false) : undefined
                   }
                 >
-                  <span id={`${parentId}-${column.key}-name`} className={classNames.cellName}>
-                    {(column.iconName || column.iconClassName) && <Icon className={classNames.iconClassName} iconName={column.iconName} />}
+                  <span id={`${parentId}-${column.key}-name`} className={this._classNames.cellName}>
+                    {(column.iconName || column.iconClassName) && (
+                      <Icon className={this._classNames.iconClassName} iconName={column.iconName} />
+                    )}
 
-                    {column.isIconOnly ? <span className={classNames.accessibleLabel}>{column.name}</span> : column.name}
+                    {column.isIconOnly ? <span className={this._classNames.accessibleLabel}>{column.name}</span> : column.name}
                   </span>
 
-                  {column.isFiltered && <Icon className={classNames.nearIcon} iconName={'Filter'} />}
+                  {column.isFiltered && <Icon className={this._classNames.nearIcon} iconName={'Filter'} />}
 
-                  {column.isSorted && <Icon className={classNames.sortIcon} iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'} />}
+                  {column.isSorted && (
+                    <Icon className={this._classNames.sortIcon} iconName={column.isSortedDescending ? 'SortDown' : 'SortUp'} />
+                  )}
 
-                  {column.isGrouped && <Icon className={classNames.nearIcon} iconName={'GroupedDescending'} />}
+                  {column.isGrouped && <Icon className={this._classNames.nearIcon} iconName={'GroupedDescending'} />}
 
                   {column.columnActionsMode === ColumnActionsMode.hasDropdown && !column.isIconOnly && (
-                    <Icon aria-hidden={true} className={classNames.filterChevron} iconName={'ChevronDown'} />
+                    <Icon aria-hidden={true} className={this._classNames.filterChevron} iconName={'ChevronDown'} />
                   )}
                 </span>
               )

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -135,21 +135,23 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       this._events.on(this._root.current, 'mousedown', this._onRootMouseDown);
     }
 
+    const classNames = this._classNames;
+
     if (this.props.isDropped) {
       if (this._root.current) {
-        this._root.current.classList.add(this._classNames.borderAfterDropping);
+        this._root.current.classList.add(classNames.borderAfterDropping);
 
         this._async.setTimeout(() => {
           if (this._root.current) {
-            this._root.current.classList.add(this._classNames.noBorderAfterDropping);
+            this._root.current.classList.add(classNames.noBorderAfterDropping);
           }
         }, CLASSNAME_ADD_INTERVAL);
       }
 
       this._async.setTimeout(() => {
         if (this._root.current) {
-          this._root.current.classList.remove(this._classNames.borderAfterDropping);
-          this._root.current.classList.remove(this._classNames.noBorderAfterDropping);
+          this._root.current.classList.remove(classNames.borderAfterDropping);
+          this._root.current.classList.remove(classNames.noBorderAfterDropping);
         }
       }, TRANSITION_DURATION_DROP + CLASSNAME_ADD_INTERVAL);
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -135,23 +135,21 @@ export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
       this._events.on(this._root.current, 'mousedown', this._onRootMouseDown);
     }
 
-    const classNames = this._classNames;
-
     if (this.props.isDropped) {
       if (this._root.current) {
-        this._root.current.classList.add(classNames.borderAfterDropping);
+        this._root.current.classList.add(this._classNames.borderAfterDropping);
 
         this._async.setTimeout(() => {
           if (this._root.current) {
-            this._root.current.classList.add(classNames.noBorderAfterDropping);
+            this._root.current.classList.add(this._classNames.noBorderAfterDropping);
           }
         }, CLASSNAME_ADD_INTERVAL);
       }
 
       this._async.setTimeout(() => {
         if (this._root.current) {
-          this._root.current.classList.remove(classNames.borderAfterDropping);
-          this._root.current.classList.remove(classNames.noBorderAfterDropping);
+          this._root.current.classList.remove(this._classNames.borderAfterDropping);
+          this._root.current.classList.remove(this._classNames.noBorderAfterDropping);
         }
       }, TRANSITION_DURATION_DROP + CLASSNAME_ADD_INTERVAL);
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Some `DetailsColumn` clean-up as I track down why `column` prop objects are causing `DetailsColumn` to unnecessarily re-render as part of #8826.

#### Focus areas to test

- Drag & drop and column resizing work (they do in my testing locally).
- CI passes.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8872)