### PR TITLE
Scope button style overrides to fabric components

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
@@ -2,6 +2,11 @@ import { getGlobalClassNames } from '../../Styling';
 import { IFabricStyleProps, IFabricStyles } from './Fabric.types';
 
 const inheritFont = { fontFamily: 'inherit' };
+const buttonStyles = {
+  ...inheritFont,
+  overflow: 'visible',
+  margin: 0
+};
 
 const GlobalClassNames = {
   root: 'ms-Fabric'
@@ -24,13 +29,9 @@ export const getStyles = (props: IFabricStyleProps): IFabricStyles => {
       {
         color: theme.palette.neutralPrimary,
         selectors: {
-          '& button': inheritFont,
+          '& button': buttonStyles,
           '& input': inheritFont,
-          '& textarea': inheritFont,
-          ':global(button)': {
-            overflow: 'visible',
-            margin: 0
-          }
+          '& textarea': inheritFont
         }
       },
       className


### PR DESCRIPTION
Addresses #9036

__Problem:__ The margin and overflow styles are applied globally and affect non-Fabric elements.

__Solution:__ The styles should be scoped to only Fabric elements.

#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9036 
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Scopes fabric button overrides to buttons wrapped in a fabric component

#### Focus areas to test

The bugs fixed by these PRs: #3970 and #4797


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9037)