### PR TITLE
TeachingBubble: Add footerContent prop

### DIFF
--- a/common/changes/office-ui-fabric-react/teachingbubble-multistep_2019-05-10-20-30.json
+++ b/common/changes/office-ui-fabric-react/teachingbubble-multistep_2019-05-10-20-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TeachingBubble: Add prop to render text for multi-step experience",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/teachingbubble-multistep_2019-05-10-20-30.json
+++ b/common/changes/office-ui-fabric-react/teachingbubble-multistep_2019-05-10-20-30.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "TeachingBubble: Add prop to render text for multi-step experience",
+      "comment": "TeachingBubble: Add footerContent prop to render custom footer text",
       "type": "minor"
     }
   ],

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5329,12 +5329,6 @@ export interface IModalStyles {
 }
 
 // @public (undocumented)
-export interface IMultistepProps {
-    className?: string;
-    text: string;
-}
-
-// @public (undocumented)
 export interface INav {
     selectedKey: string | undefined;
 }
@@ -7276,13 +7270,13 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
     ariaLabelledBy?: string;
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITeachingBubble>;
+    footerContent?: string;
     hasCloseIcon?: boolean;
     hasCondensedHeadline?: boolean;
     hasSmallHeadline?: boolean;
     headline?: string;
     illustrationImage?: IImageProps;
     isWide?: boolean;
-    multistepProps?: IMultistepProps;
     onDismiss?: (ev?: any) => void;
     primaryButtonProps?: IButtonProps;
     secondaryButtonProps?: IButtonProps;
