### PR TITLE
date-time: adjust some center alignment.

### DIFF
--- a/common/changes/@uifabric/date-time/vibraga-DateTimeCenter_2019-05-01-09-06.json
+++ b/common/changes/@uifabric/date-time/vibraga-DateTimeCenter_2019-05-01-09-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "CalendarDay: adjust styles to center align the selected days and months.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "vibraga@microsoft.com"
+}

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -114,13 +114,9 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
       padding: 0,
       width: 28,
       height: 28,
-      lineHeight: 28,
       fontSize: FontSizes.small,
       fontWeight: FontWeights.regular,
       color: palette.neutralPrimary,
-      boxSizing: 'border-box',
-      justifyContent: 'center',
-      alignItems: 'center',
       selectors: {
         ['&.' + classNames.hoverStyle]: {
           backgroundColor: palette.neutralLight
@@ -141,17 +137,14 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
       }
     ],
     weekNumberCell: {
+      margin: 0,
+      padding: 0,
       borderRight: '1px solid',
       borderColor: palette.neutralLight,
       boxSizing: 'border-box',
       width: 28,
       height: 28,
-      lineHeight: 28,
-      margin: 0,
-      fontWeight: FontWeights.regular,
-      padding: 0,
-      justifyContent: 'center',
-      alignItems: 'center'
+      fontWeight: FontWeights.regular
     },
     disabledStyle: disabledStyle,
     dayOutsideBounds: disabledStyle,
@@ -165,9 +158,8 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
         width: 24,
         height: 24,
         lineHeight: 24,
+        fontSize: FontSizes.small,
         borderRadius: 2,
-        alignItems: 'center',
-        justifyContent: 'center',
         border: 'none',
         padding: 0,
         backgroundColor: 'transparent',

--- a/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
@@ -83,6 +83,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
         minHeight: 40,
         lineHeight: 40,
         fontSize: FontSizes.small,
+        padding: 0,
         margin: '0 12px 16px 0',
         color: palette.neutralPrimary,
         backgroundColor: 'transparent',


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

@micahgodbolt, @lorejoh12 I fixed the center alignment on the selected days and also a minor cleanup of what I saw obvious not needed.

## Before:
<img width="1053" alt="Screen Shot 2019-05-01 at 2 11 16 AM" src="https://user-images.githubusercontent.com/29514833/57011472-a5b78b00-6bb6-11e9-82f4-23b836c68d08.png">

## After:
<img width="1055" alt="Screen Shot 2019-05-01 at 2 10 18 AM" src="https://user-images.githubusercontent.com/29514833/57011476-a8b27b80-6bb6-11e9-9833-bbb25d77da64.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8907)