### PR TITLE
Button disabled focus

### DIFF
--- a/common/changes/@uifabric/experiments/buttonDisabledFocus_2019-05-06-17-42.json
+++ b/common/changes/@uifabric/experiments/buttonDisabledFocus_2019-05-06-17-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Adding allowDisabledFocus prop and adding @docCategory tags on exports.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -4,18 +4,36 @@ import { IIconSlot } from '../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../Utilities';
 import { IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';
 
+/**
+ * {@docCategory Button}
+ */
 export type IButtonComponent = IComponent<IButtonProps, IButtonTokens, IButtonStyles, IButtonViewProps>;
 
 // These types are redundant with IButtonComponent but are needed until TS function return widening issue is resolved:
 // https://github.com/Microsoft/TypeScript/issues/241
 // For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+/**
+ * {@docCategory Button}
+ */
 export type IButtonTokenReturnType = ReturnType<Extract<IButtonComponent['tokens'], Function>>;
+/**
+ * {@docCategory Button}
+ */
 export type IButtonStylesReturnType = ReturnType<Extract<IButtonComponent['styles'], Function>>;
 
+/**
+ * {@docCategory Button}
+ */
 export type IButtonSlot = ISlotProp<IButtonProps>;
 
+/**
+ * {@docCategory Button}
+ */
 export type IButtonRootElements = 'a' | 'button' | 'div';
 
+/**
+ * {@docCategory Button}
+ */
 export interface IButtonSlots {
   /**
    * Defines the root slot of the component.
@@ -38,6 +56,9 @@ export interface IButtonSlots {
   icon?: IIconSlot;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IButton {
   /**
    * Sets focus to the Button.
@@ -45,6 +66,9 @@ export interface IButton {
   focus: () => void;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IButtonProps
   extends ISlottableProps<IButtonSlots>,
     IStyleableComponentProps<IButtonProps, IButtonTokens, IButtonStyles>,
@@ -79,11 +103,20 @@ export interface IButtonProps
   onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
 
   /**
+   * Defines whether disabled buttons should be tabbable via keyboard navigation or not.
+   * @defaultvalue false
+   */
+  allowDisabledFocus?: boolean;
+
+  /**
    * Defines the aria label that the screen readers use when focus goes on the Button.
    */
   ariaLabel?: string;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IButtonViewProps extends IButtonProps {
   /**
    * Defines a reference to the inner button.
@@ -91,6 +124,9 @@ export interface IButtonViewProps extends IButtonProps {
   buttonRef?: React.RefObject<HTMLButtonElement>;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IButtonTokens {
   /**
    * Defines how far should the background extend within the Button.
@@ -308,4 +344,7 @@ export interface IButtonTokens {
   width?: number | string;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export type IButtonStyles = IComponentStyles<IButtonSlots>;

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -7,7 +7,7 @@ import { Icon } from '../../utilities/factoryComponents';
 import { IButtonComponent, IButtonProps, IButtonRootElements, IButtonSlots, IButtonViewProps } from './Button.types';
 
 export const ButtonView: IButtonComponent['view'] = props => {
-  const { icon, content, children, disabled, onClick, ariaLabel, buttonRef, ...rest } = props;
+  const { icon, content, children, disabled, onClick, allowDisabledFocus, ariaLabel, buttonRef, ...rest } = props;
 
   // TODO: 'href' is anchor property... consider getNativeProps by root type
   const buttonProps = { ...getNativeProps(rest, buttonProperties) };
@@ -35,8 +35,9 @@ export const ButtonView: IButtonComponent['view'] = props => {
       role="button"
       onClick={_onClick}
       {...buttonProps}
-      disabled={disabled}
+      disabled={disabled && !allowDisabledFocus}
       aria-disabled={disabled}
+      tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
       aria-label={ariaLabel}
       ref={buttonRef}
     >

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
@@ -3,16 +3,31 @@ import { IContextualMenuSlot, IIconSlot } from '../../../utilities/factoryCompon
 import { IBaseProps } from '../../../Utilities';
 import { IButtonProps, IButtonSlot, IButtonSlots, IButtonTokens, IButtonViewProps } from '../Button.types';
 
+/**
+ * {@docCategory Button}
+ */
 export type IMenuButtonComponent = IComponent<IMenuButtonProps, IMenuButtonTokens, IMenuButtonStyles, IMenuButtonViewProps>;
 
 // These types are redundant with IButtonComponent but are needed until TS function return widening issue is resolved:
 // https://github.com/Microsoft/TypeScript/issues/241
 // For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+/**
+ * {@docCategory Button}
+ */
 export type IMenuButtonTokenReturnType = ReturnType<Extract<IMenuButtonComponent['tokens'], Function>>;
+/**
+ * {@docCategory Button}
+ */
 export type IMenuButtonStylesReturnType = ReturnType<Extract<IMenuButtonComponent['styles'], Function>>;
 
+/**
+ * {@docCategory Button}
+ */
 export type IMenuButtonSlot = ISlotProp<IMenuButtonProps>;
 
+/**
+ * {@docCategory Button}
+ */
 export interface IMenuButtonSlots extends IButtonSlots {
   /**
    * Defines the button that is going to be rendered.
@@ -30,6 +45,9 @@ export interface IMenuButtonSlots extends IButtonSlots {
   menuIcon?: IIconSlot;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IMenuButton {
   /**
    * Sets focus to the MenuButton.
@@ -37,9 +55,12 @@ export interface IMenuButton {
   focus: () => void;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IMenuButtonProps
   extends IMenuButtonSlots,
-    Pick<IButtonProps, 'href' | 'primary' | 'disabled' | 'onClick' | 'ariaLabel'>,
+    Pick<IButtonProps, 'href' | 'primary' | 'disabled' | 'onClick' | 'allowDisabledFocus' | 'ariaLabel'>,
     IStyleableComponentProps<IMenuButtonProps, IMenuButtonTokens, IMenuButtonStyles>,
     IBaseProps<IMenuButton> {
   /**
@@ -61,6 +82,9 @@ export interface IMenuButtonProps
   onKeyDown?: (ev: React.KeyboardEvent<HTMLElement>) => void;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IMenuButtonViewProps extends Pick<IButtonViewProps, 'buttonRef'>, IMenuButtonProps {
   /**
    * Defines a callback that runs after the MenuButton's contextual menu has been closed (removed from the DOM).
@@ -73,6 +97,12 @@ export interface IMenuButtonViewProps extends Pick<IButtonViewProps, 'buttonRef'
   menuTarget: HTMLElement | undefined;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface IMenuButtonTokens extends IButtonTokens {}
 
+/**
+ * {@docCategory Button}
+ */
 export type IMenuButtonStyles = IComponentStyles<IMenuButtonSlots>;

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -9,16 +9,32 @@ import {
   IMenuButtonViewProps
 } from '../MenuButton/MenuButton.types';
 
+/**
+ * {@docCategory Button}
+ */
 export type ISplitButtonComponent = IComponent<ISplitButtonProps, ISplitButtonTokens, ISplitButtonStyles, ISplitButtonViewProps>;
 
 // These types are redundant with IButtonComponent but are needed until TS function return widening issue is resolved:
 // https://github.com/Microsoft/TypeScript/issues/241
 // For now, these helper types can be used to provide return type safety when specifying tokens and styles functions.
+/**
+ * {@docCategory Button}
+ */
 export type ISplitButtonTokenReturnType = ReturnType<Extract<ISplitButtonComponent['tokens'], Function>>;
+
+/**
+ * {@docCategory Button}
+ */
 export type ISplitButtonStylesReturnType = ReturnType<Extract<ISplitButtonComponent['styles'], Function>>;
 
+/**
+ * {@docCategory Button}
+ */
 export type ISplitButtonSlot = ISlotProp<ISplitButtonProps>;
 
+/**
+ * {@docCategory Button}
+ */
 export interface ISplitButtonSlots extends IMenuButtonSlots {
   /**
    * Defines the root slot of the component.
@@ -36,6 +52,9 @@ export interface ISplitButtonSlots extends IMenuButtonSlots {
   splitDivider?: IHTMLSlot;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface ISplitButton {
   /**
    * Sets focus to the first focus stop of the SplitButton.
@@ -43,9 +62,15 @@ export interface ISplitButton {
   focus: () => void;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface ISplitButtonProps
   extends ISlottableProps<ISplitButtonSlots>,
-    Pick<IMenuButtonProps, 'href' | 'primary' | 'disabled' | 'onClick' | 'ariaLabel' | 'defaultExpanded' | 'expanded' | 'onKeyDown'>,
+    Pick<
+      IMenuButtonProps,
+      'href' | 'primary' | 'disabled' | 'onClick' | 'allowDisabledFocus' | 'ariaLabel' | 'defaultExpanded' | 'expanded' | 'onKeyDown'
+    >,
     IStyleableComponentProps<ISplitButtonProps, ISplitButtonTokens, ISplitButtonStyles>,
     IBaseProps<ISplitButton> {
   /**
@@ -60,6 +85,9 @@ export interface ISplitButtonProps
   secondaryAriaLabel?: string;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface ISplitButtonViewProps extends Pick<IMenuButtonViewProps, 'buttonRef' | 'onMenuDismiss' | 'menuTarget'>, ISplitButtonProps {
   /**
    * Defines an event callback that is triggered when the secondary action of a SplitButton is clicked.
@@ -67,6 +95,12 @@ export interface ISplitButtonViewProps extends Pick<IMenuButtonViewProps, 'butto
   onSecondaryActionClick?: (ev: React.MouseEvent<HTMLElement>) => void;
 }
 
+/**
+ * {@docCategory Button}
+ */
 export interface ISplitButtonTokens extends IMenuButtonTokens {}
 
+/**
+ * {@docCategory Button}
+ */
 export type ISplitButtonStyles = IComponentStyles<ISplitButtonSlots>;

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -15,6 +15,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     primary,
     disabled,
     onClick,
+    allowDisabledFocus,
     ariaLabel,
     expanded,
     menu: Menu,
@@ -46,6 +47,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
       <Slots.button
         primary={primary}
         disabled={primaryActionDisabled || disabled}
+        allowDisabledFocus={allowDisabledFocus}
         ariaLabel={ariaLabel}
         onClick={onClick}
         componentRef={buttonRef}
@@ -61,6 +63,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
         primary={primary}
         disabled={disabled}
         expanded={expanded}
+        allowDisabledFocus={allowDisabledFocus}
         ariaLabel={menuButtonAriaLabel}
         onClick={onSecondaryActionClick}
         menu={Menu}

--- a/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`Button view renders a default Button with content correctly 1`] = `
       }
   onClick={[Function]}
   role="button"
+  tabIndex={0}
   type="button"
 >
   <span
@@ -371,6 +372,7 @@ exports[`Button view renders a primary Button with content correctly 1`] = `
       }
   onClick={[Function]}
   role="button"
+  tabIndex={0}
   type="button"
 >
   <span


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds a `allowDisabledFocus` prop that, when set, will allow tabbable focus on disabled `Buttons`.

This PR also adds the `@docCategory` tag to public facing API so that it works with the improvements made with documentation.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8974)