### PR TITLE
Fix DetailsList large grouped demo infinite loading loop

### DIFF
--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -54,7 +54,7 @@ const categories: { Other?: ICategory; [name: string]: ICategory } = {
         Basic: {},
         Compact: {},
         Grouped: {},
-        LargeGrouped: {},
+        LargeGrouped: { title: 'Large Grouped' },
         CustomColumns: { title: 'Custom Item Columns', url: 'customitemcolumns' },
         CustomRows: { title: 'Custom Item Rows', url: 'customitemrows' },
         CustomFooter: { title: 'Custom Footer' },

--- a/apps/fabric-website/src/pages/Controls/DetailsListPage/DetailsListLargeGroupedPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/DetailsListPage/DetailsListLargeGroupedPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
-import { DetailsListGroupedPageProps } from './DetailsListGroupedPage.doc';
+import { DetailsListLargeGroupedPageProps } from './DetailsListLargeGroupedPage.doc';
 
-export const DetailsListGroupedPage: React.StatelessComponent<IControlsPageProps> = props => {
-  return <ControlsAreaPage {...props} {...DetailsListGroupedPageProps[props.platform]} />;
+export const DetailsListLargeGroupedPage: React.StatelessComponent<IControlsPageProps> = props => {
+  return <ControlsAreaPage {...props} {...DetailsListLargeGroupedPageProps[props.platform]} />;
 };

--- a/common/changes/@uifabric/fabric-website/detailslist-loop_2019-05-07-01-42.json
+++ b/common/changes/@uifabric/fabric-website/detailslist-loop_2019-05-07-01-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix DetailsList large grouped demo infinite loading loop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/detailslist-loop_2019-05-07-01-50.json
+++ b/common/changes/office-ui-fabric-react/detailslist-loop_2019-05-07-01-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Router should error if getComponent doesn't return anything",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/router/Router.tsx
@@ -92,6 +92,13 @@ export class Router extends React.Component<IRouterProps, IRouterState> {
             component = getComponent.component;
           } else {
             getComponent((resolved: React.ComponentType) => {
+              if (!resolved) {
+                throw new Error(
+                  `Router: Calling getComponent for the route with path ${route.props.path} ` +
+                    `returned ${resolved}, not a component. Check your getComponent implementation ` +
+                    `(including the name of the module member you're attempting to return).`
+                );
+              }
               component = getComponent.component = resolved;
 
               if (asynchronouslyResolved) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Fixes an existing issue: Fixes #8991
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Loading the large grouped DetailsList page caused an infinite loop due to a typo.

Also make the Router fail loudly by throwing an error (rather than infinite looping) in case something similar happens again.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/8993)