### PR TITLE
Add Fluent Styling prop to Tile

### DIFF
--- a/common/changes/@uifabric/experiments/edwl-2019-05-tileFluentStyles_2019-05-06-19-49.json
+++ b/common/changes/@uifabric/experiments/edwl-2019-05-tileFluentStyles_2019-05-06-19-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Add isFluentStyling prop and styles to Tile component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "edwl@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -26,10 +26,20 @@
 
   &.selected {
     background-color: $ms-color-neutralLight;
+
+    &.isFluentStyling {
+      .name {
+        font-weight: $ms-font-weight-semibold;
+      }
+    }
   }
 
   @include focus(true) {
     background-color: $ms-color-neutralLighter;
+
+    &.isFluentStyling {
+      background-color: transparent;
+    }
 
     &.selected {
       background-color: $ms-color-neutralQuaternaryAlt; // Todo need a color variable.
@@ -41,6 +51,10 @@
 
     &.selected {
       outline: 1px solid $ms-color-themePrimary;
+
+      &.isFluentStyling {
+        outline: 1px solid $ms-color-neutralSecondary;
+      }
     }
   }
 
@@ -105,7 +119,6 @@
   flex-direction: column;
   align-items: stretch;
   align-content: stretch;
-  text-decoration: none;
 
   pointer-events: none;
 }
@@ -263,6 +276,10 @@
 
     .link:hover & {
       text-decoration: underline;
+
+      .isFluentStyling & {
+        text-decoration: none;
+      }
     }
   }
 
@@ -338,7 +355,7 @@
   justify-content: center;
   font-weight: $ms-font-weight-regular;
   font-size: $ms-font-size-s;
-  color: #767676;
+  color: $ms-color-neutralSecondary;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -150,6 +150,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       descriptionAriaLabel,
       href,
       onClick,
+      isFluentStyling,
       ...divProps
     } = this.props;
 
@@ -219,7 +220,8 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
           [`ms-Tile--invokable ${TileStyles.invokable}`]: isInvokable,
           [`ms-Tile--uninvokable ${TileStyles.uninvokable}`]: !isInvokable,
           [`ms-Tile--isDisabled ${TileStyles.disabled}`]: !isSelectable && !isInvokable,
-          [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal
+          [`ms-Tile--showCheck ${TileStyles.showCheck}`]: isModal,
+          [`ms-Tile--isFluentStyling ${TileStyles.isFluentStyling}`]: isFluentStyling
         })}
         data-is-focusable={true}
         data-is-sub-focuszone={true}

--- a/packages/experiments/src/components/Tile/Tile.types.ts
+++ b/packages/experiments/src/components/Tile/Tile.types.ts
@@ -89,4 +89,9 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    * Link ref
    */
   linkRef?: (element: HTMLAnchorElement | HTMLButtonElement | null) => void;
