### PR TITLE
DetailsList: Animate column updates

### DIFF
--- a/common/changes/office-ui-fabric-react/phkuo-animateSimply_2019-05-02-23-53.json
+++ b/common/changes/office-ui-fabric-react/phkuo-animateSimply_2019-05-02-23-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: animate cells when content is updated",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "odbuild@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3312,6 +3312,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     dragDropEvents?: IDragDropEvents;
     // @deprecated
     enableShimmer?: boolean;
+    enableUpdateAnimations?: boolean;
     enterModalSelectionOnTouch?: boolean;
     getGroupHeight?: IGroupedListProps['getGroupHeight'];
     getKey?: (item: any, index?: number) => string;
@@ -3416,6 +3417,7 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
     dragDropEvents?: IDragDropEvents;
     // Warning: (ae-forgotten-export) The symbol "IDragDropHelper" needs to be exported by the entry point index.d.ts
     dragDropHelper?: IDragDropHelper;
+    enableUpdateAnimations?: boolean;
     eventsToRegister?: {
         eventName: string;
         callback: (item?: any, index?: number, event?: any) => void;
@@ -3512,6 +3514,7 @@ export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> & 
     className?: string;
     compact?: boolean;
     cellStyleProps?: ICellStyleProps;
+    enableUpdateAnimations?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -529,7 +529,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       useReducedRowRenderer,
       indentWidth,
       cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
-      onRenderCheckbox
+      onRenderCheckbox,
+      enableUpdateAnimations
     } = this.props;
     const collapseAllVisibility = groupProps && groupProps.collapseAllVisibility;
     const selection = this._selection;
@@ -560,7 +561,8 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
       useReducedRowRenderer: useReducedRowRenderer,
       indentWidth,
       cellStyleProps: cellStyleProps,
-      onRenderDetailsCheckbox: onRenderCheckbox
+      onRenderDetailsCheckbox: onRenderCheckbox,
+      enableUpdateAnimations
     };
 
     if (!item) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -301,6 +301,11 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    * Whether or not to disable the built-in SelectionZone, so the host component can provide its own.
    */
   disableSelectionZone?: boolean;
+
+  /**
+   * Whether to animate updates
+   */
+  enableUpdateAnimations?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -178,6 +178,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
       selection,
       indentWidth,
       shimmer,
+      enableUpdateAnimations,
       compact,
       theme,
       styles,
@@ -204,7 +205,8 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
         checkboxCellClassName,
         droppingClassName,
         className,
-        compact
+        compact,
+        enableUpdateAnimations
       })
     };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -1,5 +1,13 @@
 import { IDetailsRowStyleProps, IDetailsRowStyles, ICellStyleProps } from './DetailsRow.types';
-import { AnimationClassNames, FontSizes, HighContrastSelector, IStyle, getFocusStyle, getGlobalClassNames } from '../../Styling';
+import {
+  AnimationClassNames,
+  AnimationStyles,
+  FontSizes,
+  HighContrastSelector,
+  IStyle,
+  getFocusStyle,
+  getGlobalClassNames
+} from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-DetailsRow',
@@ -58,7 +66,8 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
     checkboxCellClassName,
     compact,
     className,
-    cellStyleProps = DEFAULT_CELL_STYLE_PROPS
+    cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
+    enableUpdateAnimations
   } = props;
 
   const { neutralPrimary, white, neutralSecondary, neutralLighter, neutralLight, neutralDark, neutralQuaternaryAlt, black } = theme.palette;
@@ -325,7 +334,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       }
     ],
 
-    cell: defaultCellStyles,
+    cell: [defaultCellStyles, enableUpdateAnimations && AnimationStyles.slideLeftIn40],
 
     cellMeasurer: [
       classNames.cellMeasurer,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -170,6 +170,9 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
    */
   shimmer?: boolean;
 
+  /** Whether to animate updates */
+  enableUpdateAnimations?: boolean;
+
   /**
    * Rerender DetailsRow only when props changed. Might cause regression when depending on external updates.
    * @defaultvalue false
@@ -235,6 +238,9 @@ export type IDetailsRowStyleProps = Required<Pick<IDetailsRowProps, 'theme'>> & 
   compact?: boolean;
 
   cellStyleProps?: ICellStyleProps;
+
+  /** Whether to animate updates */
+  enableUpdateAnimations?: boolean;
 };
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -47,6 +47,7 @@ export class DetailsRowFields extends React.PureComponent<IDetailsRowFieldsProps
               ? onRender(item, itemIndex, column)
               : getCellText(item, column);
 
