### PR TITLE
Add stub "get started" pages for mobile

### DIFF
--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/GetStarted/GetStarted.pages.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/GetStarted/GetStarted.pages.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { INavPage, LoadingComponent } from '@uifabric/example-app-base/lib/index2';
+
+export const GetStartedPages: INavPage = {
+  title: 'Get started',
+  url: '#/get-started',
+  isUhfLink: true,
+  hasPlatformPicker: true,
+  component: () => <LoadingComponent title="Get started" />,
+  getComponent: cb =>
+    require.ensure([], require => cb(require<any>('../../../pages/Overviews/GetStartedPage/GetStartedPage').GetStartedPage)),
+  platforms: {
+    web: [
+      {
+        title: 'Get started',
+        url: '#/get-started/web',
+        isHiddenFromMainNav: true,
+        component: () => <LoadingComponent title="Get started" />,
+        getComponent: cb =>
+          require.ensure([], require => cb(require<any>('../../../pages/Overviews/GetStartedPage/GetStartedPage').GetStartedPage))
+      }
+    ],
+    ios: [
+      {
+        title: 'Get started',
+        url: '#/get-started/ios',
+        isHiddenFromMainNav: true,
+        component: () => <LoadingComponent title="Get started" />,
+        getComponent: cb =>
+          require.ensure([], require => cb(require<any>('../../../pages/Overviews/GetStartedPage/GetStartedPage').GetStartedPage))
+      }
+    ],
+    android: [
+      {
+        title: 'Get started',
+        url: '#/get-started/android',
+        isHiddenFromMainNav: true,
+        component: () => <LoadingComponent title="Get started" />,
+        getComponent: cb =>
+          require.ensure([], require => cb(require<any>('../../../pages/Overviews/GetStartedPage/GetStartedPage').GetStartedPage))
+      }
+    ]
+  }
+};

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/GetStarted/index.ts
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/GetStarted/index.ts
@@ -1,0 +1,1 @@
+export * from './GetStarted.pages';

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/index.ts
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/index.ts
@@ -1,3 +1,4 @@
 export * from './Controls/Controls.pages';
+export * from './GetStarted/GetStarted.pages';
 export * from './Resources/Resources.pages';
 export * from './Styles/Styles.pages';

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ISiteDefinition, LoadingComponent } from '@uifabric/example-app-base/lib/index2';
 import { FluentCustomizations } from '@uifabric/fluent-theme';
-import { ControlsPages, ResourcesPages, StylesPages } from './SiteDefinition.pages/index';
+import { ControlsPages, ResourcesPages, StylesPages, GetStartedPages } from './SiteDefinition.pages/index';
 import { Platforms } from '../interfaces/Platforms';
 import { platforms } from './SiteDefinition.platforms';
 
@@ -21,27 +21,7 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
       component: () => <LoadingComponent title="Welcome to Microsoft UI Fabric" />,
       getComponent: cb => require.ensure([], require => cb(require<any>('../pages/HomePage/HomePage').HomePage))
     },
-    {
-      title: 'Get started',
-      url: '#/get-started',
-      isUhfLink: true,
-      hasPlatformPicker: true,
-      component: () => <LoadingComponent title="Get started" />,
-      getComponent: cb =>
-        require.ensure([], require => cb(require<any>('../pages/Overviews/GetStartedPage/GetStartedPage').GetStartedPage)),
-      platforms: {
-        web: [
-          {
-            title: 'Get started',
-            url: '#/get-started/web',
-            isHiddenFromMainNav: true,
-            component: () => <LoadingComponent title="Get started" />,
-            getComponent: cb =>
-              require.ensure([], require => cb(require<any>('../pages/Overviews/GetStartedPage/GetStartedPage').GetStartedPage))
-          }
-        ]
-      }
-    },
+    GetStartedPages,
     StylesPages,
     ControlsPages,
     ResourcesPages,
@@ -59,20 +39,21 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
       getComponent: cb => require.ensure([], require => cb(require<any>('../pages/PageTemplates/TemplatePage/TemplatePage').TemplatePage))
     }
   ],
