### PR TITLE
Button: Making all MenuButton props optional

### DIFF
--- a/common/changes/@uifabric/experiments/buttonOptionalMenu_2019-05-06-18-13.json
+++ b/common/changes/@uifabric/experiments/buttonOptionalMenu_2019-05-06-18-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Making all MenuButton props optional.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
@@ -22,7 +22,7 @@ export interface IMenuButtonSlots extends IButtonSlots {
   /**
    * Defines the contextual menu that appears when you click on the MenuButton.
    */
-  menu: IContextualMenuSlot;
+  menu?: IContextualMenuSlot;
 
   /**
    * Defines the menu chevron icon that is displayed insisde the MenuButton.
@@ -65,12 +65,12 @@ export interface IMenuButtonViewProps extends Pick<IButtonViewProps, 'buttonRef'
   /**
    * Defines a callback that runs after the MenuButton's contextual menu has been closed (removed from the DOM).
    */
-  onMenuDismiss: () => void;
+  onMenuDismiss?: () => void;
 
   /**
    * Defines the target that the contextual menu uses to position itself.
    */
-  menuTarget: HTMLElement | undefined;
+  menuTarget?: HTMLElement | undefined;
 }
 
 export interface IMenuButtonTokens extends IButtonTokens {}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR makes all of `MenuButton` props optional so that they don't have to be necessarily provided by the users of the component. This change was spurred by [this comment in #8754](https://github.com/OfficeDev/office-ui-fabric-react/pull/8754#discussion_r277104385).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8975)