### PR TITLE
Fix return type of onReduceData in CommandBar

### DIFF
--- a/common/changes/office-ui-fabric-react/anihan-commandbar-type-fix_2019-05-08-00-23.json
+++ b/common/changes/office-ui-fabric-react/anihan-commandbar-type-fix_2019-05-08-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix return type of onReduceDate in CommandBar",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2749,7 +2749,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
     onDataGrown?: (movedItem: ICommandBarItemProps) => void;
     onDataReduced?: (movedItem: ICommandBarItemProps) => void;
     onGrowData?: (data: ICommandBarData) => ICommandBarData;
-    onReduceData?: (data: ICommandBarData) => ICommandBarData;
+    onReduceData?: (data: ICommandBarData) => ICommandBarData | undefined;
     overflowButtonAs?: IComponentAs<IButtonProps>;
     overflowButtonProps?: IButtonProps;
     overflowItems?: ICommandBarItemProps[];

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -71,7 +71,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * Custom function to reduce data if items do not fit in given space. Return `undefined`
    * if no more steps can be taken to avoid infinate loop.
    */
-  onReduceData?: (data: ICommandBarData) => ICommandBarData;
+  onReduceData?: (data: ICommandBarData) => ICommandBarData | undefined;
 
   /**
    * Custom function to grow data if items are too small for the given space.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8948
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As per the documentation and also in lines with other `onReduceData` methods (such as one in `Breadcrumb`) updated the type to include `undefined` to terminate the loop.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9006)