-  redirects: {
-    '#/customizations/': '#/controls/web/customizations/',
-    '#/examples/announced/': '#/controls/web/announced/',
-    '#/components/ComboBox': '#/controls/web/combobox',
-    '#/components/Calendar': '#/controls/web/calendar',
-    '#/components': '#/controls/web',
-    '#/styles/animation': '#/styles/web/motion',
-    '#/styles/brand-icons': '#/styles/web/office-brand-icons',
-    '#/styles/colors': '#/styles/web/colors/products',
-    '#/styles/icons': '#/styles/web/icons',
-    '#/styles/layout': '#/styles/web/layout',
-    '#/styles/localization': '#/styles/web/localization',
-    '#/styles/themegenerator': '#/styles/web',
-    '#/styles/typography': '#/styles/web/typography',
-    '#/styles/utilities': '#/styles/web'
-  }
+  redirects: [
+    { from: '#/customizations/', to: '#/controls/web/customizations/' },
+    { from: '#/examples/announced/', to: '#/controls/web/announced/' },
+    { from: '#/components/ComboBox', to: '#/controls/web/combobox' },
+    { from: '#/components/Calendar', to: '#/controls/web/calendar' },
+    { from: '#/components', to: '#/controls/web' },
+    { from: '#/styles/animation', to: '#/styles/web/motion' },
+    { from: '#/styles/brand-icons', to: '#/styles/web/office-brand-icons' },
+    { from: '#/styles/colors', to: '#/styles/web/colors/products' },
+    { from: '#/styles/icons', to: '#/styles/web/icons' },
+    { from: '#/styles/layout', to: '#/styles/web/layout' },
+    { from: '#/styles/localization', to: '#/styles/web/localization' },
+    { from: '#/styles/themegenerator', to: '#/styles/web' },
+    { from: '#/styles/typography', to: '#/styles/web/typography' },
+    { from: '#/styles/utilities', to: '#/styles/web' },
+    { from: new RegExp('#/get-started$'), to: '#/get-started/web' }
+  ]
 };

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -207,6 +207,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
             <h3 className={classNames.cardTitle}>iOS</h3>
             <ul className={classNames.cardList}>
               <li className={classNames.cardListItem}>{this._renderLink('#/controls/ios', 'Controls')}</li>
+              <li className={classNames.cardListItem}>{this._renderLink('#/get-started/ios', 'Get started')}</li>
             </ul>
           </div>
           <div className={classNames.card} style={{ background: platforms.android.color }}>
@@ -214,6 +215,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
             <h3 className={classNames.cardTitle}>Android</h3>
             <ul className={classNames.cardList}>
               <li className={classNames.cardListItem}>{this._renderLink('#/controls/android', 'Controls')}</li>
+              <li className={classNames.cardListItem}>{this._renderLink('#/get-started/android', 'Get started')}</li>
             </ul>
           </div>
         </div>

--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/GetStartedPage.doc.ts
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/GetStartedPage.doc.ts
@@ -1,8 +1,19 @@
 import { TFabricPlatformPageProps } from '../../../interfaces/Platforms';
 
+const componentUrl =
+  'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/apps/fabric-website/src/pages/Overviews/GetStartedPage';
+
 export const GetStartedPageProps: TFabricPlatformPageProps = {
   web: {
     overview: require('!raw-loader!@uifabric/fabric-website/src/pages/Overviews/GetStartedPage/docs/web/GetStartedOverview.md') as string,
-    componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/apps/fabric-website/src/pages/Overviews/GetStartedPage'
+    componentUrl: componentUrl + '/web'
+  },
+  ios: {
+    overview: require('!raw-loader!@uifabric/fabric-website/src/pages/Overviews/GetStartedPage/docs/ios/GetStartedOverview.md') as string,
+    componentUrl
+  },
+  android: {
+    overview: require('!raw-loader!@uifabric/fabric-website/src/pages/Overviews/GetStartedPage/docs/android/GetStartedOverview.md') as string,
+    componentUrl
   }
 };

