### PR TITLE
DetailsList: Mark unused DetailsHeader style cellIsActionable as deprecated

### DIFF
--- a/common/changes/office-ui-fabric-react/removeUnusedDetailsHeaderStyleProp_2019-04-29-21-52.json
+++ b/common/changes/office-ui-fabric-react/removeUnusedDetailsHeaderStyleProp_2019-04-29-21-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "DetailsHeader: mark cellIsActionable as deprecated",
+      "comment": "DetailsHeader: mark cellIsActionable, cellIsEmpty, and cellWrapperPadded as deprecated",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/removeUnusedDetailsHeaderStyleProp_2019-04-29-21-52.json
+++ b/common/changes/office-ui-fabric-react/removeUnusedDetailsHeaderStyleProp_2019-04-29-21-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsHeader: mark cellIsActionable as deprecated",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3221,7 +3221,7 @@ export type IDetailsHeaderStyleProps = Required<Pick<IDetailsHeaderProps, 'theme
 export interface IDetailsHeaderStyles {
     // (undocumented)
     accessibleLabel: IStyle;
-    // (undocumented)
+    // @deprecated (undocumented)
     cellIsActionable: IStyle;
     // (undocumented)
     cellIsCheck: IStyle;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3225,7 +3225,7 @@ export interface IDetailsHeaderStyles {
     cellIsActionable: IStyle;
     // (undocumented)
     cellIsCheck: IStyle;
-    // (undocumented)
+    // @deprecated (undocumented)
     cellIsEmpty: IStyle;
     // (undocumented)
     cellIsGroupExpander: IStyle;
@@ -3237,7 +3237,7 @@ export interface IDetailsHeaderStyles {
     cellSizerEnd: IStyle;
     // (undocumented)
     cellSizerStart: IStyle;
-    // (undocumented)
+    // @deprecated (undocumented)
     cellWrapperPadded: IStyle;
     // (undocumented)
     check: IStyle;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -194,6 +194,10 @@ export type IDetailsHeaderStyleProps = Required<Pick<IDetailsHeaderProps, 'theme
 export interface IDetailsHeaderStyles {
   root: IStyle;
   check: IStyle;
+
+  /**
+   * @deprecated Not used
+   */
   cellWrapperPadded: IStyle;
   cellIsCheck: IStyle;
 
@@ -201,6 +205,10 @@ export interface IDetailsHeaderStyles {
    * @deprecated Not used
    */
   cellIsActionable: IStyle;
+
+  /**
+   * @deprecated Not used
+   */
   cellIsEmpty: IStyle;
   cellSizer: IStyle;
   cellSizerStart: IStyle;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -196,6 +196,10 @@ export interface IDetailsHeaderStyles {
   check: IStyle;
   cellWrapperPadded: IStyle;
   cellIsCheck: IStyle;
+
+  /**
+   * @deprecated Not used
+   */
   cellIsActionable: IStyle;
   cellIsEmpty: IStyle;
   cellSizer: IStyle;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes mark `cellIsActionable` as deprecated, which isn't used anywhere in the code. I'll remove it in the fabric-7 branch.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8880)