### PR TITLE
withViewport: Handle change of skipViewportMeasures value

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-withviewport-skipmeasures_2019-05-09-17-27.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-withviewport-skipmeasures_2019-05-09-17-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "withViewport: Respect value change of skipViewportMeasures by reassigning appropriate resize listener",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -40,22 +40,20 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
 
     public componentDidMount(): void {
       const { skipViewportMeasures } = this.props as IWithViewportProps;
+      const win = getWindow();
+
       this._onAsyncResize = this._async.debounce(this._onAsyncResize, RESIZE_DELAY, {
         leading: false
       });
-
-      const window = getWindow();
-      const viewportElement = this._root.current;
 
       // ResizeObserver seems always fire even window is not resized. This is
       // particularly bad when skipViewportMeasures is set when optimizing fixed layout lists.
       // It will measure and update and re-render the entire list after list is fully rendered.
       // So fallback to listen to resize event when skipViewportMeasures is set.
-      if (!skipViewportMeasures && window && (window as any).ResizeObserver) {
-        this._viewportResizeObserver = new (window as any).ResizeObserver(this._onAsyncResize);
-        this._viewportResizeObserver.observe(viewportElement);
+      if (!skipViewportMeasures && this._isResizeObserverAvailable()) {
+        this._registerResizeObserver();
       } else {
-        this._events.on(window, 'resize', this._onAsyncResize);
+        this._events.on(win, 'resize', this._onAsyncResize);
       }
 
       if (!skipViewportMeasures) {
@@ -66,17 +64,15 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     public componentDidUpdate(newProps: TProps) {
       const { skipViewportMeasures: oldSkipViewportMeasures } = this.props as IWithViewportProps;
       const { skipViewportMeasures: newSkipViewportMeasures } = newProps as IWithViewportProps;
-      const viewportElement = this._root.current;
+      const win = getWindow();
 
       if (oldSkipViewportMeasures !== newSkipViewportMeasures) {
         if (newSkipViewportMeasures) {
-          this._viewportResizeObserver.disconnect();
-          this._viewportResizeObserver = null;
-          this._events.on(window, 'resize', this._onAsyncResize);
-        } else {
-          this._events.off(window, 'resize', this._onAsyncResize);
-          this._viewportResizeObserver = new (window as any).ResizeObserver(this._onAsyncResize);
-          this._viewportResizeObserver.observe(viewportElement);
+          this._unregisterResizeObserver();
+          this._events.on(win, 'resize', this._onAsyncResize);
+        } else if (!newSkipViewportMeasures && this._isResizeObserverAvailable()) {
+          this._events.off(win, 'resize', this._onAsyncResize);
+          this._registerResizeObserver();
         }
       }
     }
@@ -108,6 +104,26 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     private _onAsyncResize(): void {
       this._updateViewport();
     }
+
+    private _isResizeObserverAvailable(): boolean {
+      const win = getWindow();
+
+      return win && (win as any).ResizeObserver;
+    }
+
+    private _registerResizeObserver = () => {
+      const win = getWindow();
+
+      this._viewportResizeObserver = new (win as any).ResizeObserver(this._onAsyncResize);
+      this._viewportResizeObserver.observe(this._root.current);
+    };
+
+    private _unregisterResizeObserver = () => {
+      if (this._viewportResizeObserver) {
+        this._viewportResizeObserver.disconnect();
+        this._viewportResizeObserver = null;
+      }
+    };
 
     /* Note: using lambda here because decorators don't seem to work in decorators. */
     private _updateViewport = (withForceUpdate?: boolean) => {

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -63,6 +63,24 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
       }
     }
 
+    public componentDidUpdate(newProps: TProps) {
+      const { skipViewportMeasures: oldSkipViewportMeasures } = this.props as IWithViewportProps;
+      const { skipViewportMeasures: newSkipViewportMeasures } = newProps as IWithViewportProps;
+      const viewportElement = this._root.current;
+
+      if (oldSkipViewportMeasures !== newSkipViewportMeasures) {
+        if (newSkipViewportMeasures) {
+          this._viewportResizeObserver.disconnect();
+          this._viewportResizeObserver = null;
+          this._events.on(window, 'resize', this._onAsyncResize);
+        } else {
+          this._events.off(window, 'resize', this._onAsyncResize);
+          this._viewportResizeObserver = new (window as any).ResizeObserver(this._onAsyncResize);
+          this._viewportResizeObserver.observe(viewportElement);
+        }
+      }
+    }
+
     public componentWillUnmount(): void {
       this._events.dispose();
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Fixes a bug @ThomasMichon discovered with the `withViewport` decorator where it did not respect a change to its prop `skipViewportMeasures`. To address, we must detect the prop change, unassign the existing listener and assign the new listener.

For context, this prop was added to avoid using `ResizeObserver` because of it only being supported in Chrome AND a separate horizontal scrollbar bug causes the viewport measure to occur twice since the scrollbar modifies the element's height. Tracking that scrollbar issue separately in https://github.com/OfficeDev/office-ui-fabric-react/issues/8826.

Separately, I find the naming of this prop somewhat confusing without having the above context.

#### Focus areas to test

Unsure how to best capture this in a unit test.

To test locally, you can modify the prop value and see that it only ever utilizes the listener callback that was initially assigned here:

https://github.com/OfficeDev/office-ui-fabric-react/blob/80119d3d40ca9b185dc6f8f0d3bedfe0296f176d/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx#L54

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9027)