### PR TITLE
Foundation: Evolve API

### DIFF
--- a/common/changes/@uifabric/experiments/jg-evolve-create-component_2019-05-13-15-52.json
+++ b/common/changes/@uifabric/experiments/jg-evolve-create-component_2019-05-13-15-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Support changes to createComponent API.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/jg-evolve-create-component_2019-05-13-15-52.json
+++ b/common/changes/@uifabric/foundation/jg-evolve-create-component_2019-05-13-15-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/foundation",
+      "comment": "Evolve create component API to separate out view and make options bag optional.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/react-cards/jg-evolve-create-component_2019-05-13-15-52.json
+++ b/common/changes/@uifabric/react-cards/jg-evolve-create-component_2019-05-13-15-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/react-cards",
+      "comment": "Support changes to createComponent API.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-evolve-create-component_2019-05-13-15-52.json
+++ b/common/changes/office-ui-fabric-react/jg-evolve-create-component_2019-05-13-15-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Support changes to createComponent API.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/experiments/src/components/Accordion/Accordion.tsx
+++ b/packages/experiments/src/components/Accordion/Accordion.tsx
@@ -8,7 +8,7 @@ import { styles } from './Accordion.styles';
 
 const AccordionItemType = (<CollapsibleSection /> as React.ReactElement<ICollapsibleSectionProps>).type;
 