+          // generate a key that auto-dirties when content changes, to force the container to re-render, to trigger animation
           let key: number | string;
           try {
             const s = JSON.stringify(cellContentsRender);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -3,6 +3,7 @@ import { IColumn } from './DetailsList.types';
 import { css } from '../../Utilities';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
+import { AnimationClassNames } from '../../Styling';
 
 const getCellText = (item: any, column: IColumn): string => {
   let value = item && column && column.fieldName ? item[column.fieldName] : '';
@@ -49,7 +50,7 @@ export class DetailsRowFields extends React.PureComponent<IDetailsRowFieldsProps
 
           return (
             <div
-              key={columnIndex}
+              key={cellContentsRender}
               role={column.isRowHeader ? 'rowheader' : 'gridcell'}
               aria-colindex={columnIndex + columnStartIndex + 1}
               className={css(
@@ -59,7 +60,8 @@ export class DetailsRowFields extends React.PureComponent<IDetailsRowFieldsProps
                 column.isIconOnly && shimmer && rowClassNames.shimmerIconPlaceholder,
                 shimmer && rowClassNames.shimmer,
                 rowClassNames.cell,
-                column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded
+                column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded,
+                AnimationClassNames.slideLeftIn40
               )}
               style={{ width }}
               data-automationid="DetailsRowCell"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -3,7 +3,6 @@ import { IColumn } from './DetailsList.types';
 import { css } from '../../Utilities';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
-import { AnimationClassNames } from '../../Styling';
 
 const getCellText = (item: any, column: IColumn): string => {
   let value = item && column && column.fieldName ? item[column.fieldName] : '';
@@ -48,9 +47,18 @@ export class DetailsRowFields extends React.PureComponent<IDetailsRowFieldsProps
               ? onRender(item, itemIndex, column)
               : getCellText(item, column);
 
+          let key: number | string;
+          try {
+            const s = JSON.stringify(cellContentsRender);
+            key = s ? s + columnIndex : String(columnIndex);
+          } catch {
+            // circular reference
+            key = columnIndex;
+          }
+
           return (
             <div
-              key={cellContentsRender}
+              key={key}
               role={column.isRowHeader ? 'rowheader' : 'gridcell'}
               aria-colindex={columnIndex + columnStartIndex + 1}
               className={css(
@@ -60,8 +68,7 @@ export class DetailsRowFields extends React.PureComponent<IDetailsRowFieldsProps
                 column.isIconOnly && shimmer && rowClassNames.shimmerIconPlaceholder,
                 shimmer && rowClassNames.shimmer,
                 rowClassNames.cell,
-                column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded,
-                AnimationClassNames.slideLeftIn40
+                column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded
               )}
               style={{ width }}
               data-automationid="DetailsRowCell"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -43,6 +43,28 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
       });
     }
 
+    // DEMO CODE TODO: REMOVE BEFORE CHECKIN
+    const LOREM_IPSUM = (
+      'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut ' +
+      'labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut ' +
+      'aliquip ex ea commodo consequat duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore ' +
+      'eu fugiat nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt '
+    ).split(' ');
+    let loremIndex = 0;
+    function _lorem(wordCount: number): string {
+      const startIndex = loremIndex + wordCount > LOREM_IPSUM.length ? 0 : loremIndex;
+      loremIndex = startIndex + wordCount;
+      return LOREM_IPSUM.slice(startIndex, loremIndex).join(' ');
+    }
+    setInterval(() => {
+      const newItems = this.state.items.slice();
+      const i = Math.floor(Math.random() * 10);
+      newItems[i] = { ...newItems[i], ...{ value: (_lorem(2) as unknown) as number, name: _lorem(1) } };
+      this.setState({ items: newItems });
+      this.forceUpdate();
+    }, 2000);
+    // END DEMO CODE
+
     this._columns = [
       { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
       { key: 'column2', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200, isResizable: true }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -59,7 +59,7 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
     setInterval(() => {
       const newItems = this.state.items.slice();
       const i = Math.floor(Math.random() * 10);
-      newItems[i] = { ...newItems[i], ...{ value: (_lorem(2) as unknown) as number, name: _lorem(1) } };
+      newItems[i] = { ...newItems[i], ...{ value: Math.floor(Math.random() * 2), name: _lorem(1) } };
       this.setState({ items: newItems });
       this.forceUpdate();
     }, 2000);
@@ -99,6 +99,7 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
             ariaLabelForSelectionColumn="Toggle selection"
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
             onItemInvoked={this._onItemInvoked}
+            enableUpdateAnimations={true}
           />
         </MarqueeSelection>
       </Fabric>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds a simple animation for individual cells when that cell's content updates. Side effect: entire list also slightly animates when it first renders, but it actually looks kind of nice.

When new content comes in, the current cell's content immediately disappears, and the new contents immediately start sliding in from the left.

The old, super-complex PR is here:
https://github.com/OfficeDev/office-ui-fabric-react/pull/5384
That implementation also animated the sliding out of the old content before animating the sliding in of the new content. Holding on to that old content caused huge amounts of extra complexity, so I cut it.

#### Focus areas to test

perf


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8936)