### PR TITLE
Add build definition to test TypeScript compatibility of office-ui-fabric-react

### DIFF
--- a/scripts/typescript-compatibility-build.yml
+++ b/scripts/typescript-compatibility-build.yml
@@ -1,0 +1,116 @@
+trigger:
+  branches:
+    include:
+      - tsc-compat-debug
+      #- refs/tags/office-ui-fabric-react_v*
+
+variables:
+  - name: PackageName
+    value: office-ui-fabric-react
+  - name: CompatRepoUrl
+    value: https://github.com/Microsoft/ui-fabric-ts-validation.git
+  - name: NodeVersion
+    value: '10.x'
+  - name: VmImage
+    value: 'Ubuntu 16.04'
+
+jobs:
+  - job: Build
+    pool:
+      vmImage: $(VmImage)
+    timeoutInMinutes: 60
+    steps:
+      - checkout: self
+        clean: true
+
+      - task: NodeTool@0
+        displayName: 'Use Node $(NodeVersion)'
+        inputs:
+          versionSpec: '$(NodeVersion)'
+          checkLatest: true
+
+      # Install Rush repo dependencies
+      - script: |
+          node common/scripts/install-run-rush.js install --bypass-policy
+        displayName: Run Rush install in office-ui-fabric-react repository
+
+      # Build package in Rush repo
+      - script: |
+          node common/scripts/install-run-rush.js build --to $(PackageName)
+        displayName: Run Rush build --to $(PackageName)
+
+      # Run npm pack to simulate installation from feed
+      - script: |
+          npm pack ./packages/$(PackageName)
+        displayName: Run npm pack $(PackageName)
+
+      # Rename built package tarball to reference later
+      - script: |
+          mv *.tgz $(Build.StagingDirectory)/$(PackageName).tgz
+        displayName: Move $(PackageName).tgz to Build.StagingDirectory
+
+      # Publish built library for validation job
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Build Artifacts
+        inputs:
+          pathtoPublish: $(Build.StagingDirectory)
+          artifactName: drop
+
+  - job: Compatibility
+    dependsOn: Build
+    condition: succeeded()
+    timeoutInMinutes: 60
+    pool:
+      vmImage: $(VmImage)
+    strategy:
+      maxParallel: 2
+      matrix:
+        'TypeScript 2.9':
+          TypeScriptVersion: 2.9
+        'TypeScript 3.0':
+          TypeScriptVersion: 3.0
+        'TypeScript 3.1':
+          TypeScriptVersion: 3.1
+        'TypeScript 3.2':
+          TypeScriptVersion: 3.2
+        'TypeScript 3.3':
+          TypeScriptVersion: 3.3
+        'TypeScript 3.4':
+          TypeScriptVersion: 3.4
+    steps:
+      - checkout: none
+      - task: NodeTool@0
+        displayName: 'Use Node $(NodeVersion)'
+        inputs:
+          versionSpec: '$(NodeVersion)'
+          checkLatest: true
+
+      # Download build library
+      - task: DownloadBuildArtifacts@0
+        displayName: 'Download Build Artifacts'
+        inputs:
+          artifactName: drop
+          downloadPath: $(Build.StagingDirectory)
+
+      # Clone repository containing versioned TypeScript sample apps
+      - script: |
+          git clone $(CompatRepoUrl) $(Build.StagingDirectory)/__tests__
+        displayName: Clone compatibility repository
+
+      # Install repository's dependencies
+      - script: |
+          node common/scripts/install-run-rush.js install
+        displayName: Run Rush install in compatibility repository
+        workingDirectory: $(Build.StagingDirectory)/__tests__
+
+      # Install built package tarball in sample app
+      - script: |
+          npm install $(Build.StagingDirectory)/drop/$(PackageName).tgz
+        displayName: Install $(PackageName) in TypeScript $(TypeScriptVersion) test app
+        workingDirectory: $(Build.StagingDirectory)/__tests__/tests/$(TypeScriptVersion)
+
+      # Build sample app consuming Office UI Fabric React to test TypeScript version compatibility
+      - script: |
+          node common/scripts/install-run-rush.js test --to $(TypeScriptVersion)-office-ui-fabric-react-test
+        displayName: Build TypeScript $(TypeScriptVersion) test app
+        workingDirectory: $(Build.StagingDirectory)/__tests__

--- a/scripts/typescript-compatibility-build.yml
+++ b/scripts/typescript-compatibility-build.yml
@@ -65,6 +65,10 @@ jobs:
     strategy:
       maxParallel: 2
       matrix:
+        'TypeScript 2.4':
+          TypeScriptVersion: 2.4
+        'TypeScript 2.7':
+          TypeScriptVersion: 2.7
         'TypeScript 2.9':
           TypeScriptVersion: 2.9
         'TypeScript 3.0':


### PR DESCRIPTION
### Overview

This PR adds a build definition that tests the compilation of `office-ui-fabric-react` against a range of TypeScript versions contained in a repository I will make public once this is merged.

Initially, the build trigger is pinned to a specific branch for testing end-to-end and to avoid resource contention.

I will follow-up with an iteration that modifies the triggers to contain `office-ui-fabric-react` tagged releases.

### Why?

The goal is to be notified when an incompatible typing is introduced so that we can:

1. Make a decision on whether or not to break compatibility for a given version
1. Provide a resource for partners to be aware of our TypeScript compatibility across major and minor releases of TypeScript.

---

### Build Overview

This build definition consists of two jobs with their runtime cost (tested on free DevOps agents) described below:

#### Job 1 - Build & Pack OUFR (~8 mins)

1. The first job clones this repository.
1. The job then installs dependencies and builds `office-ui-fabric-react` directly.
1. Finally it runs `npm pack` to produce the `office-ui-fabric-react` tarball and publishes it as an artifact for the second job to consume.

**Note:** The need for this job can likely be eliminated entirely in a subsequent iteration.

#### Job 2 - Compile OUFR in Sample App (~1 min per)

1. The second job depends on the first job _succeeding_ as it requires the `office-ui-fabric-react` tarball.
1. It is a matrix job that executes a maximum of two jobs in parallel which test compatibility for a given TypeScript version.
1. Each job clones the repository containing our sample applications consuming `office-ui-fabric-react`
1. Then the `office-ui-fabric-react` tarball is installed to the project. This is done to ensure we are not consuming a different release via NPM.
1. The job finally runs `tsc` in the root of the sample application and reports success or failure as build status.

**Note:** 30 seconds of the above runtime is the compliance step 😄.

#### Example Build Output

![image](https://user-images.githubusercontent.com/706967/57170028-01546500-6dbf-11e9-862a-693352582ee3.png)

---

**Related Issues:** https://github.com/OfficeDev/office-ui-fabric-react/issues/8458 https://github.com/OfficeDev/office-ui-fabric-react/issues/8051 https://github.com/OfficeDev/office-ui-fabric-react/issues/7054

cc: @aftab-hassan @Vitalius1 @natalieethell @patmill 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8961)