-const view: IAccordionComponent['view'] = props => {
+const AccordionView: IAccordionComponent['view'] = props => {
   const { collapseItems } = props;
 
   const children: React.ReactChild[] = React.Children.map(
@@ -43,10 +43,9 @@ const AccordionStatics = {
 
 export const Accordion: React.StatelessComponent<IAccordionProps> & {
   Item: React.StatelessComponent<ICollapsibleSectionProps>;
-} = createComponent({
+} = createComponent(AccordionView, {
   displayName: 'Accordion',
   styles,
-  view,
   statics: AccordionStatics
 });
 

--- a/packages/experiments/src/components/Button/Button.tsx
+++ b/packages/experiments/src/components/Button/Button.tsx
@@ -2,14 +2,13 @@ import { createComponent } from '../../Foundation';
 import { useButtonState as state } from './Button.state';
 import { ButtonStyles as styles, ButtonTokens as tokens } from './Button.styles';
 import { IButtonProps } from './Button.types';
-import { ButtonView as view } from './Button.view';
+import { ButtonView } from './Button.view';
 
-export const Button: React.StatelessComponent<IButtonProps> = createComponent({
+export const Button: React.StatelessComponent<IButtonProps> = createComponent(ButtonView, {
   displayName: 'Button',
   state,
   styles,
-  tokens,
-  view
+  tokens
 });
 
 export default Button;

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.tsx
@@ -2,14 +2,13 @@ import { createComponent } from '../../../Foundation';
 import { useMenuButtonState as state } from './MenuButton.state';
 import { MenuButtonStyles as styles, MenuButtonTokens as tokens } from './MenuButton.styles';
 import { IMenuButtonProps } from './MenuButton.types';
-import { MenuButtonView as view } from './MenuButton.view';
+import { MenuButtonView } from './MenuButton.view';
 
-export const MenuButton: React.StatelessComponent<IMenuButtonProps> = createComponent({
+export const MenuButton: React.StatelessComponent<IMenuButtonProps> = createComponent(MenuButtonView, {
   displayName: 'MenuButton',
   state,
   styles,
-  tokens,
-  view
+  tokens
 });
 
 export default MenuButton;

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { createComponent } from '../../../Foundation';
 import { SplitButtonStyles as styles, SplitButtonTokens as tokens } from './SplitButton.styles';
 import { ISplitButtonProps } from './SplitButton.types';
-import { SplitButtonView as view } from './SplitButton.view';
+import { SplitButtonView } from './SplitButton.view';
 
-export const SplitButton: React.StatelessComponent<ISplitButtonProps> = createComponent({
+export const SplitButton: React.StatelessComponent<ISplitButtonProps> = createComponent(SplitButtonView, {
   displayName: 'SplitButton',
   styles,
-  tokens,
-  view
+  tokens
 });
 
 export default SplitButton;

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
@@ -4,16 +4,14 @@ import { collapsibleSectionStyles } from './CollapsibleSection.styles';
 import { ICollapsibleSectionProps } from './CollapsibleSection.types';
 import { createComponent } from '../../Foundation';
 
-export const CollapsibleSection: React.StatelessComponent<ICollapsibleSectionProps> = createComponent({
+export const CollapsibleSection: React.StatelessComponent<ICollapsibleSectionProps> = createComponent(CollapsibleSectionView, {
   displayName: 'CollapsibleSection',
-  view: CollapsibleSectionView,
   state: useCollapsibleSectionState,
   styles: collapsibleSectionStyles
 });
 
 // TODO: This is only here for testing createComponent and should be removed before promoting to production
-export const CollapsibleSectionStateless: React.StatelessComponent<ICollapsibleSectionProps> = createComponent({
+export const CollapsibleSectionStateless: React.StatelessComponent<ICollapsibleSectionProps> = createComponent(CollapsibleSectionView, {
   displayName: 'CollapsibleSection',
-  view: CollapsibleSectionView,
   styles: collapsibleSectionStyles
 });

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
@@ -1,13 +1,15 @@
 import { createComponent } from '../../Foundation';
-import { CollapsibleSectionTitleView as view } from './CollapsibleSectionTitle.view';
+import { CollapsibleSectionTitleView } from './CollapsibleSectionTitle.view';
 import { getStyles as styles } from './CollapsibleSectionTitle.styles';
 import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';
 
-export const CollapsibleSectionTitle: React.FunctionComponent<ICollapsibleSectionTitleProps> = createComponent({
-  displayName: 'CollapsibleSectionTitle',
-  view,
-  styles,
-  factoryOptions: {
-    defaultProp: 'text'
+export const CollapsibleSectionTitle: React.FunctionComponent<ICollapsibleSectionTitleProps> = createComponent(
+  CollapsibleSectionTitleView,
+  {
+    displayName: 'CollapsibleSectionTitle',
+    styles,
+    factoryOptions: {
+      defaultProp: 'text'
+    }
   }
-});
+);

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
@@ -3,9 +3,8 @@ import { VerticalPersonaStyles, VerticalPersonaTokens } from './VerticalPersona.
 import { IVerticalPersonaProps } from './VerticalPersona.types';
 import { createComponent } from '../../../Foundation';
 
-export const VerticalPersona: React.StatelessComponent<IVerticalPersonaProps> = createComponent({
+export const VerticalPersona: React.StatelessComponent<IVerticalPersonaProps> = createComponent(VerticalPersonaView, {
   displayName: 'VerticalPersona',
-  view: VerticalPersonaView,
   styles: VerticalPersonaStyles,
   tokens: VerticalPersonaTokens
 });

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
@@ -4,9 +4,8 @@ import { PersonaCoinStyles } from './PersonaCoin.styles';
 import { IPersonaCoinProps } from './PersonaCoin.types';
 import { PersonaCoinView } from './PersonaCoin.view';
 
-export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps> = createComponent({
+export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps> = createComponent(PersonaCoinView, {
   displayName: 'PersonaCoin',
-  view: PersonaCoinView,
   styles: PersonaCoinStyles,
   state: usePersonaCoinState
 });

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
@@ -41,8 +41,7 @@ const PersonaCoinImageView = (props: IPersonaCoinImageProps): JSX.Element | null
   );
 };
 
-export const PersonaCoinImage: React.StatelessComponent<IPersonaCoinImageProps> = createComponent({
+export const PersonaCoinImage: React.StatelessComponent<IPersonaCoinImageProps> = createComponent(PersonaCoinImageView, {
   displayName: 'PersonaCoinImage',
-  view: PersonaCoinImageView,
   styles: personaCoinImageStyles
 });

--- a/packages/experiments/src/components/Toggle/Toggle.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.ts
@@ -1,12 +1,11 @@
-import { ToggleView as view } from './Toggle.view';
+import { ToggleView } from './Toggle.view';
 import { ToggleStyles as styles, ToggleTokens as tokens } from './Toggle.styles';
 import { useToggleState as state } from './Toggle.state';
 import { IToggleProps } from './Toggle.types';
 import { createComponent } from '../../Foundation';
 
-export const Toggle: React.StatelessComponent<IToggleProps> = createComponent({
+export const Toggle: React.StatelessComponent<IToggleProps> = createComponent(ToggleView, {
   displayName: 'Toggle',
-  view,
   state,
   styles,
   tokens

--- a/packages/foundation/etc/foundation.api.md
+++ b/packages/foundation/etc/foundation.api.md
@@ -14,7 +14,7 @@ import * as PropTypes from 'prop-types';
 import * as React_2 from 'react';
 
 // @public
-export function createComponent<TComponentProps extends ValidProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps extends TComponentProps = TComponentProps, TStatics = {}>(component: IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React_2.FunctionComponent<TComponentProps> & TStatics;
+export function createComponent<TComponentProps extends ValidProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps extends TComponentProps = TComponentProps, TStatics = {}>(view: IViewComponent<TViewProps>, options?: IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>): React_2.FunctionComponent<TComponentProps> & TStatics;
 
 // @public
 export function createFactory<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never>(DefaultComponent: React_2.ComponentType<TProps>, options?: IFactoryOptions<TProps>): ISlotFactory<TProps, TShorthandProp>;
@@ -32,18 +32,19 @@ export function getControlledDerivedProps<TProps, TProp extends keyof TProps>(pr
 export function getSlots<TComponentProps extends ISlottableProps<TComponentSlots>, TComponentSlots>(userProps: TComponentProps, slots: ISlotDefinition<Required<TComponentSlots>>): ISlots<Required<TComponentSlots>>;
 
 // @public
-export type IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>>;
+export type IComponent<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>> & {
+    view: IViewComponent<TViewProps>;
+};
 
 // @public
 export interface IComponentOptions<TComponentProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>, TViewProps = TComponentProps, TStatics = {}> {
-    displayName: string;
+    displayName?: string;
     factoryOptions?: IFactoryOptions<TComponentProps>;
     fields?: string[];
     state?: IStateComponentType<TComponentProps, TViewProps>;
     statics?: TStatics;
     styles?: IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet>;
     tokens?: ITokenFunctionOrObject<TViewProps, TTokens>;
-    view: IViewComponent<TViewProps>;
 }
 
 // @public

--- a/packages/foundation/src/IComponent.ts
+++ b/packages/foundation/src/IComponent.ts
@@ -103,9 +103,9 @@ export interface IComponentOptions<
   TStatics = {}
 > {
   /**
-   * Display name to identify component in React hierarchy.
+   * Display name to identify component in React hierarchy. This parameter is required for targeted component styling via theming.
    */
-  displayName: string;
+  displayName?: string;
   /**
    * List of fields which can be customized.
    */
@@ -114,10 +114,6 @@ export interface IComponentOptions<
    * Styles prop to pass into component.
    */
   styles?: IStylesFunctionOrObject<TViewProps, TTokens, TStyleSet>;
-  /**
-   * React view component.
-   */
-  view: IViewComponent<TViewProps>;
   /**
    * Optional state component that processes TComponentProps into TViewProps.
    */
@@ -145,7 +141,12 @@ export type IComponent<
   TStyleSet extends IStyleSet<TStyleSet>,
   TViewProps = TComponentProps,
   TStatics = {}
-> = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>>;
+> = Required<IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>> & {
+  /**
+   * Component that generates view output.
+   */
+  view: IViewComponent<TViewProps>;
+};
 
 /**
  * Factory options for creating component.

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -77,7 +77,7 @@ export function createComponent<
     return view(viewProps);
   };
 
-  result.displayName = (options && options.displayName) || view.name;
+  result.displayName = options.displayName || view.name;
 
   // If a shorthand prop is defined, create a factory for the component.
   // TODO: This shouldn't be a concern of createComponent.. factoryOptions should just be forwarded.

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -10,7 +10,8 @@ import {
   IStyleableComponentProps,
   IStylesFunctionOrObject,
   IToken,
-  ITokenFunction
+  ITokenFunction,
+  IViewComponent
 } from './IComponent';
 import { IDefaultSlotProps, ISlotCreator, ValidProps } from './ISlots';
 
@@ -27,7 +28,7 @@ import { IDefaultSlotProps, ISlotCreator, ValidProps } from './ISlots';
  * Views should simply be stateless pure functions that receive all props needed for rendering their output.
  * State component is optional. If state is not provided, created component is essentially a functional stateless component.
  *
- * @param component - component Component options. See IComponentOptions for more detail.
+ * @param options - component Component options. See IComponentOptions for more detail.
  */
 export function createComponent<
   TComponentProps extends ValidProps,
@@ -36,21 +37,23 @@ export function createComponent<
   TViewProps extends TComponentProps = TComponentProps,
   TStatics = {}
 >(
-  component: IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics>
+  view: IViewComponent<TViewProps>,
+  options: IComponentOptions<TComponentProps, TTokens, TStyleSet, TViewProps, TStatics> = {}
 ): React.FunctionComponent<TComponentProps> & TStatics {
-  const { factoryOptions = {} } = component;
+  const { factoryOptions = {} } = options;
   const { defaultProp } = factoryOptions;
+  const displayName = (options && options.displayName) || view.name;
 
   const result: React.FunctionComponent<TComponentProps> = (
     componentProps: TComponentProps & IStyleableComponentProps<TViewProps, TTokens, TStyleSet>
   ) => {
     const settings: ICustomizationProps<TViewProps, TTokens, TStyleSet> = _getCustomizations(
-      component.displayName,
+      displayName,
       React.useContext(CustomizerContext),
-      component.fields
+      options.fields
     );
 
-    const useState = component.state;
+    const useState = options.state;
 
     if (useState) {
       // Don't assume state will return all props, so spread useState result over component props.
@@ -62,8 +65,8 @@ export function createComponent<
 
     const theme = componentProps.theme || settings.theme;
 
-    const tokens = _resolveTokens(componentProps, theme, component.tokens, settings.tokens, componentProps.tokens);
-    const styles = _resolveStyles(componentProps, theme, tokens, component.styles, settings.styles, componentProps.styles);
+    const tokens = _resolveTokens(componentProps, theme, options.tokens, settings.tokens, componentProps.tokens);
+    const styles = _resolveStyles(componentProps, theme, tokens, options.styles, settings.styles, componentProps.styles);
 
     const viewProps = {
       ...componentProps,
@@ -72,19 +75,19 @@ export function createComponent<
       _defaultStyles: styles
     } as TViewProps & IDefaultSlotProps<any>;
 
-    return component.view(viewProps);
+    return view(viewProps);
   };
 
-  result.displayName = component.displayName;
+  result.displayName = displayName;
 
   // If a shorthand prop is defined, create a factory for the component.
   // TODO: This shouldn't be a concern of createComponent.. factoryOptions should just be forwarded.
-  //       Need to weigh creating default factories on component creation vs. memozing them on use in slots.tsx.
+  //       Need to weigh creating default factories on component creation vs. memoizing them on use in slots.tsx.
   if (defaultProp) {
     (result as ISlotCreator<TComponentProps, any>).create = createFactory(result, { defaultProp });
   }
 
-  assign(result, component.statics);
+  assign(result, options.statics);
 
   // Later versions of TypeSript should allow us to merge objects in a type safe way and avoid this cast.
   return result as React.FunctionComponent<TComponentProps> & TStatics;

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -47,7 +47,7 @@ export function createComponent<
     componentProps: TComponentProps & IStyleableComponentProps<TViewProps, TTokens, TStyleSet>
   ) => {
     const settings: ICustomizationProps<TViewProps, TTokens, TStyleSet> = _getCustomizations(
-      options && options.displayName,
+      options.displayName,
       React.useContext(CustomizerContext),
       options.fields
     );

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -42,13 +42,12 @@ export function createComponent<
 ): React.FunctionComponent<TComponentProps> & TStatics {
   const { factoryOptions = {} } = options;
   const { defaultProp } = factoryOptions;
-  const displayName = (options && options.displayName) || view.name;
 
   const result: React.FunctionComponent<TComponentProps> = (
     componentProps: TComponentProps & IStyleableComponentProps<TViewProps, TTokens, TStyleSet>
   ) => {
     const settings: ICustomizationProps<TViewProps, TTokens, TStyleSet> = _getCustomizations(
-      displayName,
+      options && options.displayName,
       React.useContext(CustomizerContext),
       options.fields
     );
@@ -78,7 +77,7 @@ export function createComponent<
     return view(viewProps);
   };
 
-  result.displayName = displayName;
+  result.displayName = (options && options.displayName) || view.name;
 
   // If a shorthand prop is defined, create a factory for the component.
   // TODO: This shouldn't be a concern of createComponent.. factoryOptions should just be forwarded.
@@ -144,7 +143,7 @@ function _resolveTokens<TViewProps, TTokens>(
  * @param fields Optional list of properties to grab from global store and context.
  */
 function _getCustomizations<TViewProps, TTokens, TStyleSet extends IStyleSet<TStyleSet>>(
-  displayName: string,
+  displayName: string | undefined,
   context: ICustomizerContext,
   fields?: string[]
 ): ICustomizationProps<TViewProps, TTokens, TStyleSet> {

--- a/packages/office-ui-fabric-react/src/components/Stack/Stack.tsx
+++ b/packages/office-ui-fabric-react/src/components/Stack/Stack.tsx
@@ -9,7 +9,7 @@ import { IStackComponent, IStackProps, IStackSlots } from './Stack.types';
 
 const StackItemType = (<StackItem /> as React.ReactElement<IStackItemProps>).type;
 
-const view: IStackComponent['view'] = props => {
+const StackView: IStackComponent['view'] = props => {
   const { as: RootType = 'div', disableShrink, wrap, ...rest } = props;
 
   warnDeprecations('Stack', props, {
@@ -65,10 +65,9 @@ const StackStatics = {
 
 export const Stack: React.StatelessComponent<IStackProps> & {
   Item: React.StatelessComponent<IStackItemProps>;
-} = createComponent({
+} = createComponent(StackView, {
   displayName: 'Stack',
   styles,
-  view,
   statics: StackStatics
 });
 

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.tsx
@@ -4,7 +4,7 @@ import { withSlots, createComponent, getSlots } from '../../../Foundation';
 import { IStackItemComponent, IStackItemProps, IStackItemSlots } from './StackItem.types';
 import { StackItemStyles as styles } from './StackItem.styles';
 
-const view: IStackItemComponent['view'] = props => {
+const StackItemView: IStackItemComponent['view'] = props => {
   const { children } = props;
   if (React.Children.count(children) < 1) {
     return null;
@@ -17,10 +17,9 @@ const view: IStackItemComponent['view'] = props => {
   return <Slots.root>{children}</Slots.root>;
 };
 
-export const StackItem: React.StatelessComponent<IStackItemProps> = createComponent({
+export const StackItem: React.StatelessComponent<IStackItemProps> = createComponent(StackItemView, {
   displayName: 'StackItem',
-  styles,
-  view
+  styles
 });
 
 export default StackItem;

--- a/packages/office-ui-fabric-react/src/components/Text/Text.ts
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.ts
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { createComponent } from '../../Foundation';
 import { ITextProps } from './Text.types';
-import { TextView as view } from './Text.view';
+import { TextView } from './Text.view';
 import { TextStyles as styles } from './Text.styles';
 
-export const Text: React.StatelessComponent<ITextProps> = createComponent({
+export const Text: React.StatelessComponent<ITextProps> = createComponent(TextView, {
   displayName: 'Text',
-  styles,
-  view
+  styles
 });
 
 export default Text;

--- a/packages/react-cards/src/components/Card/Card.ts
+++ b/packages/react-cards/src/components/Card/Card.ts
@@ -1,5 +1,5 @@
 import { createComponent } from '@uifabric/foundation';
-import { CardView as view } from './Card.view';
+import { CardView } from './Card.view';
 import { CardStyles as styles, CardTokens as tokens } from './Card.styles';
 import { ICardProps } from './Card.types';
 import { CardItem } from './CardItem/CardItem';
@@ -15,9 +15,8 @@ const CardStatics = {
 export const Card: React.FunctionComponent<ICardProps> & {
   Item: React.FunctionComponent<ICardItemProps>;
   Section: React.FunctionComponent<ICardSectionProps>;
-} = createComponent({
+} = createComponent(CardView, {
   displayName: 'Card',
-  view,
   styles,
   tokens,
   statics: CardStatics

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.ts
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { createComponent } from '@uifabric/foundation';
 import { CardItemStyles as styles, CardItemTokens as tokens } from './CardItem.styles';
 import { ICardItemProps } from './CardItem.types';
-import { CardItemView as view } from './CardItem.view';
+import { CardItemView } from './CardItem.view';
 
-export const CardItem: React.FunctionComponent<ICardItemProps> = createComponent({
+export const CardItem: React.FunctionComponent<ICardItemProps> = createComponent(CardItemView, {
   displayName: 'CardItem',
   styles,
-  tokens,
-  view
+  tokens
 });
 
 export default CardItem;

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.ts
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { createComponent } from '@uifabric/foundation';
 import { CardSectionStyles as styles, CardSectionTokens as tokens } from './CardSection.styles';
 import { ICardSectionProps } from './CardSection.types';
-import { CardSectionView as view } from './CardSection.view';
+import { CardSectionView } from './CardSection.view';
 
-export const CardSection: React.FunctionComponent<ICardSectionProps> = createComponent({
+export const CardSection: React.FunctionComponent<ICardSectionProps> = createComponent(CardSectionView, {
   displayName: 'CardSection',
   styles,
-  tokens,
-  view
+  tokens
 });
 
 export default CardSection;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #8931
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Changes createComponent API from:

`createComponent({ options });`

to:

`createComponent(view, { options });`

Making `options` truly optional and `view` the only required arg.

It is now possible to use `createComponent` like this:

`createComponent(ButtonView);`

While allowing options to be added for further customization.

I had also planned on addressing #8331 as part of this PR but since my shield rotation moved up I'm going to make a change just for this for now.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9072)