### PR TITLE
More "typeof window" fixes to avoid leaks in IE11.

### DIFF
--- a/common/changes/@uifabric/styling/fix-window-references_2019-05-08-17-33.json
+++ b/common/changes/@uifabric/styling/fix-window-references_2019-05-08-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Removed a few more `typeof window` references to avoid memory leaks with IE11.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/fix-window-references_2019-05-08-17-33.json
+++ b/common/changes/@uifabric/utilities/fix-window-references_2019-05-08-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Removed a few more `typeof window` references to avoid memory leaks with IE11.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fix-window-references_2019-05-08-17-33.json
+++ b/common/changes/office-ui-fabric-react/fix-window-references_2019-05-08-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed a few more `typeof window` references to avoid memory leaks with IE11.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, divProperties, getNativeProps } from '../../Utilities';
+import { classNamesFunction, divProperties, getNativeProps, getWindow } from '../../Utilities';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { ActionButton } from '../../Button';
 import { Icon } from '../../Icon';
@@ -297,7 +297,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
       return link.key === this.props.selectedKey;
     } else if (this.state.selectedKey !== undefined) {
       return link.key === this.state.selectedKey;
-    } else if (typeof window === 'undefined' || !link.url) {
+    } else if (typeof getWindow() === 'undefined' || !link.url) {
       // resolve is not supported for ssr
       return false;
     } else {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -12,6 +12,8 @@ import {
   ScreenWidthMinUhfMobile,
   IStyle
 } from '../../Styling';
+import { getWindow } from '../../Utilities';
+
 // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
 // import { IStyleFunctionOrObject } from '../../Utilities';
 // import { IButtonStyles, IButtonStyleProps } from '../../Button';
@@ -201,7 +203,8 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
   const { palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const isCustomPanel = type === PanelType.custom || type === PanelType.customNear;
-  const windowHeight = typeof window !== 'undefined' ? window.innerHeight : '100%';
+  const win = getWindow();
+  const windowHeight = typeof win !== 'undefined' ? win.innerHeight : '100%';
 
   return {
     root: [

--- a/packages/set-version/src/setVersion.ts
+++ b/packages/set-version/src/setVersion.ts
@@ -1,10 +1,20 @@
 // A packages cache that makes sure that we don't inject the same packageName twice in the same bundle -
 // this cache is local to the module closure inside this bundle
 const packagesCache: { [name: string]: string } = {};
+
+// Cache access to window to avoid IE11 memory leak.
+let _win: Window | undefined = undefined;
+
+try {
+  _win = window;
+} catch (e) {
+  /* no-op */
+}
+
 export function setVersion(packageName: string, packageVersion: string): void {
-  if (typeof window !== 'undefined') {
+  if (typeof _win !== 'undefined') {
     // tslint:disable-next-line:no-any
-    const packages = ((window as any).__packages__ = (window as any).__packages__ || {});
+    const packages = ((_win as any).__packages__ = (_win as any).__packages__ || {});
 
     // We allow either the global packages or local packages caches to invalidate so testing can just clear the global to set this state
     if (!packages[packageName] || !packagesCache[packageName]) {

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -1,7 +1,7 @@
 import { fontFace, IFontWeight } from '@uifabric/merge-styles';
 import { IFontStyles } from '../interfaces/index';
 import { createFontStyles, FontWeights, LocalizedFontFamilies, LocalizedFontNames } from './fonts';
-import { getLanguage } from '@uifabric/utilities';
+import { getLanguage, getWindow } from '@uifabric/utilities';
 import { IFabricConfig } from '../interfaces/IFabricConfig';
 
 // Default urls.
@@ -67,7 +67,7 @@ export function registerDefaultFontFaces(baseUrl: string): void {
  * Reads the fontBaseUrl from window.FabricConfig.fontBaseUrl or falls back to a default.
  */
 function _getFontBaseUrl(): string {
-  let win = typeof window !== 'undefined' ? window : undefined;
+  let win = getWindow();
 
   // tslint:disable-next-line:no-string-literal no-any
   let fabricConfig: IFabricConfig = win ? win['FabricConfig'] : undefined;

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -1,4 +1,4 @@
-import { Customizations, merge } from '@uifabric/utilities';
+import { Customizations, merge, getWindow } from '@uifabric/utilities';
 import { IPalette, ISemanticColors, ITheme, IPartialTheme, IFontStyles } from '../interfaces/index';
 import { DefaultFontStyles } from './DefaultFontStyles';
 import { DefaultPalette } from './DefaultPalette';
@@ -18,7 +18,7 @@ let _onThemeChangeCallbacks: Array<(theme: ITheme) => void> = [];
 export const ThemeSettingName = 'theme';
 
 if (!Customizations.getSettings([ThemeSettingName]).theme) {
-  let win = typeof window !== 'undefined' ? window : undefined;
+  const win = getWindow();
 
   // tslint:disable:no-string-literal no-any
   if (win && (win as any)['FabricConfig'] && (win as any)['FabricConfig'].theme) {

--- a/packages/utilities/src/GlobalSettings.ts
+++ b/packages/utilities/src/GlobalSettings.ts
@@ -1,3 +1,5 @@
+import { getWindow } from './dom/getWindow';
+
 /**
  * Storing global state in local module variables has issues when more than one copy
  * if the module gets loaded on the page (due to a bundling error or simply by consuming
@@ -102,7 +104,8 @@ export class GlobalSettings {
 }
 
 function _getGlobalSettings(): { [key: string]: any } {
-  const globalObj: { [key: string]: any } = typeof window !== 'undefined' ? window : {};
+  const win = getWindow();
+  const globalObj: { [key: string]: any } = win || {};
 
   if (!globalObj[GLOBAL_SETTINGS_PROP_NAME]) {
     globalObj[GLOBAL_SETTINGS_PROP_NAME] = {

--- a/packages/utilities/src/dom/getWindow.ts
+++ b/packages/utilities/src/dom/getWindow.ts
@@ -1,4 +1,16 @@
 import { _isSSR } from './setSSR';
+
+let _window: Window | undefined = undefined;
+
+// Note: Accessing "window" in IE11 is somewhat expensive, and calling "typeof window"
+// hits a memory leak, whereas aliasing it and calling "typedef _window" does not.
+// Caching the window value at the file scope lets us minimize the impact.
+try {
+  _window = window;
+} catch (e) {
+  /* no-op */
+}
+
 /**
  * Helper to get the window object. Note that in popup scenarios the window object
  * may not be the window use ex
@@ -6,11 +18,11 @@ import { _isSSR } from './setSSR';
  * @public
  */
 export function getWindow(rootElement?: Element | null): Window | undefined {
-  if (_isSSR || typeof window === 'undefined') {
+  if (_isSSR || typeof _window === 'undefined') {
     return undefined;
   } else {
     return rootElement && rootElement.ownerDocument && rootElement.ownerDocument.defaultView
       ? rootElement.ownerDocument.defaultView
-      : window;
+      : _window;
   }
 }

--- a/packages/utilities/src/dom/getWindow.ts
+++ b/packages/utilities/src/dom/getWindow.ts
@@ -3,7 +3,7 @@ import { _isSSR } from './setSSR';
 let _window: Window | undefined = undefined;
 
 // Note: Accessing "window" in IE11 is somewhat expensive, and calling "typeof window"
-// hits a memory leak, whereas aliasing it and calling "typedef _window" does not.
+// hits a memory leak, whereas aliasing it and calling "typeof _window" does not.
 // Caching the window value at the file scope lets us minimize the impact.
 try {
   _window = window;
@@ -13,7 +13,7 @@ try {
 
 /**
  * Helper to get the window object. The helper will make sure to use a cached variable
- * of "window", to avoid overhead and memory leaks in IE11. Note that in popup scenarios the 
+ * of "window", to avoid overhead and memory leaks in IE11. Note that in popup scenarios the
  * window object won't match the "global" window object, and for these scenarios, you should
  * pass in an element hosted within the popup.
  *

--- a/packages/utilities/src/dom/getWindow.ts
+++ b/packages/utilities/src/dom/getWindow.ts
@@ -12,8 +12,10 @@ try {
 }
 
 /**
- * Helper to get the window object. Note that in popup scenarios the window object
- * may not be the window use ex
+ * Helper to get the window object. The helper will make sure to use a cached variable
+ * of "window", to avoid overhead and memory leaks in IE11. Note that in popup scenarios the 
+ * window object won't match the "global" window object, and for these scenarios, you should
+ * pass in an element hosted within the popup.
  *
  * @public
  */

--- a/packages/utilities/src/localStorage.ts
+++ b/packages/utilities/src/localStorage.ts
@@ -1,3 +1,5 @@
+import { getWindow } from './dom/getWindow';
+
 /**
  * Fetches an item from local storage without throwing an exception
  * @param key The key of the item to fetch from local storage
@@ -5,7 +7,8 @@
 export function getItem(key: string): string | null {
   let result = null;
   try {
-    result = window.localStorage.getItem(key);
+    const win = getWindow();
+    result = win ? win.localStorage.getItem(key) : null;
   } catch (e) {
     /* Eat the exception */
   }
@@ -19,7 +22,9 @@ export function getItem(key: string): string | null {
  */
 export function setItem(key: string, data: string): void {
   try {
-    window.localStorage.setItem(key, data);
+    const win = getWindow();
+
+    win && win.localStorage.setItem(key, data);
   } catch (e) {
     /* Eat the exception */
   }

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -1,13 +1,12 @@
 import { Stylesheet } from '@uifabric/merge-styles';
+import { getWindow } from './dom/getWindow';
 
 // Initialize global window id.
 const CURRENT_ID_PROPERTY = '__currentId__';
 const DEFAULT_ID_STRING = 'id__';
 
-declare const process: {};
-
 // tslint:disable-next-line:no-any
-let _global: any = (typeof window !== 'undefined' && window) || process;
+let _global: any = getWindow() || {};
 
 if (_global[CURRENT_ID_PROPERTY] === undefined) {
   _global[CURRENT_ID_PROPERTY] = 0;

--- a/packages/utilities/src/osDetector.ts
+++ b/packages/utilities/src/osDetector.ts
@@ -9,7 +9,7 @@ let isMacResult: boolean | undefined;
 export function isMac(reset?: boolean): boolean {
   if (typeof isMacResult === 'undefined' || reset) {
     const win = getWindow();
-    const userAgent = win && window.navigator.userAgent;
+    const userAgent = win && win.navigator.userAgent;
 
     isMacResult = !!userAgent && userAgent.indexOf('Macintosh') !== -1;
   }

--- a/packages/utilities/src/osDetector.ts
+++ b/packages/utilities/src/osDetector.ts
@@ -1,3 +1,5 @@
+import { getWindow } from './dom/getWindow';
+
 let isMacResult: boolean | undefined;
 
 /**
@@ -6,7 +8,9 @@ let isMacResult: boolean | undefined;
  */
 export function isMac(reset?: boolean): boolean {
   if (typeof isMacResult === 'undefined' || reset) {
-    const userAgent = typeof window !== 'undefined' && window.navigator.userAgent;
+    const win = getWindow();
+    const userAgent = win && window.navigator.userAgent;
+
     isMacResult = !!userAgent && userAgent.indexOf('Macintosh') !== -1;
   }
   return !!isMacResult;


### PR DESCRIPTION
Did a search to find more `typeof window` references in our codebase and reworked things to use `getWindow`, which will returned a cached variable pointing to window. This can be safely `typeof`d without hitting the leak situation.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9010)