### PR TITLE
Fabric-website: Include markdown files in npm package

### DIFF
--- a/apps/fabric-website/.npmignore
+++ b/apps/fabric-website/.npmignore
@@ -10,3 +10,4 @@ jsconfig.json
 webpack.config.js
 typings
 
+!src/**/docs/*.md

--- a/common/changes/@uifabric/fabric-website/include-md-files-in-npm-package_2019-05-06-19-07.json
+++ b/common/changes/@uifabric/fabric-website/include-md-files-in-npm-package_2019-05-06-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Include .md files in npm package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "jordancjanzen@gmail.com"
+}

--- a/common/changes/@uifabric/fabric-website/include-md-files-in-npm-package_2019-05-06-19-07.json
+++ b/common/changes/@uifabric/fabric-website/include-md-files-in-npm-package_2019-05-06-19-07.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@uifabric/fabric-website",
-  "email": "jordancjanzen@gmail.com"
+  "email": "v-jojanz@microsoft.com"
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds `!src/**/docs/*.md` to the fabric-website .npmignore so I can import markdown files from the npm package for the HIG.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8977)