### PR TITLE
Fix UHF header style bugs

### DIFF
--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -14,7 +14,7 @@ import {
   Stack,
   IRawStyle
 } from 'office-ui-fabric-react';
-import { trackEvent, EventNames, getSiteArea } from '@uifabric/example-app-base/lib/index2';
+import { trackEvent, EventNames, getSiteArea, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { platforms } from '../../SiteDefinition/SiteDefinition.platforms';
 import { AndroidLogo, AppleLogo, WebLogo, getParameterByName } from '../../utilities/index';
 import { IHomePageProps, IHomePageStyles, IHomePageStyleProps } from './HomePage.types';
@@ -158,7 +158,9 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
           <div className={classNames.card} style={{ background: platforms.web.color }}>
             <Icon iconName="WebLogo-homePage" className={classNames.cardIcon} />
             <Stack horizontal verticalAlign="baseline" horizontalAlign="space-between">
-              <h3 className={classNames.cardTitle}>Web</h3>
+              <MarkdownHeader as="h3" className={classNames.cardTitle}>
+                Web
+              </MarkdownHeader>
               <ActionButton
                 allowDisabledFocus={true}
                 className={classNames.versionSwitcher}
@@ -194,14 +196,18 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
           </div>
           <div className={classNames.card} style={{ background: platforms.ios.color }}>
             <Icon iconName="AppleLogo-homePage" className={classNames.cardIcon} />
-            <h3 className={classNames.cardTitle}>iOS</h3>
+            <MarkdownHeader as="h3" className={classNames.cardTitle}>
+              iOS
+            </MarkdownHeader>
             <ul className={classNames.cardList}>
               <li className={classNames.cardListItem}>{this._renderLink('#/controls/ios', 'Controls')}</li>
             </ul>
           </div>
           <div className={classNames.card} style={{ background: platforms.android.color }}>
             <Icon iconName="AndroidLogo-homePage" className={classNames.cardIcon} />
-            <h3 className={classNames.cardTitle}>Android</h3>
+            <MarkdownHeader as="h3" className={classNames.cardTitle}>
+              Android
+            </MarkdownHeader>
             <ul className={classNames.cardList}>
               <li className={classNames.cardListItem}>{this._renderLink('#/controls/android', 'Controls')}</li>
             </ul>

--- a/apps/fabric-website/src/pages/Overviews/StylesPage/StylesPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/StylesPage/StylesPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link, Icon } from 'office-ui-fabric-react';
-import { withPlatform, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import { withPlatform, Page, IPageProps, IPageSectionProps, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { getSubTitle } from '../../../utilities/index';
 import * as styles from './StylesPage.module.scss';
 import { Platforms } from '../../../interfaces/Platforms';
@@ -28,9 +28,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/colors/products" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="colors" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="colors" className={styles.cardTitle}>
                   Colors
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="Color" className={styles.cardIcon} />
               </div>
             </Link>
@@ -41,9 +41,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/elevation" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="elevation" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="elevation" className={styles.cardTitle}>
                   Elevation
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="ArrangeSendBackward" className={styles.cardIcon} />
               </div>
             </Link>
@@ -54,9 +54,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/icons" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="iconography" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="iconography" className={styles.cardTitle}>
                   Iconography
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="EmojiTabSymbols" className={styles.cardIcon} />
               </div>
             </Link>
@@ -67,9 +67,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/layout" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="layout" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="layout" className={styles.cardTitle}>
                   Layout
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="Tiles" className={styles.cardIcon} />
               </div>
             </Link>
@@ -80,9 +80,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/motion" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="motion" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="motion" className={styles.cardTitle}>
                   Motion
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="MiniExpand" className={styles.cardIcon} />
               </div>
             </Link>
@@ -93,9 +93,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/typography" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="typography" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="typography" className={styles.cardTitle}>
                   Typography
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="FontSize" className={styles.cardIcon} />
               </div>
             </Link>
@@ -106,9 +106,9 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
           content: (
             <Link href="#/styles/web/localization" className={styles.cardLink}>
               <div className={styles.cardContent}>
-                <h2 id="localization" className={styles.cardTitle}>
+                <MarkdownHeader as="h2" id="localization" className={styles.cardTitle}>
                   Localization
-                </h2>
+                </MarkdownHeader>
                 <Icon iconName="World" className={styles.cardIcon} />
               </div>
             </Link>

--- a/apps/fabric-website/src/pages/Styles/Colors/ProductsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/ProductsPage.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Markdown, ColorPalette, IColor, IColorPaletteTheme, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import {
+  Markdown,
+  MarkdownHeader,
+  ColorPalette,
+  IColor,
+  IColorPaletteTheme,
+  IPageSectionProps
+} from '@uifabric/example-app-base/lib/index2';
 import { IStylesPageProps, StylesAreaPage } from '../StylesAreaPage';
 import { ColorsProductsPageProps } from './ProductsPage.doc';
 
@@ -57,7 +64,7 @@ export class ColorsProductsPage extends React.Component<IStylesPageProps, IColor
                 <ColorPalette colors={AppColorSwatches} onColorSelected={this._changeApp} />
                 {activeAppColorPalette && (
                   <>
-                    <h2>{activeAppColorPalette.name}</h2>
+                    <MarkdownHeader as="h2">{activeAppColorPalette.name}</MarkdownHeader>
                     <p>{activeAppColorPalette.notes}</p>
                     <ColorPalette colors={activeAppColorPalette.colors} />
                   </>

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/Excel.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/Excel.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { WXPNeutrals } from './WXPNeutrals';
 
 export const Excel = () => {
   return (
     <>
-      <h2>Excel</h2>
+      <MarkdownHeader as="h2">Excel</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/Exchange.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/Exchange.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 export const Exchange = () => {
   return (
     <>
-      <h2>Exchange</h2>
+      <MarkdownHeader as="h2">Exchange</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -75,7 +75,7 @@ export const Exchange = () => {
         ]}
       />
 
-      <h3>Neutrals</h3>
+      <MarkdownHeader as="h3">Neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/OneDrive.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/OneDrive.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 export const OneDrive = () => {
   return (
     <>
-      <h2>OneDrive</h2>
+      <MarkdownHeader as="h2">OneDrive</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -75,7 +75,7 @@ export const OneDrive = () => {
         ]}
       />
 
-      <h3>Neutrals</h3>
+      <MarkdownHeader as="h3">Neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/OneNote.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/OneNote.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 export const OneNote = () => {
   return (
     <>
-      <h2>OneNote</h2>
+      <MarkdownHeader as="h2">OneNote</MarkdownHeader>
 
       <ColorPalette
         colors={[

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/PowerPoint.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/PowerPoint.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 import { WXPNeutrals } from './WXPNeutrals';
 
 export const PowerPoint = () => {
   return (
     <>
-      <h2>PowerPoint</h2>
+      <MarkdownHeader as="h2">PowerPoint</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/SharePoint.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/SharePoint.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ColorPalette, IColor } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, IColor, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { SharePointNeutrals, SharePointThemes } from './sharePointThemes';
 
 export class SharePoint extends React.Component<{}, { activeThemeName?: string }> {
@@ -16,9 +16,9 @@ export class SharePoint extends React.Component<{}, { activeThemeName?: string }
 
     return (
       <>
-        <h2>SharePoint</h2>
+        <MarkdownHeader as="h2">SharePoint</MarkdownHeader>
 
-        <h3>Themes</h3>
+        <MarkdownHeader as="h3">Themes</MarkdownHeader>
         <ColorPalette
           colors={SharePointThemes.map(theme => ({
             name: theme.name,
@@ -31,10 +31,10 @@ export class SharePoint extends React.Component<{}, { activeThemeName?: string }
 
         {activeThemeColors && (
           <>
-            <h3>{`${activeThemeName} theme`}</h3>
+            <MarkdownHeader as="h3">{`${activeThemeName} theme`}</MarkdownHeader>
             <ColorPalette colors={activeThemeColors} />
 
-            <h3>{`Neutrals for ${activeThemeName} theme (${activeThemeData.background} background)`}</h3>
+            <MarkdownHeader as="h3">{`Neutrals for ${activeThemeName} theme (${activeThemeData.background} background)`}</MarkdownHeader>
             <ColorPalette colors={activeNeutralColors} />
           </>
         )}

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/Skype.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/Skype.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 export const Skype = () => {
   return (
     <>
-      <h2>Skype</h2>
+      <MarkdownHeader as="h2">Skype</MarkdownHeader>
 
-      <h3>Blue theme (default)</h3>
+      <MarkdownHeader as="h3">Blue theme (default)</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -38,7 +38,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Blurple theme</h3>
+      <MarkdownHeader as="h3">Blurple theme</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -59,7 +59,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Purple theme</h3>
+      <MarkdownHeader as="h3">Purple theme</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -80,7 +80,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Pink theme</h3>
+      <MarkdownHeader as="h3">Pink theme</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -101,7 +101,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Orange theme</h3>
+      <MarkdownHeader as="h3">Orange theme</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -132,7 +132,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Default theme neutrals</h3>
+      <MarkdownHeader as="h3">Default theme neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -218,7 +218,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Dark theme neutrals</h3>
+      <MarkdownHeader as="h3">Dark theme neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -304,7 +304,7 @@ export const Skype = () => {
         ]}
       />
 
-      <h3>Call theme neutrals</h3>
+      <MarkdownHeader as="h3">Call theme neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/Teams.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/Teams.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 export const Teams = () => {
   return (
     <>
-      <h2>Teams</h2>
-      <h3>Default theme</h3>
+      <MarkdownHeader as="h2">Teams</MarkdownHeader>
+      <MarkdownHeader as="h3">Default theme</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -39,7 +39,7 @@ export const Teams = () => {
           }
         ]}
       />
-      <h3>Default theme neutrals</h3>
+      <MarkdownHeader as="h3">Default theme neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -124,7 +124,7 @@ export const Teams = () => {
           }
         ]}
       />
-      <h3>Dark theme neutrals</h3>
+      <MarkdownHeader as="h3">Dark theme neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {
@@ -209,7 +209,7 @@ export const Teams = () => {
           }
         ]}
       />
-      <h3>Call theme neutrals</h3>
+      <MarkdownHeader as="h3">Call theme neutrals</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/WXPNeutrals.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/WXPNeutrals.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 
 export class WXPNeutrals extends React.Component {
   public render() {
     return (
       <>
-        <h3>Colorful Theme</h3>
+        <MarkdownHeader as="h3">Colorful Theme</MarkdownHeader>
         <ColorPalette
           colors={[
             {
@@ -92,7 +92,7 @@ export class WXPNeutrals extends React.Component {
           ]}
         />
 
-        <h3>Dark Gray Theme</h3>
+        <MarkdownHeader as="h3">Dark Gray Theme</MarkdownHeader>
         <ColorPalette
           colors={[
             {
@@ -202,7 +202,7 @@ export class WXPNeutrals extends React.Component {
           ]}
         />
 
-        <h3>Black Theme</h3>
+        <MarkdownHeader as="h3">Black Theme</MarkdownHeader>
         <ColorPalette
           colors={[
             {

--- a/apps/fabric-website/src/pages/Styles/Colors/palettes/Word.tsx
+++ b/apps/fabric-website/src/pages/Styles/Colors/palettes/Word.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-import { ColorPalette } from '@uifabric/example-app-base/lib/index2';
+import { ColorPalette, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { WXPNeutrals } from './WXPNeutrals';
 
 export const Word = () => {
   return (
     <>
-      <h2>Word</h2>
+      <MarkdownHeader as="h2">Word</MarkdownHeader>
       <ColorPalette
         colors={[
           {

--- a/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LayoutPage/LayoutPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Table } from '../../../components/Table/Table';
-import { IPageSectionProps, CodeSnippet } from '@uifabric/example-app-base/lib/index2';
+import { IPageSectionProps, CodeSnippet, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { IStylesPageProps, StylesAreaPage } from '../StylesAreaPage';
 import { LayoutPageProps } from './LayoutPage.doc';
 import * as styles from './LayoutPage.module.scss';
@@ -169,7 +169,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 </div>
               </div>
 
-              <h4>Inheritance</h4>
+              <MarkdownHeader as="h4">Inheritance</MarkdownHeader>
               <p>
                 Because Fabric is mobile-first, any layout defined for small screens is automatically inherited by medium and large screens.
                 The small size utilities (ms-sm6) are required. If you want to change the layout on larger screens, you can apply the other
@@ -188,7 +188,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 </div>
               </div>
 
-              <h4>Push and pull</h4>
+              <MarkdownHeader as="h4">Push and pull</MarkdownHeader>
               <p>
                 You might want your column source order to differ from the display order, or to change the column display order based on the
                 screen size. The push and pull utilities make this possible. Push moves a column to the right; pull moves it to the left.
@@ -208,7 +208,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 </div>
               </div>
 
-              <h4>Visibility</h4>
+              <MarkdownHeader as="h4">Visibility</MarkdownHeader>
               <p>
                 Some designs call for certain content to be shown or hidden depending on the screen size. You can achieve this using
                 Fabric's responsive visibility classes. These allow you to show or hide content at a specific screen size, or across a whole

--- a/apps/fabric-website/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/LocalizationPage/LocalizationPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Markdown, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import { Markdown, MarkdownHeader, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { Table } from '../../../components/Table/Table';
 import { IStylesPageProps, StylesAreaPage } from '../StylesAreaPage';
 import { LocalizationPageProps } from './LocalizationPage.doc';
@@ -63,7 +63,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
               <Markdown>
                 {require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/LocalizationPage/docs/web/LocalizationRTL.md')}
               </Markdown>
-              <h3>Supported languages</h3>
+              <MarkdownHeader as="h3">Supported languages</MarkdownHeader>
               <p>Fabric supports a variety of language codes, which map to the following font stacks:</p>
               <Table content={localizedFontsData} />
             </>

--- a/apps/fabric-website/src/pages/Styles/MotionPage/MotionPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/MotionPage/MotionPage.tsx
@@ -5,6 +5,7 @@ import {
   AnimationExample,
   IPageSectionProps,
   Markdown,
+  MarkdownHeader,
   Table,
   Video
 } from '@uifabric/example-app-base/lib/index2';
@@ -62,7 +63,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 {require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/MotionPage/docs/web/MotionAnimationPatterns.md') as string}
               </Markdown>
 
-              <h3>Delete & Slide</h3>
+              <MarkdownHeader as="h3">Delete & Slide</MarkdownHeader>
               <p>This pattern for deleting an object from the view and how the remaining objects realign themselves.</p>
               <Video source="https://static2.sharepointonline.com/files/fabric/fabric-website/video/deleteslide.mp4" />
               <PatternTable
@@ -84,7 +85,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 ]}
               />
 
-              <h3>Slide & Add</h3>
+              <MarkdownHeader as="h3">Slide & Add</MarkdownHeader>
               <p>This pattern for adding an object to a view, and how the other objects react to the new element.</p>
               <Video source="https://static2.sharepointonline.com/files/fabric/fabric-website/video/slideadd.mp4" />
               <PatternTable
@@ -106,7 +107,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 ]}
               />
 
-              <h3>Drill In</h3>
+              <MarkdownHeader as="h3">Drill In</MarkdownHeader>
               <p>
                 This pattern handles the transition from one view into another. Some elements persist, some leave the view, and new ones
                 enter as well.
@@ -131,7 +132,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 ]}
               />
 
-              <h3>Drill In with Continuity</h3>
+              <MarkdownHeader as="h3">Drill In with Continuity</MarkdownHeader>
               <p>
                 This pattern handles the transition from one view into another. Some elements persist, some leave the view, and new ones
                 enter as well.
@@ -163,7 +164,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 ]}
               />
 
-              <h3>Tabs & Pivots</h3>
+              <MarkdownHeader as="h3">Tabs & Pivots</MarkdownHeader>
               <p>
                 This pattern describes the transition from selecting one tab to another. Includes the selection state that travels across
                 the tab set. Also describes the tab content coming in and out as well.
@@ -207,14 +208,14 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 {require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/MotionPage/docs/web/MotionBasicAnimations.md') as string}
               </Markdown>
 
-              <h3>Fade</h3>
+              <MarkdownHeader as="h3">Fade</MarkdownHeader>
               <p>The most basic and fundamental animation for adding and removing objects. Use fades as the default choice.</p>
               <AnimationDetailGrid>
                 <AnimationDetail animation="Fade in" coreClass="ms-motion-fadeIn" reactVariable="MotionAnimations.fadeIn" />
                 <AnimationDetail animation="Fade out" coreClass="ms-motion-fadeOut" reactVariable="MotionAnimations.fadeOut" />
               </AnimationDetailGrid>
 
-              <h3>Scale</h3>
+              <MarkdownHeader as="h3">Scale</MarkdownHeader>
               <p>
                 A more dramatic animation than fading, scaling draws the eye and implies a sense of depth. Use these animations sparingly
                 where more emphasis is needed.
@@ -228,7 +229,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 />
               </AnimationDetailGrid>
 
-              <h3>Slide</h3>
+              <MarkdownHeader as="h3">Slide</MarkdownHeader>
               <p>
                 Use sliding animations for when there is an obvious directionality to the entrance and exit of an object. These animations
                 help users build a mental model of where the object can be found when it isn’t visible.

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/OfficeBrandIconsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IconGrid } from '../../../components/IconGrid/IconGrid';
 import { Image, Icon } from 'office-ui-fabric-react';
 import { getFileTypeIconProps } from '@uifabric/file-type-icons';
-import { Markdown, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import { Markdown, MarkdownHeader, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { IStylesPageProps, StylesAreaPage } from '../StylesAreaPage';
 import { OfficeBrandIconsPageProps } from './OfficeBrandIconsPage.doc';
 import { Platforms } from '../../../interfaces/Platforms';
@@ -35,7 +35,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                   require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsOverview.md') as string
                 }
               </Markdown>
-              <h3>Product icons</h3>
+              <MarkdownHeader as="h3">Product icons</MarkdownHeader>
               <div className="ms-Grid">
                 <div className="ms-Grid-row">
                   <div className="ms-Grid-col ms-sm12 ms-lg6">
@@ -73,7 +73,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 </div>
               </div>
 
-              <h3>File type icons</h3>
+              <MarkdownHeader as="h3">File type icons</MarkdownHeader>
               <div className="ms-Grid">
                 <div className="ms-Grid-row">
                   <div className="ms-Grid-col ms-sm12 ms-lg6">
@@ -219,7 +219,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
           sectionName: 'Branded icon library',
           content: (
             <>
-              <h3>Product icons</h3>
+              <MarkdownHeader as="h3">Product icons</MarkdownHeader>
               <ul className={styles.iconList}>
                 {productIcons.map((icon, iconIndex) => (
                   <li key={iconIndex}>
@@ -235,7 +235,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 ))}
               </ul>
 
-              <h3>File type icons</h3>
+              <MarkdownHeader as="h3">File type icons</MarkdownHeader>
               <ul className={styles.iconList}>
                 {documentIcons.map((icon, iconIndex) => (
                   <li key={iconIndex}>
@@ -255,7 +255,7 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
                 ))}
               </ul>
 
-              <h3>Single-color icons</h3>
+              <MarkdownHeader as="h3">Single-color icons</MarkdownHeader>
               <Markdown>
                 {
                   require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsSingleColor.md') as string

--- a/common/changes/@uifabric/example-app-base/UHF-typography-style-bugs_2019-05-06-23-02.json
+++ b/common/changes/@uifabric/example-app-base/UHF-typography-style-bugs_2019-05-06-23-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix UHF header style bugs.",
+      "packageName": "@uifabric/example-app-base",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/UHF-typography-style-bugs_2019-05-06-23-02.json
+++ b/common/changes/@uifabric/fabric-website/UHF-typography-style-bugs_2019-05-06-23-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix UHF header styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/example-app-base/src/components/Markdown/MarkdownHeader.tsx
+++ b/packages/example-app-base/src/components/Markdown/MarkdownHeader.tsx
@@ -9,6 +9,7 @@ import { FontSizes } from '@uifabric/fluent-theme';
 export interface IMarkdownHeaderProps {
   as?: keyof React.ReactHTML;
   children?: React.ReactNode;
+  className?: string;
   id?: string;
 
   theme?: ITheme;
@@ -20,6 +21,7 @@ export interface IMarkdownHeaderProps {
  */
 export type IMarkdownHeaderStyleProps = {
   as: string;
+  className?: string;
 };
 
 /**
@@ -30,6 +32,7 @@ export interface IMarkdownHeaderStyles {
 }
 
 const getStyles: IStyleFunction<IMarkdownHeaderStyleProps, IMarkdownHeaderStyles> = props => {
+  const { className } = props;
   return {
     root: [
       {
@@ -66,7 +69,8 @@ const getStyles: IStyleFunction<IMarkdownHeaderStyleProps, IMarkdownHeaderStyles
           fontSize: FontSizes.size20,
           marginBottom: '8px'
         }
-      ]
+      ],
+      className
     ]
   };
 };
@@ -74,9 +78,9 @@ const getStyles: IStyleFunction<IMarkdownHeaderStyleProps, IMarkdownHeaderStyles
 const getClassNames = classNamesFunction<IMarkdownHeaderStyleProps, IMarkdownHeaderStyles>();
 
 const MarkdownHeaderBase: React.StatelessComponent<IMarkdownHeaderProps> = props => {
-  const { as: RootType = 'h1', children, id, styles } = props;
+  const { as: RootType = 'h1', children, id, styles, className } = props;
 
-  const classNames = getClassNames(styles, { as: RootType });
+  const classNames = getClassNames(styles, { as: RootType, className });
   return (
     <RootType className={classNames.root} id={id}>
       {children}

--- a/packages/example-app-base/src/components/Page/sections/BestPracticesSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/BestPracticesSection.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { EditSection } from '../../EditSection/index';
 import { css } from 'office-ui-fabric-react';
 import { getEditUrl, pascalize } from '../../../utilities/index2';
-import { Markdown } from '../../Markdown/index';
+import { Markdown, MarkdownHeader } from '../../Markdown/index';
 import { IPageSectionProps } from '../Page.types';
 import * as styles from '../Page.module.scss';
 
@@ -60,7 +60,9 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
       <div className={styles.subSection} key="dosAndDonts">
         <div className={styles.doSection}>
           <div className={styles.sectionHeader}>
-            <h3 className={styles.smallSubHeading}>Do</h3>
+            <MarkdownHeader as="h3" className={styles.smallSubHeading}>
+              Do
+            </MarkdownHeader>
             {dos && dosUrl && <EditSection className={styles.edit} title={title} section="Dos" url={dosUrl} />}
           </div>
           {dos && (
@@ -71,7 +73,9 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
         </div>
         <div className={styles.dontSection}>
           <div className={styles.sectionHeader}>
-            <h3 className={css(styles.smallSubHeading)}>Don&rsquo;t</h3>
+            <MarkdownHeader as="h3" className={css(styles.smallSubHeading)}>
+              Don&rsquo;t
+            </MarkdownHeader>
             {donts && dontsUrl && <EditSection className={styles.edit} title={title} section="Don'ts" url={dontsUrl} />}
           </div>
           {donts && (

--- a/packages/example-app-base/src/components/SideRail/SideRail.tsx
+++ b/packages/example-app-base/src/components/SideRail/SideRail.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { css, FocusZone, FocusZoneDirection, Link, IProcessedStyleSet, classNamesFunction, styled } from 'office-ui-fabric-react';
 import { isPageActive, removeAnchorLink, jumpToAnchor } from '../../utilities/index2';
+import { MarkdownHeader } from '../Markdown/index';
 import { ISideRailProps, ISideRailLink, ISideRailStyles, ISideRailStyleProps } from './SideRail.types';
 import { getStyles } from './SideRail.styles';
 
@@ -90,7 +91,9 @@ class SideRailBase extends React.Component<ISideRailProps, ISideRailState> {
     ));
     return (
       <div className={css(classNames.section, classNames.jumpLinkSection)}>
-        <h3 className={classNames.sectionTitle}>On this page</h3>
+        <MarkdownHeader as="h3" className={classNames.sectionTitle}>
+          On this page
+        </MarkdownHeader>
         <ul className={classNames.links}>{links}</ul>
       </div>
     );
@@ -120,7 +123,9 @@ class SideRailBase extends React.Component<ISideRailProps, ISideRailState> {
     if (links) {
       return (
         <div className={css(classNames.section)}>
-          <h3 className={classNames.sectionTitle}>{title}</h3>
+          <MarkdownHeader as="h3" className={classNames.sectionTitle}>
+            {title}
+          </MarkdownHeader>
           {links}
         </div>
       );


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Use `MarkdownHeader` in place of standard `<h2>` and `<h3>` tags because UHF applies global styles to all header tags.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8989)