@@ -7325,8 +7319,6 @@ export interface ITeachingBubbleStyles {
     headline: IStyle;
     // (undocumented)
     imageContent: IStyle;
-    // (undocumented)
-    multistepText: IStyle;
     // (undocumented)
     primaryButton: IStyle;
     // (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7270,7 +7270,7 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
     ariaLabelledBy?: string;
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITeachingBubble>;
-    footerContent?: string;
+    footerContent?: string | JSX.Element;
     hasCloseIcon?: boolean;
     hasCondensedHeadline?: boolean;
     hasSmallHeadline?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5329,6 +5329,12 @@ export interface IModalStyles {
 }
 
 // @public (undocumented)
+export interface IMultistepProps {
+    className?: string;
+    text: string;
+}
+
+// @public (undocumented)
 export interface INav {
     selectedKey: string | undefined;
 }
@@ -7276,6 +7282,7 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
     headline?: string;
     illustrationImage?: IImageProps;
     isWide?: boolean;
+    multistepProps?: IMultistepProps;
     onDismiss?: (ev?: any) => void;
     primaryButtonProps?: IButtonProps;
     secondaryButtonProps?: IButtonProps;
@@ -7295,6 +7302,7 @@ export interface ITeachingBubbleState {
 // @public (undocumented)
 export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'theme'>> & Pick<ITeachingBubbleProps, 'hasCondensedHeadline' | 'hasSmallHeadline' | 'isWide'> & {
     calloutClassName?: string;
+    multistepTextClassName?: string;
     primaryButtonClassName?: string;
     secondaryButtonClassName?: string;
 };
@@ -7317,6 +7325,8 @@ export interface ITeachingBubbleStyles {
     headline: IStyle;
     // (undocumented)
     imageContent: IStyle;
+    // (undocumented)
+    multistepText: IStyle;
     // (undocumented)
     primaryButton: IStyle;
     // (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7296,7 +7296,6 @@ export interface ITeachingBubbleState {
 // @public (undocumented)
 export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'theme'>> & Pick<ITeachingBubbleProps, 'hasCondensedHeadline' | 'hasSmallHeadline' | 'isWide'> & {
     calloutClassName?: string;
-    multistepTextClassName?: string;
     primaryButtonClassName?: string;
     secondaryButtonClassName?: string;
 };

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -23,6 +23,7 @@ const globalClassNames = {
   headerIsLarge: 'ms-TeachingBubble-header--large',
   headline: 'ms-TeachingBubble-headline',
   image: 'ms-TeachingBubble-image',
+  multistepText: 'ms-TeachingBubble-multistepText',
   primaryButton: 'ms-TeachingBubble-primaryButton',
   secondaryButton: 'ms-TeachingBubble-secondaryButton',
   subText: 'ms-TeachingBubble-subText',
@@ -142,6 +143,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     hasCondensedHeadline,
     hasSmallHeadline,
     isWide,
+    multistepTextClassName,
     primaryButtonClassName,
     secondaryButtonClassName,
     theme
@@ -293,6 +295,17 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
             borderColor: palette.white
           }
         }
+      }
+    ],
+    multistepText: [
+      classNames.multistepText,
+      multistepTextClassName,
+      {
+        alignItems: 'center',
+        backgroundColor: palette.themePrimary,
+        color: palette.white,
+        display: 'flex',
+        padding: '0 16px'
       }
     ],
     subText: [

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -23,7 +23,6 @@ const globalClassNames = {
   headerIsLarge: 'ms-TeachingBubble-header--large',
   headline: 'ms-TeachingBubble-headline',
   image: 'ms-TeachingBubble-image',
-  multistepText: 'ms-TeachingBubble-multistepText',
   primaryButton: 'ms-TeachingBubble-primaryButton',
   secondaryButton: 'ms-TeachingBubble-secondaryButton',
   subText: 'ms-TeachingBubble-subText',
@@ -143,7 +142,6 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     hasCondensedHeadline,
     hasSmallHeadline,
     isWide,
-    multistepTextClassName,
     primaryButtonClassName,
     secondaryButtonClassName,
     theme
@@ -199,9 +197,10 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
       classNames.footer,
       {
         display: 'flex',
+        alignItems: 'center',
+        color: palette.white,
         selectors: {
-          // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
-          [`.${classNames.button}:not(:first-child)`]: {
+          '> *:not(:first-child)': {
             marginLeft: '20px'
           }
         }
@@ -295,17 +294,6 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
             borderColor: palette.white
           }
         }
-      }
-    ],
-    multistepText: [
-      classNames.multistepText,
-      multistepTextClassName,
-      {
-        alignItems: 'center',
-        backgroundColor: palette.themePrimary,
-        color: palette.white,
-        display: 'flex',
-        padding: '0 16px'
       }
     ],
     subText: [

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
@@ -88,6 +88,12 @@ describe('TeachingBubble', () => {
     expect(treeContent).toMatchSnapshot();
   });
 
+  it('renders TeachingBubbleContent with multistep text', () => {
+    const componentContent = renderer.create(<TeachingBubbleContent multistepProps={{ text: '1 of 2' }}>Content</TeachingBubbleContent>);
+    const treeContent = componentContent.toJSON();
+    expect(treeContent).toMatchSnapshot();
+  });
+
   it('merges callout classNames', () => {
     ReactTestUtils.renderIntoDocument(<TeachingBubbleContent headline="Title" calloutProps={{ className: 'foo' }} />);
     setTimeout(() => {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
@@ -88,8 +88,8 @@ describe('TeachingBubble', () => {
     expect(treeContent).toMatchSnapshot();
   });
 
-  it('renders TeachingBubbleContent with multistep text', () => {
-    const componentContent = renderer.create(<TeachingBubbleContent multistepProps={{ text: '1 of 2' }}>Content</TeachingBubbleContent>);
+  it('renders TeachingBubbleContent with custom footer text', () => {
+    const componentContent = renderer.create(<TeachingBubbleContent footerContent="1 of 2">Content</TeachingBubbleContent>);
     const treeContent = componentContent.toJSON();
     expect(treeContent).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -17,6 +17,17 @@ export interface ITeachingBubble {
   focus(): void;
 }
 
+export interface IMultistepProps {
+  /**
+   * If provided, additional class name to provide on the root element.
+   */
+  className?: string;
+
+  /**
+   * Text to render for multi-step callouts, for example "1 of 2".
+   */
+  text: string;
+}
 /**
  * TeachingBubble component props.
  * {@docCategory TeachingBubble}
@@ -109,6 +120,11 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
    * Defines the element id referencing the element containing the description for the TeachingBubble.
    */
   ariaDescribedBy?: string;
+
+  /**
+   * Props for a multi-step callout experience.
+   */
+  multistepProps?: IMultistepProps;
 }
 
 /**
@@ -118,6 +134,8 @@ export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'the
   Pick<ITeachingBubbleProps, 'hasCondensedHeadline' | 'hasSmallHeadline' | 'isWide'> & {
     /** Class name for callout. */
     calloutClassName?: string;
+    /** Class name for multistep text */
+    multistepTextClassName?: string;
     /** Class name for primary button. */
     primaryButtonClassName?: string;
     /** Class name for secondary button. */
@@ -137,6 +155,7 @@ export interface ITeachingBubbleStyles {
   header: IStyle;
   headline: IStyle;
   imageContent: IStyle;
+  multistepText: IStyle;
   primaryButton: IStyle;
   secondaryButton: IStyle;
   subText: IStyle;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -17,17 +17,6 @@ export interface ITeachingBubble {
   focus(): void;
 }
 
-export interface IMultistepProps {
-  /**
-   * If provided, additional class name to provide on the root element.
-   */
-  className?: string;
-
-  /**
-   * Text to render for multi-step callouts, for example "1 of 2".
-   */
-  text: string;
-}
 /**
  * TeachingBubble component props.
  * {@docCategory TeachingBubble}
@@ -85,6 +74,11 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
   secondaryButtonProps?: IButtonProps;
 
   /**
+   * Text that will be rendered in the footer of the TeachingBubble. May be rendered alongside primary and secondary buttons.
+   */
+  footerContent?: string;
+
+  /**
    * @deprecated use target instead
    * Element to anchor the TeachingBubble to.
    */
@@ -120,11 +114,6 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
    * Defines the element id referencing the element containing the description for the TeachingBubble.
    */
   ariaDescribedBy?: string;
-
-  /**
-   * Props for a multi-step callout experience.
-   */
-  multistepProps?: IMultistepProps;
 }
 
 /**
@@ -155,7 +144,6 @@ export interface ITeachingBubbleStyles {
   header: IStyle;
   headline: IStyle;
   imageContent: IStyle;
-  multistepText: IStyle;
   primaryButton: IStyle;
   secondaryButton: IStyle;
   subText: IStyle;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -123,8 +123,6 @@ export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'the
   Pick<ITeachingBubbleProps, 'hasCondensedHeadline' | 'hasSmallHeadline' | 'isWide'> & {
     /** Class name for callout. */
     calloutClassName?: string;
-    /** Class name for multistep text */
-    multistepTextClassName?: string;
     /** Class name for primary button. */
     primaryButtonClassName?: string;
     /** Class name for secondary button. */

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -76,7 +76,7 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
   /**
    * Text that will be rendered in the footer of the TeachingBubble. May be rendered alongside primary and secondary buttons.
    */
-  footerContent?: string;
+  footerContent?: string | JSX.Element;
 
   /**
    * @deprecated use target instead

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -60,7 +60,8 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       styles,
       theme,
       ariaDescribedBy,
-      ariaLabelledBy
+      ariaLabelledBy,
+      multistepProps
     } = this.props;
 
     let imageContent;
@@ -74,6 +75,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       hasCondensedHeadline,
       hasSmallHeadline,
       isWide,
+      multistepTextClassName: multistepProps ? multistepProps.className : undefined,
       primaryButtonClassName: primaryButtonProps ? primaryButtonProps.className : undefined,
       secondaryButtonClassName: secondaryButtonProps ? secondaryButtonProps.className : undefined
     });
@@ -110,11 +112,12 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       );
     }
 
-    if (primaryButtonProps || secondaryButtonProps) {
+    if (primaryButtonProps || secondaryButtonProps || multistepProps) {
       footerContent = (
         <div className={classNames.footer}>
           {primaryButtonProps && <PrimaryButton {...primaryButtonProps} className={classNames.primaryButton} />}
           {secondaryButtonProps && <DefaultButton {...secondaryButtonProps} className={classNames.secondaryButton} />}
+          {multistepProps && <div className={classNames.multistepText}>{multistepProps.text}</div>}
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -61,7 +61,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       theme,
       ariaDescribedBy,
       ariaLabelledBy,
-      multistepProps
+      footerContent: customFooterContent
     } = this.props;
 
     let imageContent;
@@ -75,7 +75,6 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       hasCondensedHeadline,
       hasSmallHeadline,
       isWide,
-      multistepTextClassName: multistepProps ? multistepProps.className : undefined,
       primaryButtonClassName: primaryButtonProps ? primaryButtonProps.className : undefined,
       secondaryButtonClassName: secondaryButtonProps ? secondaryButtonProps.className : undefined
     });
@@ -112,12 +111,12 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       );
     }
 
-    if (primaryButtonProps || secondaryButtonProps || multistepProps) {
+    if (primaryButtonProps || secondaryButtonProps || customFooterContent) {
       footerContent = (
         <div className={classNames.footer}>
           {primaryButtonProps && <PrimaryButton {...primaryButtonProps} className={classNames.primaryButton} />}
           {secondaryButtonProps && <DefaultButton {...secondaryButtonProps} className={classNames.secondaryButton} />}
-          {multistepProps && <div className={classNames.multistepText}>{multistepProps.text}</div>}
+          {customFooterContent && <span>{customFooterContent}</span>}
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -912,6 +912,90 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
 </div>
 `;
 
+exports[`TeachingBubble renders TeachingBubbleContent with multistep text 1`] = `
+<div
+  className=
+      ms-TeachingBubble-content
+      {
+        animation-duration: 2000ms;
+        animation-fill-mode: both;
+        animation-name: keyframes 0%{transform:matrix3d(0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}1.7%{transform:matrix3d(0.658, 0, 0, 0, 0, 0.703, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}2.35%{transform:matrix3d(0.725, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}3.4%{transform:matrix3d(0.83, 0, 0, 0, 0, 0.946, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}4.7%{transform:matrix3d(0.942, 0, 0, 0, 0, 1.084, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}5.11%{transform:matrix3d(0.971, 0, 0, 0, 0, 1.113, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}6.81%{transform:matrix3d(1.062, 0, 0, 0, 0, 1.166, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}7.06%{transform:matrix3d(1.07, 0, 0, 0, 0, 1.165, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}8.76%{transform:matrix3d(1.104, 0, 0, 0, 0, 1.12, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}9.36%{transform:matrix3d(1.106, 0, 0, 0, 0, 1.094, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}10.66%{transform:matrix3d(1.098, 0, 0, 0, 0, 1.035, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}12.16%{transform:matrix3d(1.075, 0, 0, 0, 0, 0.98, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}12.61%{transform:matrix3d(1.067, 0, 0, 0, 0, 0.969, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}14.51%{transform:matrix3d(1.031, 0, 0, 0, 0, 0.948, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}14.96%{transform:matrix3d(1.024, 0, 0, 0, 0, 0.949, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}17.77%{transform:matrix3d(0.99, 0, 0, 0, 0, 0.981, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}18.37%{transform:matrix3d(0.986, 0, 0, 0, 0, 0.989, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}20.52%{transform:matrix3d(0.98, 0, 0, 0, 0, 1.011, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}22.22%{transform:matrix3d(0.983, 0, 0, 0, 0, 1.016, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}26.08%{transform:matrix3d(0.996, 0, 0, 0, 0, 1.003, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}29.93%{transform:matrix3d(1.003, 0, 0, 0, 0, 0.995, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}31.63%{transform:matrix3d(1.004, 0, 0, 0, 0, 0.996, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}37.64%{transform:matrix3d(1.001, 0, 0, 0, 0, 1.002, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}42.74%{transform:matrix3d(0.999, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}45.35%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}49.9%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}50%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}52.15%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}54.3%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}56.46%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}58.61%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}64.16%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}69.72%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}80.83%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}91.99%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}100%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);} keyframes 0%{opacity:0;animation-timing-function:cubic-bezier(.1,.25,.75,.9);}26.26%{opacity:1;}100%{opacity:1;};
+        animation-timing-function: linear;
+        border: 0px;
+        box-shadow: none !important;
+        display: block;
+        max-width: 364px;
+        outline: transparent;
+        width: calc(100% + 1px);
+      }
+  data-is-focusable={true}
+  role="dialog"
+  tabIndex={-1}
+>
+  <div
+    className=
+        ms-TeachingBubble-bodycontent
+        {
+          padding-bottom: 20px;
+          padding-left: 20px;
+          padding-right: 20px;
+          padding-top: 20px;
+        }
+  >
+    <div
+      className=
+          ms-TeachingBubble-body
+          &:not(:last-child) {
+            margin-bottom: 20px;
+          }
+    >
+      <p
+        className=
+            ms-TeachingBubble-subText
+            {
+              color: #ffffff;
+              font-size: 14px;
+              font-weight: 300;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+            }
+      >
+        Content
+      </p>
+    </div>
+    <div
+      className=
+          ms-TeachingBubble-footer
+          {
+            display: flex;
+          }
+          & .ms-Button:not(:first-child) {
+            margin-left: 20px;
+          }
+    >
+      <div
+        className=
+            ms-TeachingBubble-multistepText
+            {
+              align-items: center;
+              background-color: #0078d4;
+              color: #ffffff;
+              display: flex;
+              padding-bottom: 0;
+              padding-left: 16px;
+              padding-right: 16px;
+              padding-top: 0;
+            }
+      >
+        1 of 2
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TeachingBubble renders TeachingBubbleContent with small headline correctly 1`] = `
 <div
   className=

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -300,9 +300,11 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
       className=
           ms-TeachingBubble-footer
           {
+            align-items: center;
+            color: #ffffff;
             display: flex;
           }
-          & .ms-Button:not(:first-child) {
+          & > *:not(:first-child) {
             margin-left: 20px;
           }
     >
@@ -788,6 +790,79 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
 </div>
 `;
 
+exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`] = `
+<div
+  className=
+      ms-TeachingBubble-content
+      {
+        animation-duration: 2000ms;
+        animation-fill-mode: both;
+        animation-name: keyframes 0%{transform:matrix3d(0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}1.7%{transform:matrix3d(0.658, 0, 0, 0, 0, 0.703, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}2.35%{transform:matrix3d(0.725, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}3.4%{transform:matrix3d(0.83, 0, 0, 0, 0, 0.946, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}4.7%{transform:matrix3d(0.942, 0, 0, 0, 0, 1.084, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}5.11%{transform:matrix3d(0.971, 0, 0, 0, 0, 1.113, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}6.81%{transform:matrix3d(1.062, 0, 0, 0, 0, 1.166, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}7.06%{transform:matrix3d(1.07, 0, 0, 0, 0, 1.165, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}8.76%{transform:matrix3d(1.104, 0, 0, 0, 0, 1.12, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}9.36%{transform:matrix3d(1.106, 0, 0, 0, 0, 1.094, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}10.66%{transform:matrix3d(1.098, 0, 0, 0, 0, 1.035, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}12.16%{transform:matrix3d(1.075, 0, 0, 0, 0, 0.98, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}12.61%{transform:matrix3d(1.067, 0, 0, 0, 0, 0.969, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}14.51%{transform:matrix3d(1.031, 0, 0, 0, 0, 0.948, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}14.96%{transform:matrix3d(1.024, 0, 0, 0, 0, 0.949, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}17.77%{transform:matrix3d(0.99, 0, 0, 0, 0, 0.981, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}18.37%{transform:matrix3d(0.986, 0, 0, 0, 0, 0.989, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}20.52%{transform:matrix3d(0.98, 0, 0, 0, 0, 1.011, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}22.22%{transform:matrix3d(0.983, 0, 0, 0, 0, 1.016, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}26.08%{transform:matrix3d(0.996, 0, 0, 0, 0, 1.003, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}29.93%{transform:matrix3d(1.003, 0, 0, 0, 0, 0.995, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}31.63%{transform:matrix3d(1.004, 0, 0, 0, 0, 0.996, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}37.64%{transform:matrix3d(1.001, 0, 0, 0, 0, 1.002, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}42.74%{transform:matrix3d(0.999, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}45.35%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}49.9%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}50%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}52.15%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}54.3%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}56.46%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}58.61%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}64.16%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}69.72%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}80.83%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}91.99%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}100%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);} keyframes 0%{opacity:0;animation-timing-function:cubic-bezier(.1,.25,.75,.9);}26.26%{opacity:1;}100%{opacity:1;};
+        animation-timing-function: linear;
+        border: 0px;
+        box-shadow: none !important;
+        display: block;
+        max-width: 364px;
+        outline: transparent;
+        width: calc(100% + 1px);
+      }
+  data-is-focusable={true}
+  role="dialog"
+  tabIndex={-1}
+>
+  <div
+    className=
+        ms-TeachingBubble-bodycontent
+        {
+          padding-bottom: 20px;
+          padding-left: 20px;
+          padding-right: 20px;
+          padding-top: 20px;
+        }
+  >
+    <div
+      className=
+          ms-TeachingBubble-body
+          &:not(:last-child) {
+            margin-bottom: 20px;
+          }
+    >
+      <p
+        className=
+            ms-TeachingBubble-subText
+            {
+              color: #ffffff;
+              font-size: 14px;
+              font-weight: 300;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+            }
+      >
+        Content
+      </p>
+    </div>
+    <div
+      className=
+          ms-TeachingBubble-footer
+          {
+            align-items: center;
+            color: #ffffff;
+            display: flex;
+          }
+          & > *:not(:first-child) {
+            margin-left: 20px;
+          }
+    >
+      <span>
+        1 of 2
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] = `
 <div
   className=
@@ -907,90 +982,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
       >
         Content
       </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`TeachingBubble renders TeachingBubbleContent with multistep text 1`] = `
-<div
-  className=
-      ms-TeachingBubble-content
-      {
-        animation-duration: 2000ms;
-        animation-fill-mode: both;
-        animation-name: keyframes 0%{transform:matrix3d(0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}1.7%{transform:matrix3d(0.658, 0, 0, 0, 0, 0.703, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}2.35%{transform:matrix3d(0.725, 0, 0, 0, 0, 0.8, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}3.4%{transform:matrix3d(0.83, 0, 0, 0, 0, 0.946, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}4.7%{transform:matrix3d(0.942, 0, 0, 0, 0, 1.084, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}5.11%{transform:matrix3d(0.971, 0, 0, 0, 0, 1.113, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}6.81%{transform:matrix3d(1.062, 0, 0, 0, 0, 1.166, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}7.06%{transform:matrix3d(1.07, 0, 0, 0, 0, 1.165, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}8.76%{transform:matrix3d(1.104, 0, 0, 0, 0, 1.12, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}9.36%{transform:matrix3d(1.106, 0, 0, 0, 0, 1.094, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}10.66%{transform:matrix3d(1.098, 0, 0, 0, 0, 1.035, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}12.16%{transform:matrix3d(1.075, 0, 0, 0, 0, 0.98, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}12.61%{transform:matrix3d(1.067, 0, 0, 0, 0, 0.969, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}14.51%{transform:matrix3d(1.031, 0, 0, 0, 0, 0.948, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}14.96%{transform:matrix3d(1.024, 0, 0, 0, 0, 0.949, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}17.77%{transform:matrix3d(0.99, 0, 0, 0, 0, 0.981, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}18.37%{transform:matrix3d(0.986, 0, 0, 0, 0, 0.989, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}20.52%{transform:matrix3d(0.98, 0, 0, 0, 0, 1.011, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}22.22%{transform:matrix3d(0.983, 0, 0, 0, 0, 1.016, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}26.08%{transform:matrix3d(0.996, 0, 0, 0, 0, 1.003, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}29.93%{transform:matrix3d(1.003, 0, 0, 0, 0, 0.995, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}31.63%{transform:matrix3d(1.004, 0, 0, 0, 0, 0.996, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}37.64%{transform:matrix3d(1.001, 0, 0, 0, 0, 1.002, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}42.74%{transform:matrix3d(0.999, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}45.35%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}49.9%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}50%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}52.15%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}54.3%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}56.46%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}58.61%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}64.16%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}69.72%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}80.83%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}91.99%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);}100%{transform:matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);} keyframes 0%{opacity:0;animation-timing-function:cubic-bezier(.1,.25,.75,.9);}26.26%{opacity:1;}100%{opacity:1;};
-        animation-timing-function: linear;
-        border: 0px;
-        box-shadow: none !important;
-        display: block;
-        max-width: 364px;
-        outline: transparent;
-        width: calc(100% + 1px);
-      }
-  data-is-focusable={true}
-  role="dialog"
-  tabIndex={-1}
->
-  <div
-    className=
-        ms-TeachingBubble-bodycontent
-        {
-          padding-bottom: 20px;
-          padding-left: 20px;
-          padding-right: 20px;
-          padding-top: 20px;
-        }
-  >
-    <div
-      className=
-          ms-TeachingBubble-body
-          &:not(:last-child) {
-            margin-bottom: 20px;
-          }
-    >
-      <p
-        className=
-            ms-TeachingBubble-subText
-            {
-              color: #ffffff;
-              font-size: 14px;
-              font-weight: 300;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-            }
-      >
-        Content
-      </p>
-    </div>
-    <div
-      className=
-          ms-TeachingBubble-footer
-          {
-            display: flex;
-          }
-          & .ms-Button:not(:first-child) {
-            margin-left: 20px;
-          }
-    >
-      <div
-        className=
-            ms-TeachingBubble-multistepText
-            {
-              align-items: center;
-              background-color: #0078d4;
-              color: #ffffff;
-              display: flex;
-              padding-bottom: 0;
-              padding-left: 16px;
-              padding-right: 16px;
-              padding-top: 0;
-            }
-      >
-        1 of 2
-      </div>
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Basic.Example.tsx
@@ -44,6 +44,7 @@ export class TeachingBubbleBasicExample extends React.Component<{}, ITeachingBub
             <TeachingBubble
               target={this._menuButtonElement}
               primaryButtonProps={examplePrimaryButton}
+              multistepProps={{ text: '1 of 2' }}
               secondaryButtonProps={exampleSecondaryButtonProps}
               onDismiss={this._onDismiss}
               headline="Discover what’s trending around you"

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Basic.Example.tsx
@@ -44,9 +44,9 @@ export class TeachingBubbleBasicExample extends React.Component<{}, ITeachingBub
             <TeachingBubble
               target={this._menuButtonElement}
               primaryButtonProps={examplePrimaryButton}
-              multistepProps={{ text: '1 of 2' }}
               secondaryButtonProps={exampleSecondaryButtonProps}
               onDismiss={this._onDismiss}
+              footerContent="1 of 2"
               headline="Discover what’s trending around you"
             >
               Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni harum non?


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added prop `multistepProps` to render text for a multi-step teaching bubble experience, e.g. "1 of 2".

Could also make the prop name more generic like `footerText` or something like that. Let me know what you think.

![multistep](https://user-images.githubusercontent.com/15041132/57555222-8b08b300-7328-11e9-91d4-c88744c3e13e.PNG)





#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9056)