### PR TITLE
Fix UHF element selectors for un-overriding font

### DIFF
--- a/apps/fabric-website/src/components/Site/Site.module.scss
+++ b/apps/fabric-website/src/components/Site/Site.module.scss
@@ -3,11 +3,15 @@
 
 // #headerWrapper is the UHF header wrapper. The p, ul, ol style in _typography.scss was making
 // the header links larger than they should be, so reset that here.
-:global(#headerWrapper, #footerWrapper, #socialMediaContainer, .m-back-to-top) {
-  p,
-  ul,
-  ol {
-    font-size: inherit;
+:global {
+  #headerWrapper,
+  #footerWrapper #socialMediaContainer,
+  .m-back-to-top {
+    p,
+    ul,
+    ol {
+      font-size: inherit;
+    }
   }
 }
 

--- a/apps/fabric-website/src/components/Site/Site.module.scss
+++ b/apps/fabric-website/src/components/Site/Site.module.scss
@@ -5,7 +5,8 @@
 // the header links larger than they should be, so reset that here.
 :global {
   #headerWrapper,
-  #footerWrapper #socialMediaContainer,
+  #footerWrapper,
+  #socialMediaContainer,
   .m-back-to-top {
     p,
     ul,

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -51,19 +51,17 @@ const fabricVersionOptions: IContextualMenuItem[] = [
   {
     key: '6',
     text: 'Fabric 6',
-    data: '6'
+    checked: true
   },
   {
     key: '5',
-    text: 'Fabric 5',
-    data: '5'
+    text: 'Fabric 5'
   }
 ];
 
 export interface IHomePageState {
   isMounted: boolean;
   isMountedOffset: boolean;
-  fabricVer: string;
 }
 
 export class HomePageBase extends React.Component<IHomePageProps, IHomePageState> {
@@ -73,17 +71,9 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
   constructor(props: IHomePageProps) {
     super(props);
 
-    let sessionStorageVersion: string | undefined;
-    try {
-      sessionStorageVersion = window.sessionStorage.getItem('fabricVer');
-    } catch (ex) {
-      // ignore
-    }
-
     this.state = {
       isMounted: false,
-      isMountedOffset: false,
-      fabricVer: getParameterByName('fabricVer') || sessionStorageVersion || fabricVersionOptions[0].data
+      isMountedOffset: false
     };
   }
 
@@ -333,6 +323,9 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
   };
 
   private _onVersionMenuClick = (event: any, item: IContextualMenuItem): void => {
-    this.setState({ fabricVer: item.data });
+    if (item.key === '5') {
+      // Reload the page to switch to version 5
+      location.href = `${location.protocol}//${location.host}${location.pathname}?fabricVer=5`;
+    }
   };
 }

--- a/common/changes/@uifabric/fabric-website/really-fix-header_2019-05-06-19-43.json
+++ b/common/changes/@uifabric/fabric-website/really-fix-header_2019-05-06-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix UHF element selectors for un-overriding font",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fix the selector used when un-overriding the font in the UHF parts of the website.

Also fix the version selector dropdown to reload the page if version 5 is selected.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8981)