### PR TITLE
Support suggestions Truncation in ie11

### DIFF
--- a/apps/vr-tests/src/stories/Suggestions.stories.tsx
+++ b/apps/vr-tests/src/stories/Suggestions.stories.tsx
@@ -48,6 +48,8 @@ const ProvinceSuggestionItem = ({ name, id }: Province) => (
   <div
     id={`province-${id}`}
     style={{
+      // Required for text truncation in IE11
+      overflow: 'hidden',
       minWidth: 0,
       flexShrink: 1
     }}

--- a/common/changes/office-ui-fabric-react/u-mahuangh-suggestions-overflow-ie11_2019-05-06-22-50.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-suggestions-overflow-ie11_2019-05-06-22-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Truncate suggestions in IE11",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.scss
@@ -10,6 +10,7 @@
   box-sizing: border-box;
   width: 100%;
   position: relative;
+  overflow: hidden;
 
   &:hover {
     background: $ms-color-neutralLighter;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -46,6 +46,8 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
         // Force the item button to be collapsible so it can always shrink
         // to accommodate the close button as a peer in its flex container.
         minWidth: 0,
+        // Require for IE11 to truncate the component.
+        overflow: 'hidden',
         selectors: {
           [HighContrastSelector]: {
             color: 'WindowText',

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -189,6 +190,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -321,6 +323,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -453,6 +456,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -585,6 +589,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -717,6 +722,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -849,6 +855,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -981,6 +988,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1113,6 +1121,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1245,6 +1254,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1377,6 +1387,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1509,6 +1520,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1641,6 +1653,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1773,6 +1786,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -1905,6 +1919,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2067,6 +2082,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2202,6 +2218,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2334,6 +2351,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2466,6 +2484,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2598,6 +2617,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2730,6 +2750,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2862,6 +2883,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -2994,6 +3016,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3126,6 +3149,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3258,6 +3282,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3390,6 +3415,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3522,6 +3548,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3654,6 +3681,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3786,6 +3814,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -3918,6 +3947,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4083,6 +4113,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4215,6 +4246,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4347,6 +4379,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4479,6 +4512,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4611,6 +4645,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4743,6 +4778,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -4875,6 +4911,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5007,6 +5044,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5141,6 +5179,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5276,6 +5315,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5408,6 +5448,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5540,6 +5581,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5672,6 +5714,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5804,6 +5847,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;
@@ -5936,6 +5980,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 height: 100%;
                 min-width: 0px;
                 outline: transparent;
+                overflow: hidden;
                 padding-bottom: 0px;
                 padding-left: 0px;
                 padding-right: 0px;


### PR DESCRIPTION
#### Pull request checklist

- ~~[ ] Addresses an existing issue: Fixes #0000~~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Suggestions were not being truncated in IE11.

It looks like it and only truncates when the element being truncated in the flex context itself is overflow:hidden, even if the descendant elements could be truncated to a size that fits.

Example bug in OWA:
![image](https://user-images.githubusercontent.com/1174858/57260101-188d8f80-7017-11e9-91b7-7c64a2764ff9.png)

See example of fixed behaviour by going to the storybook in IE11
![image](https://user-images.githubusercontent.com/1174858/57260144-34913100-7017-11e9-960d-b31a603d5f5c.png)

#### Focus areas to test

Suggestions

---

After this is reviewed and merged, this needs to be repeated against `fabric-7` and #8720 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8988)