### PR TITLE
Add office-ui-fabric-react release tag trigger to TypeScript compatibility build def

### DIFF
--- a/scripts/typescript-compatibility-build.yml
+++ b/scripts/typescript-compatibility-build.yml
@@ -2,7 +2,9 @@ trigger:
   branches:
     include:
       - tsc-compat-debug
-      #- refs/tags/office-ui-fabric-react_v*
+  tags:
+    include:
+      - office-ui-fabric-react_v*
 
 variables:
   - name: PackageName


### PR DESCRIPTION
#### Description of changes

I currently have the TypeScript compatibility build running on a schedule and against a debug branch `tsc-compat-debug`.

Since the intent of this is to validate TypeScript compatibility per release of `office-ui-fabric-react`, I'm recommending we add a tag trigger ([documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#tags)) to the build definition: `office-ui-fabric-react_v*`.

The build is currently hosted publicly: https://dev.azure.com/RushStack/Gearbox%20GitHub%20Projects/_build?definitionId=16&_a=summary.

And the validation test suite repository is open-source at: https://github.com/microsoft/ui-fabric-ts-validation.

#### Focus areas to test

None. I'll make sure the build runs as releases are uploaded daily.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9074)