### PR TITLE
Button: Adding keytips to new Button

### DIFF
--- a/common/changes/@uifabric/experiments/buttonKeytips_2019-05-10-23-18.json
+++ b/common/changes/@uifabric/experiments/buttonKeytips_2019-05-10-23-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Adding keytips to new Button.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -1,5 +1,5 @@
 import { IComponent, IComponentStyles, IHTMLElementSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
-import { IFontWeight, IStackSlot, ITextSlot } from 'office-ui-fabric-react';
+import { IFontWeight, IKeytipProps, IStackSlot, ITextSlot } from 'office-ui-fabric-react';
 import { IIconSlot } from '../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../Utilities';
 import { IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';
@@ -117,6 +117,11 @@ export interface IButtonProps
    * Defines the aria label that the screen readers use when focus goes on the Button.
    */
   ariaLabel?: string;
+
+  /**
+   * Defines optional keytips for this button.
+   */
+  keytipProps?: IKeytipProps;
 }
 
 /**

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -1,5 +1,5 @@
 /** @jsx withSlots */
-import { Stack, Text } from 'office-ui-fabric-react';
+import { Stack, Text, KeytipData } from 'office-ui-fabric-react';
 import { withSlots, getSlots } from '../../Foundation';
 import { getNativeProps, buttonProperties } from '../../Utilities';
 import { Icon } from '../../utilities/factoryComponents';
@@ -7,7 +7,7 @@ import { Icon } from '../../utilities/factoryComponents';
 import { IButtonComponent, IButtonProps, IButtonRootElements, IButtonSlots, IButtonViewProps } from './Button.types';
 
 export const ButtonView: IButtonComponent['view'] = props => {
-  const { icon, content, children, disabled, onClick, allowDisabledFocus, ariaLabel, buttonRef, ...rest } = props;
+  const { icon, content, children, disabled, onClick, allowDisabledFocus, ariaLabel, keytipProps, buttonRef, ...rest } = props;
 
   // TODO: 'href' is anchor property... consider getNativeProps by root type
   const buttonProps = { ...getNativeProps(rest, buttonProperties) };
@@ -30,23 +30,28 @@ export const ButtonView: IButtonComponent['view'] = props => {
   };
 
   return (
-    <Slots.root
-      type="button" // stack doesn't take in native button props
-      role="button"
-      onClick={_onClick}
-      {...buttonProps}
-      disabled={disabled && !allowDisabledFocus}
-      aria-disabled={disabled}
-      tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
-      aria-label={ariaLabel}
-      ref={buttonRef}
-    >
-      <Slots.stack horizontal as="span" tokens={{ childrenGap: 8 }} verticalAlign="center" horizontalAlign="center" verticalFill>
-        <Slots.icon />
-        <Slots.content />
-        {children}
-      </Slots.stack>
-    </Slots.root>
+    <KeytipData keytipProps={keytipProps} disabled={disabled && !allowDisabledFocus}>
+      {(keytipAttributes: any): JSX.Element => (
+        <Slots.root
+          type="button" // stack doesn't take in native button props
+          role="button"
+          onClick={_onClick}
+          {...buttonProps}
+          {...keytipAttributes}
+          disabled={disabled && !allowDisabledFocus}
+          aria-disabled={disabled}
+          tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
+          aria-label={ariaLabel}
+          ref={buttonRef}
+        >
+          <Slots.stack horizontal as="span" tokens={{ childrenGap: 8 }} verticalAlign="center" horizontalAlign="center" verticalFill>
+            <Slots.icon />
+            <Slots.content />
+            {children}
+          </Slots.stack>
+        </Slots.root>
+      )}
+    </KeytipData>
   );
 };
 

--- a/packages/experiments/src/components/Button/ButtonPage.tsx
+++ b/packages/experiments/src/components/Button/ButtonPage.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { ExampleCard, IComponentDemoPageProps, ComponentPage, PageMarkdown, PropertiesTableSet } from '@uifabric/example-app-base';
+import { KeytipLayer } from 'office-ui-fabric-react';
 
 import { ButtonExample } from './examples/Button.Example';
 import { MenuButtonExample } from './MenuButton/examples/MenuButton.Example';
 import { SplitButtonExample } from './SplitButton/examples/SplitButton.Example';
+import { ButtonKeytipsExample } from './examples/Button.Keytips.Example';
 import { ButtonSlotsExample } from './examples/Button.Slots.Example';
 import { ButtonStylesExample } from './examples/Button.Styles.Example';
 import { ButtonToggleExample } from './examples/Button.Toggle.Example';
@@ -13,6 +15,7 @@ import { ButtonVariantsExample } from './examples/Button.Variants.Example';
 const ButtonExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Example.tsx') as string;
 const MenuButtonExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/MenuButton/examples/MenuButton.Example.tsx') as string;
 const SplitButtonExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/SplitButton/examples/SplitButton.Example.tsx') as string;
+const ButtonKeytipsExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Keytips.Example.tsx') as string;
 const ButtonSlotsExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Slots.Example.tsx') as string;
 const ButtonStylesExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Styles.Example.tsx') as string;
 const ButtonToggleExampleCode = require('!raw-loader!@uifabric/experiments/src/components/Button/examples/Button.Toggle.Example.tsx') as string;
@@ -33,24 +36,28 @@ export class ButtonPage extends React.Component<IComponentDemoPageProps, {}> {
             <ExampleCard title="Menu Button Examples" code={MenuButtonExampleCode}>
               <MenuButtonExample />
             </ExampleCard>
-            <ExampleCard title="Split Button with two focus stops" code={SplitButtonExampleCode}>
+            <ExampleCard title="Split Button Examples" code={SplitButtonExampleCode}>
               <SplitButtonExample />
             </ExampleCard>
             <ExampleCard title="Button Variants Examples" code={ButtonVariantsExampleCode}>
               <ButtonVariantsExample />
             </ExampleCard>
-            <ExampleCard title="Toggle Buttons" code={ButtonToggleExampleCode}>
+            <ExampleCard title="Toggle Button Examples" code={ButtonToggleExampleCode}>
               <ButtonToggleExample />
+            </ExampleCard>
+            <ExampleCard title="Buttons with Keytips" code={ButtonKeytipsExampleCode}>
+              <ButtonKeytipsExample />
             </ExampleCard>
             <ExampleCard title="Button Slots Customization" code={ButtonSlotsExampleCode}>
               <ButtonSlotsExample />
             </ExampleCard>
-            <ExampleCard title="Button Styles" code={ButtonStylesExampleCode}>
+            <ExampleCard title="Button Styles Customization" code={ButtonStylesExampleCode}>
               <ButtonStylesExample />
             </ExampleCard>
-            <ExampleCard title="Button Tokens" code={ButtonTokensExampleCode}>
+            <ExampleCard title="Button Tokens Customization" code={ButtonTokensExampleCode}>
               <ButtonTokensExample />
             </ExampleCard>
+            <KeytipLayer content="Alt Windows" />
           </div>
         }
         propertiesTables={

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
@@ -60,7 +60,7 @@ export interface IMenuButton {
  */
 export interface IMenuButtonProps
   extends IMenuButtonSlots,
-    Pick<IButtonProps, 'href' | 'primary' | 'disabled' | 'onClick' | 'checked' | 'allowDisabledFocus' | 'ariaLabel'>,
+    Pick<IButtonProps, 'href' | 'primary' | 'disabled' | 'onClick' | 'checked' | 'allowDisabledFocus' | 'ariaLabel' | 'keytipProps'>,
     IStyleableComponentProps<IMenuButtonProps, IMenuButtonTokens, IMenuButtonStyles>,
     IBaseProps<IMenuButton> {
   /**

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
@@ -7,7 +7,27 @@ import { Button } from '../Button';
 import { IMenuButtonComponent, IMenuButtonProps, IMenuButtonSlots } from './MenuButton.types';
 
 export const MenuButtonView: IMenuButtonComponent['view'] = props => {
-  const { children, disabled, onClick, expanded, onMenuDismiss, menuTarget, buttonRef, ...rest } = props;
+  const {
+    children,
+    disabled,
+    onClick,
+    allowDisabledFocus,
+    keytipProps: keytips,
+    menu,
+    expanded,
+    onMenuDismiss,
+    menuTarget,
+    buttonRef,
+    ...rest
+  } = props;
+  let { keytipProps } = props;
+
+  if (keytipProps && menu) {
+    keytipProps = {
+      ...keytipProps,
+      hasMenu: true
+    };
+  }
 
   const Slots = getSlots<IMenuButtonProps, IMenuButtonSlots>(props, {
     root: 'div',
@@ -21,7 +41,15 @@ export const MenuButtonView: IMenuButtonComponent['view'] = props => {
 
   return (
     <Slots.root>
-      <Slots.button aria-expanded={expanded} onClick={onClick} disabled={disabled} componentRef={buttonRef} {...rest}>
+      <Slots.button
+        aria-expanded={expanded}
+        onClick={onClick}
+        disabled={disabled}
+        componentRef={buttonRef}
+        allowDisabledFocus={allowDisabledFocus}
+        keytipProps={keytipProps}
+        {...rest}
+      >
         {children}
         <Stack.Item>
           <Slots.menuIcon iconName="ChevronDown" />

--- a/packages/experiments/src/components/Button/MenuButton/examples/MenuButton.Example.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/examples/MenuButton.Example.tsx
@@ -20,10 +20,14 @@ const tokens = {
     childrenGap: 32
   },
   headingStack: {
-    childrenGap: 16
+    childrenGap: 16,
+    padding: 8
   },
   buttonStack: {
     childrenGap: 12
+  },
+  multilineButtonStack: {
+    padding: '8px 0px'
   }
 };
 
@@ -38,7 +42,7 @@ export class MenuButtonExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack tokens={tokens.sectionStack}>
-        <Stack tokens={tokens.headingStack} padding={8}>
+        <Stack tokens={tokens.headingStack}>
           <div>
             <Stack tokens={tokens.buttonStack}>
               <ButtonStack>
@@ -48,7 +52,7 @@ export class MenuButtonExample extends React.Component<{}, {}> {
               </ButtonStack>
               <ButtonStack>
                 <MenuButton icon="Share" menu={menuProps}>
-                  <Stack padding="8px 0" as="span" horizontalAlign="start">
+                  <Stack as="span" horizontalAlign="start" tokens={tokens.multilineButtonStack}>
                     <Text>I am a compound multiline button.</Text>
                     <Text variant="small">I can have a caption.</Text>
                   </Stack>

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -76,6 +76,7 @@ export interface ISplitButtonProps
       | 'checked'
       | 'allowDisabledFocus'
       | 'ariaLabel'
+      | 'keytipProps'
       | 'defaultExpanded'
       | 'expanded'
       | 'onKeyDown'

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -17,6 +17,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     onClick,
     allowDisabledFocus,
     ariaLabel,
+    keytipProps,
     expanded,
     root,
     button,
@@ -68,6 +69,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
         allowDisabledFocus={allowDisabledFocus}
         ariaLabel={menuButtonAriaLabel}
         onClick={onSecondaryActionClick}
+        keytipProps={keytipProps}
         menu={menu}
       />
     </Slots.root>

--- a/packages/experiments/src/components/Button/SplitButton/examples/SplitButton.Example.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/examples/SplitButton.Example.tsx
@@ -20,7 +20,8 @@ const tokens = {
     childrenGap: 32
   },
   headingStack: {
-    childrenGap: 16
+    childrenGap: 16,
+    padding: 8
   },
   buttonStack: {
     childrenGap: 12
@@ -42,7 +43,7 @@ export class SplitButtonExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack tokens={tokens.sectionStack}>
-        <Stack tokens={tokens.headingStack} padding={8}>
+        <Stack tokens={tokens.headingStack}>
           <div>
             <Stack tokens={tokens.buttonStack}>
               <ButtonStack>

--- a/packages/experiments/src/components/Button/examples/Button.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Example.tsx
@@ -7,7 +7,8 @@ const tokens = {
     childrenGap: 32
   },
   headingStack: {
-    childrenGap: 16
+    childrenGap: 16,
+    padding: 8
   },
   buttonStack: {
     childrenGap: 12
@@ -29,7 +30,7 @@ export class ButtonExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Stack tokens={tokens.sectionStack}>
-        <Stack tokens={tokens.headingStack} padding={8}>
+        <Stack tokens={tokens.headingStack}>
           <Stack tokens={tokens.buttonStack}>
             <ButtonStack>
               <Button content="Default button" onClick={alertClicked} slots={{ content: { render: () => <div>I'm new</div> } }} />

--- a/packages/experiments/src/components/Button/examples/Button.Keytips.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Keytips.Example.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { Button } from '../Button';
+import { MenuButton } from '../MenuButton/MenuButton';
+import { IMenuButtonProps } from '../MenuButton/MenuButton.types';
+import { SplitButton } from '../SplitButton/SplitButton';
+import { Stack, IStackTokens } from 'office-ui-fabric-react';
+import { buildKeytipConfigMap, IKeytipConfig, IKeytipConfigMap } from 'office-ui-fabric-react/lib/utilities/keytips/index';
+
+const btnExecute = (el: HTMLElement) => {
+  el.click();
+};
+
+// Setup keytips
+const keytipConfig: IKeytipConfig = {
+  keytips: [
+    {
+      id: 'Button',
+      content: '1A',
+      optionalProps: {
+        onExecute: btnExecute
+      }
+    },
+    {
+      id: 'MenuButton',
+      content: '1B',
+      optionalProps: {
+        onExecute: btnExecute
+      },
+      children: [
+        {
+          id: 'MenuItem1',
+          content: 'E'
+        },
+        {
+          id: 'MenuItem2',
+          content: '8'
+        }
+      ]
+    },
+    {
+      id: 'MenuButton2',
+      content: '1C',
+      optionalProps: {
+        onExecute: btnExecute
+      },
+      children: [
+        {
+          id: 'MenuItem1',
+          content: 'E'
+        },
+        {
+          id: 'MenuItem2',
+          content: '8'
+        }
+      ]
+    },
+    {
+      id: 'SplitButton',
+      content: '2',
+      optionalProps: {
+        onExecute: btnExecute
+      }
+    }
+  ]
+};
+const keytipMap: IKeytipConfigMap = buildKeytipConfigMap(keytipConfig);
+
+const alertClicked = (): void => {
+  alert('Clicked');
+};
+
+const menuProps: IMenuButtonProps['menu'] = {
+  items: [
+    {
+      key: 'a',
+      text: 'Item a',
+      keytipProps: keytipMap.MenuItem1
+    },
+    {
+      key: 'b',
+      text: 'Item b',
+      keytipProps: keytipMap.MenuItem2
+    }
+  ],
+  shouldFocusOnContainer: true,
+  shouldFocusOnMount: true
+};
+
+// tslint:disable:jsx-no-lambda
+export class ButtonKeytipsExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    const stackTokens: IStackTokens = { childrenGap: 12 };
+
+    return (
+      <Stack horizontal disableShrink tokens={stackTokens}>
+        <Button content="Button with keytip" onClick={alertClicked} keytipProps={keytipMap.Button} />
+        <Button content="Button without keytip" onClick={alertClicked} />
+        <MenuButton content="Menu Button with keytip" keytipProps={keytipMap.MenuButton} menu={menuProps} />
+        <SplitButton content="Split Button with keytip" keytipProps={keytipMap.SplitButton} menu={menuProps} />
+      </Stack>
+    );
+  }
+}

--- a/packages/experiments/src/components/Button/examples/Button.Styles.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Styles.Example.tsx
@@ -18,7 +18,8 @@ const tokens = {
     childrenGap: 32
   },
   headingStack: {
-    childrenGap: 16
+    childrenGap: 16,
+    padding: 8
   },
   buttonStack: {
     childrenGap: 12
@@ -51,7 +52,7 @@ export class ButtonStylesExample extends React.Component<{}, {}> {
 
     return (
       <Stack tokens={tokens.sectionStack}>
-        <Stack tokens={tokens.headingStack} padding={8}>
+        <Stack tokens={tokens.headingStack}>
           <div>
             <Stack tokens={tokens.buttonStack}>
               <ButtonStack>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds the `keytipProps` prop to the new `Button` to make its API and functionality closer to that of the old `Button`, while making the necessary changes so that `MenuButton` and `SplitButton` also work correctly. A new example showing this is also added, which can be seen in the GIF below:

![Button](https://user-images.githubusercontent.com/7798177/57561340-fe69ef00-733f-11e9-8ce6-82c43ca62003.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9061)