### PR TITLE
DetailsList: Export missing public API symbols

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-dl-forgotten-exports_2019-05-10-21-13.json
+++ b/common/changes/office-ui-fabric-react/keco-dl-forgotten-exports_2019-05-10-21-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: Export missing public API symbols",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -839,6 +839,18 @@ export class DefaultButton extends BaseComponent<IButtonProps, {}> {
 export type DefaultProps = Required<Pick<ISpinButtonProps, 'step' | 'min' | 'max' | 'disabled' | 'labelPosition' | 'label' | 'incrementButtonIcon' | 'decrementButtonIcon'>>;
 
 // @public (undocumented)
+export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
+    // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
+    componentDidUpdate(): void;
+    // (undocumented)
+    componentWillUnmount(): void;
+    // (undocumented)
+    render(): JSX.Element;
+    }
+
+// @public (undocumented)
 export const DetailsHeader: React_2.StatelessComponent<IDetailsHeaderBaseProps>;
 
 // @public (undocumented)
@@ -2583,7 +2595,6 @@ export interface IColumn {
     onColumnContextMenu?: (column?: IColumn, ev?: React.MouseEvent<HTMLElement>) => void;
     onColumnResize?: (width?: number) => void;
     onRender?: (item?: any, index?: number, column?: IColumn) => any;
-    // Warning: (ae-forgotten-export) The symbol "IDetailsColumnProps" needs to be exported by the entry point index.d.ts
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;
@@ -3134,6 +3145,89 @@ export interface IDetailsCheckboxProps {
 }
 
 // @public (undocumented)
+export interface IDetailsColumnProps extends React_2.ClassAttributes<DetailsColumnBase> {
+    // (undocumented)
+    cellStyleProps?: ICellStyleProps;
+    // (undocumented)
+    column: IColumn;
+    // (undocumented)
+    columnIndex: number;
+    // (undocumented)
+    componentRef?: () => void;
+    // Warning: (ae-forgotten-export) The symbol "IDragDropHelper" needs to be exported by the entry point index.d.ts
+    // 
+    // (undocumented)
+    dragDropHelper?: IDragDropHelper | null;
+    // (undocumented)
+    isDraggable?: boolean;
+    // (undocumented)
+    isDropped?: boolean;
+    // (undocumented)
+    onColumnClick?: (ev: React_2.MouseEvent<HTMLElement>, column: IColumn) => void;
+    // (undocumented)
+    onColumnContextMenu?: (column: IColumn, ev: React_2.MouseEvent<HTMLElement>) => void;
+    // (undocumented)
+    onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
+    // (undocumented)
+    parentId?: string;
+    // (undocumented)
+    setDraggedItemIndex?: (itemIndex: number) => void;
+    // (undocumented)
+    styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
+    // (undocumented)
+    theme?: ITheme;
+    // (undocumented)
+    updateDragInfo?: (props: {
+        itemIndex: number;
+    }, event?: MouseEvent) => void;
+}
+
+// @public (undocumented)
+export type IDetailsColumnStyleProps = Required<Pick<IDetailsColumnProps, 'theme' | 'cellStyleProps'>> & {
+    headerClassName?: string;
+    isActionable?: boolean;
+    isEmpty?: boolean;
+    isIconVisible?: boolean;
+    isPadded?: boolean;
+    isIconOnly?: boolean;
+    iconClassName?: string;
+    transitionDurationDrag?: number;
+    transitionDurationDrop?: number;
+};
+
+// @public (undocumented)
+export interface IDetailsColumnStyles {
+    // (undocumented)
+    accessibleLabel: IStyle;
+    // (undocumented)
+    borderAfterDropping: IStyle;
+    // (undocumented)
+    borderWhileDragging: IStyle;
+    // (undocumented)
+    cellName: IStyle;
+    // (undocumented)
+    cellTitle: IStyle;
+    // (undocumented)
+    cellTooltip: IStyle;
+    // (undocumented)
+    filterChevron: IStyle;
+    // (undocumented)
+    gripperBarVerticalStyle: IStyle;
+    // (undocumented)
+    iconClassName: IStyle;
+    // (undocumented)
+    nearIcon: IStyle;
+    // (undocumented)
+    noBorderAfterDropping: IStyle;
+    // (undocumented)
+    noBorderWhileDragging: IStyle;
+    // (undocumented)
+    root: IStyle;
+    // (undocumented)
+    sortIcon: IStyle;
+}
+
+// @public (undocumented)
 export interface IDetailsFooterBaseProps extends IDetailsItemProps {
 }
 
@@ -3414,7 +3508,6 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
     compact?: boolean;
     componentRef?: IRefObject<IDetailsRow>;
     dragDropEvents?: IDragDropEvents;
-    // Warning: (ae-forgotten-export) The symbol "IDragDropHelper" needs to be exported by the entry point index.d.ts
     dragDropHelper?: IDragDropHelper;
     eventsToRegister?: {
         eventName: string;
@@ -3428,7 +3521,6 @@ export interface IDetailsRowBaseProps extends Pick<IDetailsListProps, 'onRenderI
     onRenderCheck?: (props: IDetailsRowCheckProps) => JSX.Element;
     onRenderDetailsCheckbox?: IRenderFunction<IDetailsCheckboxProps>;
     onWillUnmount?: (row?: DetailsRowBase) => void;
-    // Warning: (ae-forgotten-export) The symbol "IDetailsRowFieldsProps" needs to be exported by the entry point index.d.ts
     rowFieldsAs?: React.StatelessComponent<IDetailsRowFieldsProps> | React.ComponentClass<IDetailsRowFieldsProps>;
     // @deprecated
     shimmer?: boolean;
@@ -3467,6 +3559,29 @@ export interface IDetailsRowCheckStyles {
     isDisabled: IStyle;
     // (undocumented)
     root: IStyle;
+}
+
+// @public (undocumented)
+export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
+    // (undocumented)
+    cellStyleProps?: ICellStyleProps;
+    columns: IColumn[];
+    columnStartIndex: number;
+    compact?: boolean;
+    item: any;
+    itemIndex: number;
+    rowClassNames: {
+        isMultiline: string;
+        isRowHeader: string;
+        shimmerIconPlaceholder: string;
+        shimmer: string;
+        cell: string;
+        cellPadded: string;
+        cellUnpadded: string;
+        fields: string;
+    };
+    // @deprecated
+    shimmer?: boolean;
 }
 
 // @public (undocumented)
@@ -5510,6 +5625,9 @@ export interface IOverlayStyleProps {
 export interface IOverlayStyles {
     root: IStyle;
 }
+
+// @public (undocumented)
+export type IOverrideColumnRenderProps = Pick<IDetailsListProps, 'onRenderItemColumn'> & Pick<IDetailsRowProps, 'cellsByColumn'>;
 
 // @public (undocumented)
 export interface IPage<T = any> {

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4219,8 +4219,6 @@ export interface IDragDropEvents {
 export interface IDragDropHelper {
     // (undocumented)
     dispose: () => void;
-    // Warning: (ae-forgotten-export) The symbol "IDragDropOptions" needs to be exported by the entry point index.d.ts
-    // 
     // (undocumented)
     subscribe: (root: HTMLElement, events: EventGroup, options: IDragDropOptions) => {
         key: string;
@@ -4228,6 +4226,35 @@ export interface IDragDropHelper {
     };
     // (undocumented)
     unsubscribe: (root: HTMLElement, key: string) => void;
+}
+
+// @public (undocumented)
+export interface IDragDropOptions {
+    // (undocumented)
+    canDrag?: (item?: any) => boolean;
+    // (undocumented)
+    canDrop?: (dropContext?: IDragDropContext, dragContext?: IDragDropContext) => boolean;
+    // (undocumented)
+    context: IDragDropContext;
+    // (undocumented)
+    eventMap?: {
+        eventName: string;
+        callback: (context: IDragDropContext, event?: any) => void;
+    }[];
+    // (undocumented)
+    key?: string;
+    // (undocumented)
+    onDragEnd?: (item?: any, event?: DragEvent) => void;
+    // (undocumented)
+    onDragOver?: (item?: any, event?: DragEvent) => void;
+    // (undocumented)
+    onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
+    // (undocumented)
+    onDrop?: (item?: any, event?: DragEvent) => void;
+    // (undocumented)
+    selectionIndex: number;
+    // (undocumented)
+    updateDropState: (isDropping: boolean, event: DragEvent) => void;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3154,8 +3154,6 @@ export interface IDetailsColumnProps extends React_2.ClassAttributes<DetailsColu
     columnIndex: number;
     // (undocumented)
     componentRef?: () => void;
-    // Warning: (ae-forgotten-export) The symbol "IDragDropHelper" needs to be exported by the entry point index.d.ts
-    // 
     // (undocumented)
     dragDropHelper?: IDragDropHelper | null;
     // (undocumented)
@@ -4215,6 +4213,21 @@ export interface IDragDropEvents {
     onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
     // (undocumented)
     onDrop?: (item?: any, event?: DragEvent) => void;
+}
+
+// @public (undocumented)
+export interface IDragDropHelper {
+    // (undocumented)
+    dispose: () => void;
+    // Warning: (ae-forgotten-export) The symbol "IDragDropOptions" needs to be exported by the entry point index.d.ts
+    // 
+    // (undocumented)
+    subscribe: (root: HTMLElement, events: EventGroup, options: IDragDropOptions) => {
+        key: string;
+        dispose: () => void;
+    };
+    // (undocumented)
+    unsubscribe: (root: HTMLElement, key: string) => void;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3367,7 +3367,6 @@ export interface IDetailsItemProps {
     indentWidth?: number | undefined;
     selection?: ISelection | undefined;
     selectionMode?: SelectionMode | undefined;
-    // Warning: (ae-forgotten-export) The symbol "IViewport" needs to be exported by the entry point index.d.ts
     viewport?: IViewport | undefined;
 }
 
@@ -3382,8 +3381,6 @@ export interface IDetailsList extends IList {
 export interface IDetailsListCheckboxProps extends IDetailsCheckboxProps {
 }
 
-// Warning: (ae-forgotten-export) The symbol "IWithViewportProps" needs to be exported by the entry point index.d.ts
-// 
 // @public (undocumented)
 export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps {
     ariaLabel?: string;
@@ -3402,7 +3399,6 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     componentRef?: IRefObject<IDetailsList>;
     constrainMode?: ConstrainMode;
     disableSelectionZone?: boolean;
-    // Warning: (ae-forgotten-export) The symbol "IDragDropEvents" needs to be exported by the entry point index.d.ts
     dragDropEvents?: IDragDropEvents;
     // @deprecated
     enableShimmer?: boolean;
@@ -4191,6 +4187,34 @@ export interface IDocumentCardTitleStyleProps {
 export interface IDocumentCardTitleStyles {
     // (undocumented)
     root: IStyle;
+}
+
+// @public (undocumented)
+export interface IDragDropContext {
+    // (undocumented)
+    data: any;
+    // (undocumented)
+    index: number;
+    // (undocumented)
+    isGroup?: boolean;
+}
+
+// @public (undocumented)
+export interface IDragDropEvents {
+    // (undocumented)
+    canDrag?: (item?: any) => boolean;
+    // (undocumented)
+    canDrop?: (dropContext?: IDragDropContext, dragContext?: IDragDropContext) => boolean;
+    // (undocumented)
+    onDragEnd?: (item?: any, event?: DragEvent) => void;
+    // (undocumented)
+    onDragEnter?: (item?: any, event?: DragEvent) => string;
+    // (undocumented)
+    onDragLeave?: (item?: any, event?: DragEvent) => void;
+    // (undocumented)
+    onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
+    // (undocumented)
+    onDrop?: (item?: any, event?: DragEvent) => void;
 }
 
 // @public (undocumented)
@@ -7768,6 +7792,20 @@ export interface IVerticalDividerStyles {
 }
 
 // @public (undocumented)
+export interface IViewport {
+    // (undocumented)
+    height: number;
+    // (undocumented)
+    width: number;
+}
+
+// @public (undocumented)
+export interface IWithViewportProps {
+    // (undocumented)
+    skipViewportMeasures?: boolean;
+}
+
+// @public (undocumented)
 export enum KeyboardSpinDirection {
     // (undocumented)
     down = -1,
@@ -9413,10 +9451,6 @@ export * from "@uifabric/foundation";
 export * from "@uifabric/icons";
 export * from "@uifabric/styling";
 export * from "@uifabric/utilities";
-
-// Warnings were encountered during analysis:
-// 
-// lib/components/DetailsList/DetailsList.types.d.ts:111:9 - (ae-forgotten-export) The symbol "IDragDropContext" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -838,7 +838,7 @@ export class DefaultButton extends BaseComponent<IButtonProps, {}> {
 // @public (undocumented)
 export type DefaultProps = Required<Pick<ISpinButtonProps, 'step' | 'min' | 'max' | 'disabled' | 'labelPosition' | 'label' | 'incrementButtonIcon' | 'decrementButtonIcon'>>;
 
-// @public (undocumented)
+// @public
 export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
     // (undocumented)
     componentDidMount(): void;
@@ -3146,35 +3146,21 @@ export interface IDetailsCheckboxProps {
 
 // @public (undocumented)
 export interface IDetailsColumnProps extends React_2.ClassAttributes<DetailsColumnBase> {
-    // (undocumented)
     cellStyleProps?: ICellStyleProps;
-    // (undocumented)
     column: IColumn;
-    // (undocumented)
     columnIndex: number;
-    // (undocumented)
     componentRef?: () => void;
-    // (undocumented)
     dragDropHelper?: IDragDropHelper | null;
-    // (undocumented)
     isDraggable?: boolean;
-    // (undocumented)
     isDropped?: boolean;
-    // (undocumented)
     onColumnClick?: (ev: React_2.MouseEvent<HTMLElement>, column: IColumn) => void;
-    // (undocumented)
     onColumnContextMenu?: (column: IColumn, ev: React_2.MouseEvent<HTMLElement>) => void;
-    // (undocumented)
     onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
-    // (undocumented)
     parentId?: string;
-    // (undocumented)
+    // @deprecated (undocumented)
     setDraggedItemIndex?: (itemIndex: number) => void;
-    // (undocumented)
     styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
-    // (undocumented)
     theme?: ITheme;
-    // (undocumented)
     updateDragInfo?: (props: {
         itemIndex: number;
     }, event?: MouseEvent) => void;
@@ -3195,33 +3181,19 @@ export type IDetailsColumnStyleProps = Required<Pick<IDetailsColumnProps, 'theme
 
 // @public (undocumented)
 export interface IDetailsColumnStyles {
-    // (undocumented)
     accessibleLabel: IStyle;
-    // (undocumented)
     borderAfterDropping: IStyle;
-    // (undocumented)
     borderWhileDragging: IStyle;
-    // (undocumented)
     cellName: IStyle;
-    // (undocumented)
     cellTitle: IStyle;
-    // (undocumented)
     cellTooltip: IStyle;
-    // (undocumented)
     filterChevron: IStyle;
-    // (undocumented)
     gripperBarVerticalStyle: IStyle;
-    // (undocumented)
     iconClassName: IStyle;
-    // (undocumented)
     nearIcon: IStyle;
-    // (undocumented)
     noBorderAfterDropping: IStyle;
-    // (undocumented)
     noBorderWhileDragging: IStyle;
-    // (undocumented)
     root: IStyle;
-    // (undocumented)
     sortIcon: IStyle;
 }
 
@@ -3555,9 +3527,8 @@ export interface IDetailsRowCheckStyles {
     root: IStyle;
 }
 
-// @public (undocumented)
+// @public
 export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
-    // (undocumented)
     cellStyleProps?: ICellStyleProps;
     columns: IColumn[];
     columnStartIndex: number;
@@ -4187,73 +4158,49 @@ export interface IDocumentCardTitleStyles {
     root: IStyle;
 }
 
-// @public (undocumented)
+// @public
 export interface IDragDropContext {
-    // (undocumented)
     data: any;
-    // (undocumented)
     index: number;
-    // (undocumented)
     isGroup?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export interface IDragDropEvents {
-    // (undocumented)
     canDrag?: (item?: any) => boolean;
-    // (undocumented)
     canDrop?: (dropContext?: IDragDropContext, dragContext?: IDragDropContext) => boolean;
-    // (undocumented)
     onDragEnd?: (item?: any, event?: DragEvent) => void;
-    // (undocumented)
     onDragEnter?: (item?: any, event?: DragEvent) => string;
-    // (undocumented)
     onDragLeave?: (item?: any, event?: DragEvent) => void;
-    // (undocumented)
     onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
-    // (undocumented)
     onDrop?: (item?: any, event?: DragEvent) => void;
 }
 
-// @public (undocumented)
+// @public
 export interface IDragDropHelper {
-    // (undocumented)
     dispose: () => void;
-    // (undocumented)
     subscribe: (root: HTMLElement, events: EventGroup, options: IDragDropOptions) => {
         key: string;
         dispose: () => void;
     };
-    // (undocumented)
     unsubscribe: (root: HTMLElement, key: string) => void;
 }
 
-// @public (undocumented)
+// @public
 export interface IDragDropOptions {
-    // (undocumented)
     canDrag?: (item?: any) => boolean;
-    // (undocumented)
     canDrop?: (dropContext?: IDragDropContext, dragContext?: IDragDropContext) => boolean;
-    // (undocumented)
     context: IDragDropContext;
-    // (undocumented)
     eventMap?: {
         eventName: string;
         callback: (context: IDragDropContext, event?: any) => void;
     }[];
-    // (undocumented)
     key?: string;
-    // (undocumented)
     onDragEnd?: (item?: any, event?: DragEvent) => void;
-    // (undocumented)
     onDragOver?: (item?: any, event?: DragEvent) => void;
-    // (undocumented)
     onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
-    // (undocumented)
     onDrop?: (item?: any, event?: DragEvent) => void;
-    // (undocumented)
     selectionIndex: number;
-    // (undocumented)
     updateDropState: (isDropping: boolean, event: DragEvent) => void;
 }
 
@@ -5690,7 +5637,7 @@ export interface IOverlayStyles {
     root: IStyle;
 }
 
-// @public (undocumented)
+// @public
 export type IOverrideColumnRenderProps = Pick<IDetailsListProps, 'onRenderItemColumn'> & Pick<IDetailsRowProps, 'cellsByColumn'>;
 
 // @public (undocumented)
@@ -7831,17 +7778,14 @@ export interface IVerticalDividerStyles {
     wrapper: IStyle;
 }
 
-// @public (undocumented)
+// @public
 export interface IViewport {
-    // (undocumented)
     height: number;
-    // (undocumented)
     width: number;
 }
 
-// @public (undocumented)
+// @public
 export interface IWithViewportProps {
-    // (undocumented)
     skipViewportMeasures?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -16,6 +16,11 @@ const TRANSITION_DURATION_DRAG = 200; // ms
 const TRANSITION_DURATION_DROP = 1500; // ms
 const CLASSNAME_ADD_INTERVAL = 20; // ms
 
+/**
+ * Component for rendering columns in a {@link DetailsList}.
+ *
+ * {@docCategory DetailsList}
+ */
 export class DetailsColumnBase extends BaseComponent<IDetailsColumnProps> {
   private _root = React.createRef<HTMLDivElement>();
   private _dragDropSubscription: IDisposable;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -10,21 +10,65 @@ import { ITheme, IStyle } from '../../Styling';
  * {@docCategory DetailsList}
  */
 export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumnBase> {
+  /**
+   * The theme object to respect during render.
+   */
   theme?: ITheme;
+  /**
+   * The component styles to respect during render.
+   */
   styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
+  /**
+   * A reference to the component instance.
+   */
   componentRef?: () => void;
+  /**
+   * The column definition for the component instance.
+   */
   column: IColumn;
+  /**
+   * The column index for the component instance.
+   */
   columnIndex: number;
+  /**
+   * Parent ID used for accessibility label(s).
+   */
   parentId?: string;
+  /**
+   * Render function for providing a column header tooltip.
+   */
   onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
+  /**
+   * Callback fired when click event occurs.
+   */
   onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void;
+  /**
+   * Callback fired on contextual menu event to provide contextual menu UI.
+   */
   onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
+  /**
+   * The drag and drop helper for the component instance.
+   */
   dragDropHelper?: IDragDropHelper | null;
+  /**
+   * Whether or not the column can be re-ordered via drag and drop.
+   */
   isDraggable?: boolean;
-  // @deprecated, use `updateDragInfo`
+  /**
+   * @deprecated, use `updateDragInfo`
+   */
   setDraggedItemIndex?: (itemIndex: number) => void;
+  /**
+   * Callback on drag and drop event.
+   */
   updateDragInfo?: (props: { itemIndex: number }, event?: MouseEvent) => void;
+  /**
+   * Whether or not the column has been dropped via drag and drop.
+   */
   isDropped?: boolean;
+  /**
+   * Custom styles for cell rendering.
+   */
   cellStyleProps?: ICellStyleProps;
 }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -55,7 +55,7 @@ export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumn
    */
   isDraggable?: boolean;
   /**
-   * @deprecated, use `updateDragInfo`
+   * @deprecated use `updateDragInfo`
    */
   setDraggedItemIndex?: (itemIndex: number) => void;
   /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -76,14 +76,41 @@ export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumn
  * {@docCategory DetailsList}
  */
 export type IDetailsColumnStyleProps = Required<Pick<IDetailsColumnProps, 'theme' | 'cellStyleProps'>> & {
+  /**
+   * Classname to provide for header region.
+   */
   headerClassName?: string;
+  /**
+   * Whether or not the column is actionable.
+   */
   isActionable?: boolean;
+  /**
+   * Whether or not the column contains contents.
+   */
   isEmpty?: boolean;
+  /**
+   * Whether or not the column has a visible icon.
+   */
   isIconVisible?: boolean;
+  /**
+   * Whether or not the column is padded.
+   */
   isPadded?: boolean;
+  /**
+   * Whether or not the column has icon only content/
+   */
   isIconOnly?: boolean;
+  /**
+   * Classname to provide for the header's icon region.
+   */
   iconClassName?: string;
+  /**
+   * CSS transition duration on drag event.
+   */
   transitionDurationDrag?: number;
+  /**
+   * CSS transition duration on drop event.
+   */
   transitionDurationDrop?: number;
 };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -118,18 +118,60 @@ export type IDetailsColumnStyleProps = Required<Pick<IDetailsColumnProps, 'theme
  * {@docCategory DetailsList}
  */
 export interface IDetailsColumnStyles {
+  /**
+   * Styleable root region.
+   */
   root: IStyle;
+  /**
+   * Styleable resize glyph region.
+   */
   gripperBarVerticalStyle: IStyle;
+  /**
+   * Styleable cell tooltip region.
+   */
   cellTooltip: IStyle;
+  /**
+   * Styleable cell title region.
+   */
   cellTitle: IStyle;
+  /**
+   * Styleable cell name region.
+   */
   cellName: IStyle;
+  /**
+   * Styleable icon region.
+   */
   iconClassName: IStyle;
+  /**
+   * Styleable margin by icon region.
+   */
   nearIcon: IStyle;
+  /**
+   * Styleable label region.
+   */
   accessibleLabel: IStyle;
+  /**
+   * Styleable column sort icon region.
+   */
   sortIcon: IStyle;
+  /**
+   * Styleable filter glyph.
+   */
   filterChevron: IStyle;
+  /**
+   * Styleable border region after drag & drop.
+   */
   borderAfterDropping: IStyle;
+  /**
+   * Transparent no border region after drag & drop to avoid content shift.
+   */
   noBorderAfterDropping: IStyle;
+  /**
+   * Styleable border while drag & drop occurs.
+   */
   borderWhileDragging: IStyle;
+  /**
+   * Transparent no border region while drag & drop occurs to avoid content shift.
+   */
   noBorderWhileDragging: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -14,7 +14,14 @@ import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
 import { IDetailsColumnProps } from './DetailsColumn';
 import { IDetailsCheckboxProps } from './DetailsRowCheck.types';
 
-export { IDetailsHeaderProps, IDetailsRowBaseProps, IDetailsHeaderBaseProps, IDetailsFooterBaseProps };
+export {
+  IDetailsHeaderProps,
+  IDetailsRowBaseProps,
+  IDetailsHeaderBaseProps,
+  IDetailsFooterBaseProps,
+  IDragDropContext,
+  IWithViewportProps
+};
 
 /**
  * {@docCategory DetailsList}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -20,6 +20,7 @@ export {
   IDetailsHeaderBaseProps,
   IDetailsFooterBaseProps,
   IDragDropContext,
+  IViewport,
   IWithViewportProps
 };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -20,6 +20,7 @@ export {
   IDetailsHeaderBaseProps,
   IDetailsFooterBaseProps,
   IDragDropContext,
+  IDragDropEvents,
   IViewport,
   IWithViewportProps
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DetailsListBase } from './DetailsList.base';
 import { ISelection, SelectionMode, ISelectionZoneProps } from '../../utilities/selection/index';
 import { IRefObject, IBaseProps, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
-import { IDragDropEvents, IDragDropContext } from './../../utilities/dragdrop/index';
+import { IDragDropEvents, IDragDropContext, IDragDropHelper, IDragDropOptions } from './../../utilities/dragdrop/index';
 import { IGroup, IGroupRenderProps, IGroupDividerProps, IGroupedListProps } from '../GroupedList/index';
 import { IDetailsRowProps, IDetailsRowBaseProps } from '../DetailsList/DetailsRow';
 import { IDetailsHeaderProps, IDetailsHeaderBaseProps } from './DetailsHeader';
@@ -21,6 +21,8 @@ export {
   IDetailsFooterBaseProps,
   IDragDropContext,
   IDragDropEvents,
+  IDragDropHelper,
+  IDragDropOptions,
   IViewport,
   IWithViewportProps
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -3,14 +3,14 @@ import { DetailsRowBase } from './DetailsRow.base';
 import { IStyle, ITheme } from '../../Styling';
 import { IColumn, CheckboxVisibility, IDetailsListProps } from './DetailsList.types';
 import { ISelection, SelectionMode } from '../../utilities/selection/interfaces';
-import { IDragDropHelper, IDragDropEvents } from '../../utilities/dragdrop/interfaces';
+import { IDragDropHelper, IDragDropEvents, IDragDropOptions } from '../../utilities/dragdrop/interfaces';
 import { IViewport } from '../../utilities/decorators/withViewport';
 import { CollapseAllVisibility } from '../GroupedList/GroupedList.types';
 import { IBaseProps, IRefObject, IStyleFunctionOrObject, IRenderFunction } from '../../Utilities';
 import { IDetailsRowCheckProps, IDetailsCheckboxProps } from './DetailsRowCheck.types';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 
-export { IDragDropHelper };
+export { IDragDropHelper, IDragDropOptions };
 
 /**
  * {@docCategory DetailsList}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -3,14 +3,12 @@ import { DetailsRowBase } from './DetailsRow.base';
 import { IStyle, ITheme } from '../../Styling';
 import { IColumn, CheckboxVisibility, IDetailsListProps } from './DetailsList.types';
 import { ISelection, SelectionMode } from '../../utilities/selection/interfaces';
-import { IDragDropHelper, IDragDropEvents, IDragDropOptions } from '../../utilities/dragdrop/interfaces';
+import { IDragDropHelper, IDragDropEvents } from '../../utilities/dragdrop/interfaces';
 import { IViewport } from '../../utilities/decorators/withViewport';
 import { CollapseAllVisibility } from '../GroupedList/GroupedList.types';
 import { IBaseProps, IRefObject, IStyleFunctionOrObject, IRenderFunction } from '../../Utilities';
 import { IDetailsRowCheckProps, IDetailsCheckboxProps } from './DetailsRowCheck.types';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
-
-export { IDragDropHelper, IDragDropOptions };
 
 /**
  * {@docCategory DetailsList}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts
@@ -10,6 +10,8 @@ import { IBaseProps, IRefObject, IStyleFunctionOrObject, IRenderFunction } from 
 import { IDetailsRowCheckProps, IDetailsCheckboxProps } from './DetailsRowCheck.types';
 import { IDetailsRowFieldsProps } from './DetailsRowFields.types';
 
+export { IDragDropHelper };
+
 /**
  * {@docCategory DetailsList}
  */

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -14,6 +14,11 @@ const getCellText = (item: any, column: IColumn): string => {
   return value;
 };
 
+/**
+ * Component for rendering a row's cells in a {@link DetailsList}.
+ *
+ * {@docCategory DetailsList}
+ */
 export class DetailsRowFields extends React.PureComponent<IDetailsRowFieldsProps> {
   public render(): JSX.Element {
     const {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -9,6 +9,8 @@ import { IDetailsRowProps } from './DetailsRow';
 export type IOverrideColumnRenderProps = Pick<IDetailsListProps, 'onRenderItemColumn'> & Pick<IDetailsRowProps, 'cellsByColumn'>;
 
 /**
+ * Props interface for the {@link DetailsRowFields} component.
+ *
  * {@docCategory DetailsList}
  */
 export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
@@ -57,5 +59,8 @@ export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
     fields: string;
   };
 
+  /**
+   * Style properties to customize cell render output.
+   */
   cellStyleProps?: ICellStyleProps;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -4,6 +4,8 @@ import { IDetailsListProps } from './DetailsList';
 import { IDetailsRowProps } from './DetailsRow';
 
 /**
+ * Extended column render props.
+ *
  * {@docCategory DetailsList}
  */
 export type IOverrideColumnRenderProps = Pick<IDetailsListProps, 'onRenderItemColumn'> & Pick<IDetailsRowProps, 'cellsByColumn'>;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -11,7 +11,7 @@ import { IDetailsRowProps } from './DetailsRow';
 export type IOverrideColumnRenderProps = Pick<IDetailsListProps, 'onRenderItemColumn'> & Pick<IDetailsRowProps, 'cellsByColumn'>;
 
 /**
- * Props interface for the {@link DetailsRowFields} component.
+ * Props interface for the DetailsRowFields component.
  *
  * {@docCategory DetailsList}
  */

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -13,4 +13,5 @@ export * from './DetailsRowCheck';
 export * from './DetailsRowCheck.types';
 export * from './DetailsRowFields.types';
 export * from './DetailsFooter.types';
+export * from './DetailsColumn.base';
 export * from './DetailsColumn.types';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -11,5 +11,6 @@ export * from './DetailsRow.base';
 export * from './DetailsRow.types';
 export * from './DetailsRowCheck';
 export * from './DetailsRowCheck.types';
+export * from './DetailsRowFields.types';
 export * from './DetailsFooter.types';
 export * from './DetailsColumn.types';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -12,3 +12,4 @@ export * from './DetailsRow.types';
 export * from './DetailsRowCheck';
 export * from './DetailsRowCheck.types';
 export * from './DetailsFooter.types';
+export * from './DetailsColumn.types';

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -4,6 +4,8 @@ import { findScrollableParent, getRect, getWindow } from '../../Utilities';
 
 /**
  * Viewport rectangle dimensions.
+ *
+ * {@docCategory DetailsList}
  */
 export interface IViewport {
   /**
@@ -22,6 +24,8 @@ export interface IWithViewportState {
 
 /**
  * Props interface for {@link withViewport}.
+ *
+ * {@docCategory DetailsList}
  */
 export interface IWithViewportProps {
   /**

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -2,8 +2,17 @@ import * as React from 'react';
 import { BaseDecorator } from './BaseDecorator';
 import { findScrollableParent, getRect, getWindow } from '../../Utilities';
 
+/**
+ * Viewport rectangle dimensions.
+ */
 export interface IViewport {
+  /**
+   * Width in pixels.
+   */
   width: number;
+  /**
+   * Height in pixels.
+   */
   height: number;
 }
 
@@ -11,13 +20,29 @@ export interface IWithViewportState {
   viewport?: IViewport;
 }
 
+/**
+ * Props interface for {@link withViewport}.
+ */
 export interface IWithViewportProps {
+  /**
+   * Whether or not to use ResizeObserver (if available) to detect
+   * and measure viewport on 'resize' events.
+   *
+   * Falls back to window 'resize' event.
+   *
+   * @defaultValue false
+   */
   skipViewportMeasures?: boolean;
 }
 
 const RESIZE_DELAY = 500;
 const MAX_RESIZE_ATTEMPTS = 3;
 
+/**
+ * A decorator to update decorated component on viewport or window resize events.
+ *
+ * @param ComposedComponent decorated React component reference.
+ */
 export function withViewport<TProps extends { viewport?: IViewport }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>
 ): any {

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -23,7 +23,7 @@ export interface IWithViewportState {
 }
 
 /**
- * Props interface for {@link withViewport}.
+ * Props interface for the withViewport component.
  *
  * {@docCategory DetailsList}
  */

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { EventGroup } from '../../Utilities';
 
+/**
+ * Helper for subscribing and unsubscribing to
+ * drag and drop events on an {@link HTMLElement}.
+ */
 export interface IDragDropHelper {
+  /**
+   * Subscribe to events on a DOM node with drag and drop configuration.
+   */
   subscribe: (
     root: HTMLElement,
     events: EventGroup,
@@ -10,23 +17,65 @@ export interface IDragDropHelper {
     key: string;
     dispose: () => void;
   };
+  /**
+   * Unsubscribe to events registered on a DOM node with key.
+   */
   unsubscribe: (root: HTMLElement, key: string) => void;
+  /**
+   * Dispose of listeners bound to instance of helper.
+   */
   dispose: () => void;
 }
 
+/**
+ * Drag & drop event callback interface.
+ */
 export interface IDragDropEvents {
+  /**
+   * Whether or not drop action is allowed.
+   */
   canDrop?: (dropContext?: IDragDropContext, dragContext?: IDragDropContext) => boolean;
+  /**
+   * Whether or not drag action is allowed.
+   */
   canDrag?: (item?: any) => boolean;
-  onDragEnter?: (item?: any, event?: DragEvent) => string; // return string is the css classes that will be added to the enterring element.
+  /**
+   * On drag enter region event callback.
+   */
+  onDragEnter?: (item?: any, event?: DragEvent) => string; // return string is the css classes that will be added to the entering element.
+  /**
+   * On drag leave region event callback.
+   */
   onDragLeave?: (item?: any, event?: DragEvent) => void;
+  /**
+   * On drop event callback.
+   */
   onDrop?: (item?: any, event?: DragEvent) => void;
+  /**
+   * On drag start event callback.
+   */
   onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
+  /**
+   * On drag end event callback.
+   */
   onDragEnd?: (item?: any, event?: DragEvent) => void;
 }
 
+/**
+ * Drag & drop event contextual information.
+ */
 export interface IDragDropContext {
+  /**
+   * Data associated with drag & drop action.
+   */
   data: any;
+  /**
+   * Index of drag & drop action.
+   */
   index: number;
+  /**
+   * Whether or not drag & drop region is indivual or group of content.
+   */
   isGroup?: boolean;
 }
 
@@ -36,17 +85,53 @@ export interface IDragDropTarget {
   key: string;
 }
 
+/**
+ * The drag and drop event listener configuration.
+ */
 export interface IDragDropOptions {
+  /**
+   * Unique key to associate with instance.
+   */
   key?: string;
+  /**
+   * Map of event name to callback function to subscribe to.
+   */
   eventMap?: { eventName: string; callback: (context: IDragDropContext, event?: any) => void }[];
+  /**
+   * Selection index on drag and drop event.
+   */
   selectionIndex: number;
+  /**
+   * Context associated with drag and drop event.
+   */
   context: IDragDropContext;
+  /**
+   * Callback on drop state update.
+   */
   updateDropState: (isDropping: boolean, event: DragEvent) => void;
+  /**
+   * Whether or not drop action is allowed.
+   */
   canDrop?: (dropContext?: IDragDropContext, dragContext?: IDragDropContext) => boolean;
+  /**
+   * Whether or not drag action is allowed.
+   */
   canDrag?: (item?: any) => boolean;
+  /**
+   * On drag start event callback.
+   */
   onDragStart?: (item?: any, itemIndex?: number, selectedItems?: any[], event?: MouseEvent) => void;
+  /**
+   * On drop event callback.
+   */
   onDrop?: (item?: any, event?: DragEvent) => void;
+  /**
+   * On drag end event callback.
+   */
   onDragEnd?: (item?: any, event?: DragEvent) => void;
+  /**
+   * On drag over element(s) event callback.
+   */
   onDragOver?: (item?: any, event?: DragEvent) => void;
 }
 

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -5,7 +5,7 @@ import { EventGroup } from '../../Utilities';
  * Helper for subscribing and unsubscribing to
  * drag and drop events on an {@link HTMLElement}.
  *
- * {@docCategory DetailsList}
+ * {@docCategory IDragDropHelper}
  */
 export interface IDragDropHelper {
   /**
@@ -32,7 +32,7 @@ export interface IDragDropHelper {
 /**
  * Drag & drop event callback interface.
  *
- * {@docCategory DetailsList}
+ * {@docCategory IDragDropHelper}
  */
 export interface IDragDropEvents {
   /**
@@ -68,7 +68,7 @@ export interface IDragDropEvents {
 /**
  * Drag & drop event contextual information.
  *
- * {@docCategory DetailsList}
+ * {@docCategory IDragDropHelper}
  */
 export interface IDragDropContext {
   /**
@@ -94,7 +94,7 @@ export interface IDragDropTarget {
 /**
  * The drag and drop event listener configuration.
  *
- * {@docCategory DetailsList}
+ * {@docCategory IDragDropHelper}
  */
 export interface IDragDropOptions {
   /**
@@ -147,7 +147,7 @@ export interface IDragDropOptions {
 }
 
 /**
- * {@docCategory DetailsList}
+ * {@docCategory IDragDropHelper}
  */
 export interface IDragDropEvent {
   /**

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -4,6 +4,8 @@ import { EventGroup } from '../../Utilities';
 /**
  * Helper for subscribing and unsubscribing to
  * drag and drop events on an {@link HTMLElement}.
+ *
+ * {@docCategory DetailsList}
  */
 export interface IDragDropHelper {
   /**
@@ -29,6 +31,8 @@ export interface IDragDropHelper {
 
 /**
  * Drag & drop event callback interface.
+ *
+ * {@docCategory DetailsList}
  */
 export interface IDragDropEvents {
   /**
@@ -63,6 +67,8 @@ export interface IDragDropEvents {
 
 /**
  * Drag & drop event contextual information.
+ *
+ * {@docCategory DetailsList}
  */
 export interface IDragDropContext {
   /**
@@ -87,6 +93,8 @@ export interface IDragDropTarget {
 
 /**
  * The drag and drop event listener configuration.
+ *
+ * {@docCategory DetailsList}
  */
 export interface IDragDropOptions {
   /**
@@ -96,7 +104,10 @@ export interface IDragDropOptions {
   /**
    * Map of event name to callback function to subscribe to.
    */
-  eventMap?: { eventName: string; callback: (context: IDragDropContext, event?: any) => void }[];
+  eventMap?: {
+    eventName: string;
+    callback: (context: IDragDropContext, event?: any) => void;
+  }[];
   /**
    * Selection index on drag and drop event.
    */
@@ -135,6 +146,12 @@ export interface IDragDropOptions {
   onDragOver?: (item?: any, event?: DragEvent) => void;
 }
 
+/**
+ * {@docCategory DetailsList}
+ */
 export interface IDragDropEvent {
+  /**
+   * Whether or not the drag & drop event was handled.
+   */
   isHandled?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -3,7 +3,7 @@ import { EventGroup } from '../../Utilities';
 
 /**
  * Helper for subscribing and unsubscribing to
- * drag and drop events on an {@link HTMLElement}.
+ * drag and drop events on an HTMLElement.
  *
  * {@docCategory IDragDropHelper}
  */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

Mentioned in https://github.com/OfficeDev/office-ui-fabric-react/issues/8867#issuecomment-489392890.

#### Description of changes

Exports all missing `DetailsList` exports.

As an aside, there's a duplicate export that will require upstream changes prior to removal as it would break our AMD partners.

https://github.com/OfficeDev/office-ui-fabric-react/blob/9e86e1ae040720383ea84deb9fa1d5d59a565d10/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.ts#L6

---

@Vitalius1 you may consider exporting these missing shimmer related types:

https://github.com/OfficeDev/office-ui-fabric-react/blame/master/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md#L6554

#### Focus areas to test

None.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9058)