### PR TITLE
ColorPicker: don't convert 3-digit hex to 6-digit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,12 +8,13 @@
       "program": "${workspaceRoot}/scripts/debug-test.js",
       "cwd": "${fileDirname}",
       "stopOnEntry": false,
-      "args": ["-i"],
+      "args": ["-i", "--watch"],
       "runtimeExecutable": null,
       "runtimeArgs": ["--nolazy", "--debug"],
       "env": {
         "NODE_ENV": "development"
       },
+      "console": "integratedTerminal",
       "sourceMaps": true
     },
     {
@@ -23,13 +24,14 @@
       "program": "${workspaceRoot}/scripts/debug-test.js",
       "cwd": "${fileDirname}",
       "stopOnEntry": false,
-      "args": ["-i", "--testPathPattern=${file}"],
+      "args": ["-i", "--testPathPattern=${file}", "--watch"],
       "runtimeExecutable": null,
       "runtimeArgs": ["--nolazy", "--debug"],
       "env": {
         "NODE_ENV": "development"
       },
       "sourceMaps": true,
+      "console": "integratedTerminal",
       "outputCapture": "std"
     },
     {

--- a/common/changes/office-ui-fabric-react/color-bug_2019-04-29-20-49.json
+++ b/common/changes/office-ui-fabric-react/color-bug_2019-04-29-20-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ColorPicker: don't convert 3-digit hex to 6-digit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -162,6 +162,9 @@ export class ColorPickerBase extends BaseComponent<IColorPickerProps, IColorPick
     let newColor: IColor | undefined;
     if (isHex) {
       newColor = getColorFromString('#' + newValue);
+      if (newColor && newValue && newValue.length === 3) {
+        newColor.hex = newValue;
+      }
     } else {
       newColor = getColorFromRGBA({
         r: color.r,

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -180,6 +180,21 @@ describe('ColorPicker', () => {
     expect(colorPicker!.color.str).toBe('rgba(0, 255, 0, 0.5)');
   });
 
+  it('does not convert 3 digit hex to 6 digit', () => {
+    let updatedColor: IColor | undefined;
+    const onChange = jest.fn((ev: any, color: IColor) => {
+      updatedColor = color;
+    });
+
+    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+
+    const hexInput = wrapper.getDOMNode().querySelector('.ms-ColorPicker-input input')!;
+    ReactTestUtils.Simulate.input(hexInput, mockEvent('aaa'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(updatedColor!.str).toBe('#aaa');
+    expect(updatedColor!.hex).toBe('aaa');
+  });
+
   it('allows updating text fields when alpha slider is hidden', () => {
     let updatedColor: string | undefined;
     const onChange = jest.fn((ev: any, color: IColor) => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8876
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The ColorPicker was being overly enthusiastic about converting a 3-digit hex to 6-digit before the user has finished typing. Fixed that and added a test (and verified that the test failed without my change).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8877)