### PR TITLE
Properly propagate Esc in DatePicker

### DIFF
--- a/common/changes/office-ui-fabric-react/anihan-datePicker-esc_2019-05-02-23-49.json
+++ b/common/changes/office-ui-fabric-react/anihan-datePicker-esc_2019-05-02-23-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Properly propagate Esc in DatePicker",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -413,7 +413,9 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   };
 
   private _handleEscKey = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    ev.stopPropagation();
+    if (this.state.isDatePickerShown) {
+      ev.stopPropagation();
+    }
     this._calendarDismissed();
   };
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -7,8 +7,9 @@ import { DatePickerBase } from './DatePicker.base';
 import { IDatePickerStrings } from './DatePicker.types';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { shallow, mount, ReactWrapper } from 'enzyme';
-import { resetIds } from '../../Utilities';
+import { resetIds, KeyCodes } from '../../Utilities';
 import { Callout } from '../Callout/Callout';
+import { PrimaryButton } from '../Button/PrimaryButton/PrimaryButton';
 
 describe('DatePicker', () => {
   beforeEach(() => {
@@ -112,6 +113,33 @@ describe('DatePicker', () => {
     const calloutProps = datePicker.find(Callout).props();
 
     expect(calloutProps.ariaLabel).toBe('Calendar');
+  });
+
+  it('should close parent Callout if Esc is pressed', () => {
+    const menu = (props: any) => {
+      return (
+        <Callout {...props}>
+          <DatePicker />
+        </Callout>
+      );
+    };
+    const wrapper = mount(
+      <PrimaryButton
+        menuAs={menu}
+        menuProps={{
+          items: []
+        }}
+      />
+    );
+    wrapper.simulate('click');
+    let callout = wrapper.find(Callout);
+    expect(callout.exists()).toBe(true);
+
+    const datePicker = wrapper.find(DatePickerBase);
+    datePicker.simulate('keydown', { which: KeyCodes.escape });
+
+    callout = wrapper.find(Callout);
+    expect(callout.exists()).toBe(false);
   });
 
   describe('when Calendar properties are not specified', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8866
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Only `stopPropagation()` of Esc event when `isDatePickerShown` is `true`

#### Focus areas to test

Any side effects of propagating the event during other instances 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8935)