### PR TITLE
Update rest state border colors in Fluent theme

### DIFF
--- a/common/changes/@uifabric/fluent-theme/wcag_2019-05-08-19-43.json
+++ b/common/changes/@uifabric/fluent-theme/wcag_2019-05-08-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Update border colors during rest state for certain components",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/FluentStyles.ts
+++ b/packages/fluent-theme/src/fluent/FluentStyles.ts
@@ -28,6 +28,7 @@ import { PersonaStyles } from './styles/Persona.styles';
 import { PivotStyles } from './styles/Pivot.styles';
 import { PrimaryButtonStyles } from './styles/PrimaryButton.styles';
 import { RatingStyles } from './styles/Rating.styles';
+import { SearchBoxStyles } from './styles/SearchBox.styles';
 import { SliderStyles } from './styles/Slider.styles';
 import { SpinButtonStyles } from './styles/SpinButton.styles';
 import { SuggestionItemStyles, SuggestionsStyles } from './styles/PickerSuggestions.styles';
@@ -152,6 +153,9 @@ export const FluentStyles: any = {
   },
   Rating: {
     styles: RatingStyles
+  },
+  SearchBox: {
+    styles: SearchBoxStyles
   },
   Slider: {
     styles: SliderStyles

--- a/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
@@ -5,11 +5,12 @@ export const BasePickerStyles = (props: IBasePickerStyleProps): Partial<IBasePic
   if (!theme) {
     throw new Error('Theme is undefined or null.');
   }
-  const { effects } = theme;
+  const { effects, palette } = theme;
 
   return {
     text: {
-      borderRadius: effects.roundedCorner2
+      borderRadius: effects.roundedCorner2,
+      borderColor: palette.neutralSecondaryAlt
     },
     input: {
       borderRadius: effects.roundedCorner2

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -10,6 +10,7 @@ export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> 
   return {
     root: {
       borderRadius: effects.roundedCorner2, // the bound input box
+      borderColor: palette.neutralSecondaryAlt,
       paddingLeft: 8
     },
     rootHovered: {

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -96,6 +96,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     title: [
       {
         borderRadius: isOpen ? titleOpenBorderRadius : effects.roundedCorner2,
+        borderColor: palette.neutralSecondaryAlt,
         padding: `0 28px 0 8px`
       },
       hasError && { borderColor: !isOpen ? palette.red : palette.redDark },

--- a/packages/fluent-theme/src/fluent/styles/SearchBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SearchBox.styles.ts
@@ -1,0 +1,15 @@
+import { ISearchBoxStyleProps, ISearchBoxStyles } from 'office-ui-fabric-react/lib/SearchBox';
+
+export const SearchBoxStyles = (props: ISearchBoxStyleProps): Partial<ISearchBoxStyles> => {
+  const { theme } = props;
+  const { effects, palette } = theme;
+
+  return {
+    root: [
+      {
+        borderRadius: effects.roundedCorner2,
+        borderColor: palette.neutralSecondaryAlt
+      }
+    ]
+  };
+};

--- a/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
@@ -28,7 +28,8 @@ export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonSt
 
   return {
     spinButtonWrapper: {
-      borderRadius: effects.roundedCorner2
+      borderRadius: effects.roundedCorner2,
+      borderColor: palette.neutralSecondaryAlt
     },
     input: {
       padding: '0 8px',

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -6,7 +6,10 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
 
   return {
     fieldGroup: [
-      { borderRadius: effects.roundedCorner2 },
+      {
+        borderRadius: effects.roundedCorner2,
+        borderColor: palette.neutralSecondaryAlt
+      },
       hasErrorMessage && [
         {
           borderColor: palette.red,
@@ -33,6 +36,9 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         }
       }
     ],
+    wrapper: {
+      borderColor: palette.neutralSecondaryAlt // For underlined and borderless TextFields
+    },
     errorMessage: {
       color: palette.redDark
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8910
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update border colors in components Textfield, Dropdown, Spinbutton, Combobox, Pickers, SearchBox in Fluent theme to meet WCAG 2.1 requirements


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9012)