### PR TITLE
[new website] Accessibility and other bug fixes

### DIFF
--- a/apps/fabric-website-resources/src/components/DemoPage.tsx
+++ b/apps/fabric-website-resources/src/components/DemoPage.tsx
@@ -5,7 +5,8 @@ import {
   ApiReferencesTableSet,
   PropertiesTableSet,
   PageMarkdown,
-  FeedbackList
+  FeedbackList,
+  TypeScriptSnippet
 } from '@uifabric/example-app-base';
 import * as React from 'react';
 
@@ -31,7 +32,7 @@ export const DemoPage: React.StatelessComponent<IDemoPageProps> = demoPageProps 
         implementationExamples && (
           <div>
             {implementationExamples.map(example => (
-              <ExampleCard title={example.title} code={example.code} key={example.title}>
+              <ExampleCard title={example.title} code={example.code} key={example.title} codeHighlighter={TypeScriptSnippet}>
                 {example.view}
               </ExampleCard>
             ))}

--- a/apps/fabric-website-resources/src/components/DemoPage.tsx
+++ b/apps/fabric-website-resources/src/components/DemoPage.tsx
@@ -6,7 +6,7 @@ import {
   PropertiesTableSet,
   PageMarkdown,
   FeedbackList,
-  TypeScriptSnippet
+  Highlight
 } from '@uifabric/example-app-base';
 import * as React from 'react';
 
@@ -32,7 +32,7 @@ export const DemoPage: React.StatelessComponent<IDemoPageProps> = demoPageProps 
         implementationExamples && (
           <div>
             {implementationExamples.map(example => (
-              <ExampleCard title={example.title} code={example.code} key={example.title} codeHighlighter={TypeScriptSnippet}>
+              <ExampleCard title={example.title} code={example.code} key={example.title} codeHighlighter={Highlight}>
                 {example.view}
               </ExampleCard>
             ))}

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html dir="ltr">
+<html dir="ltr" lang="en-us">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" user-scalable="no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" user-scalable="no" />
     <title>Office UI Fabric</title>
     <link href="https://devofficecdn.azureedge.net/themes/DevOffice/Content/favicon.ico" rel="shortcut icon" type="image/x-icon" />
     <style type="text/css">

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Styles/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Styles/web.tsx
@@ -13,6 +13,9 @@ export const stylesPagesWeb: INavPage[] = [
     title: 'Colors',
     url: '#/styles/web/colors',
     isCategory: true,
+    // workaround to show the Products page if someone goes directly to #/styles/web/colors
+    component: () => <LoadingComponent title="Products" />,
+    getComponent: cb => require.ensure([], require => cb(require<any>('../../../pages/Styles/Colors/ProductsPage').ColorsProductsPage)),
     pages: [
       {
         title: 'Products',

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
@@ -64,6 +64,15 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
     '#/examples/announced/': '#/controls/web/announced/',
     '#/components/ComboBox': '#/controls/web/combobox',
     '#/components/Calendar': '#/controls/web/calendar',
-    '#/components': '#/controls/web'
+    '#/components': '#/controls/web',
+    '#/styles/animation': '#/styles/web/motion',
+    '#/styles/brand-icons': '#/styles/web/office-brand-icons',
+    '#/styles/colors': '#/styles/web/colors/products',
+    '#/styles/icons': '#/styles/web/icons',
+    '#/styles/layout': '#/styles/web/layout',
+    '#/styles/localization': '#/styles/web/localization',
+    '#/styles/themegenerator': '#/styles/web',
+    '#/styles/typography': '#/styles/web/typography',
+    '#/styles/utilities': '#/styles/web'
   }
 };

--- a/apps/fabric-website/src/components/Nav/Nav.module.scss
+++ b/apps/fabric-website/src/components/Nav/Nav.module.scss
@@ -18,6 +18,8 @@ $nav-group-header-height: 32px;
 }
 
 .link {
+  display: block;
+
   a {
     color: $ms-color-neutralPrimary;
     font-weight: $ms-font-weight-semibold;

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -183,7 +183,7 @@ export class Nav extends React.Component<INavProps, INavState> {
     if (page.isCategory && page.pages && this._hasMatchChild(page)) {
       const key = `${page.title}-${sectionIndex}`;
       return (
-        <div key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
+        <li key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
           <CollapsibleSection
             collapsed={!(this.state.collapsedSections[key] || hasActiveChild(page))}
             title={{
@@ -193,7 +193,7 @@ export class Nav extends React.Component<INavProps, INavState> {
           >
             {this._renderLinkList(page.pages, false)}
           </CollapsibleSection>
-        </div>
+        </li>
       );
     }
   };

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -312,12 +312,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
     return fabricUsageIcons.map((icon, iconIndex) => (
       <li key={icon.title + iconIndex} className={this._classNames.usageIconListItem}>
         <TooltipHost content={icon.title} id={icon.title + iconIndex} styles={{ root: { display: 'inline-block' } }}>
-          <Image
-            src={icon.src}
-            className={this._classNames.usageIcon}
-            alt={`${icon.title} icon`}
-            aria-describedby={icon.title + iconIndex}
-          />
+          <Image src={icon.src} className={this._classNames.usageIcon} alt={`${icon.title} icon`} />
         </TooltipHost>
       </li>
     ));

--- a/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
+++ b/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDesignResources.md
@@ -10,7 +10,8 @@ These design toolkits provide styles, controls and layout templates that enable 
   <li class="mdut--half">[Microsoft Android Fluent (Figma)](https://aka.ms/FluentToolkits/Android/Figma)</li>
 </ul>
 
-### SharePoint Framework
+<!-- headings get auto-generated IDs usually, and this page has two "SharePoint Framework" headings -->
+<h3 id="sharepoint-framework-design">SharePoint Framework</h3>
 
 These SharePoint design resources provide everything you need to design your web parts, including responsive page grids and columns.
 
@@ -19,7 +20,7 @@ These SharePoint design resources provide everything you need to design your web
   <li class="mdut--half">[SharePoint Toolkit (XD)](https://aka.ms/sharepoint-toolkit)</li>
 </ul>
 
-### Office Add-ins
+<h3 id="office-add-ins-design">Office Add-ins</h3>
 
 The Add-ins design toolkit provides layouts for interface elements and commonly used patterns in Word, Excel, and PowerPoint. Use it in addition to the Microsoft design toolkits to create an add-in that fits within Office.
 

--- a/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
+++ b/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
@@ -7,7 +7,7 @@ Get started with React and learn how to build your first projects.
   <li class="mdut--full">[Fabric React tutorial](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Getting-Started-with-UI-Fabric)</li>
 </ul>
 
-### SharePoint Framework
+<h3 id="sharepoint-framework-dev">SharePoint Framework</h3>
 
 SharePoint uses Fabric, so if you’re building on top of or within a SharePoint experience, you can be sure that your UI will blend in.
 
@@ -18,7 +18,7 @@ SharePoint uses Fabric, so if you’re building on top of or within a SharePoint
   <li class="mdut--half">[Get started with building client-side web parts](https://aka.ms/spfx-tutorials)</li>
 </ul>
 
-### Office Add-ins
+<h3 id="office-add-ins-dev">Office Add-ins</h3>
 
 Fabric is the official UI toolkit for creating Office Add-ins. Check out some of these resources to learn more about how to use Fabric in your next Add-in.
 

--- a/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.module.scss
+++ b/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.module.scss
@@ -4,6 +4,7 @@
 .demoBlock {
   background-color: $ms-color-neutralTertiary;
   color: $ms-color-white;
+  font-weight: $ms-font-weight-semibold;
   height: 40px;
   line-height: 40px;
   margin-bottom: 16px;

--- a/apps/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationFonts.md
+++ b/apps/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationFonts.md
@@ -1,6 +1,7 @@
 By default, Fabric presents all text using the Western European character set of Segoe UI. For languages with other characters, Fabric will either serve a version of Segoe UI with a different character set or use a system font.
 
-### Implementation
+<!-- headings get auto-generated IDs usually, and this page has two "Implementation" headings -->
+<h3 id="fonts-implementation">Implementation</h3>
 
 The HTML “lang” attribute specifies the language of the element's content. This is typically applied to the root HTML element, where it will be inherited by the entire page. In this example the entire page is in Thai.
 

--- a/apps/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationRTL.md
+++ b/apps/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationRTL.md
@@ -1,6 +1,7 @@
 Fabric comes with an alternate CSS file for pages written in right-to-left (RTL) languages, such as Arabic and Hebrew. This reverses the order of columns in the responsive grid, making it easy to create an RTL layout without writing additional templates. Many icons are also reversed, particularly those used for navigation such as arrows.
 
-### Implementation
+<!-- headings get auto-generated IDs usually, and this page has two "Implementation" headings -->
+<h3 id="rtl-implementation">Implementation</h3>
 
 Apply the “dir” attribute to the HTML tag, and reference the RTL version of Fabric.
 

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx
@@ -87,18 +87,21 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                     <ul className={styles.exampleIcons}>
                       <li>
                         <Icon
+                          aria-label="Word file icon"
                           className={styles.productIcon}
                           {...getFileTypeIconProps({ extension: 'docx', size: 96, imageFileType: 'svg' })}
                         />
                       </li>
                       <li>
                         <Icon
+                          aria-label="Excel file icon"
                           className={styles.productIcon}
                           {...getFileTypeIconProps({ extension: 'xlsx', size: 96, imageFileType: 'svg' })}
                         />
                       </li>
                       <li>
                         <Icon
+                          aria-label="PowerPoint file icon"
                           className={styles.productIcon}
                           {...getFileTypeIconProps({ extension: 'pptx', size: 96, imageFileType: 'svg' })}
                         />
@@ -242,7 +245,11 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                       height="48"
                       alt={icon.name + ' file type icon'}
                     /> */}
-                    <Icon {...getFileTypeIconProps({ extension: icon.name, size: 48, imageFileType: 'svg' })} className={styles.icon} />
+                    <Icon
+                      {...getFileTypeIconProps({ extension: icon.name, size: 48, imageFileType: 'svg' })}
+                      className={styles.icon}
+                      role="presentation"
+                    />
                     <span className={styles.iconName}>{icon.name}</span>
                   </li>
                 ))}

--- a/apps/fabric-website/src/styles/_highlight.scss
+++ b/apps/fabric-website/src/styles/_highlight.scss
@@ -9,15 +9,15 @@
 
   .hljs-comment,
   .hljs-quote {
-      color: #998;
+      color: $ms-color-gray120;
       font-style: italic;
   }
 
   .hljs-keyword,
   .hljs-selector-tag,
   .hljs-subst {
-      color: $ms-color-gray160;
-      font-weight: normal;
+    color: $ms-color-gray160;
+    font-weight: normal;
   }
 
   .hljs-number,

--- a/apps/fabric-website/src/styles/_highlight.scss
+++ b/apps/fabric-website/src/styles/_highlight.scss
@@ -7,119 +7,64 @@
     background: $ms-color-gray20;
   }
 
-  .hljs-comment {
-      color: #998;
-      font-style: italic;
-  }
-
+  .hljs-comment,
   .hljs-quote {
       color: #998;
       font-style: italic;
   }
 
-  .hljs-keyword {
-      color: $ms-color-gray160;
-      font-weight: bold;
-  }
-
-  .hljs-selector-tag {
-      color: $ms-color-gray160;
-      font-weight: bold;
-  }
-
+  .hljs-keyword,
+  .hljs-selector-tag,
   .hljs-subst {
       color: $ms-color-gray160;
       font-weight: normal;
   }
 
-  .hljs-number {
+  .hljs-number,
+  .hljs-literal,
+  .hljs-variable,
+  .hljs-template-variable,
+  .hljs-tag .hljs-attr { // attribute name
       color: #008080;
   }
 
-  .hljs-literal {
-      color: #008080;
-  }
-
-  .hljs-variable {
-      color: #008080;
-  }
-
-  .hljs-template-variable {
-      color: #008080;
-  }
-
-  .hljs-tag .hljs-attr {
-      color: #008080;
-  }
-
-  .hljs-string {
+  .hljs-string,
+  .hljs-doctag { // @param
       color: #d14;
   }
 
-  .hljs-doctag {
-      color: #d14;
-  }
-
-  .hljs-title {
-      color: #900;
-      font-weight: bold;
-  }
-
-  .hljs-section {
-      color: #900;
-      font-weight: bold;
-  }
-
+  .hljs-title,
+  .hljs-section,
   .hljs-selector-id {
       color: #900;
       font-weight: bold;
   }
 
-  .hljs-type {
-      color: #458;
-      font-weight: bold;
-  }
-
+  .hljs-type,
   .hljs-class .hljs-title {
       color: #458;
       font-weight: bold;
   }
 
-  .hljs-tag {
+  .hljs-tag,
+  .hljs-name,
+  .hljs-attribute { // rarely used--like a keyword?
       color: #000080;
       font-weight: normal;
   }
 
-  .hljs-name {
-      color: #000080;
-      font-weight: normal;
-  }
-
-  .hljs-attribute {
-      color: #000080;
-      font-weight: normal;
-  }
-
-  .hljs-regexp {
-      color: #009926;
-  }
-
+  .hljs-regexp,
   .hljs-link {
       color: #009926;
   }
 
-  .hljs-symbol {
-      color: #990073;
-  }
-
+  .hljs-symbol,
   .hljs-bullet {
       color: #990073;
+      color: #990073;
   }
 
-  .hljs-built_in {
-      color: #0086b3;
-  }
-
+  .hljs-built_in,
   .hljs-builtin-name {
       color: #0086b3;
   }

--- a/common/changes/@uifabric/example-app-base/website-more-bugs_2019-05-05-18-47.json
+++ b/common/changes/@uifabric/example-app-base/website-more-bugs_2019-05-05-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Syntax highlighting optimizations",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/website-more-bugs_2019-05-05-18-47.json
+++ b/common/changes/@uifabric/fabric-website-resources/website-more-bugs_2019-05-05-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website-resources",
+      "comment": "Specify component for syntax highlighting",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/website-more-bugs_2019-05-05-18-47.json
+++ b/common/changes/@uifabric/fabric-website/website-more-bugs_2019-05-05-18-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Accessibility fixes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
@@ -23,7 +23,8 @@ SyntaxHighlighter.registerLanguage('markdown', md);
 SyntaxHighlighter.registerLanguage('bash', bash);
 SyntaxHighlighter.registerLanguage('html', xml);
 
-// Customize imported SyntaxHighlighter styles
+// Customize imported SyntaxHighlighter styles. Available properties:
+// https://github.com/conorhastings/react-syntax-highlighter/blob/master/src/styles/hljs/github.js
 style.hljs = {
   fontSize: FontSizes.size14,
   padding: 8,
@@ -31,6 +32,13 @@ style.hljs = {
   color: NeutralColors.gray160,
   overflowX: 'auto'
 };
+// Darken comment color for accessibility
+style['hljs-comment'] = style['hljs-quote'] = {
+  color: NeutralColors.gray120,
+  fontStyle: 'italic'
+};
+
+export const codeFontFamily = 'Monaco, Menlo, Consolas, "Droid Sans Mono", "Inconsolata", "Courier New", monospace';
 
 export interface ICodeSnippetProps {
   className?: string;
@@ -55,7 +63,7 @@ const getStyles: IStyleFunction<ICodeSnippetStyleProps, ICodeSnippetStyles> = pr
 
       selectors: {
         code: {
-          fontFamily: 'Monaco, Menlo, Consolas, "Droid Sans Mono", "Inconsolata", "Courier New", monospace',
+          fontFamily: codeFontFamily,
           lineHeight: '1.6'
         }
       }

--- a/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyleFunctionOrObject, ITheme, IStyle, IStyleFunction, styled, classNamesFunction } from 'office-ui-fabric-react';
+import { IStyleFunctionOrObject, ITheme, IStyle, IStyleFunction, styled, classNamesFunction, IRawStyle } from 'office-ui-fabric-react';
 import { FontSizes, NeutralColors } from '@uifabric/fluent-theme';
 
 // tslint:disable no-any
@@ -7,27 +7,21 @@ const SyntaxHighlighter = require<any>('react-syntax-highlighter/dist/esm/light'
 
 // Import languages from SyntaxHighlighter
 const ts = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/typescript').default;
-const js = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/javascript').default;
-const css = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/css').default;
 const scss = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/scss').default;
 const md = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/markdown').default;
 const bash = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/bash').default;
-const shell = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/shell').default;
-const diff = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/diff').default;
+const xml = require<any>('react-syntax-highlighter/dist/esm/languages/hljs/xml').default;
+// tslint:enable no-any
 
 // Import SyntaxHighlighter styles
-const style = require<any>('react-syntax-highlighter/dist/styles/hljs/github').default;
-// tslint:enable no-any
+const style: { [key: string]: IRawStyle } = require('react-syntax-highlighter/dist/styles/hljs/github').default;
 
 // Register languages
 SyntaxHighlighter.registerLanguage('typescript', ts);
-SyntaxHighlighter.registerLanguage('javascript', js);
-SyntaxHighlighter.registerLanguage('css', css);
 SyntaxHighlighter.registerLanguage('scss', scss);
 SyntaxHighlighter.registerLanguage('markdown', md);
 SyntaxHighlighter.registerLanguage('bash', bash);
-SyntaxHighlighter.registerLanguage('shell', shell);
-SyntaxHighlighter.registerLanguage('diff', diff);
+SyntaxHighlighter.registerLanguage('html', xml);
 
 // Customize imported SyntaxHighlighter styles
 style.hljs = {
@@ -71,10 +65,21 @@ const getStyles: IStyleFunction<ICodeSnippetStyleProps, ICodeSnippetStyles> = pr
 
 const getClassNames = classNamesFunction<ICodeSnippetStyleProps, ICodeSnippetStyles>();
 
+const languageMapping: { [key: string]: string } = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'typescript',
+  javascript: 'typescript',
+  jsx: 'typescript',
+  shell: 'bash',
+  md: 'markdown',
+  css: 'scss'
+};
+
 const CodeSnippetBase: React.StatelessComponent<ICodeSnippetProps> = props => {
   const classNames = getClassNames(props.styles, {});
   return (
-    <SyntaxHighlighter language={props.language} className={classNames.root} style={style}>
+    <SyntaxHighlighter language={languageMapping[props.language!] || props.language || 'text'} className={classNames.root} style={style}>
       {props.children}
     </SyntaxHighlighter>
   );

--- a/packages/example-app-base/src/components/ColorPalette/ColorPalette.tsx
+++ b/packages/example-app-base/src/components/ColorPalette/ColorPalette.tsx
@@ -94,26 +94,31 @@ class ColorPaletteBase extends React.Component<IColorPaletteProps, IColorPalette
           <div className={classNames.detailValues}>
             <span className={classNames.detailHex}>{hex}</span>
             {code && (
-              <>
-                <span className={classNames.detailCode} aria-describedby="code">
-                  {code.react.split('.')[1]}{' '}
-                  <TooltipHost
-                    tooltipProps={{
-                      onRenderContent: () => this._renderCodeDetails(code)
-                    }}
-                    closeDelay={500}
-                    id="code"
-                  >
-                    <Icon className={classNames.detailCodeInfoIcon} iconName="Info" />
-                  </TooltipHost>
-                </span>
-              </>
+              <span className={classNames.detailCode} aria-label={this._getCodeAriaLabel(code)}>
+                {code.react.split('.')[1]}{' '}
+                <TooltipHost
+                  tooltipProps={{
+                    onRenderContent: () => this._renderCodeDetails(code)
+                  }}
+                  closeDelay={500}
+                  id="code"
+                >
+                  <Icon className={classNames.detailCodeInfoIcon} iconName="Info" />
+                </TooltipHost>
+              </span>
             )}
           </div>
         </div>
       </div>
     );
   };
+
+  private _getCodeAriaLabel(code: IColorCode): string | undefined {
+    const { core, react } = code;
+    if (core || react) {
+      return (core ? `Fabric Core: ${core}. ` : '') + (react ? `Fabric React: ${react}` : '');
+    }
+  }
 
   private _renderCodeDetails = (code: IColorCode): JSX.Element | null => {
     const { core, react } = code;

--- a/packages/example-app-base/src/components/EditSection/EditSection.tsx
+++ b/packages/example-app-base/src/components/EditSection/EditSection.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { IEditSectionProps, IEditSectionStyleProps, IEditSectionStyles } from './EditSection.types';
 import { IconButton, TooltipHost } from 'office-ui-fabric-react';
 import { IStyleFunction, classNamesFunction, styled, css } from 'office-ui-fabric-react/lib/Utilities';
-import { pascalize } from '../../utilities/string';
 
 const getStyles: IStyleFunction<IEditSectionStyleProps, IEditSectionStyles> = () => ({});
 
@@ -22,13 +21,12 @@ export const EditSectionBase: React.StatelessComponent<IEditSectionProps> = prop
   const classNames = getClassNames(styles, { theme: theme! });
   const buttonStyles = classNames.subComponentStyles.button;
 
-  const sectionName = title && title !== section ? `Edit ${title} ${section}` : `Edit ${section}`;
-  const tooltipHostId = pascalize(sectionName) + '-editButtonHost';
+  const tooltipContent = title && title !== section ? `Edit ${title} ${section}` : `Edit ${section}`;
 
   return (
-    <TooltipHost content={sectionName} id={tooltipHostId} hostClassName={css(classNames.root, className)}>
+    <TooltipHost content={tooltipContent} hostClassName={css(classNames.root, className)}>
       <IconButton
-        aria-label={sectionName}
+        aria-label={tooltipContent}
         iconProps={{ iconName: 'Edit' }}
         href={url}
         target="_blank"

--- a/packages/example-app-base/src/components/EditSection/EditSection.tsx
+++ b/packages/example-app-base/src/components/EditSection/EditSection.tsx
@@ -28,7 +28,7 @@ export const EditSectionBase: React.StatelessComponent<IEditSectionProps> = prop
   return (
     <TooltipHost content={sectionName} id={tooltipHostId} hostClassName={css(classNames.root, className)}>
       <IconButton
-        aria-labelledby={tooltipHostId}
+        aria-label={sectionName}
         iconProps={{ iconName: 'Edit' }}
         href={url}
         target="_blank"

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -6,11 +6,11 @@ import { IStackComponent, Stack } from 'office-ui-fabric-react/lib/Stack';
 import { styled, classNamesFunction, Customizer, css, CustomizerContext } from 'office-ui-fabric-react/lib/Utilities';
 import { ISchemeNames, IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 
-import { Highlight } from '../Highlight/Highlight';
 import { AppCustomizationsContext, IAppCustomizations, IExampleCardCustomizations } from '../../utilities/customizations';
 import { CodepenComponent } from '../CodepenComponent/CodepenComponent';
 import { IExampleCardProps, IExampleCardStyleProps, IExampleCardStyles } from './ExampleCard.types';
 import { getStyles } from './ExampleCard.styles';
+import { CodeSnippet } from '../CodeSnippet';
 
 export interface IExampleCardState {
   isCodeVisible?: boolean;
@@ -49,7 +49,18 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
   }
 
   public render(): JSX.Element {
-    const { title, code, children, styles, isRightAligned = false, isScrollable = true, codepenJS, theme } = this.props;
+    const {
+      title,
+      code,
+      children,
+      styles,
+      isRightAligned = false,
+      isScrollable = true,
+      codepenJS,
+      theme,
+      codeHighlighter: Highlighter = CodeSnippet,
+      codeHighlighterProps = {}
+    } = this.props;
     const { isCodeVisible, schemeIndex, themeIndex } = this.state;
 
     return (
@@ -121,7 +132,7 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
                 </div>
               </div>
 
-              <div className={classNames.code}>{isCodeVisible && <Highlight>{code}</Highlight>}</div>
+              <div className={classNames.code}>{isCodeVisible && <Highlighter {...codeHighlighterProps}>{code}</Highlighter>}</div>
 
               {activeCustomizations ? (
                 <CustomizerContext.Provider value={{ customizations: { settings: {}, scopedSettings: {} } }}>

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -10,7 +10,7 @@ import { AppCustomizationsContext, IAppCustomizations, IExampleCardCustomization
 import { CodepenComponent } from '../CodepenComponent/CodepenComponent';
 import { IExampleCardProps, IExampleCardStyleProps, IExampleCardStyles } from './ExampleCard.types';
 import { getStyles } from './ExampleCard.styles';
-import { CodeSnippet } from '../CodeSnippet';
+import { CodeSnippet } from '../CodeSnippet/index';
 
 export interface IExampleCardState {
   isCodeVisible?: boolean;

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.types.ts
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.types.ts
@@ -21,6 +21,10 @@ export interface IExampleCardProps {
   isScrollable?: boolean;
   /** JS string used in the example card's "Export to CodePen" button */
   codepenJS?: string;
+  /** Code highlighting component to use when showing code (default CodeSnippet) */
+  codeHighlighter?: React.ComponentType;
+  /** Props for the code highlighting component */
+  codeHighlighterProps?: {};
 
   /** Theme provided by higher-order component. */
   theme?: ITheme;

--- a/packages/example-app-base/src/components/FeedbackList/FeedbackList.styles.ts
+++ b/packages/example-app-base/src/components/FeedbackList/FeedbackList.styles.ts
@@ -30,7 +30,7 @@ export const getStyles: IStyleFunction<IFeedbackListStyleProps, IFeedbackListSty
         // Temporary workaround for https://github.com/OfficeDev/office-ui-fabric-react/issues/6782.
         selectors: {
           '&a:link, &a:hover, &a:focus, &a:visited': {
-            color: theme.palette.white
+            color: theme.palette.white + ' !important'
           }
         }
       },

--- a/packages/example-app-base/src/components/Markdown/Markdown.tsx
+++ b/packages/example-app-base/src/components/Markdown/Markdown.tsx
@@ -1,23 +1,33 @@
 import * as React from 'react';
 import MarkdownToJsx, { MarkdownProps } from 'markdown-to-jsx';
-import { DefaultButton, Image, IImageStyles, Link, classNamesFunction, IStyleFunction, styled } from 'office-ui-fabric-react';
+import { DefaultButton, Image, IImageStyles, Link, classNamesFunction, IStyleFunction, styled, ILinkStyles } from 'office-ui-fabric-react';
 import * as MDTable from '../MarkdownTable/index';
 import { MarkdownCode } from './MarkdownCode';
 import { MarkdownHeader } from './MarkdownHeader';
 import { MarkdownParagraph } from './MarkdownParagraph';
 import { IMarkdownProps, IMarkdownSubComponentStyles, IMarkdownStyleProps, IMarkdownStyles } from './Markdown.types';
 
-const getStyles: IStyleFunction<IMarkdownStyleProps, IMarkdownStyles> = () => {
+const getStyles: IStyleFunction<IMarkdownStyleProps, IMarkdownStyles> = props => {
   const imageStyles: Partial<IImageStyles> = {
     root: {
       maxWidth: '100%',
       margin: '8px 0'
     }
   };
+  const linkStyles: Partial<ILinkStyles> = {
+    root: {
+      selectors: {
+        '&:link': {
+          // UHF override...
+          color: props.theme.semanticColors.link + ' !important'
+        }
+      }
+    }
+  };
 
   return {
     root: 'ms-Markdown',
-    subComponentStyles: { image: imageStyles } as IMarkdownSubComponentStyles
+    subComponentStyles: { image: imageStyles, link: linkStyles } as IMarkdownSubComponentStyles
   };
 };
 
@@ -25,7 +35,7 @@ const getClassNames = classNamesFunction<IMarkdownStyleProps, IMarkdownStyles>()
 
 const MarkdownBase: React.StatelessComponent<IMarkdownProps> & { displayName?: string } = props => {
   const { styles, theme, children } = props;
-  const classNames = getClassNames(styles, { theme });
+  const classNames = getClassNames(styles, { theme: theme! });
   return (
     <div className={classNames.root}>
       <MarkdownToJsx {...getMarkdownProps(classNames.subComponentStyles)}>{children}</MarkdownToJsx>

--- a/packages/example-app-base/src/components/Markdown/Markdown.types.ts
+++ b/packages/example-app-base/src/components/Markdown/Markdown.types.ts
@@ -15,7 +15,7 @@ export interface IMarkdownProps {
   styles?: IStyleFunctionOrObject<IMarkdownStyleProps, IMarkdownStyles>;
 }
 
-export type IMarkdownStyleProps = {};
+export type IMarkdownStyleProps = Required<Pick<IMarkdownProps, 'theme'>>;
 
 export interface IMarkdownStyles {
   root: IStyle;

--- a/packages/example-app-base/src/components/Markdown/MarkdownCode.tsx
+++ b/packages/example-app-base/src/components/Markdown/MarkdownCode.tsx
@@ -33,28 +33,11 @@ const getStyles: IStyleFunction<IMarkdownCodeStyleProps, IMarkdownCodeStyles> = 
 
 const getClassNames = classNamesFunction<IMarkdownCodeStyleProps, IMarkdownCodeStyles>();
 
-// These class names will be automatically passed in to PageTag instances created by
-// markdown-to-jsx based on the language specified in the markdown code block.
-const languageClassNames: { [key: string]: string } = {
-  'lang-tsx': 'typescript',
-  'lang-typescript': 'typescript',
-  'lang-jsx': 'javascript',
-  'lang-js': 'javascript',
-  'lang-javascript': 'javascript',
-  'lang-html': 'html',
-  'lang-bash': 'bash',
-  'lang-shell': 'shell',
-  'lang-css': 'css',
-  'lang-scss': 'scss',
-  'lang-md': 'markdown',
-  'lang-diff': 'diff'
-};
-
 const MarkdownCodeBase: React.StatelessComponent<IMarkdownCodeProps> = props => {
   const { theme, className, styles, ...rest } = props;
   const classNames = getClassNames(styles, { theme: theme! });
 
-  const language = languageClassNames[className!];
+  const language = (className || '').replace('lang-', '');
   if (language || (typeof props.children === 'string' && props.children.indexOf('\n') !== -1)) {
     return <CodeSnippet {...rest} language={language} className={className} />;
   }

--- a/packages/example-app-base/src/components/Markdown/MarkdownCode.tsx
+++ b/packages/example-app-base/src/components/Markdown/MarkdownCode.tsx
@@ -1,7 +1,7 @@
 import { IStyleFunctionOrObject, IStyleFunction, classNamesFunction, styled } from 'office-ui-fabric-react/lib/Utilities';
 import { ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
 import * as React from 'react';
-import { CodeSnippet } from '../CodeSnippet/index';
+import { CodeSnippet, codeFontFamily } from '../CodeSnippet/index';
 
 export interface IMarkdownCodeProps {
   className?: string;
@@ -20,7 +20,7 @@ const getStyles: IStyleFunction<IMarkdownCodeStyleProps, IMarkdownCodeStyles> = 
   const { theme } = props;
   return {
     root: {
-      fontFamily: 'monospace',
+      fontFamily: codeFontFamily,
       fontSize: '14px',
       padding: '0 4px',
       background: theme.palette.neutralLighter,

--- a/packages/example-app-base/src/components/Page/Page.module.scss
+++ b/packages/example-app-base/src/components/Page/Page.module.scss
@@ -2,6 +2,7 @@
 @import '../../styles/mixins';
 
 $PageSubHeadMargin: 20px;
+$PageParagraphMargin: 1.2em;
 $usageListPadding: 24px;
 
 .Page {
@@ -82,7 +83,7 @@ $usageListPadding: 24px;
   p,
   pre {
     margin-top: 0;
-    margin-bottom: 1.2em;
+    margin-bottom: $PageParagraphMargin;
 
     &:last-child {
       margin-bottom: 0;
@@ -110,6 +111,13 @@ $usageListPadding: 24px;
 
   li {
     margin-bottom: 8px;
+  }
+
+  hr {
+    border: 0;
+    height: 1px;
+    background: $ms-color-gray100;
+    margin: $PageParagraphMargin 0;
   }
 }
 

--- a/packages/example-app-base/src/components/Page/sections/ExamplesSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/ExamplesSection.tsx
@@ -3,7 +3,7 @@ import { ExampleCard } from '../../ExampleCard/index';
 import { pascalize } from '../../../utilities/index2';
 import { IExample, IPageSectionProps } from '../Page.types';
 import * as styles from '../Page.module.scss';
-import { ICodeSnippetProps } from '../../CodeSnippet';
+import { ICodeSnippetProps } from '../../CodeSnippet/index';
 
 export interface IExamplesSectionProps extends IPageSectionProps {
   exampleKnobs?: React.ReactNode;

--- a/packages/example-app-base/src/components/Page/sections/ExamplesSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/ExamplesSection.tsx
@@ -3,6 +3,7 @@ import { ExampleCard } from '../../ExampleCard/index';
 import { pascalize } from '../../../utilities/index2';
 import { IExample, IPageSectionProps } from '../Page.types';
 import * as styles from '../Page.module.scss';
+import { ICodeSnippetProps } from '../../CodeSnippet';
 
 export interface IExamplesSectionProps extends IPageSectionProps {
   exampleKnobs?: React.ReactNode;
@@ -13,6 +14,9 @@ export const ExamplesSection: React.StatelessComponent<IExamplesSectionProps> = 
   const { className, examples, exampleKnobs, sectionName = 'Usage', style } = props;
   const { readableSectionName = sectionName } = props;
   const sectionId = pascalize(sectionName);
+  const codeHighlighterProps: ICodeSnippetProps = {
+    language: 'typescript'
+  };
 
   return (
     <div className={className} style={style}>
@@ -27,7 +31,9 @@ export const ExamplesSection: React.StatelessComponent<IExamplesSectionProps> = 
           const { view, ...exampleProps } = example;
           return (
             <div key={example.title + '-key'} className={styles.subSection}>
-              <ExampleCard {...exampleProps}>{view}</ExampleCard>
+              <ExampleCard {...exampleProps} codeHighlighterProps={codeHighlighterProps}>
+                {view}
+              </ExampleCard>
             </div>
           );
         })}

--- a/packages/example-app-base/src/components/PlatformBar/PlatformBar.base.tsx
+++ b/packages/example-app-base/src/components/PlatformBar/PlatformBar.base.tsx
@@ -55,7 +55,7 @@ export class PlatformBarBase<TPlatforms extends string = string> extends React.P
         <DefaultButton
           href={pages && this._getFirstPageUrl(pages)}
           className={classNames.platformButton}
-          aria-describedby={platformKey}
+          aria-label={name}
           /* tslint:disable-next-line jsx-no-lambda */
           onClick={() => this._handlePlatformClick(platformKey)}
           disabled={disabled}

--- a/packages/example-app-base/src/components/PlatformBar/PlatformBar.base.tsx
+++ b/packages/example-app-base/src/components/PlatformBar/PlatformBar.base.tsx
@@ -20,7 +20,8 @@ export class PlatformBarBase<TPlatforms extends string = string> extends React.P
     return (
       <div className={this._classNames.root}>
         <div className={this._classNames.inner}>
-          <FocusZone as="ul" className={this._classNames.platformGrid}>
+          {/* Override default role of "presentation" to prevent warning about li outside of ul */}
+          <FocusZone as="ul" className={this._classNames.platformGrid} role="list">
             {this._renderPlatformGrid(platforms)}
           </FocusZone>
         </div>

--- a/packages/example-app-base/src/components/SideRail/SideRail.tsx
+++ b/packages/example-app-base/src/components/SideRail/SideRail.tsx
@@ -18,19 +18,17 @@ class SideRailBase extends React.Component<ISideRailProps, ISideRailState> {
   public componentDidMount(): void {
     if (typeof IntersectionObserver !== 'undefined') {
       const { observe, jumpLinks } = this.props;
-      if (observe) {
+      if (observe && jumpLinks) {
         this._observer = new IntersectionObserver(this._handleObserver, {
           threshold: [0.5]
         });
 
-        if (jumpLinks) {
-          jumpLinks.forEach((jumpLink: ISideRailLink) => {
-            const element = document.getElementById(jumpLink.url);
-            if (element) {
-              this._observer.observe(element);
-            }
-          });
-        }
+        jumpLinks.forEach((jumpLink: ISideRailLink) => {
+          const element = document.getElementById(jumpLink.url);
+          if (element) {
+            this._observer.observe(element);
+          }
+        });
       }
     }
   }

--- a/packages/example-app-base/src/components/TopNav/TopNav.tsx
+++ b/packages/example-app-base/src/components/TopNav/TopNav.tsx
@@ -121,9 +121,9 @@ export class TopNav extends React.Component<ITopNavProps, ITopNavState> {
     const home = pages.filter((page: INavPage) => page.isHomePage)[0];
     if (home) {
       return (
-        <a href={home.url} title="UI Fabric Home page" aria-label="UI Fabric Home page" className={styles.appLogo}>
+        <a href={home.url} className={styles.appLogo}>
           {/* @todo: Set up baseImageUrl to easily swap image host. */}
-          <img src={this.props.siteLogoSource} />
+          <img src={this.props.siteLogoSource} alt="UI Fabric Home page" />
         </a>
       );
     }

--- a/packages/example-app-base/src/components/TopNav/TopNav.tsx
+++ b/packages/example-app-base/src/components/TopNav/TopNav.tsx
@@ -121,9 +121,9 @@ export class TopNav extends React.Component<ITopNavProps, ITopNavState> {
     const home = pages.filter((page: INavPage) => page.isHomePage)[0];
     if (home) {
       return (
-        <a href={home.url} className={styles.appLogo}>
+        <a href={home.url} className={styles.appLogo} title="UI Fabric Home page">
           {/* @todo: Set up baseImageUrl to easily swap image host. */}
-          <img src={this.props.siteLogoSource} alt="UI Fabric Home page" />
+          <img src={this.props.siteLogoSource} role="presentation" />
         </a>
       );
     }

--- a/packages/example-app-base/src/styles/_highlight.scss
+++ b/packages/example-app-base/src/styles/_highlight.scss
@@ -3,20 +3,20 @@
 :global {
   .hljs {
     display: block;
-    color: $ms-color-gray160;
+    color: $ms-color-gray180;
     background: $ms-color-gray20;
   }
 
   .hljs-comment,
   .hljs-quote {
-      color: #998;
+      color: $ms-color-gray120;
       font-style: italic;
   }
 
   .hljs-keyword,
   .hljs-selector-tag,
   .hljs-subst {
-      color: $ms-color-gray160;
+      color: $ms-color-gray180;
       font-weight: normal;
   }
 

--- a/packages/example-app-base/src/styles/_highlight.scss
+++ b/packages/example-app-base/src/styles/_highlight.scss
@@ -7,119 +7,64 @@
     background: $ms-color-gray20;
   }
 
-  .hljs-comment {
-      color: #998;
-      font-style: italic;
-  }
-
+  .hljs-comment,
   .hljs-quote {
       color: #998;
       font-style: italic;
   }
 
-  .hljs-keyword {
-      color: $ms-color-gray160;
-      font-weight: bold;
-  }
-
-  .hljs-selector-tag {
-      color: $ms-color-gray160;
-      font-weight: bold;
-  }
-
+  .hljs-keyword,
+  .hljs-selector-tag,
   .hljs-subst {
       color: $ms-color-gray160;
       font-weight: normal;
   }
 
-  .hljs-number {
+  .hljs-number,
+  .hljs-literal,
+  .hljs-variable,
+  .hljs-template-variable,
+  .hljs-tag .hljs-attr { // attribute name
       color: #008080;
   }
 
-  .hljs-literal {
-      color: #008080;
-  }
-
-  .hljs-variable {
-      color: #008080;
-  }
-
-  .hljs-template-variable {
-      color: #008080;
-  }
-
-  .hljs-tag .hljs-attr {
-      color: #008080;
-  }
-
-  .hljs-string {
+  .hljs-string,
+  .hljs-doctag { // @param
       color: #d14;
   }
 
-  .hljs-doctag {
-      color: #d14;
-  }
-
-  .hljs-title {
-      color: #900;
-      font-weight: bold;
-  }
-
-  .hljs-section {
-      color: #900;
-      font-weight: bold;
-  }
-
+  .hljs-title,
+  .hljs-section,
   .hljs-selector-id {
       color: #900;
       font-weight: bold;
   }
 
-  .hljs-type {
-      color: #458;
-      font-weight: bold;
-  }
-
+  .hljs-type,
   .hljs-class .hljs-title {
       color: #458;
       font-weight: bold;
   }
 
-  .hljs-tag {
+  .hljs-tag,
+  .hljs-name,
+  .hljs-attribute { // rarely used--like a keyword?
       color: #000080;
       font-weight: normal;
   }
 
-  .hljs-name {
-      color: #000080;
-      font-weight: normal;
-  }
-
-  .hljs-attribute {
-      color: #000080;
-      font-weight: normal;
-  }
-
-  .hljs-regexp {
-      color: #009926;
-  }
-
+  .hljs-regexp,
   .hljs-link {
       color: #009926;
   }
 
-  .hljs-symbol {
-      color: #990073;
-  }
-
+  .hljs-symbol,
   .hljs-bullet {
       color: #990073;
+      color: #990073;
   }
 
-  .hljs-built_in {
-      color: #0086b3;
-  }
-
+  .hljs-built_in,
   .hljs-builtin-name {
       color: #0086b3;
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix some of the accessibility issues with the new website flagged by Accessibility Insights. 

We still have a lot of color contrast issues with code snippets--will need input from design later to fix that.

Added redirects for pages under `#/styles` on the old site.

Fix UHF style battle issues that were overriding the link colors.

I also made some fixes and optimizations with code block highlighting: only loading and registering languages which are not redundant with each other, and adding highlighting for HTML. I changed the ExampleCard to use CodeSnippet for its code by default, but also added an option to go back to Highlight (the old highlighter) and used it in the local demo site code which hasn't been updated yet.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8968)