### PR TITLE
Button: Fixing SplitButton so that root and button slot props do not propagate to inner slots

### DIFF
--- a/common/changes/@uifabric/experiments/buttonErrors_2019-05-09-20-53.json
+++ b/common/changes/@uifabric/experiments/buttonErrors_2019-05-09-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Fixing SplitButton so that `root` and `button` slot props do not propagate to inner slots.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -18,6 +18,8 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     allowDisabledFocus,
     ariaLabel,
     expanded,
+    root: Root,
+    button: primaryActionButton,
     menu: Menu,
     primaryActionDisabled,
     secondaryAriaLabel,

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -18,9 +18,9 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     allowDisabledFocus,
     ariaLabel,
     expanded,
-    root: Root,
-    button: primaryActionButton,
-    menu: Menu,
+    root,
+    button,
+    menu,
     primaryActionDisabled,
     secondaryAriaLabel,
     buttonRef,
@@ -68,7 +68,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
         allowDisabledFocus={allowDisabledFocus}
         ariaLabel={menuButtonAriaLabel}
         onClick={onSecondaryActionClick}
-        menu={Menu}
+        menu={menu}
       />
     </Slots.root>
   );

--- a/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, IStackProps } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { IMenuButtonProps, MenuButton } from '@uifabric/experiments/lib/MenuButton';
 import { ISplitButtonProps, SplitButton } from '@uifabric/experiments/lib/SplitButton';
@@ -51,10 +51,16 @@ const RibbonMenuButtonVerticalStyles = {
 };
 
 export const RibbonMenuButton: React.SFC<IRibbonMenuButtonProps> = props => {
+  const stackProps: IStackProps = {
+    horizontal: false,
+    tokens: { childrenGap: 0 },
+    verticalFill: true
+  };
+
   const mergedProps: IMenuButtonProps = props.vertical
     ? {
         ...props,
-        stack: { horizontal: false, tokens: { childrenGap: 0 }, verticalFill: true },
+        stack: stackProps,
         menuIcon: 'ChevronDownSmall',
         styles: RibbonMenuButtonVerticalStyles,
         tokens: RibbonMenuButtonVerticalTokens
@@ -99,6 +105,11 @@ const SplitMenuButtonVerticalSlots: ISplitRibbonMenuButtonProps['slots'] = {
 export const RibbonSplitMenuButton: React.SFC<ISplitRibbonMenuButtonProps> = props => {
   const { content, vertical, ...rest } = props;
 
+  const rootProps: IStackProps = {
+    horizontal: false,
+    horizontalAlign: 'center'
+  };
+
   // TODO: This cast is required because menu is required in IMenuButtonSlots.
   // However, it's provided by the top level props of ISplitRibbonMenuButton props, so it shouldn't be required in multiple places.
   // Should menu be made optional in IMenuButtonSlots?
@@ -108,7 +119,7 @@ export const RibbonSplitMenuButton: React.SFC<ISplitRibbonMenuButtonProps> = pro
   const mergedProps: ISplitRibbonMenuButtonProps = vertical
     ? {
         ...rest,
-        root: { horizontal: false, horizontalAlign: 'center' },
+        root: rootProps,
         menuButton: verticalMenuButtonProps,
         styles: SplitMenuButtonVerticalStyles,
         tokens: SplitMenuButtonVerticalTokens,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Whenever the `Button` doc page was rendered in the browser, a couple of error messages appeared in the console even though everything was being rendered correctly. This was due to `SplitButton` propagating its `root` and `button` props to the inner slottable components that had the same props. This PR fixes this issue by avoiding this propagation while also cleaning up the example code a little bit.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9033)