### PR TITLE
Update focus handling in DatePicker and FocusTrapZone

### DIFF
--- a/common/changes/office-ui-fabric-react/phtucker-focus_fix_2019-04-29-19-41.json
+++ b/common/changes/office-ui-fabric-react/phtucker-focus_fix_2019-04-29-19-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove out-of-date IE focus handling work-around. Pass forceFocusInsideTrap={false} to DatePicker FocusTrapZone. Adjust FocusTrapZone return focus handling.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phtucker@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -129,11 +129,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
   public componentDidUpdate(prevProps: IDatePickerProps, prevState: IDatePickerState) {
     if (prevState.isDatePickerShown && !this.state.isDatePickerShown) {
-      // In browsers like IE, textfield gets unfocused when datepicker is collapsed
-      if (this.props.allowTextInput) {
-        this._async.requestAnimationFrame(() => this.focus());
-      }
-
       // If DatePicker's menu (Calendar) is closed, run onAfterMenuDismiss
       if (this.props.onAfterMenuDismiss) {
         this.props.onAfterMenuDismiss();
@@ -236,7 +231,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             onDismiss={this._calendarDismissed}
             onPositioned={this._onCalloutPositioned}
           >
-            <FocusTrapZone isClickableOutsideFocusTrap={true} disableFirstFocus={this.props.disableAutoFocus}>
+            <FocusTrapZone isClickableOutsideFocusTrap={true} disableFirstFocus={this.props.disableAutoFocus} forceFocusInsideTrap={false}>
               <CalendarType
                 {...calendarProps}
                 onSelectDate={this._onSelectDate}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -62,7 +62,12 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
   }
 
   public componentWillUnmount(): void {
-    if (!this.props.disabled) {
+    // don't handle return focus unless forceFocusInsideTrap is true or focus is still within FocusTrapZone
+    if (
+      !this.props.disabled ||
+      this.props.forceFocusInsideTrap ||
+      !elementContains(this._root.current, document.activeElement as HTMLElement)
+    ) {
       this._returnFocusToInitiator();
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Issues encountered when DatePicker flyout is expanded and another element on the page requires focus ie: a modal alert dialog. In these instances the current focus handling will prevent another element from focusing and will return focus to the DatePicker TextField whenever the flyout is collapsed regardless of where the current focus is on the page ie: an entirely different element.

To support the above scenario DatePicker flyout should not aggressively keep focus and therefore should set the forceFocusInsideTrap to false of its FocusTrapZone. In addition, FocusTrapZone should not handle return focus if forceFocusInsideTrap is false and the currently focused element is not within the FocusTrapZone.

DatePicker should also allow FocusTrapZone to handle return focus exclusively. Removing out-of-date custom IE code wherein DatePicker interferes with return focus logic that should be the responsibility of FocusTrapZone.

#### Focus areas to test

FocusTrapZone
DatePicker