+
+  /**
+   * Whether the component should render with Fluent styling or not
+   */
+  isFluentStyling?: boolean;
 }

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Document.Example.tsx
@@ -42,6 +42,7 @@ export interface ITilesListDocumentExampleState {
   isModalSelection: boolean;
   isDataLoaded: boolean;
   cells: (ITilesGridItem<IExampleItem> | ITilesGridSegment<IExampleItem>)[];
+  isFluentStyling: boolean;
 }
 
 export interface ITilesListDocumentExampleProps {
@@ -64,6 +65,7 @@ export class TilesListDocumentExample extends React.Component<ITilesListDocument
     this.state = {
       isModalSelection: this._selection.isModal(),
       isDataLoaded: false,
+      isFluentStyling: false,
       cells: getTileCells(SHIMMER_GROUPS, {
         onRenderCell: this._onRenderShimmerCell,
         onRenderHeader: this._onRenderShimmerHeader,
@@ -73,9 +75,9 @@ export class TilesListDocumentExample extends React.Component<ITilesListDocument
     };
   }
 
-  public componentDidUpdate(previousProps: ITilesListDocumentExampleProps): void {
+  public componentDidUpdate(previousProps: ITilesListDocumentExampleProps, prevState: ITilesListDocumentExampleState): void {
     const { isDataLoaded } = this.state;
-    if (this.props.tileSize !== previousProps.tileSize) {
+    if (this.props.tileSize !== previousProps.tileSize || this.state.isFluentStyling !== prevState.isFluentStyling) {
       if (!isDataLoaded) {
         this.setState({
           cells: getTileCells(SHIMMER_GROUPS, {
@@ -114,6 +116,13 @@ export class TilesListDocumentExample extends React.Component<ITilesListDocument
           onChange={this._onToggleIsDataLoaded}
           onText="Loaded"
           offText="Loading..."
+        />
+        <Toggle
+          label="Enable Fluent Styling"
+          checked={this.state.isFluentStyling}
+          onChange={this._onToggleIsFluentStyling}
+          onText="Fluent"
+          offText="Default"
         />
         <MarqueeSelection selection={this._selection}>
           <SelectionZone selection={this._selection} onItemInvoked={this._onItemInvoked} enterModalOnTouch={true}>
@@ -154,6 +163,17 @@ export class TilesListDocumentExample extends React.Component<ITilesListDocument
     });
   };
 
+  private _onToggleIsFluentStyling = (event: React.MouseEvent<HTMLElement>, checked: boolean): void => {
+    this.setState(
+      {
+        isFluentStyling: checked
+      },
+      () => {
+        console.log(this.state);
+      }
+    );
+  };
+
   private _onSelectionChange = (): void => {
     this.setState({
       isModalSelection: this._selection.isModal()
@@ -179,6 +199,7 @@ export class TilesListDocumentExample extends React.Component<ITilesListDocument
         className={AnimationClassNames.fadeIn400}
         selection={this._selection}
         selectionIndex={item.index}
+        isFluentStyling={this.state.isFluentStyling}
         invokeSelection={true}
         foreground={
           <img


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Add `isFluentStyling` to Tile component in experiments

**Resting/Default**:
<img width="155" alt="Screen Shot 2019-05-06 at 12 34 56 PM" src="https://user-images.githubusercontent.com/1291968/57250122-8e83fd80-6ffb-11e9-9d56-34be25fea3da.png">

**Focus (non selected)**
<img width="153" alt="Screen Shot 2019-05-06 at 12 35 07 PM" src="https://user-images.githubusercontent.com/1291968/57250138-980d6580-6ffb-11e9-8d27-5d8f2b3b5166.png">

**Hover**
<img width="149" alt="Screen Shot 2019-05-06 at 12 35 36 PM" src="https://user-images.githubusercontent.com/1291968/57250148-9ba0ec80-6ffb-11e9-8936-c14592f69e2c.png">

**Hover on check**
<img width="149" alt="Screen Shot 2019-05-06 at 12 35 19 PM" src="https://user-images.githubusercontent.com/1291968/57250145-99d72900-6ffb-11e9-9d24-4a4f61956cf7.png">

**Selected**
<img width="156" alt="Screen Shot 2019-05-06 at 12 38 26 PM" src="https://user-images.githubusercontent.com/1291968/57250293-ecb0e080-6ffb-11e9-82d4-1da5803358b8.png">

**Focus (selected**
<img width="154" alt="Screen Shot 2019-05-06 at 12 36 03 PM" src="https://user-images.githubusercontent.com/1291968/57250160-9f347380-6ffb-11e9-878d-acb1f8291f0f.png">

**Hover on Selected**
<img width="151" alt="Screen Shot 2019-05-06 at 12 36 12 PM" src="https://user-images.githubusercontent.com/1291968/57250165-a0fe3700-6ffb-11e9-826c-0a5efa2c9c69.png">


**Design**
<img width="1414" alt="Screen Shot 2019-05-06 at 12 41 07 PM" src="https://user-images.githubusercontent.com/1291968/57250420-40232e80-6ffc-11e9-855b-3d627dc924a3.png">


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8980)