### PR TITLE
[new website] Add API docs

### DIFF
--- a/apps/fabric-website-resources/src/AppDefinition.tsx
+++ b/apps/fabric-website-resources/src/AppDefinition.tsx
@@ -14,19 +14,17 @@ const propertiesTableMargins = mergeStyles({
 });
 
 function loadReferences(): IAppLink[] {
-  const pageList: IReferencesList = require('@uifabric/api-docs/lib/pages/references/list.json');
+  const requireContext = require.context('@uifabric/api-docs/lib/pages/references', false, /\w+\.page\.json$/);
 
-  return pageList.pages.map(pageName => ({
-    component: () => (
-      <ApiReferencesTableSet
-        className={propertiesTableMargins}
-        jsonDocs={require('@uifabric/api-docs/lib/pages/references/' + pageName + '.page.json')}
-      />
-    ),
-    key: pageName,
-    name: pageName,
-    url: '#/examples/references/' + pageName.toLowerCase()
-  }));
+  return requireContext.keys().map(pagePath => {
+    const pageName = pagePath.match(/(\w+)\.page\.json/)![1];
+    return {
+      component: () => <ApiReferencesTableSet className={propertiesTableMargins} jsonDocs={requireContext(pagePath)} />,
+      key: pageName,
+      name: pageName,
+      url: '#/examples/references/' + pageName.toLowerCase()
+    };
+  });
 }
 
 export const AppDefinition: IAppDefinition = {

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -269,7 +269,7 @@ function _loadReferences(): INavPage[] {
       component: () => <LoadingComponent title={pageName} />,
       getComponent: cb =>
         requireContext(pagePath).then((jsonDocs: IPageJson) => {
-          cb(() => <ControlsAreaPage jsonDocs={jsonDocs} title={pageName} />);
+          cb(() => <ControlsAreaPage jsonDocs={jsonDocs} title={pageName} hideImplementationTitle />);
         })
     };
   });

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
-import { INavPage, LoadingComponent, Page } from '@uifabric/example-app-base/lib/index2';
+import { INavPage, LoadingComponent } from '@uifabric/example-app-base/lib/index2';
+import { ControlsAreaPage } from '../../../pages/Controls/ControlsAreaPage';
+import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
 import { Omit } from 'office-ui-fabric-react/lib/Utilities';
 
 type CategoryPage = Partial<Omit<INavPage, 'pages'>> & { subPages?: ICategory };
@@ -123,6 +125,7 @@ const categories: { Other?: ICategory; [name: string]: ICategory } = {
   'Fluent Theme': {
     FluentTheme: { title: 'Fluent Theme', url: 'fluent-theme' }
   },
+  References: {},
   Other: {}
 };
 
@@ -221,6 +224,9 @@ function generateCategories() {
     }
   }
 
+  // Add reference pages
+  pagesByCategory.References = _loadReferences();
+
   // Convert the categories to an array (filter out empty categories)
   return categoryNames
     .filter(category => !!pagesByCategory[category].length)
@@ -249,6 +255,24 @@ function _generatePage(
     getComponent: cb => requireContext(pagePath).then((mod: any) => cb(mod[componentName + 'Page'])),
     ...nonUrlOverrides
   };
