### PR TITLE
Documentation: Handle type aliases

### DIFF
--- a/common/changes/@uifabric/api-docs/handleTypeAliases_2019-05-13-17-41.json
+++ b/common/changes/@uifabric/api-docs/handleTypeAliases_2019-05-13-17-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/api-docs",
+      "comment": "handle type aliases",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/api-docs",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/common/changes/@uifabric/api-docs/handleTypeAliases_2019-05-13-17-41.json
+++ b/common/changes/@uifabric/api-docs/handleTypeAliases_2019-05-13-17-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/api-docs",
-      "comment": "handle type aliases",
+      "comment": "PageJsonGenerator: handle type aliases.",
       "type": "minor"
     }
   ],

--- a/common/changes/@uifabric/example-app-base/handleTypeAliases_2019-05-13-17-41.json
+++ b/common/changes/@uifabric/example-app-base/handleTypeAliases_2019-05-13-17-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "handle type aliases",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/common/changes/@uifabric/example-app-base/handleTypeAliases_2019-05-13-17-41.json
+++ b/common/changes/@uifabric/example-app-base/handleTypeAliases_2019-05-13-17-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/example-app-base",
-      "comment": "handle type aliases",
+      "comment": "ApiReferencesTable/ApiReferencesTableSet: handle type aliases.",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/handleTypeAliases_2019-05-13-17-41.json
+++ b/common/changes/office-ui-fabric-react/handleTypeAliases_2019-05-13-17-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "fix IBasePickerProps doc comment and add type alias to DocPage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "natalie.ethell@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/handleTypeAliases_2019-05-13-17-41.json
+++ b/common/changes/office-ui-fabric-react/handleTypeAliases_2019-05-13-17-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "fix IBasePickerProps doc comment and add type alias to DocPage",
+      "comment": "Picker/DocPage: fix IBasePickerProps doc comment and add type alias to DocPage.",
       "type": "patch"
     }
   ],

--- a/packages/api-docs/src/PageJsonGenerator.types.ts
+++ b/packages/api-docs/src/PageJsonGenerator.types.ts
@@ -45,7 +45,7 @@ export interface IEnumTableRowJson {
 }
 
 export interface ITableJson {
-  kind: 'interface' | 'enum' | 'class';
+  kind: 'interface' | 'enum' | 'class' | 'typeAlias';
   name: string;
   description: string;
   extendsTokens: ITokenJson[];

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -23,6 +23,7 @@ export interface IApiReferencesTableProps {
   methods?: IMethod[];
   renderAsEnum?: boolean;
   renderAsClass?: boolean;
+  renderAsTypeAlias?: boolean;
   key?: string;
   name?: string;
   description?: string;
@@ -34,6 +35,7 @@ export interface IApiReferencesTableState {
   methods?: IMethod[];
   isEnum: boolean;
   isClass: boolean;
+  isTypeAlias: boolean;
 }
 
 export const XSMALL_GAP_SIZE = 2.5;
@@ -92,7 +94,8 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
       this.state = {
         properties,
         isEnum: true,
-        isClass: false
+        isClass: false,
+        isTypeAlias: false
       };
     } else if (props.renderAsClass) {
       const members = (props.properties as IApiInterfaceProperty[])
@@ -107,6 +110,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
         properties: members,
         isEnum: false,
         isClass: true,
+        isTypeAlias: false,
         methods: methods
       };
     } else {
@@ -117,7 +121,8 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
       this.state = {
         properties,
         isEnum: !!props.renderAsEnum,
-        isClass: !!props.renderAsClass
+        isClass: !!props.renderAsClass,
+        isTypeAlias: !!props.renderAsTypeAlias
       };
     }
 
