### PR TITLE
 Dropdown: Add breakpoint for small screen sizes

### DIFF
--- a/common/changes/office-ui-fabric-react/anihan-dropdown-panelFix_2019-05-03-01-35.json
+++ b/common/changes/office-ui-fabric-react/anihan-dropdown-panelFix_2019-05-03-01-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add min panel width for small screen sizes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -8,7 +8,9 @@ import {
   IStyle,
   getGlobalClassNames,
   normalize,
-  HighContrastSelectorWhite
+  HighContrastSelectorWhite,
+  getScreenSelector,
+  ScreenWidthMinMedium
 } from '../../Styling';
 
 const GlobalClassNames = {
@@ -61,6 +63,8 @@ const highContrastBorderState: IRawStyle = {
     }
   }
 };
+
+const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMinMedium);
 
 export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = props => {
   const { theme, hasError, className, isOpen, disabled, required, isRenderingPlaceholder, panelClassName, calloutClassName } = props;
@@ -288,7 +292,14 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         root: [panelClassName],
         main: {
           // Force drop shadow even under medium breakpoint
-          boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)'
+          boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)',
+          selectors: {
+            // In case of extra small screen sizes
+            [MinimumScreenSelector]: {
+              // panelWidth xs
+              width: 272
+            }
+          }
         },
         contentInner: { padding: '0 0 20px' }
       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Small screen sizes (<480px in width) can't back out of the Dropdown. This PR reduces the width for these screens so that tap of empty area and dismiss the Panel.

#### Focus areas to test

Various screen breakpoints when we render Dropdown on a Panel surface 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8937)