### PR TITLE
Add version dropdown and fix other bugs

### DIFF
--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -200,7 +200,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
           text="You can now implement the new Fluent styles in Fabric Web controls."
           linkText="Learn more"
           linkUrl="#/controls/web/fluent-theme"
-          localStoragePrefix="WebFluentUpdates"
+          sessionStoragePrefix="WebFluentUpdates"
         />
       );
     } else if (/^#?\/?$/.test(pagePath)) {
@@ -209,6 +209,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
           text="Microsoft employees can sign in to see additional documentation."
           linkText="Sign in"
           linkUrl="http://aka.ms/hig"
+          sessionStoragePrefix="SignIn"
         />
       );
     }

--- a/apps/fabric-website/src/components/Site/SiteMessageBar.tsx
+++ b/apps/fabric-website/src/components/Site/SiteMessageBar.tsx
@@ -14,10 +14,10 @@ export interface ISiteMessageBarProps {
   linkUrl?: string;
 
   /**
-   * Prefix for local storage key for storing if the message bar has been closed.
+   * Prefix for session storage key for storing if the message bar has been closed.
    * If not provided, local storage will not be used.
    */
-  localStoragePrefix?: string;
+  sessionStoragePrefix?: string;
 
   /** Styles for the message bar */
   styles?: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles>;
@@ -28,17 +28,17 @@ export interface ISiteMessageBarState {
 }
 
 export default class SiteMessageBar extends React.Component<ISiteMessageBarProps, ISiteMessageBarState> {
-  private _localStorageKey: string | undefined;
+  private _sessionStorageKey: string | undefined;
 
   constructor(props: ISiteMessageBarProps) {
     super(props);
 
     let isVisible = true;
-    if (props.localStoragePrefix) {
-      this._localStorageKey = props.localStoragePrefix + 'MessageBarHidden';
+    if (props.sessionStoragePrefix) {
+      this._sessionStorageKey = props.sessionStoragePrefix + 'MessageBarHidden';
       try {
-        // Accessing localStorage can throw for various reasons--just ignore if this happens
-        isVisible = !localStorage.getItem(this._localStorageKey);
+        // Accessing sessionStorage can throw for various reasons--just ignore if this happens
+        isVisible = !sessionStorage.getItem(this._sessionStorageKey);
       } catch (ex) {
         isVisible = true;
       }
@@ -64,9 +64,9 @@ export default class SiteMessageBar extends React.Component<ISiteMessageBarProps
   }
 
   private _onClose = () => {
-    if (this._localStorageKey) {
+    if (this._sessionStorageKey) {
       try {
-        localStorage.setItem(this._localStorageKey, '1');
+        sessionStorage.setItem(this._sessionStorageKey, '1');
       } catch (ex) {
         // ignore
       }

--- a/apps/fabric-website/src/components/Site/customizations.ts
+++ b/apps/fabric-website/src/components/Site/customizations.ts
@@ -4,7 +4,7 @@ import { IAppCustomizations, IExampleCardCustomizations } from '@uifabric/exampl
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Fluent', customizations: FluentCustomizations },
-  { title: 'MDL2', customizations: DefaultCustomizations }
+  { title: 'Pre-Fluent', customizations: DefaultCustomizations }
 ];
 
 export const AppCustomizations: IAppCustomizations = {

--- a/apps/fabric-website/src/components/Site/customizations.ts
+++ b/apps/fabric-website/src/components/Site/customizations.ts
@@ -4,7 +4,7 @@ import { IAppCustomizations, IExampleCardCustomizations } from '@uifabric/exampl
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Fluent', customizations: FluentCustomizations },
-  { title: 'Pre-Fluent', customizations: DefaultCustomizations }
+  { title: 'Default', customizations: DefaultCustomizations }
 ];
 
 export const AppCustomizations: IAppCustomizations = {

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -1,9 +1,26 @@
 import * as React from 'react';
-import { Async, Icon, Image, Link, TooltipHost, classNamesFunction, registerIcons, IProcessedStyleSet } from 'office-ui-fabric-react';
+import {
+  Async,
+  css,
+  Icon,
+  Image,
+  Link,
+  TooltipHost,
+  classNamesFunction,
+  registerIcons,
+  IProcessedStyleSet,
+  IContextualMenuItem,
+  DirectionalHint,
+  ActionButton,
+  Stack,
+  IRawStyle
+} from 'office-ui-fabric-react';
 import { trackEvent, EventNames, getSiteArea } from '@uifabric/example-app-base/lib/index2';
 import { platforms } from '../../SiteDefinition/SiteDefinition.platforms';
-import { AndroidLogo, AppleLogo, WebLogo } from '../../utilities/index';
+import { AndroidLogo, AppleLogo, WebLogo, getParameterByName } from '../../utilities/index';
 import { IHomePageProps, IHomePageStyles, IHomePageStyleProps } from './HomePage.types';
+import { monoFont } from './HomePage.styles';
+const reactPackageData = require<any>('office-ui-fabric-react/package.json');
 
 const getClassNames = classNamesFunction<IHomePageStyleProps, IHomePageStyles>();
 
@@ -31,19 +48,45 @@ const fabricUsageIcons = [
   { src: fabricUsageIconBaseUrl + 'teams_48x1.svg', title: 'Teams' }
 ];
 
+const fabricVersionOptions: IContextualMenuItem[] = [
+  {
+    key: '6',
+    text: 'Fabric 6',
+    data: '6'
+  },
+  {
+    key: '5',
+    text: 'Fabric 5',
+    data: '5'
+  }
+];
+
 export interface IHomePageState {
   isMounted: boolean;
   isMountedOffset: boolean;
+  fabricVer: string;
 }
 
 export class HomePageBase extends React.Component<IHomePageProps, IHomePageState> {
-  public readonly state: IHomePageState = {
-    isMounted: false,
-    isMountedOffset: false
-  };
-
   private _async = new Async();
   private _classNames: IProcessedStyleSet<IHomePageStyles>;
+
+  constructor(props: IHomePageProps) {
+    super(props);
+
+    let sessionStorageVersion: string | undefined;
+    try {
+      sessionStorageVersion = window.sessionStorage.getItem('fabricVer');
+    } catch (ex) {
+      // ignore
+    }
+
+    this.state = {
+      isMounted: false,
+      isMountedOffset: false,
+      fabricVer: getParameterByName('fabricVer') || sessionStorageVersion || fabricVersionOptions[0].data
+    };
+  }
 
   public componentDidMount(): void {
     // Delay adding section transition styles after page is mounted.
@@ -117,12 +160,43 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
       isInverted: true
     });
 
+    const versionSwitcherColor: IRawStyle = { color: theme.palette.black };
+    const versionSwitcherActiveColor: IRawStyle = { color: theme.palette.neutralPrimary };
+
     return (
       <div className={classNames.platformCardsSection}>
         <div className={classNames.inner}>
           <div className={classNames.card} style={{ background: platforms.web.color }}>
             <Icon iconName="WebLogo-homePage" className={classNames.cardIcon} />
-            <h3 className={classNames.cardTitle}>Web</h3>
+            <Stack horizontal verticalAlign="baseline" horizontalAlign="space-between">
+              <h3 className={classNames.cardTitle}>Web</h3>
+              <ActionButton
+                allowDisabledFocus={true}
+                className={classNames.versionSwitcher}
+                styles={{
+                  root: versionSwitcherColor,
+                  flexContainer: { fontFamily: monoFont },
+                  menuIcon: versionSwitcherColor,
+                  rootHovered: versionSwitcherActiveColor,
+                  rootPressed: versionSwitcherActiveColor,
+                  rootExpanded: versionSwitcherActiveColor
+                }}
+                menuProps={{
+                  gapSpace: 3,
+                  beakWidth: 8,
+                  isBeakVisible: true,
+                  shouldFocusOnMount: true,
+                  items: fabricVersionOptions,
+                  directionalHint: DirectionalHint.bottomCenter,
+                  onItemClick: this._onVersionMenuClick,
+                  styles: {
+                    root: { minWidth: 100 }
+                  }
+                }}
+              >
+                Fabric React {reactPackageData.version}
+              </ActionButton>
+            </Stack>
             <ul className={classNames.cardList}>
               <li className={classNames.cardListItem}>{this._renderLink('#/styles/web', 'Styles')}</li>
               <li className={classNames.cardListItem}>{this._renderLink('#/controls/web', 'Controls')}</li>
@@ -210,7 +284,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
           <figure className={this._classNames.oneHalf}>
             <ul className={this._classNames.usageIconList}>{this._renderUsageIconList()}</ul>
             <figcaption>
-              <strong>+ many additional Microsoft sites and products</strong>
+              <strong>+ 52 additional Microsoft sites and products</strong>
             </figcaption>
           </figure>
         </div>
@@ -262,5 +336,9 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
       nextPage: url,
       currentPage: window.location.hash
     });
+  };
+
+  private _onVersionMenuClick = (event: any, item: IContextualMenuItem): void => {
+    this.setState({ fabricVer: item.data });
   };
 }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -283,7 +283,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
           <figure className={this._classNames.oneHalf}>
             <ul className={this._classNames.usageIconList}>{this._renderUsageIconList()}</ul>
             <figcaption>
-              <strong>+ 52 additional Microsoft sites and products</strong>
+              <strong>+ many additional Microsoft sites and products</strong>
             </figcaption>
           </figure>
         </div>

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Async,
-  css,
   Icon,
   Image,
   Link,

--- a/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
@@ -1,4 +1,4 @@
-import { IStyle, getGlobalClassNames, Shade, getShade, getColorFromString } from 'office-ui-fabric-react';
+import { IStyle, getGlobalClassNames, Shade, getShade, getColorFromString, IRawStyle } from 'office-ui-fabric-react';
 import { MotionDurations, MotionTimings, FontSizes } from '@uifabric/fluent-theme';
 import { IHomePageStyleProps, IHomePageStyles } from './HomePage.types';
 import { appPadding, mediaQuery } from '../../styles/constants';
@@ -25,6 +25,7 @@ const GlobalClassNames: { [key in keyof IHomePageStyles]: string } = {
   inner: 'ms-HomePage-inner',
   card: 'ms-HomePage-card',
   cardTitle: 'ms-HomePage-cardTitle',
+  versionSwitcher: 'ms-HomePage-versionSwitcher',
   cardList: 'ms-HomePage-cardList',
   cardListItem: 'ms-HomePage-cardListItem',
   cardIcon: 'ms-HomePage-cardIcon',
@@ -33,6 +34,10 @@ const GlobalClassNames: { [key in keyof IHomePageStyles]: string } = {
   linkText: 'ms-HomePage-linkText',
   illustration: 'ms-HomePage-illustration'
 };
+
+export const monoFont =
+  '"Segoe UI Mono",Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono",' +
+  '"Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace';
 
 export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
   const { theme, className, isMountedOffset, isInverted, beforeColor, afterColor } = props;
@@ -66,9 +71,10 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
     ...sectionAnimation
   ];
 
+  const sectionTitleSize = FontSizes.size32;
   const sectionTitleStyles: IStyle = [
     {
-      fontSize: FontSizes.size32,
+      fontSize: sectionTitleSize,
       lineHeight: '1.1',
       marginTop: 0,
       marginBottom: '3em',
@@ -338,6 +344,14 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
       }
     ],
 
+    versionSwitcher: [
+      classNames.versionSwitcher,
+      {
+        marginBottom: sectionTitleSize,
+        height: '1em'
+      }
+    ],
+
     cardList: [
       classNames.cardList,
       {
@@ -375,8 +389,7 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
     link: [
       classNames.link,
       {
-        fontFamily:
-          '"Segoe UI Mono",Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace',
+        fontFamily: monoFont,
         display: 'flex',
         alignItems: 'center',
         color: 'inherit',

--- a/apps/fabric-website/src/pages/HomePage/HomePage.types.ts
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.types.ts
@@ -35,6 +35,7 @@ export interface IHomePageStyles {
   inner: IStyle;
   card: IStyle;
   cardTitle: IStyle;
+  versionSwitcher: IStyle;
   cardList: IStyle;
   cardListItem: IStyle;
   cardIcon: IStyle;

--- a/apps/fabric-website/src/utilities/location.ts
+++ b/apps/fabric-website/src/utilities/location.ts
@@ -9,3 +9,24 @@ export const hasUHF: boolean =
  * Determines if the site is running locally.
  */
 export const isLocal: boolean = window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
+
+/**
+ * Get URL parameters by name
+ * @param name - Name of the URL parameter to look for
+ * @param url - Target URL. If URL is not defined, look for window.location.href
+ */
+export function getParameterByName(name: string, url?: string): string | null {
+  url = url || window.location.href;
+
+  name = name.replace(/[\[\]]/g, '\\$&');
+  const regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+    results = regex.exec(url);
+  if (!results) {
+    return null;
+  }
+
+  if (!results[2]) {
+    return '';
+  }
+  return decodeURIComponent(results[2].replace(/\+/g, ' '));
+}

--- a/common/changes/@uifabric/example-app-base/website-versions_2019-05-04-23-22.json
+++ b/common/changes/@uifabric/example-app-base/website-versions_2019-05-04-23-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "More EditSection tooltip fixes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/website-versions_2019-05-03-21-12.json
+++ b/common/changes/@uifabric/fabric-website/website-versions_2019-05-03-21-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Add version dropdown and fix other bugs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -179,7 +179,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
             <div className={classNames.dosDontsSection}>
               <Stack className={classNames.dosDontsHeading} {...headingWithEditStackProps}>
                 <h3>Do</h3>
-                {dosUrl && <EditSection section={title + ' Dos'} url={dosUrl} />}
+                {dosUrl && <EditSection title={title} section="Dos" url={dosUrl} />}
               </Stack>
               <hr className={css(classNames.dosDontsLine, classNames.dosLine)} />
               {dos}
@@ -187,7 +187,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
             <div className={css(classNames.dosDontsSection, classNames.dontsSection)}>
               <Stack className={classNames.dosDontsHeading} {...headingWithEditStackProps}>
                 <h3>Don&rsquo;t</h3>
-                {dontsUrl && <EditSection section={title + " Don'ts"} url={dontsUrl} />}
+                {dontsUrl && <EditSection title={title} section="Don'ts" url={dontsUrl} />}
               </Stack>
               <hr className={css(classNames.dosDontsLine, classNames.dontsLine)} />
               {donts}
@@ -267,7 +267,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
           <h2 className={css(titleClass)} id={!!id ? id : undefined}>
             {title}
           </h2>
-          {editUrl && <EditSection section={`${this.props.title} ${title}`} url={editUrl} />}
+          {editUrl && <EditSection title={this.props.title} section={title} url={editUrl} />}
         </Stack>
         {sectionContent}
       </div>

--- a/packages/example-app-base/src/components/EditSection/EditSection.tsx
+++ b/packages/example-app-base/src/components/EditSection/EditSection.tsx
@@ -22,7 +22,7 @@ export const EditSectionBase: React.StatelessComponent<IEditSectionProps> = prop
   const classNames = getClassNames(styles, { theme: theme! });
   const buttonStyles = classNames.subComponentStyles.button;
 
-  const sectionName = title ? `Edit ${title} ${section}` : `Edit ${section}`;
+  const sectionName = title && title !== section ? `Edit ${title} ${section}` : `Edit ${section}`;
   const tooltipHostId = pascalize(sectionName) + '-editButtonHost';
 
   return (

--- a/packages/example-app-base/src/components/EditSection/EditSection.types.ts
+++ b/packages/example-app-base/src/components/EditSection/EditSection.types.ts
@@ -14,7 +14,6 @@ export interface IEditSectionProps {
 
   /**
    * The name of the component
-   * @deprecated Specify the whole name of the thing to be edited as `section`
    */
   title?: string;
 

--- a/packages/example-app-base/src/components/Page/sections/BestPracticesSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/BestPracticesSection.tsx
@@ -44,12 +44,7 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
           {readableSectionName}
         </h2>
         {bestPractices && bestPracticesUrl && (
-          <EditSection
-            className={styles.edit}
-            section={title + ' Best Practices'}
-            readableSection={readableSectionName}
-            url={bestPracticesUrl}
-          />
+          <EditSection className={styles.edit} title={title} section="Best Practices" url={bestPracticesUrl} />
         )}
       </div>
       {bestPractices && (
@@ -66,7 +61,7 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
         <div className={styles.doSection}>
           <div className={styles.sectionHeader}>
             <h3 className={styles.smallSubHeading}>Do</h3>
-            {dos && dosUrl && <EditSection className={styles.edit} section={title + ' Dos'} url={dosUrl} />}
+            {dos && dosUrl && <EditSection className={styles.edit} title={title} section="Dos" url={dosUrl} />}
           </div>
           {dos && (
             <div className={css(styles.content, styles.doList)}>
@@ -77,7 +72,7 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
         <div className={styles.dontSection}>
           <div className={styles.sectionHeader}>
             <h3 className={css(styles.smallSubHeading)}>Don&rsquo;t</h3>
-            {donts && dontsUrl && <EditSection className={styles.edit} section={title + " Don'ts"} url={dontsUrl} />}
+            {donts && dontsUrl && <EditSection className={styles.edit} title={title} section="Don'ts" url={dontsUrl} />}
           </div>
           {donts && (
             <div className={css(styles.content, styles.dontList)}>
@@ -90,7 +85,7 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
   }
 
   return (
-    <div className={className} style={style}>
+    <div id="BestPractices" className={className} style={style}>
       {dosAndDonts}
     </div>
   );

--- a/packages/example-app-base/src/components/Page/sections/MarkdownSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/MarkdownSection.tsx
@@ -23,7 +23,9 @@ export const MarkdownSection: React.StatelessComponent<IPageSectionProps> = prop
   const editUrl =
     props.editUrl || (componentUrl && getEditUrl({ name: fileNamePrefix || title, section: sectionId, baseUrl: componentUrl, platform }));
 
-  const editSection = editUrl && <EditSection className={styles.edit} section={`${title} ${sectionName}`} url={editUrl} />;
+  const editSection = editUrl && (
+    <EditSection className={styles.edit} title={sectionName} section={readableSectionName || 'Markdown'} url={editUrl} />
+  );
 
   return (
     <div className={className} style={style}>

--- a/packages/example-app-base/src/components/Page/sections/OtherPageSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/OtherPageSection.tsx
@@ -9,9 +9,11 @@ import { Markdown } from '../../Markdown/index';
 export const OtherPageSection: React.StatelessComponent<IPageSectionProps> = props => {
   const { className, content, editUrl, sectionName, readableSectionName = sectionName, style, title = 'Page' } = props;
 
-  const sectionId = sectionName ? pascalize(sectionName || 'Other') : '';
+  const sectionId = sectionName ? pascalize(sectionName || readableSectionName || 'Other') : '';
 
-  const editSection = editUrl && <EditSection className={styles.edit} section={`${title} ${sectionName || ''}`} url={editUrl} />;
+  const editSection = editUrl && (
+    <EditSection className={styles.edit} title={title} section={readableSectionName || 'Other'} url={editUrl} />
+  );
 
   return (
     <div className={className} style={style}>

--- a/packages/example-app-base/src/components/Page/sections/OverviewSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/OverviewSection.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { EditSection } from '../../EditSection/index';
-import { css } from 'office-ui-fabric-react';
-import { camelize, getEditUrl, pascalize } from '../../../utilities/index2';
+import { getEditUrl, pascalize } from '../../../utilities/index2';
 import { Markdown } from '../../Markdown/index';
 import { IPageSectionProps } from '../Page.types';
 import * as styles from '../Page.module.scss';
@@ -9,23 +8,20 @@ import * as styles from '../Page.module.scss';
 export const OverviewSection: React.StatelessComponent<IPageSectionProps> = props => {
   const { className, content: overview, fileNamePrefix, componentUrl, platform, sectionName = 'Overview', style, title = 'Page' } = props;
   const { readableSectionName = sectionName } = props;
-  const sectionClassName = camelize(sectionName);
   const sectionId = pascalize(sectionName);
   const editUrl = componentUrl
     ? getEditUrl({ name: fileNamePrefix || title, section: sectionId, baseUrl: componentUrl, platform })
     : undefined;
 
   return (
-    <div className={css(`Page-${sectionClassName}Section`, className)} style={style}>
-      <div className={css(styles.sectionHeader, `Page-${sectionClassName}SectionHeader`)}>
-        <h2 className={css(styles.subHeading, `Page-subHeading`)} id={sectionId}>
+    <div className={className} style={style}>
+      <div className={styles.sectionHeader}>
+        <h2 className={styles.subHeading} id={sectionId}>
           {readableSectionName}
         </h2>
-        {editUrl && (
-          <EditSection className={styles.edit} title={title} section={sectionId} readableSection={readableSectionName} url={editUrl} />
-        )}
+        {editUrl && <EditSection className={styles.edit} title={title} section={readableSectionName} url={editUrl} />}
       </div>
-      <div className={css(styles.content, `Page-${sectionClassName}SectionContent`)}>
+      <div className={styles.content}>
         <Markdown>{overview}</Markdown>
       </div>
     </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add the version selector dropdown to the website, use session storage to track message bars being closed, and fix some wording/links. Also changed "MDL2" in the theme dropdown to "Pre-Fluent" since the meaning should be much more obvious to the world at large (open to other naming suggestions). EDIT: Peter suggested "Default" instead, which I'm now using.

I currently have the version selector text black by default, neutralPrimary on hover/active. Feedback appreciated on the open state and hover/active colors.

![image](https://user-images.githubusercontent.com/5864305/57167520-ee3b9800-6db2-11e9-9285-0aabd5b312f4.png)  ![image](https://user-images.githubusercontent.com/5864305/57167539-01e6fe80-6db3-11e9-8773-9668fd3c0017.png)

![image](https://user-images.githubusercontent.com/5864305/57167562-11664780-6db3-11e9-8c0d-2e9a9f1345fe.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8956)