### PR TITLE
merge-styles: getInstance now with less IE11 memory leaks

### DIFF
--- a/common/changes/@uifabric/merge-styles/merge-styles-tweak_2019-05-08-00-07.json
+++ b/common/changes/@uifabric/merge-styles/merge-styles-tweak_2019-05-08-00-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "merge-styles: Removing `typeof window` call in `getInstance` to remove an IE11 memory leak.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -65,7 +65,15 @@ export interface IStyleSheetConfig {
 const STYLESHEET_SETTING = '__stylesheet__';
 
 // tslint:disable-next-line:no-any
-const _fileScopedGlobal: { [key: string]: any } = {};
+let _global: { [key: string]: any } = {};
+
+// Grab window.
+try {
+  _global = window;
+} catch {
+  /* leave as blank object */
+}
+
 let _stylesheet: Stylesheet;
 
 /**
@@ -94,14 +102,13 @@ export class Stylesheet {
    */
   public static getInstance(): Stylesheet {
     // tslint:disable-next-line:no-any
-    const global: any = typeof window !== 'undefined' ? window : _fileScopedGlobal;
-    _stylesheet = global[STYLESHEET_SETTING] as Stylesheet;
+    _stylesheet = _global[STYLESHEET_SETTING] as Stylesheet;
 
     if (!_stylesheet || (_stylesheet._lastStyleElement && _stylesheet._lastStyleElement.ownerDocument !== document)) {
       // tslint:disable-next-line:no-string-literal
-      const fabricConfig = (global && global['FabricConfig']) || {};
+      const fabricConfig = (_global && _global['FabricConfig']) || {};
 
-      _stylesheet = global[STYLESHEET_SETTING] = new Stylesheet(fabricConfig.mergeStyles);
+      _stylesheet = _global[STYLESHEET_SETTING] = new Stylesheet(fabricConfig.mergeStyles);
     }
 
     return _stylesheet;


### PR DESCRIPTION
It turns out that IE11 does not like references to `window`, especially in hot spots. It's totally fine with variable instances pointing to `window`.

What it hates even more is when you say `typedef window` to check for existence. This creates a memory leak in IE11.

So; as a first immediate step, we should remove the references to `window` and `typedef window` in the hotspot.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9004)