### PR TITLE
Fix types for tooltip and tooltiphost content

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2019-05-01-00-44.json
+++ b/common/changes/office-ui-fabric-react/master_2019-05-01-00-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip/TooltipHost: content now can take JSX content.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7536,7 +7536,7 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
     calloutProps?: ICalloutProps;
     closeDelay?: number;
     componentRef?: IRefObject<ITooltipHost>;
-    content?: string;
+    content?: string | JSX.Element | JSX.Element[];
     delay?: TooltipDelay;
     directionalHint?: DirectionalHint;
     directionalHintForRTL?: DirectionalHint;
@@ -7570,7 +7570,7 @@ export interface ITooltipHostStyles {
 export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | TooltipBase> {
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITooltip>;
-    content?: string;
+    content?: string | JSX.Element | JSX.Element[];
     delay?: TooltipDelay;
     directionalHint?: DirectionalHint;
     directionalHintForRTL?: DirectionalHint;

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -1,10 +1,10 @@
-import * as React from "react";
-import { TooltipBase } from "./Tooltip.base";
-import { ICalloutProps } from "../../Callout";
-import { IRenderFunction } from "../../Utilities";
-import { DirectionalHint } from "../../common/DirectionalHint";
-import { IStyle, ITheme } from "../../Styling";
-import { IRefObject, IStyleFunctionOrObject } from "../../Utilities";
+import * as React from 'react';
+import { TooltipBase } from './Tooltip.base';
+import { ICalloutProps } from '../../Callout';
+import { IRenderFunction } from '../../Utilities';
+import { DirectionalHint } from '../../common/DirectionalHint';
+import { IStyle, ITheme } from '../../Styling';
+import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 
 /**
  * {@docCategory Tooltip}
@@ -15,8 +15,7 @@ export interface ITooltip {}
  * Tooltip component props.
  * {@docCategory Tooltip}
  */
-export interface ITooltipProps
-  extends React.HTMLAttributes<HTMLDivElement | TooltipBase> {
+export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | TooltipBase> {
   /**
    * Optional callback to access the ITooltip interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -1,10 +1,10 @@
-import * as React from 'react';
-import { TooltipBase } from './Tooltip.base';
-import { ICalloutProps } from '../../Callout';
-import { IRenderFunction } from '../../Utilities';
-import { DirectionalHint } from '../../common/DirectionalHint';
-import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import * as React from "react";
+import { TooltipBase } from "./Tooltip.base";
+import { ICalloutProps } from "../../Callout";
+import { IRenderFunction } from "../../Utilities";
+import { DirectionalHint } from "../../common/DirectionalHint";
+import { IStyle, ITheme } from "../../Styling";
+import { IRefObject, IStyleFunctionOrObject } from "../../Utilities";
 
 /**
  * {@docCategory Tooltip}
@@ -15,7 +15,8 @@ export interface ITooltip {}
  * Tooltip component props.
  * {@docCategory Tooltip}
  */
-export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | TooltipBase> {
+export interface ITooltipProps
+  extends React.HTMLAttributes<HTMLDivElement | TooltipBase> {
   /**
    * Optional callback to access the ITooltip interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -29,9 +30,9 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
   calloutProps?: ICalloutProps;
 
   /**
-   *  String to be passed to the tooltip
+   *  Content to be passed to the tooltip
    */
-  content?: string;
+  content?: string | JSX.Element | JSX.Element[];
 
   /**
    *  Render function to populate content area

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
@@ -1,10 +1,10 @@
-import * as React from "react";
-import { TooltipHostBase } from "./TooltipHost.base";
-import { TooltipDelay, ITooltipProps } from "./Tooltip.types";
-import { ICalloutProps } from "../../Callout";
-import { DirectionalHint } from "../../common/DirectionalHint";
-import { IRefObject, IStyleFunctionOrObject } from "../../Utilities";
-import { IStyle, ITheme } from "../../Styling";
+import * as React from 'react';
+import { TooltipHostBase } from './TooltipHost.base';
+import { TooltipDelay, ITooltipProps } from './Tooltip.types';
+import { ICalloutProps } from '../../Callout';
+import { DirectionalHint } from '../../common/DirectionalHint';
+import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IStyle, ITheme } from '../../Styling';
 
 export interface ITooltipHost {
   /**
@@ -29,8 +29,7 @@ export enum TooltipOverflowMode {
 /**
  * Tooltip component props.
  */
-export interface ITooltipHostProps
-  extends React.HTMLAttributes<HTMLDivElement | TooltipHostBase> {
+export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement | TooltipHostBase> {
   /**
    * Optional callback to access the ITooltipHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -51,7 +50,7 @@ export interface ITooltipHostProps
   closeDelay?: number;
 
   /**
-   * Content to be passed to the tooltip
+   *  Content to be passed to the tooltip
    */
   content?: string | JSX.Element | JSX.Element[];
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
@@ -1,10 +1,10 @@
-import * as React from 'react';
-import { TooltipHostBase } from './TooltipHost.base';
-import { TooltipDelay, ITooltipProps } from './Tooltip.types';
-import { ICalloutProps } from '../../Callout';
-import { DirectionalHint } from '../../common/DirectionalHint';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
-import { IStyle, ITheme } from '../../Styling';
+import * as React from "react";
+import { TooltipHostBase } from "./TooltipHost.base";
+import { TooltipDelay, ITooltipProps } from "./Tooltip.types";
+import { ICalloutProps } from "../../Callout";
+import { DirectionalHint } from "../../common/DirectionalHint";
+import { IRefObject, IStyleFunctionOrObject } from "../../Utilities";
+import { IStyle, ITheme } from "../../Styling";
 
 export interface ITooltipHost {
   /**
@@ -29,7 +29,8 @@ export enum TooltipOverflowMode {
 /**
  * Tooltip component props.
  */
-export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement | TooltipHostBase> {
+export interface ITooltipHostProps
+  extends React.HTMLAttributes<HTMLDivElement | TooltipHostBase> {
   /**
    * Optional callback to access the ITooltipHost interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -50,9 +51,9 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
   closeDelay?: number;
 
   /**
-   * String to be passed to the tooltip
+   * Content to be passed to the tooltip
    */
-  content?: string;
+  content?: string | JSX.Element | JSX.Element[];
 
   /**
    * Length of delay


### PR DESCRIPTION
Provides an accurate type for the content of tooltip and tooltiphost content.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8901)