### PR TITLE
Prevent pickers from showing "ms-clear" icon when typing.

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-peoplepicker_2019-05-09-21-35.json
+++ b/common/changes/office-ui-fabric-react/fix-peoplepicker_2019-05-09-21-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "In Edge, prevent pickers from showing \"ms-clear\" icon when typing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -108,6 +108,9 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -72,6 +72,9 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -202,6 +202,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}
@@ -290,6 +293,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                   padding-left: 6px;
                   padding-right: 6px;
                   padding-top: 0;
+                }
+                &::-ms-clear {
+                  display: none;
                 }
             data-lpignore={true}
             disabled={false}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -90,7 +90,12 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
         flexGrow: 1,
         outline: 'none',
         padding: '0 6px 0',
-        alignSelf: 'flex-end'
+        alignSelf: 'flex-end',
+        selectors: {
+          '::-ms-clear': {
+            display: 'none'
+          }
+        }
       },
       inputClassName
     ],

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -69,6 +69,9 @@ exports[`PeoplePicker renders correctly 1`] = `
                 padding-right: 6px;
                 padding-top: 0;
               }
+              &::-ms-clear {
+                display: none;
+              }
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}
@@ -614,6 +617,9 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                 padding-left: 6px;
                 padding-right: 6px;
                 padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
               }
           data-lpignore={true}
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -69,6 +69,9 @@ exports[`TagPicker renders correctly 1`] = `
                 padding-right: 6px;
                 padding-top: 0;
               }
+              &::-ms-clear {
+                display: none;
+              }
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9032
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Hide "X" icon when interacting with pickers.

Reflects this change to `TextField`: https://github.com/OfficeDev/office-ui-fabric-react/commit/539ae367462f66aae44bbd5087d9e79ea2ad4904

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9035)