### PR TITLE
Export Omit from utilities

### DIFF
--- a/common/changes/@uifabric/utilities/omit_2019-04-30-23-07.json
+++ b/common/changes/@uifabric/utilities/omit_2019-04-30-23-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Export Omit from utilities",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -9,6 +9,7 @@ import { IProcessedStyleSet } from '@uifabric/merge-styles';
 import { IStyleFunction } from '@uifabric/merge-styles';
 import { IStyleFunctionOrObject } from '@uifabric/merge-styles';
 import { IStyleSet } from '@uifabric/merge-styles';
+import { Omit } from '@uifabric/merge-styles';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
@@ -835,6 +836,8 @@ export function mergeSettings(oldSettings?: ISettings, newSettings?: ISettings |
 
 // @public
 export function nullRender(): JSX.Element | null;
+
+export { Omit }
 
 // @public (undocumented)
 export function on(element: Element | Window, eventName: string, callback: (ev: Event) => void, options?: boolean): () => void;

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -60,7 +60,7 @@ export * from './scroll';
 export * from './string';
 export * from './styled';
 export * from './warn';
-export { IStyleFunctionOrObject } from '@uifabric/merge-styles';
+export { IStyleFunctionOrObject, Omit } from '@uifabric/merge-styles';
 export { setFocusVisibility } from './setFocusVisibility';
 export { setSSR } from './dom/setSSR';
 import './version';


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Re-export the Omit utility type (defined in merge-styles) from uifabric utilities, so we can use it anywhere.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8899)