### PR TITLE
Remove aria-hidden from FocusTrapZone's bumpers

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-focus_2019-05-09-00-32.json
+++ b/common/changes/office-ui-fabric-react/panel-focus_2019-05-09-00-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix ARIA issue in Surfaces",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -82,7 +82,6 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
         position: 'fixed' // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them
       },
       tabIndex: disabled ? -1 : 0, // make bumpers tabbable only when enabled
-      'aria-hidden': true,
       'data-is-visible': true
     } as React.HTMLAttributes<HTMLDivElement>;
 

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -142,7 +142,6 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
             onFocusCapture={[Function]}
           >
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -170,7 +169,6 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -329,7 +327,6 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
             onFocusCapture={[Function]}
           >
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -355,7 +352,6 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -126,7 +126,6 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
           }
         >
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -153,7 +152,6 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
             Test Content
           </div>
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -306,7 +304,6 @@ exports[`Modal renders Modal correctly 1`] = `
           onFocusCapture={[Function]}
         >
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -333,7 +330,6 @@ exports[`Modal renders Modal correctly 1`] = `
             Test Content
           </div>
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -465,7 +461,6 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
           onFocusCapture={[Function]}
         >
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -492,7 +487,6 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
             Test Content
           </div>
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -155,7 +155,6 @@ exports[`Panel renders Panel correctly 1`] = `
           style={Object {}}
         >
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -404,7 +403,6 @@ exports[`Panel renders Panel correctly 1`] = `
             </div>
           </div>
           <div
-            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -2119,7 +2119,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                 onFocusCapture={[Function]}
                               >
                                 <div
-                                  aria-hidden={true}
                                   data-is-visible={true}
                                   onFocus={[Function]}
                                   style={
@@ -2356,7 +2355,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                   </div>
                                 </div>
                                 <div
-                                  aria-hidden={true}
                                   data-is-visible={true}
                                   onFocus={[Function]}
                                   style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -7,7 +7,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
   onFocusCapture={[Function]}
 >
   <div
-    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={
@@ -401,7 +400,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
     </a>
   </div>
   <div
-    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -189,7 +189,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
     onFocusCapture={[Function]}
   >
     <div
-      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -583,7 +582,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
       </a>
     </div>
     <div
-      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -189,7 +189,6 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
     onFocusCapture={[Function]}
   >
     <div
-      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -584,7 +583,6 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
       </a>
     </div>
     <div
-      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -7,7 +7,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
   onFocusCapture={[Function]}
 >
   <div
-    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={
@@ -1094,7 +1093,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
     </div>
   </div>
   <div
-    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -123,7 +123,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
     onFocusCapture={[Function]}
   >
     <div
-      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -448,7 +447,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         onFocusCapture={[Function]}
       >
         <div
-          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -774,7 +772,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             onFocusCapture={[Function]}
           >
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1096,7 +1093,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               </button>
             </div>
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1114,7 +1110,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             onFocusCapture={[Function]}
           >
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1436,7 +1431,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               </button>
             </div>
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1450,7 +1444,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           </div>
         </div>
         <div
-          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -1468,7 +1461,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         onFocusCapture={[Function]}
       >
         <div
-          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -1789,7 +1781,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           </button>
         </div>
         <div
-          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -1803,7 +1794,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       </div>
     </div>
     <div
-      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -248,7 +248,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
             style={Object {}}
           >
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -497,7 +496,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
               </div>
             </div>
             <div
-              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8911
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As bumpers are focus-able, having `aria-hidden: true` is violating a rule. Having no `aria-hidden` is better in this case.

I noticed the implementation of trapping focus in a [W3 aria examples](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html), they didn't require any `aria-hidden` for bumpers. Windows Narrator doesn't inform their presence either. 

#### Focus areas to test

Any accessibility regressions


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9019)