### PR TITLE
Fix some pages not rendering

### DIFF
--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
@@ -53,8 +53,7 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
     { from: '#/styles/localization', to: '#/styles/web/localization' },
     { from: '#/styles/themegenerator', to: '#/styles/web' },
     { from: '#/styles/typography', to: '#/styles/web/typography' },
-    { from: '#/styles/utilities', to: '#/styles/web' },
-    { from: new RegExp('#/get-started$'), to: '#/get-started/web' }
+    { from: '#/styles/utilities', to: '#/styles/web' }
   ],
   messageBars: [
     {

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -19,8 +19,7 @@ import {
   TPlatformPages,
   jumpToAnchor,
   removeAnchorLink,
-  SiteMessageBar,
-  pascalize
+  SiteMessageBar
 } from '@uifabric/example-app-base/lib/index2';
 import { Nav } from '../Nav/index';
 import { AppCustomizations } from './customizations';
@@ -66,39 +65,41 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
     super(props);
 
     this._async = new Async();
-    this.state = {
-      initialRender: true,
-      activePlatforms: {},
-      platform: 'default' as TPlatforms
-    };
-  }
 
-  public componentDidMount(): void {
+    let activePlatforms: ISiteState<TPlatforms>['activePlatforms'] = {};
+
     const { siteDefinition } = this.props;
     if (siteDefinition.pages) {
       // Get top level pages with platforms.
       const topLevelPages = siteDefinition.pages.filter(page => !!page.platforms).map(page => page.title);
 
       // Get local storage platforms for top level pages.
-      let activePlatforms: ISiteState<TPlatforms>['activePlatforms'];
       try {
         // Accessing localStorage can throw for various reasons
         activePlatforms = JSON.parse(localStorage.getItem('activePlatforms') || '') || {};
       } catch (ex) {
-        activePlatforms = {};
+        // ignore
       }
 
       // Set active platform for each top level page to local storage platform or the first platform defined for that page.
       topLevelPages.forEach(item => {
-        activePlatforms[pascalize(item)] = activePlatforms[item] || getPageFirstPlatform(item, siteDefinition);
+        activePlatforms[item] = activePlatforms[item] || getPageFirstPlatform(item, siteDefinition);
       });
-
-      // Set the initial state with navigation data and the activePlatforms.
-      this.setState({ ...(this._getNavData() as ISiteState<TPlatforms>), activePlatforms }, this._setActivePlatforms);
-      // Handle hash routing
-      window.addEventListener('hashchange', this._handleRouteChange);
-      this._handleRouteChange();
     }
+
+    this.state = {
+      initialRender: true,
+      activePlatforms: activePlatforms,
+      platform: 'default' as TPlatforms
+    };
+  }
+
+  public componentDidMount(): void {
+    // Set the initial state with navigation data.
+    this.setState({ ...(this._getNavData() as ISiteState<TPlatforms>) }, this._setActivePlatforms);
+    // Handle hash routing
+    window.addEventListener('hashchange', this._handleRouteChange);
+    this._handleRouteChange();
   }
 
   public componentWillUnmount(): void {
@@ -250,12 +251,14 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
   }
 
   private _renderPageNav(): JSX.Element | null {
-    const { activePages, searchablePageTitle, isContentFullBleed, pagePlatforms = {} } = this.state;
+    const { activePages, searchablePageTitle, isContentFullBleed, pagePlatforms } = this.state;
+    const { siteDefinition } = this.props;
 
     if (!isContentFullBleed && activePages) {
       // If current page doesn't have pages for the active platform, switch to its first platform.
       if (Object.keys(pagePlatforms).length > 0 && activePages.length === 0) {
-        this._onPlatformChanged(Object.keys(pagePlatforms)[0] as TPlatforms);
+        const firstPlatform = getPageFirstPlatform(getSiteArea(siteDefinition.pages), siteDefinition);
+        this._onPlatformChanged(firstPlatform);
       }
 
       return (
@@ -281,7 +284,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
    * Determines the current page's platform.
    */
   private _getPlatform = (): TPlatforms => {
-    const currentPage = getSiteArea();
+    const currentPage = getSiteArea(this.props.siteDefinition.pages);
     const { activePlatforms } = this.state;
 
     if (activePlatforms[currentPage]) {
@@ -349,12 +352,13 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
    */
   private _onTopNavLinkClick = (ev: React.MouseEvent<HTMLAnchorElement>) => {
     const { platform } = this.state;
+    const { siteDefinition } = this.props;
     const target = ev.currentTarget as HTMLAnchorElement;
     trackEvent(EventNames.ClickedTopNavLink, {
       // Use the dom element's title or innerText as the topic.
       topic: target.title || target.innerText, // @TODO: Remove topic when data is stale.
-      currentArea: getSiteArea(),
-      nextArea: getSiteArea(target.hash || target.href),
+      currentArea: getSiteArea(siteDefinition.pages),
+      nextArea: getSiteArea(siteDefinition.pages, target.hash || target.href),
       nextPage: target.hash || target.href,
       currentPage: window.location.hash,
       platform: platform === 'default' ? 'None' : platform, // @TODO: Remove platform when data is stale.
@@ -367,12 +371,13 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
    */
   private _onLeftNavLinkClick = (ev: React.MouseEvent<HTMLAnchorElement>) => {
     const { platform } = this.state;
+    const { siteDefinition } = this.props;
     const target = ev.currentTarget as HTMLAnchorElement;
     trackEvent(EventNames.ClickedLeftNavLink, {
       // Use the dom element's title or innerText as the topic.
       topic: target.title || target.innerText, // @TODO: Remove topic when data is stale.
-      currentArea: getSiteArea(),
-      nextArea: getSiteArea(target.hash || target.href),
+      currentArea: getSiteArea(siteDefinition.pages),
+      nextArea: getSiteArea(siteDefinition.pages, target.hash || target.href),
       nextPage: target.hash || target.href,
       currentPage: window.location.hash,
       platform: platform === 'default' ? 'None' : platform, // @TODO: Remove platform when data is stale.
@@ -385,10 +390,11 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
    */
   private _onLeftNavSearchBoxClick = (ev: React.MouseEvent<HTMLAnchorElement>) => {
     const { platform } = this.state;
+    const { siteDefinition } = this.props;
     trackEvent(EventNames.ClickedSearchFilter, {
       // Use the dom element's title or innerText as the topic.
-      topic: getSiteArea(undefined, false), // @TODO: Remove topic when data is stale.
-      currentArea: getSiteArea(),
+      topic: getSiteArea(siteDefinition.pages), // @TODO: Remove topic when data is stale.
+      currentArea: getSiteArea(siteDefinition.pages),
       platform: platform === 'default' ? 'None' : platform, // @TODO: Remove platform when data is stale.
       currentPlatform: platform === 'default' ? 'None' : platform // Pages that don't have a platform will say 'none'
     });
@@ -399,17 +405,18 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
    * @param platformKey The key of the target platform as defined in siteDefinition.
    */
   private _onPlatformChanged = (platformKey: TPlatforms): void => {
+    const { siteDefinition } = this.props;
     if (platformKey !== this.state.platform) {
       trackEvent(EventNames.ChangedPlatform, {
-        topic: getSiteArea(undefined, false), // @TODO: Remove topic when data is stale.
-        currentArea: getSiteArea(),
+        topic: getSiteArea(siteDefinition.pages), // @TODO: Remove topic when data is stale.
+        currentArea: getSiteArea(siteDefinition.pages),
         platform: platformKey, // @TODO: Remove platform when data is stale.
         currentPlatform: this.state.platform,
         nextPlatform: platformKey
       });
 
       const { activePlatforms } = this.state;
-      const currentPage = getSiteArea();
+      const currentPage = getSiteArea(siteDefinition.pages);
 
       this.setState(
         {
@@ -468,7 +475,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
 
     // @TODO: investigate using real page name.
     trackPageView('FabricPage', newPagePath, {
-      currentArea: getSiteArea(),
+      currentArea: getSiteArea(siteDefinition.pages),
       previousPage: prevPagePath,
       platform: platform === 'default' ? 'None' : platform, // @TODO: Remove platform when data is stale.
       currentPlatform: platform === 'default' ? 'None' : platform, // Pages that don't have a platform will say 'none'

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -19,7 +19,8 @@ import {
   TPlatformPages,
   jumpToAnchor,
   removeAnchorLink,
-  SiteMessageBar
+  SiteMessageBar,
+  pascalize
 } from '@uifabric/example-app-base/lib/index2';
 import { Nav } from '../Nav/index';
 import { AppCustomizations } from './customizations';
@@ -89,7 +90,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
 
       // Set active platform for each top level page to local storage platform or the first platform defined for that page.
       topLevelPages.forEach(item => {
-        activePlatforms[item] = activePlatforms[item] || getPageFirstPlatform(item, siteDefinition);
+        activePlatforms[pascalize(item)] = activePlatforms[item] || getPageFirstPlatform(item, siteDefinition);
       });
 
       // Set the initial state with navigation data and the activePlatforms.
@@ -453,14 +454,16 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
       // Test if the platform has changed on each hashchange to avoid costly forEach below.
       const isCurrentPlatform = new RegExp(`/${platform}`);
 
-      !isCurrentPlatform.test(newPagePath) &&
-        platformKeys.forEach(platformKey => {
+      if (!isCurrentPlatform.test(newPagePath)) {
+        for (const key of platformKeys) {
           // If the user navigates directly to a platform specific page, set the active platform to that of the new page.
-          const isNewPlatform = new RegExp(`/${platformKey}`, 'gi');
+          const isNewPlatform = new RegExp(`/${key}`, 'gi');
           if (isNewPlatform.test(newPagePath)) {
-            this._onPlatformChanged(platformKey);
+            this._onPlatformChanged(key);
+            break;
           }
-        });
+        }
+      }
     }
 
     // @TODO: investigate using real page name.

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -459,9 +459,9 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
     const platformKeys = platforms && (Object.keys(platforms) as TPlatforms[]);
     if (platformKeys && platformKeys.length > 0) {
       // Test if the platform has changed on each hashchange to avoid costly forEach below.
-      const isCurrentPlatform = new RegExp(`/${platform}`);
+      const currentPlatformRegex = new RegExp(`/${platform}\\b`);
 
-      if (!isCurrentPlatform.test(newPagePath)) {
+      if (!currentPlatformRegex.test(newPagePath)) {
         for (const key of platformKeys) {
           // If the user navigates directly to a platform specific page, set the active platform to that of the new page.
           const isNewPlatform = new RegExp(`/${key}`, 'gi');

--- a/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Page, IPageProps, withPlatform } from '@uifabric/example-app-base/lib/index2';
+import { Page, IPageProps, PlatformContext } from '@uifabric/example-app-base/lib/index2';
 import { getSubTitle } from '../../utilities/index';
 import { Platforms } from '../../interfaces/Platforms';
 import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
@@ -22,4 +22,6 @@ const ControlsAreaPageBase: React.StatelessComponent<IControlsPageProps> = props
   return <Page subTitle={getSubTitle(props.platform)} jsonDocs={jsonDocs} {...props} />;
 };
 
-export const ControlsAreaPage: React.StatelessComponent<IControlsPageProps> = withPlatform<Platforms>(ControlsAreaPageBase);
+export const ControlsAreaPage: React.StatelessComponent<IPageProps<Platforms>> = (props: IPageProps<Platforms>) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <ControlsAreaPageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/Controls/FluentThemePage/FluentThemePage.tsx
+++ b/apps/fabric-website/src/pages/Controls/FluentThemePage/FluentThemePage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withPlatform } from '@uifabric/example-app-base/lib/index2';
+import { PlatformContext } from '@uifabric/example-app-base/lib/index2';
 import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
 import { FluentThemePageProps } from './FluentThemePage.doc';
 import { Platforms } from '../../../interfaces/Platforms';
@@ -11,4 +11,6 @@ export class FluentThemePageBase extends React.Component<IControlsPageProps, {}>
   }
 }
 
-export const FluentThemePage: React.StatelessComponent<IControlsPageProps> = withPlatform<Platforms>(FluentThemePageBase);
+export const FluentThemePage: React.StatelessComponent<IControlsPageProps> = (props: IControlsPageProps) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <FluentThemePageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -324,7 +324,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
     trackEvent(EventNames.ClickedInternalLink, {
       topic: url, // @TODO: Remove topic when data is stale.
       currentArea: getSiteArea(),
-      nextArea: getSiteArea(url),
+      nextArea: getSiteArea(undefined, url),
       nextPage: url,
       currentPage: window.location.hash
     });

--- a/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css, Link } from 'office-ui-fabric-react';
-import { Page, withPlatform, INavPage, IPageSectionProps, IPageProps } from '@uifabric/example-app-base/lib/index2';
+import { Page, PlatformContext, INavPage, IPageSectionProps, IPageProps } from '@uifabric/example-app-base/lib/index2';
 import * as PageStyles from '@uifabric/example-app-base/lib/components/Page/Page.module.scss';
 import { SiteDefinition } from '../../../SiteDefinition/index';
 import { getSubTitle } from '../../../utilities/index';
@@ -55,4 +55,6 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
   }
 }
 
-export const ControlsPage: React.StatelessComponent<IPageProps<Platforms>> = withPlatform<Platforms>(ControlsPageBase);
+export const ControlsPage: React.StatelessComponent<IPageProps<Platforms>> = (props: IPageProps<Platforms>) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <ControlsPageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/GetStartedPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/GetStartedPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withPlatform, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import { PlatformContext, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { GetStartedPageProps } from './GetStartedPage.doc';
 import { Platforms } from '../../../interfaces/Platforms';
 import { getSubTitle } from '../../../utilities/index';
@@ -63,4 +63,6 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
   }
 }
 
-export const GetStartedPage: React.StatelessComponent<IGetStartedPageProps> = withPlatform<Platforms>(GetStartedPageBase);
+export const GetStartedPage: React.StatelessComponent<IGetStartedPageProps> = (props: IGetStartedPageProps) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <GetStartedPageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/Overviews/ResourcesPage/ResourcesPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/ResourcesPage/ResourcesPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Markdown, withPlatform, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import { Markdown, PlatformContext, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { ResourcesPageProps } from './ResourcesPage.doc';
 import { Platforms } from '../../../interfaces/Platforms';
 
@@ -49,4 +49,6 @@ function _otherSections(): IPageSectionProps[] {
   ];
 }
 
-export const ResourcesPage: React.StatelessComponent<IResourcesPageProps> = withPlatform<Platforms>(ResourcesPageBase);
+export const ResourcesPage: React.StatelessComponent<IResourcesPageProps> = (props: IResourcesPageProps) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <ResourcesPageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/Overviews/StylesPage/StylesPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/StylesPage/StylesPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link, Icon } from 'office-ui-fabric-react';
-import { withPlatform, Page, IPageProps, IPageSectionProps, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
+import { PlatformContext, Page, IPageProps, IPageSectionProps, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { getSubTitle } from '../../../utilities/index';
 import * as styles from './StylesPage.module.scss';
 import { Platforms } from '../../../interfaces/Platforms';
@@ -126,4 +126,6 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
   }
 }
 
-export const StylesPage: React.StatelessComponent<IPageProps<Platforms>> = withPlatform<Platforms>(StylesPageBase);
+export const StylesPage: React.StatelessComponent<IPageProps<Platforms>> = (props: IPageProps<Platforms>) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <StylesPageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/PageTemplates/TemplatePage/TemplatePage.tsx
+++ b/apps/fabric-website/src/pages/PageTemplates/TemplatePage/TemplatePage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from 'office-ui-fabric-react';
-import { Markdown, withPlatform, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
+import { Markdown, PlatformContext, Page, IPageProps, IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { getSubTitle } from '../../../utilities/index';
 import { TemplatePageProps } from './TemplatePage.doc';
 
@@ -100,5 +100,7 @@ function _otherSections(platform: Platforms): IPageSectionProps[] {
   }
 }
 
-// Use the `withPlatform` higher-order component to ensure the platform prop is passed to the page from App correctly using react context.
-export const TemplatePage: React.StatelessComponent<IPageProps<Platforms>> = withPlatform<Platforms>(TemplatePageBase);
+// Use the `PlatformContext.Consumer` component to ensure the platform prop is passed to the page from App correctly using react context.
+export const TemplatePage: React.StatelessComponent<IPageProps<Platforms>> = (props: IPageProps<Platforms>) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <TemplatePageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/apps/fabric-website/src/pages/Styles/StylesAreaPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/StylesAreaPage.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { Page, IPageProps, withPlatform } from '@uifabric/example-app-base/lib/index2';
+import { Page, IPageProps, PlatformContext } from '@uifabric/example-app-base/lib/index2';
 import { getSubTitle } from '../../utilities/index';
 import { Platforms } from '../../interfaces/Platforms';
 
 export interface IStylesPageProps extends IPageProps<Platforms> {}
 
-export const StylesPageBase: React.StatelessComponent<IStylesPageProps> = props => {
+export const StylesAreaPageBase: React.StatelessComponent<IStylesPageProps> = props => {
   const { platform } = props;
   return <Page {...props} platform={platform} subTitle={getSubTitle(platform)} />;
 };
 
-export const StylesAreaPage: React.StatelessComponent<IStylesPageProps> = withPlatform<Platforms>(StylesPageBase);
+export const StylesAreaPage: React.StatelessComponent<IStylesPageProps> = (props: IStylesPageProps) => (
+  <PlatformContext.Consumer>{(platform: Platforms) => <StylesAreaPageBase platform={platform} {...props} />}</PlatformContext.Consumer>
+);

--- a/common/changes/@uifabric/example-app-base/fix-page-render_2019-05-11-02-29.json
+++ b/common/changes/@uifabric/example-app-base/fix-page-render_2019-05-11-02-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "getSiteArea now pulls name from page definition instead of URL",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/fix-page-render_2019-05-11-00-15.json
+++ b/common/changes/@uifabric/fabric-website/fix-page-render_2019-05-11-00-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix pages not rendering on first load",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "v-jojanz@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/getSiteArea.ts
+++ b/packages/example-app-base/src/utilities/getSiteArea.ts
@@ -6,8 +6,8 @@ import { pascalize } from './string';
  * @param pascal - If the returned string should be in pascal case.
  */
 export function getSiteArea(hash?: string, pascal?: boolean): string {
+  pascal = pascal || false;
   hash = hash || window.location.hash;
-  const mod = pascal !== false;
   const area = hash.indexOf('#/') > -1 ? hash.split('#/')[1].split('/')[0] : '';
-  return mod ? pascalize(area) : area;
+  return pascal ? pascalize(area) : area;
 }

--- a/packages/example-app-base/src/utilities/getSiteArea.ts
+++ b/packages/example-app-base/src/utilities/getSiteArea.ts
@@ -6,14 +6,16 @@ import { removeAnchorLink } from './removeAnchorLink';
  * @param pages - Array of pages.
  * @param hash - The hash.
  */
-
 export function getSiteArea(pages?: INavPage[], hash: string = location.hash): string {
   hash = removeAnchorLink(hash);
+  // Get the first level from the URL as a fallback. "#/controls/web/button" would be "controls"
   const topLevel = hash.indexOf('#/') > -1 ? hash.split('#/')[1].split('/')[0] : '';
+  const urlRegex = new RegExp(`\^#/${topLevel}\\b`);
   let area = topLevel;
   if (pages) {
     for (const page of pages) {
-      if (page.url.indexOf(topLevel) === 2) {
+      // Test if the page url starts with '#/' + the topLevel string
+      if (urlRegex.test(page.url)) {
         area = page.title;
         break;
       }

--- a/packages/example-app-base/src/utilities/getSiteArea.ts
+++ b/packages/example-app-base/src/utilities/getSiteArea.ts
@@ -1,13 +1,21 @@
-import { pascalize } from './string';
+import { INavPage } from '../components/Nav/index';
 
 /**
- * Retrieves the current top level page name from the window URL or the passed hash.
+ * Retrieves the current top level page name defined in the pages array from the window URL or the passed hash.
+ * @param pages - Array of pages.
  * @param hash - The hash.
- * @param pascal - If the returned string should be in pascal case.
  */
-export function getSiteArea(hash?: string, pascal?: boolean): string {
-  pascal = pascal || false;
-  hash = hash || window.location.hash;
-  const area = hash.indexOf('#/') > -1 ? hash.split('#/')[1].split('/')[0] : '';
-  return pascal ? pascalize(area) : area;
+
+export function getSiteArea(pages?: INavPage[], hash: string = location.hash): string {
+  const topLevel = hash.indexOf('#/') > -1 ? hash.split('#/')[1].split('/')[0] : '';
+  let area = topLevel;
+  if (pages) {
+    for (const page of pages) {
+      if (page.url.indexOf(topLevel) === 2) {
+        area = page.title;
+        break;
+      }
+    }
+  }
+  return area;
 }

--- a/packages/example-app-base/src/utilities/getSiteArea.ts
+++ b/packages/example-app-base/src/utilities/getSiteArea.ts
@@ -1,4 +1,5 @@
 import { INavPage } from '../components/Nav/index';
+import { removeAnchorLink } from './removeAnchorLink';
 
 /**
  * Retrieves the current top level page name defined in the pages array from the window URL or the passed hash.
@@ -7,6 +8,7 @@ import { INavPage } from '../components/Nav/index';
  */
 
 export function getSiteArea(pages?: INavPage[], hash: string = location.hash): string {
+  hash = removeAnchorLink(hash);
   const topLevel = hash.indexOf('#/') > -1 ? hash.split('#/')[1].split('/')[0] : '';
   let area = topLevel;
   if (pages) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

It seems `withPlatform` wasn't correctly passing the platform prop to the page so it wouldn't render the correct content. I replaced occurrences of it with `PlatformContext.Consumer`.

I refactored `getSiteArea` to pull the name of the area from site definition, instead of the url so the initial site state should be fixed.

#### Focus areas to test

We need to see if the page render breaks when navigating between controls and get started.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9062)