--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/android/GetStartedOverview.md
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/android/GetStartedOverview.md
@@ -1,0 +1,11 @@
+UI Fabric for Android is an [open-source](https://github.com/OfficeDev/ui-fabric-android) native library that provides the Office UI experience for the Android platform. It contains information about colors and typography, as well as custom controls and customizations for platform controls, all from the official Fluent design language used in Office and Office 365 products.
+
+### Controls
+
+UI Fabric for Android includes an expanding library of controls written in Kotlin. These controls implement the Fluent design language and bring consistency across Office app experiences.
+
+Documentation for the controls is a work in progress. Some controls can be found in the [Controls section](#/controls/android) of this site, and the full list can be viewed in [this source folder](https://github.com/OfficeDev/ui-fabric-android/blob/master/OfficeUIFabric/src/main/java/com/microsoft/officeuifabric).
+
+### More Information
+
+Setup instructions and more information can be found in [the library's readme](https://github.com/OfficeDev/ui-fabric-android#readme).

--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/ios/GetStartedOverview.md
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/ios/GetStartedOverview.md
@@ -1,0 +1,11 @@
+UI Fabric for iOS is an [open-source](https://github.com/OfficeDev/ui-fabric-ios) native library that provides the Office UI experience for the iOS platform. It contains information about colors and typography, as well as custom controls and customizations for platform controls, all from the official Fluent design language used in Office and Office 365 products.
+
+### Controls
+
+UI Fabric for iOS includes an expanding library of controls written in Swift and supporting Objective-C. These controls implement the Fluent Design language and provide consistency across Office experiences.
+
+Documentation for the controls is a work in progress. Some controls can be found in the [Controls section](#/controls/ios) of this site, and the full list can be viewed in [this source folder](https://github.com/OfficeDev/ui-fabric-ios/tree/master/OfficeUIFabric).
+
+### More Information
+
+Setup instructions and more information can be found in [the library's readme](https://github.com/OfficeDev/ui-fabric-ios#readme).

--- a/common/changes/@uifabric/example-app-base/website-mobile_2019-05-06-19-17.json
+++ b/common/changes/@uifabric/example-app-base/website-mobile_2019-05-06-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Allow regex redirects",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/website-mobile_2019-05-06-19-17.json
+++ b/common/changes/@uifabric/fabric-website/website-mobile_2019-05-06-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Add stub \"get started\" pages for mobile",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/SiteDefinition.types.ts
+++ b/packages/example-app-base/src/utilities/SiteDefinition.types.ts
@@ -26,8 +26,15 @@ export interface ISiteDefinition<TPlatforms extends string = string> {
   siteLogoSource?: string;
 
   /**
-   * If the hash contains any of this object's keys, replace that segment of the hash with the
-   * given value and redirect.
+   * If the hash contains any of the strings or matches any of the regular expressions specified in
+   * an entry's `from` property, replace that segment of the hash with the `to` property and redirect.
    */
-  redirects?: { [from: string]: string };
+  redirects?: IRedirect[];
+}
+
+export interface IRedirect {
+  /** Look for URLs containing this string or matching this regex */
+  from: string | RegExp;
+  /** Replace the matching segment with this string */
+  to: string;
 }

--- a/packages/example-app-base/src/utilities/redirects.ts
+++ b/packages/example-app-base/src/utilities/redirects.ts
@@ -1,25 +1,28 @@
+import { IRedirect } from './SiteDefinition.types';
+
 /**
  * If the hash contains any of the given object's keys, replace that segment of the hash with the
  * given value and redirect.
  */
-export function handleRedirects(redirectMap?: { [from: string]: string }) {
-  if (!redirectMap) {
+export function handleRedirects(redirects?: IRedirect[]) {
+  if (!redirects) {
     return;
   }
 
   // handle the current URL first
-  redirectLegacyUrls(redirectMap, window.location.hash);
+  redirectLegacyUrls(redirects, window.location.hash);
 
   // then, if any change to hash would trigger this
   window.addEventListener('hashchange', () => {
-    redirectLegacyUrls(redirectMap, window.location.hash);
+    redirectLegacyUrls(redirects, window.location.hash);
   });
 }
 
-function redirectLegacyUrls(redirectMap: { [from: string]: string }, hash: string) {
-  for (const from of Object.keys(redirectMap)) {
-    if (hash.indexOf(from) !== -1) {
-      window.location.hash = hash.replace(from, redirectMap[from]);
+function redirectLegacyUrls(redirects: IRedirect[], hash: string) {
+  for (const { from, to } of redirects) {
+    const isMatch = typeof from === 'string' ? hash.indexOf(from) !== -1 : from.test(hash);
+    if (isMatch) {
+      window.location.hash = hash.replace(from, to);
       break;
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add simple "Get started" pages for iOS and Android, with content copied from the repos' readmes. 

For some reason, adding more platforms to the get started page caused odd behavior when navigating directly to `#/get-started`, so I changed that URL to redirect to `#/get-started/web` for now. (Adding that redirect required adding regex support to redirect handling, to prevent infinite redirects: `#/get-started/web/web/web/web/web/web`.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8978)