### PR TITLE
FocusZone: focus busted in example, fixing.

### DIFF
--- a/common/changes/office-ui-fabric-react/fix-fz-example_2019-05-13-21-23.json
+++ b/common/changes/office-ui-fabric-react/fix-fz-example_2019-05-13-21-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "The FocusZone photos example now correctly renders focus rectangles.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Photos.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.Photos.Example.tsx
@@ -20,19 +20,17 @@ const classNames = mergeStyleSets({
     boxSizing: 'border-box',
     selectors: {
       '&:focus': {
-        outline: 'none',
-        selectors: {
-          '&:after': {
-            content: '',
-            position: 'absolute',
-            right: 4,
-            left: 4,
-            top: 4,
-            bottom: 4,
-            border: '1px solid ' + theme.palette.white,
-            outline: '2px solid ' + theme.palette.themePrimary
-          }
-        }
+        outline: 'none'
+      },
+      '&:focus:after': {
+        content: '""',
+        position: 'absolute',
+        right: 4,
+        left: 4,
+        top: 4,
+        bottom: 4,
+        border: '1px solid ' + theme.palette.white,
+        outline: '2px solid ' + theme.palette.themePrimary
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Photos.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Photos.Example.tsx.shot
@@ -41,10 +41,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -107,10 +107,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -173,10 +173,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -239,10 +239,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -305,10 +305,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -371,10 +371,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -437,10 +437,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -503,10 +503,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -569,10 +569,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -635,10 +635,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -701,10 +701,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -767,10 +767,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -833,10 +833,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -899,10 +899,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -965,10 +965,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -1031,10 +1031,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -1097,10 +1097,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -1163,10 +1163,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -1229,10 +1229,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;
@@ -1295,10 +1295,10 @@ exports[`Component Examples renders FocusZone.Photos.Example.tsx correctly 1`] =
         &:focus {
           outline: none;
         }
-        &:after {
+        &:focus:after {
           border: 1px solid #ffffff;
           bottom: 4px;
-          content: ;
+          content: "";
           left: 4px;
           outline: 2px solid #0078d4;
           position: absolute;


### PR DESCRIPTION
The Photos example in focuszone is not showing correct focus rectangle treatments because the styling is messed up. Addressing this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9079)