### PR TITLE
Fix nav section behavior

### DIFF
--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -20,9 +20,6 @@ export interface INavState {
   searchQuery: string;
   defaultSortState: keyof typeof NavSortType;
   sortState: keyof typeof NavSortType;
-  collapsedSections: {
-    [sectionKey: string]: boolean;
-  };
 }
 
 export interface INavLocalItems {
@@ -42,7 +39,6 @@ export class Nav extends React.Component<INavProps, INavState> {
       : {};
 
     this.state = {
-      collapsedSections: {},
       defaultSortState: this._localItems.defaultSortState ? NavSortType[this._localItems.defaultSortState] : NavSortType.categories,
       searchQuery: '',
       sortState: this._localItems.defaultSortState ? NavSortType[this._localItems.defaultSortState] : NavSortType.categories
@@ -184,28 +180,12 @@ export class Nav extends React.Component<INavProps, INavState> {
       const key = `${page.title}-${sectionIndex}`;
       return (
         <li key={key} className={css(styles.section, hasActiveChild(page) && styles.hasActiveChild)}>
-          <CollapsibleSection
-            collapsed={!(this.state.collapsedSections[key] || hasActiveChild(page))}
-            title={{
-              text: page.title,
-              onClick: () => this._handleSectionClick(key)
-            }}
-          >
+          <CollapsibleSection defaultCollapsed={!hasActiveChild(page)} title={page.title}>
             {this._renderLinkList(page.pages, false)}
           </CollapsibleSection>
         </li>
       );
     }
-  };
-
-  private _handleSectionClick = (sectionKey: string) => {
-    const collapsedSections = { ...this.state.collapsedSections };
-    this.setState((prevState: INavState) => ({
-      collapsedSections: {
-        ...collapsedSections,
-        [sectionKey]: !prevState.collapsedSections[sectionKey]
-      }
-    }));
   };
 
   private _renderSortedLinks(pages: INavPage[]): React.ReactElement<{}> {

--- a/common/changes/@uifabric/fabric-website/nav-behavior_2019-05-13-20-56.json
+++ b/common/changes/@uifabric/fabric-website/nav-behavior_2019-05-13-20-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix left nav section behavior",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "v-jojanz@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8999 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`CollapsibleSection` is more mature now than when I implemented it in the website's left nav. It's no longer required to implement custom `collapsed` logic, just `defaultCollapsed`.

#### Testing

Test by navigating from page to page and opening/closing sections: http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/9078/merge/fabric-website/dist/index.html?devhost#/controls/web/button


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9078)