### PR TITLE
adding an artifact drop for API JSON files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,18 @@ steps:
       artifactName: 'CodeAnalysisLogs'
     displayName: publish sarif a11y reports
 
+  - task: CopyFiles@2
+    inputs:
+      contents: 'packages/*/*.api.json'
+      targetFolder: $(Build.ArtifactStagingDirectory)/api
+    displayName: Copying API JSON files to Staging Area
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.ArtifactStagingDirectory)/api
+      artifactName: 'ApiJsonArtifacts'
+    displayName: Publishing API JSON files as Artifacts
+
   - script: |
       git config --global user.email "fabrictactical@microsoft.com"
       git config --global user.name "Fabric Tactical"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

This adds a new artifact drop to our Azure DevOps job to publish api.json files. This is needed to have our APIs documented also on docs.microsoft.com

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9054)