### PR TITLE
Update README examples to reference mergeStyleSets instead of mergeSt…

### DIFF
--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -7,13 +7,13 @@ The library was built for speed and size; the entire package is 2.62k gzipped. I
 Simple usage:
 
 ```
-import { mergeStyles, mergeStyleSet } from '@uifabric/merge-styles';
+import { mergeStyles, mergeStyleSets } from '@uifabric/merge-styles';
 
 // Produces 'css-0' class name which can be used anywhere
 mergeStyles({ background: 'red' });
 
 // Produces a class map for a bunch of rules all at once
-mergeStyleSet({
+mergeStyleSets({
   root: { background: 'red' },
   child: { background: 'green' }
 });
@@ -57,7 +57,7 @@ The api surfaces consists of 3 methods and a handful of interfaces:
 
 `mergeStyles(..args[]: IStyle[]): string` - Takes in one or more style objects, merges them in the right order, and produces a single css class name which can be injected into any component.
 
-`mergeStyleSet(...args[]: IStyleSet[]): { [key: string]: string }` - Takes in one or more style set objects, each consisting of a set of areas, each which will produce a class name. Using this is analogous to calling mergeStyles for each property in the object, but ensures we maintain the set ordering when multiple style sets are merged.
+`mergeStyleSets(...args[]: IStyleSet[]): { [key: string]: string }` - Takes in one or more style set objects, each consisting of a set of areas, each which will produce a class name. Using this is analogous to calling mergeStyles for each property in the object, but ensures we maintain the set ordering when multiple style sets are merged.
 
 `concatStyleSet(...args[]: IStyleSet[]): IStyleSet` - In some cases you simply need to combine style sets, without actually generating class names (it is costs in performance to generate class names.) This tool returns a single set merging many together.
 
@@ -356,7 +356,7 @@ In the following example, the root class generated will be different depending o
 
 ```tsx
 export const getClassNames = (isToggled: boolean): IComponentClassNames => {
-  return mergeStyleSet({
+  return mergeStyleSets({
     root: [
       {
         background: 'red'
@@ -395,7 +395,7 @@ Resolving the class names on every render can be an unwanted expense especially 
 import { memoizeFunction } from '@uifabric/utilities';
 
 export const getClassNames = memoizeFunction((isToggled: boolean) => {
-  return mergeStyleSet({
+  return mergeStyleSets({
     // ...
   });
 });


### PR DESCRIPTION
…yleSet which does not work.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Some of the README examples incorrectly inform the user to import mergeStyleSet instead of mergeStyleSets.

#### Focus areas to test

N/A


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8990)