### PR TITLE
fabric-website: export categories object for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@ fabric-website/ @jordandrako
 # ssr-tests/
 # test-bundle-button/ @dzearing
 # todo-app/
-SiteDefinition.pages/Controls/web.tsx @Vitalius1 @natalieethell
+Controls/web.tsx @Vitalius1 @natalieethell
 
 #### Packages
 packages/charting/ @Raghurk @veeray @chankev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@ fabric-website/ @jordandrako
 # ssr-tests/
 # test-bundle-button/ @dzearing
 # todo-app/
+SiteDefinition.pages/Controls/web.tsx @Vitalius1 @natalieethell
 
 #### Packages
 packages/charting/ @Raghurk @veeray @chankev

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -6,7 +6,7 @@ import { Omit } from 'office-ui-fabric-react/lib/Utilities';
 
 type CategoryPage = Partial<Omit<INavPage, 'pages'>> & { subPages?: ICategory };
 
-interface ICategory {
+export interface ICategory {
   [component: string]: CategoryPage;
 }
 

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -11,8 +11,8 @@ export interface ICategory {
 }
 
 // Exporting this object to be used in generating a TOC (table of content) for docs.microsoft documentation repo.
-// Any changes to this object need to be communicated to `vibraga@microsoft.com` or any member of Gearbox team
-// to avoid accidental breaking of the documentation and to allow the appropriate actions to be taken to mitigate this.
+// Any changes to this object need to be communicated to avoid accidental breaking of the documentation
+// and to allow the appropriate actions to be taken to mitigate this.
 export const categories: { Other?: ICategory; [name: string]: ICategory } = {
   'Basic Inputs': {
     Button: {},

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -10,7 +10,10 @@ interface ICategory {
   [component: string]: CategoryPage;
 }
 
-const categories: { Other?: ICategory; [name: string]: ICategory } = {
+// Exporting this object to be used in generating a TOC (table of content) for docs.microsoft documentation repo.
+// Any changes to this object need to be communicated to `vibraga@microsoft.com` or any member of Gearbox team
+// to avoid accidental breaking of the documentation and to allow the appropriate actions to be taken to mitigate this.
+export const categories: { Other?: ICategory; [name: string]: ICategory } = {
   'Basic Inputs': {
     Button: {},
     Checkbox: {},

--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -4,7 +4,7 @@ import { ControlsAreaPage } from '../../../pages/Controls/ControlsAreaPage';
 import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
 import { Omit } from 'office-ui-fabric-react/lib/Utilities';
 
-type CategoryPage = Partial<Omit<INavPage, 'pages'>> & { subPages?: ICategory };
+export type CategoryPage = Partial<Omit<INavPage, 'pages'>> & { subPages?: ICategory };
 
 export interface ICategory {
   [component: string]: CategoryPage;

--- a/common/changes/@uifabric/fabric-website/vibraga-exportSideDefinition_2019-05-11-01-41.json
+++ b/common/changes/@uifabric/fabric-website/vibraga-exportSideDefinition_2019-05-11-01-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Export `categories` object to serve as a source of navigation structure for the table of content on docs.microsoft",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "vibraga@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Need this object to be importable from `fabric-website` package to allow us to use it as source of truth for the navigation we try to implement on docs.microsoft documentation portal. I intentionally did not surfaced it to the surface API and intend to have it imported by digging into the folder. @ecraig12345 if you think there is no reason why we should not export it from the surface entry point of the package I will leave the PR as is. But if you think it's safe to get it all the way to the surface I can make the change. Let me know

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9066)