### PR TITLE
Add DocumentCardTitle scenario to perf-test app

### DIFF
--- a/apps/perf-test/src/Scenarios.tsx
+++ b/apps/perf-test/src/Scenarios.tsx
@@ -9,7 +9,8 @@ import {
   Toggle,
   Selection,
   SelectionMode,
-  createTheme
+  createTheme,
+  DocumentCardTitle
 } from 'office-ui-fabric-react';
 import { Button as NewButton, Toggle as NewToggle } from '@uifabric/experiments';
 
@@ -65,5 +66,13 @@ export const Scenarios: IDropdownOption[] = [
     }
   },
   { key: 'toggles', text: 'Toggles', data: { timing: [], content: <Toggle checked /> } },
-  { key: 'newtoggles', text: 'NewToggle', data: { timing: [], content: <NewToggle checked /> } }
+  { key: 'newtoggles', text: 'NewToggle', data: { timing: [], content: <NewToggle checked /> } },
+  {
+    key: 'documentcardtitle',
+    text: 'DocumentCardTitle with truncation',
+    data: {
+      timing: [],
+      content: <DocumentCardTitle title="This is the Title of a Very Interesting Document That Everyone Wnats to Read" shouldTruncate />
+    }
+  }
 ];


### PR DESCRIPTION
#### Description of changes
Add DocumentCardTitle to perf-test scenarios.There is an outstanding pr that improves the perf. It would be interesting to see if any changes are reflected in perf comment.
https://github.com/OfficeDev/office-ui-fabric-react/pull/8887

#### Focus areas to test
see perf comment with new scenario


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8891)