+}
+
+function _loadReferences(): INavPage[] {
+  const requireContext = require.context('@uifabric/api-docs/lib/pages/references', false, /\w+\.page\.json$/, 'lazy');
+
+  return requireContext.keys().map(pagePath => {
+    const pageName = pagePath.match(/(\w+)\.page\.json/)![1];
+    return {
+      title: pageName,
+      url: '#/controls/web/references/' + pageName.toLowerCase(),
+      isFilterable: true,
+      component: () => <LoadingComponent title={pageName} />,
+      getComponent: cb =>
+        requireContext(pagePath).then((jsonDocs: IPageJson) => {
+          cb(() => <ControlsAreaPage jsonDocs={jsonDocs} title={pageName} />);
+        })
+    };
+  });
 }
 
 export const controlsPagesWeb: INavPage[] = [

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { INavPage, LoadingComponent, Page } from '@uifabric/example-app-base/lib/index2';
+import { Omit } from 'office-ui-fabric-react/lib/Utilities';
 
-type Omit<U, K extends keyof U> = Pick<U, Exclude<keyof U, K>>;
 type CategoryPage = Partial<Omit<INavPage, 'pages'>> & { subPages?: ICategory };
 
 interface ICategory {

--- a/apps/fabric-website/src/components/App/AppState.tsx
+++ b/apps/fabric-website/src/components/App/AppState.tsx
@@ -34,21 +34,24 @@ const StylesLoadingComponent = (props: any): JSX.Element => {
 };
 
 function loadReferences(): ILegacyNavPage[] {
-  const pageList: IReferencesList = require('@uifabric/api-docs/lib/pages/references/list.json');
+  const requireContext = require.context('@uifabric/api-docs/lib/pages/references', false, /\w+\.page\.json$/);
 
-  return pageList.pages.map(pageName => ({
-    title: pageName,
-    url: '#/components/references/' + pageName.toLowerCase(),
-    isFilterable: true,
-    component: () => (
-      <div className={pageStyles.basePage}>
-        <ComponentPage>
-          <PageHeader pageTitle={pageName} backgroundColor="#038387" />
-          <ApiReferencesTableSet jsonDocs={require('@uifabric/api-docs/lib/pages/references/' + pageName + '.page.json')} />
-        </ComponentPage>
-      </div>
-    )
-  }));
+  return requireContext.keys().map(pagePath => {
+    const pageName = pagePath.match(/(\w+)\.page\.json/)![1];
+    return {
+      title: pageName,
+      url: '#/components/references/' + pageName.toLowerCase(),
+      isFilterable: true,
+      component: () => (
+        <div className={pageStyles.basePage}>
+          <ComponentPage>
+            <PageHeader pageTitle={pageName} backgroundColor="#038387" />
+            <ApiReferencesTableSet jsonDocs={require('@uifabric/api-docs/lib/pages/references/' + pageName + '.page.json')} />
+          </ComponentPage>
+        </div>
+      )
+    };
+  });
 }
 
 export const AppState: IAppState = {

--- a/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
@@ -2,12 +2,24 @@ import * as React from 'react';
 import { Page, IPageProps, withPlatform } from '@uifabric/example-app-base/lib/index2';
 import { getSubTitle } from '../../utilities/index';
 import { Platforms } from '../../interfaces/Platforms';
+import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 export interface IControlsPageProps extends IPageProps<Platforms> {}
 
+const apiRequireContext = require.context('@uifabric/api-docs/lib/pages/office-ui-fabric-react');
+
 const ControlsAreaPageBase: React.StatelessComponent<IControlsPageProps> = props => {
-  const { platform, ...rest } = props;
-  return <Page platform={platform} subTitle={getSubTitle(platform)} {...rest} />;
+  let jsonDocs: IPageJson;
+  if (props.platform === 'web' && !props.jsonDocs) {
+    // Get the control's .page.json file for API docs if it exists
+    for (const path of apiRequireContext.keys()) {
+      if (path.indexOf(`/${props.title}.page.json`) !== -1) {
+        jsonDocs = apiRequireContext<IPageJson>(path);
+        break;
+      }
+    }
+  }
+  return <Page subTitle={getSubTitle(props.platform)} jsonDocs={jsonDocs} {...props} />;
 };
 
 export const ControlsAreaPage: React.StatelessComponent<IControlsPageProps> = withPlatform<Platforms>(ControlsAreaPageBase);

--- a/packages/api-docs/src/PageJsonGenerator.tsx
+++ b/packages/api-docs/src/PageJsonGenerator.tsx
@@ -154,12 +154,6 @@ function createPageJsonFiles(collectedData: CollectedData, options: IPageJsonOpt
       JsonFile.save(pageJson, pageJsonPath);
     }
   });
-
-  if (kind === 'References') {
-    const listJsonPath: string = path.join(options.pageJsonFolderPath, 'list.json');
-    referencesList.pages = referencesList.pages.sort();
-    JsonFile.save(referencesList, listJsonPath);
-  }
 }
 
 function renderDefaultValue(section: DocNodeContainer): string {

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -43,7 +43,6 @@ export const LARGE_GAP_SIZE = 48;
 const DEPRECATED_ROW_COLOR = '#FFF1CC';
 
 const backticksRegex = new RegExp('`[^`]*`', 'g');
-const hashRegex = new RegExp(/\#\/\w+\//);
 
 const referencesTableCell = (text: string | JSX.Element[], deprecated: boolean) => {
   return (
@@ -460,19 +459,24 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
     return (
       <>
         {linkTokens.map((token: ILinkToken, index: number) => {
-          let match: RegExpMatchArray | null = null;
           let hash: string = '/components/';
           // get hash to set correct href value on the links for the local site vs. the Fabric site
-          if (this._baseUrl !== '') {
-            match = this._baseUrl.match(hashRegex);
-            if (match !== null) {
-              hash = match[0].substring(1);
+
+          const split = this._baseUrl.split('#');
+          const cleanedSplit = split.filter(value => !!value);
+          if (cleanedSplit && cleanedSplit.length > 1) {
+            // handle /references/referenceName structure
+            if (cleanedSplit[1].indexOf('/references/') !== -1) {
+              const indexOfReferenceName = cleanedSplit[1].lastIndexOf('/');
+              const indexOfReferences = cleanedSplit[1].lastIndexOf('/', indexOfReferenceName - 1);
+              hash = cleanedSplit[1].substring(0, indexOfReferences + 1);
+            } else {
+              const indexOfPageName = cleanedSplit[1].lastIndexOf('/');
+              hash = cleanedSplit[1].substring(0, indexOfPageName + 1);
             }
           }
           if (token.pageKind && token.hyperlinkedPage) {
             let href;
-            const split = this._baseUrl.split('#');
-            const cleanedSplit = split.filter(value => !!value);
 
             // whether the link should be opened in a new tab, defaults to true
             let newTab = true;

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { ActionButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-import { css } from 'office-ui-fabric-react/lib/Utilities';
 import { ApiReferencesTable, MEDIUM_GAP_SIZE, LARGE_GAP_SIZE } from './ApiReferencesTable';
 import { IApiProperty, IApiInterfaceProperty, IApiEnumProperty, IMethod, IApiReferencesTableSetProps } from './ApiReferencesTableSet.types';
 import { IEnumTableRowJson, ITableRowJson, ITableJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
@@ -15,10 +13,6 @@ export interface IApiReferencesTableSetState {
   properties: Array<IApiProperty>;
   showSeeMore: boolean;
 }
-
-const apiReferencesTableTopMargin = mergeStyles({
-  marginTop: '40px'
-});
 
 const TITLE_LINE_HEIGHT = 31.5;
 
@@ -35,7 +29,7 @@ export class ApiReferencesTableSet extends React.Component<IApiReferencesTableSe
   public render(): JSX.Element {
     const { className } = this.props;
     return (
-      <Stack gap={LARGE_GAP_SIZE} className={css(apiReferencesTableTopMargin, className)}>
+      <Stack gap={LARGE_GAP_SIZE} className={className}>
         {this._renderFirst()}
         {this._renderEach()}
       </Stack>

--- a/packages/example-app-base/src/components/Nav/Nav.types.ts
+++ b/packages/example-app-base/src/components/Nav/Nav.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { TPlatformPages } from '../PlatformPicker/PlatformPicker.types';
+import { IRouteProps } from 'office-ui-fabric-react/lib/utilities/router/Route';
 
 /**
  * Props for the nav.
@@ -24,7 +25,7 @@ export interface INavProps<TPlatforms extends string = string> {
   searchablePageTitle?: string;
 }
 
-export interface INavPage<TPlatform extends string = string> {
+export interface INavPage<TPlatform extends string = string> extends Pick<IRouteProps, 'component' | 'getComponent'> {
   /**
    * The page's title, as shown in the navigation.
    */
@@ -39,16 +40,6 @@ export interface INavPage<TPlatform extends string = string> {
    * Unique CSS class name for this page.
    */
   className?: string;
-
-  /**
-   * The component to render for this page's content.
-   */
-  component?: React.ComponentType;
-
-  /**
-   * Loads the component using require.ensure;
-   */
-  getComponent?: (cb: (component: React.ComponentType) => void) => void;
 
   /**
    * Optional array of child pages belonging to this one.

--- a/packages/example-app-base/src/components/Page/Page.tsx
+++ b/packages/example-app-base/src/components/Page/Page.tsx
@@ -112,6 +112,7 @@ export class Page extends React.Component<IPageProps, IPageState> {
       componentUrl,
       platform,
       propertiesTablesSources,
+      jsonDocs,
       title,
       usage
     } = this.props;
@@ -157,14 +158,15 @@ export class Page extends React.Component<IPageProps, IPageState> {
       sections.push(examplesProps);
     }
 
-    if (propertiesTablesSources) {
+    if (propertiesTablesSources || jsonDocs) {
       const propertiesTablesProps: IImplementationSectionProps = {
         renderAs: ImplementationSection,
         ...sectionProps,
         allowNativeProps,
         nativePropsElement,
         allowNativePropsForComponentName,
-        propertiesTablesSources
+        propertiesTablesSources,
+        jsonDocs
       };
       sections.push(propertiesTablesProps);
     }

--- a/packages/example-app-base/src/components/Page/Page.tsx
+++ b/packages/example-app-base/src/components/Page/Page.tsx
@@ -112,6 +112,7 @@ export class Page extends React.Component<IPageProps, IPageState> {
       componentUrl,
       platform,
       propertiesTablesSources,
+      hideImplementationTitle,
       jsonDocs,
       title,
       usage
@@ -166,6 +167,7 @@ export class Page extends React.Component<IPageProps, IPageState> {
         nativePropsElement,
         allowNativePropsForComponentName,
         propertiesTablesSources,
+        hideImplementationTitle,
         jsonDocs
       };
       sections.push(propertiesTablesProps);

--- a/packages/example-app-base/src/components/Page/Page.types.ts
+++ b/packages/example-app-base/src/components/Page/Page.types.ts
@@ -84,6 +84,9 @@ export interface IPageProps<TPlatforms extends string = string> {
    */
   allowNativePropsForComponentName?: string;
 
+  /** For properties (implementation) section, whether to hide the section title. */
+  hideImplementationTitle?: boolean;
+
   /** (8) Array of custom sections. */
   otherSections?: IPageSectionProps[];
 

--- a/packages/example-app-base/src/components/Page/Page.types.ts
+++ b/packages/example-app-base/src/components/Page/Page.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IComponentAs } from 'office-ui-fabric-react';
 import { IExampleCardProps } from '../ExampleCard/index';
 import { ISideRailLink } from '../SideRail/index';
+import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 /**
  * Props for the page.
@@ -59,16 +60,28 @@ export interface IPageProps<TPlatforms extends string = string> {
   /** Knobs that applies to all the examples. */
   exampleKnobs?: React.ReactNode;
 
-  /** (7) Properties table(s) as Markdown string. */
+  /** (7) JSON to populate the API reference tables. Mutually exclusive with `propertiesTableSources`. */
+  jsonDocs?: IPageJson;
+
+  /** (7) Properties table(s) as Markdown string. Mutually exclusive with `jsonDocs`. */
   propertiesTablesSources?: string[];
 
-  /** For properties (implementation) section, whether the component allows native props. */
+  /**
+   * For properties (implementation) section, whether the component allows native props.
+   * Only relevant if using `propertiesTableSources`.
+   */
   allowNativeProps?: boolean;
 
-  /** For properties (implementation) section, native props root element. */
+  /**
+   * For properties (implementation) section, native props root element.
+   * Only relevant if using `propertiesTableSources`.
+   */
   nativePropsElement?: string | string[];
 
-  /** For properties (implementation) section, override component name to use in the native props message */
+  /**
+   * For properties (implementation) section, override component name to use in the native props message.
+   * Only relevant if using `propertiesTableSources`.
+   */
   allowNativePropsForComponentName?: string;
 
   /** (8) Array of custom sections. */

--- a/packages/example-app-base/src/components/Page/sections/ImplementationSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/ImplementationSection.tsx
@@ -4,16 +4,19 @@ import { MessageBar, css } from 'office-ui-fabric-react';
 import { camelize, pascalize } from '../../../utilities/index2';
 import { IPageSectionProps } from '../Page.types';
 import * as styles from './ImplementationSection.module.scss';
+import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
+import { ApiReferencesTableSet } from '../../ApiReferencesTable/index';
 
 export interface IImplementationSectionProps extends IPageSectionProps {
-  propertiesTablesSources: string[];
+  jsonDocs?: IPageJson;
+  propertiesTablesSources?: string[];
   allowNativeProps?: boolean;
   nativePropsElement?: string | string[];
   allowNativePropsForComponentName?: string;
 }
 
 export const ImplementationSection: React.StatelessComponent<IImplementationSectionProps> = props => {
-  const { className, sectionName = 'Implementation', style, propertiesTablesSources } = props;
+  const { className, sectionName = 'Implementation', style, propertiesTablesSources, jsonDocs } = props;
   const { readableSectionName = sectionName } = props;
   const sectionClassName = camelize(sectionName);
   const sectionId = pascalize(sectionName);
@@ -24,8 +27,9 @@ export const ImplementationSection: React.StatelessComponent<IImplementationSect
           {readableSectionName}
         </h2>
       </div>
-      {_getNativePropsInfo(props)}
-      <PropertiesTableSet sources={propertiesTablesSources} />
+      {jsonDocs && <ApiReferencesTableSet jsonDocs={jsonDocs} />}
+      {!jsonDocs && _getNativePropsInfo(props)}
+      {!jsonDocs && <PropertiesTableSet sources={propertiesTablesSources} />}
     </div>
   );
 };

--- a/packages/example-app-base/src/components/Page/sections/ImplementationSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/ImplementationSection.tsx
@@ -13,20 +13,23 @@ export interface IImplementationSectionProps extends IPageSectionProps {
   allowNativeProps?: boolean;
   nativePropsElement?: string | string[];
   allowNativePropsForComponentName?: string;
+  hideImplementationTitle?: boolean;
 }
 
 export const ImplementationSection: React.StatelessComponent<IImplementationSectionProps> = props => {
-  const { className, sectionName = 'Implementation', style, propertiesTablesSources, jsonDocs } = props;
+  const { className, sectionName = 'Implementation', style, propertiesTablesSources, jsonDocs, hideImplementationTitle } = props;
   const { readableSectionName = sectionName } = props;
   const sectionClassName = camelize(sectionName);
   const sectionId = pascalize(sectionName);
   return (
     <div className={css(`Page-${sectionClassName}Section`, className)} style={style}>
-      <div className={css(styles.sectionHeader, `Page-${sectionClassName}SectionHeader`)}>
-        <h2 className={css(styles.subHeading, `Page-subHeading`)} id={sectionId}>
-          {readableSectionName}
-        </h2>
-      </div>
+      {!hideImplementationTitle && (
+        <div className={css(styles.sectionHeader, `Page-${sectionClassName}SectionHeader`)}>
+          <h2 className={css(styles.subHeading, `Page-subHeading`)} id={sectionId}>
+            {readableSectionName}
+          </h2>
+        </div>
+      )}
       {jsonDocs && <ApiReferencesTableSet jsonDocs={jsonDocs} />}
       {!jsonDocs && _getNativePropsInfo(props)}
       {!jsonDocs && <PropertiesTableSet sources={propertiesTablesSources} />}

--- a/packages/office-ui-fabric-react/src/utilities/router/Route.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/router/Route.tsx
@@ -1,9 +1,26 @@
 import * as React from 'react';
 
-export interface IRouteProps {
+/** A component function which doesn't explicitly declare itself as React.StatelessComponent/SFC/FunctionComponent */
+export type ComponentLike = (props?: {}) => React.ReactElement<{}> | null;
+// ^^ This is needed so we don't break consumers who may not explicitly declare their
+// functional components as one of React's functional component types.
+
+export interface IRouteProps extends React.ClassAttributes<Route> {
   path?: string;
-  component?: React.Component<any, any>;
-  getComponent?: (cb: any) => void;
+
+  children?: React.ReactNode;
+
+  /**
+   * The component to render for this route's content (or a loading placeholder if `getComponent` is provided).
+   */
+  component?: React.ComponentType | ComponentLike;
+
+  /**
+   * Function that loads the component asynchronously.
+   * Notify when loading has finished using `cb`.
+   * If `component` is provided, it will be rendered while waiting for the callback.
+   */
+  getComponent?: (cb: (component: React.ComponentType | ComponentLike) => void) => void;
 }
 
-export class Route extends React.Component<any, any> {}
+export class Route extends React.PureComponent<IRouteProps> {}

--- a/packages/office-ui-fabric-react/src/utilities/router/Route.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/router/Route.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 /** A component function which doesn't explicitly declare itself as React.StatelessComponent/SFC/FunctionComponent */
-export type ComponentLike = (props?: {}) => React.ReactElement<{}> | null;
+export type ComponentLike<P = {}> = React.ComponentClass<P> | ((props?: P) => React.ReactElement<P> | null);
 // ^^ This is needed so we don't break consumers who may not explicitly declare their
 // functional components as one of React's functional component types.
 
@@ -13,14 +13,14 @@ export interface IRouteProps extends React.ClassAttributes<Route> {
   /**
    * The component to render for this route's content (or a loading placeholder if `getComponent` is provided).
    */
-  component?: React.ComponentType | ComponentLike;
+  component?: ComponentLike;
 
   /**
    * Function that loads the component asynchronously.
    * Notify when loading has finished using `cb`.
    * If `component` is provided, it will be rendered while waiting for the callback.
    */
-  getComponent?: (cb: (component: React.ComponentType | ComponentLike) => void) => void;
+  getComponent?: (cb: (component: ComponentLike) => void) => void;
 }
 
 export class Route extends React.PureComponent<IRouteProps> {}


### PR DESCRIPTION
Show the API documentation tables @natalieethell added on the web control pages on the new website, and add a References section to the web controls left nav for utility/interface references.

Also includes:

- Use [require.context](https://webpack.js.org/api/module-methods/#requirecontext) instead of generating a list.json file to get the list of reference pages

- Router typing improvements

- Export and use Omit from utilities (from #8899)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8900)