@@ -255,19 +260,15 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
 
     return (
       <Stack gap={MEDIUM_GAP_SIZE}>
-        {description && extendsTokens && extendsTokens.length > 0 ? (
-          <Stack gap={SMALL_GAP_SIZE}>
-            {this._renderTitle()}
-            {(description || (extendsTokens && extendsTokens.length > 0)) && (
-              <Stack gap={XSMALL_GAP_SIZE}>
-                {this._renderDescription()}
-                {this._renderExtends()}
-              </Stack>
-            )}
-          </Stack>
-        ) : (
-          this._renderTitle()
-        )}
+        <Stack gap={SMALL_GAP_SIZE}>
+          {this._renderTitle()}
+          {(description || (extendsTokens && extendsTokens.length > 0)) && (
+            <Stack gap={XSMALL_GAP_SIZE}>
+              {this._renderDescription()}
+              {this._renderExtends()}
+            </Stack>
+          )}
+        </Stack>
         {isClass
           ? this._renderClass()
           : properties.length >= 1 && (
@@ -421,8 +422,16 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
   };
 
   private _parseILinkTokens(extend: boolean, linkTokens?: ILinkToken[]): JSX.Element | undefined {
+    const { isTypeAlias } = this.state;
+
     if (linkTokens && linkTokens.length > 0) {
-      if (extend) {
+      if (isTypeAlias) {
+        return (
+          <Text variant={'medium'}>
+            <code>{this._parseILinkTokensHelper(linkTokens, false)}</code>
+          </Text>
+        );
+      } else if (extend) {
         return (
           <Text variant={'small'}>
             {'Extends '}

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.tsx
@@ -115,6 +115,7 @@ export class ApiReferencesTableSet extends React.Component<IApiReferencesTableSe
         methods={item.methods}
         renderAsEnum={item.propertyType === PropertyType.enum}
         renderAsClass={item.propertyType === PropertyType.class}
+        renderAsTypeAlias={item.propertyType === PropertyType.typeAlias}
       />
     );
   }
@@ -215,6 +216,7 @@ export class ApiReferencesTableSet extends React.Component<IApiReferencesTableSe
     // the type alias
     return {
       propertyName: table.name,
+      extendsTokens: table.extendsTokens,
       description: table.description,
       title: table.name,
       propertyType: PropertyType.typeAlias,

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.tsx
@@ -177,6 +177,10 @@ export class ApiReferencesTableSet extends React.Component<IApiReferencesTableSe
             preResults.push(this._generateClassProperty(jsonDocs.tables[j]));
             break;
           }
+          case 'typeAlias': {
+            preResults.push(this._generateTypeAliasProperty(jsonDocs.tables[j]));
+            break;
+          }
         }
       }
     }
@@ -204,6 +208,17 @@ export class ApiReferencesTableSet extends React.Component<IApiReferencesTableSe
       title: table.kind ? table.name + ' ' + table.kind : table.name,
       propertyType: PropertyType.enum,
       property: enumMembers
+    };
+  }
+
+  private _generateTypeAliasProperty(table: ITableJson): IApiProperty {
+    // the type alias
+    return {
+      propertyName: table.name,
+      description: table.description,
+      title: table.name,
+      propertyType: PropertyType.typeAlias,
+      property: []
     };
   }
 

--- a/packages/example-app-base/src/utilities/parser/interfaces.ts
+++ b/packages/example-app-base/src/utilities/parser/interfaces.ts
@@ -28,5 +28,6 @@ export interface IEnumProperty {
 export enum PropertyType {
   enum = 0,
   interface = 1,
-  class = 2
+  class = 2,
+  typeAlias = 3
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1609,7 +1609,7 @@ export interface IBasePicker<T> {
     items: T[] | undefined;
 }
 
-// @public (undocumented)
+// @public
 export interface IBasePickerProps<T> extends React.Props<any> {
     className?: string;
     componentRef?: IRefObject<IBasePicker<T>>;

--- a/packages/office-ui-fabric-react/src/common/DocPage.types.ts
+++ b/packages/office-ui-fabric-react/src/common/DocPage.types.ts
@@ -184,7 +184,7 @@ export type IEnumTableRowJson = Required<Pick<ITableRowJson, 'name' | 'descripti
  * Api table
  */
 export interface ITableJson {
-  kind: 'interface' | 'enum' | 'class';
+  kind: 'interface' | 'enum' | 'class' | 'typeAlias';
   name: string;
   extendsTokens: ILinkToken[];
   description: string;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -21,7 +21,8 @@ export interface IBasePicker<T> {
   focusInput: () => void;
 }
 
-/* Type T is the type of the item that is displayed
+/**
+ * Type T is the type of the item that is displayed
  * and searched for by the picker. For example, if the picker is
  * displaying persona's then type T could either be of Persona or IPersona props
  * {@docCategory Pickers}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes expose type aliases in the API documentation. Here's an example of how one would now be displayed on the site:

<img width="926" alt="Screen Shot 2019-05-13 at 10 44 47 AM" src="https://user-images.githubusercontent.com/14134000/57642437-2a69b800-756c-11e9-9588-c1236deeb4bf.png">

This PR also fixes the doc comment for IBasePicker.

#### Focus areas to test

Ensure that all exported type aliases are rendered.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9075)