### PR TITLE
TextField: add support for multiple line error msg

### DIFF
--- a/common/changes/office-ui-fabric-react/iamchangming-textfield_multiple_line_error_msg_2019-05-13-21-14.json
+++ b/common/changes/office-ui-fabric-react/iamchangming-textfield_multiple_line_error_msg_2019-05-13-21-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add TextField multiple-line errorMessage support",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "iamchangming@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/iamchangming-textfield_multiple_line_error_msg_2019-05-14-19-03.json
+++ b/common/changes/office-ui-fabric-react/iamchangming-textfield_multiple_line_error_msg_2019-05-14-19-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "iamchangming@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/iamchangming-textfield_multiple_line_error_msg_2019-05-14-20-11.json
+++ b/common/changes/office-ui-fabric-react/iamchangming-textfield_multiple_line_error_msg_2019-05-14-20-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "iamchangming@gmail.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7365,7 +7365,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
     deferredValidationTime?: number;
     description?: string;
     disabled?: boolean;
-    errorMessage?: string;
+    errorMessage?: TextFieldErrorMessage;
     // @deprecated (undocumented)
     iconClass?: string;
     iconProps?: IIconProps;
@@ -7381,8 +7381,8 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
     onChange?: (event: React_2.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     // @deprecated (undocumented)
     onChanged?: (newValue: any) => void;
-    onGetErrorMessage?: (value: string) => string | PromiseLike<string> | undefined;
-    onNotifyValidationResult?: (errorMessage: string, value: string | undefined) => void;
+    onGetErrorMessage?: (value: string) => TextFieldErrorMessage | PromiseLike<TextFieldErrorMessage> | undefined;
+    onNotifyValidationResult?: (errorMessage: TextFieldErrorMessage, value: string | undefined) => void;
     // @deprecated (undocumented)
     onRenderAddon?: IRenderFunction<ITextFieldProps>;
     onRenderDescription?: IRenderFunction<ITextFieldProps>;
@@ -7404,7 +7404,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
 
 // @public (undocumented)
 export interface ITextFieldState {
-    errorMessage: string;
+    errorMessage: TextFieldErrorMessage;
     isFocused: boolean;
     // (undocumented)
     value: string;
@@ -9141,6 +9141,9 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     setSelectionStart(value: number): void;
     readonly value: string | undefined;
 }
+
+// @public (undocumented)
+export type TextFieldErrorMessage = string | JSX.Element;
 
 // @public (undocumented)
 export const TextStyles: ITextComponent['styles'];

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7365,7 +7365,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
     deferredValidationTime?: number;
     description?: string;
     disabled?: boolean;
-    errorMessage?: TextFieldErrorMessage;
+    errorMessage?: string | JSX.Element;
     // @deprecated (undocumented)
     iconClass?: string;
     iconProps?: IIconProps;
@@ -7381,8 +7381,8 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
     onChange?: (event: React_2.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     // @deprecated (undocumented)
     onChanged?: (newValue: any) => void;
-    onGetErrorMessage?: (value: string) => TextFieldErrorMessage | PromiseLike<TextFieldErrorMessage> | undefined;
-    onNotifyValidationResult?: (errorMessage: TextFieldErrorMessage, value: string | undefined) => void;
+    onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
+    onNotifyValidationResult?: (errorMessage: string | JSX.Element, value: string | undefined) => void;
     // @deprecated (undocumented)
     onRenderAddon?: IRenderFunction<ITextFieldProps>;
     onRenderDescription?: IRenderFunction<ITextFieldProps>;
@@ -7404,7 +7404,7 @@ export interface ITextFieldProps extends React_2.AllHTMLAttributes<HTMLInputElem
 
 // @public (undocumented)
 export interface ITextFieldState {
-    errorMessage: TextFieldErrorMessage;
+    errorMessage: string | JSX.Element;
     isFocused: boolean;
     // (undocumented)
     value: string;
@@ -9141,9 +9141,6 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     setSelectionStart(value: number): void;
     readonly value: string | undefined;
 }
-
-// @public (undocumented)
-export type TextFieldErrorMessage = string | JSX.Element;
 
 // @public (undocumented)
 export const TextStyles: ITextComponent['styles'];

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -16,7 +16,7 @@ import {
   warnDeprecations,
   warnMutuallyExclusive
 } from '../../Utilities';
-import { ITextField, ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles, TextFieldErrorMessage } from './TextField.types';
+import { ITextField, ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
 
 const getClassNames = classNamesFunction<ITextFieldStyleProps, ITextFieldStyles>();
 
@@ -32,7 +32,7 @@ export interface ITextFieldState {
    * - If there is no validation error or we have not validated the input value, errorMessage is an empty string.
    * - If we have done the validation and there is validation error, errorMessage is the validation error message.
    */
-  errorMessage: TextFieldErrorMessage;
+  errorMessage: string | JSX.Element;
 }
 
 const DEFAULT_STATE_VALUE = '';
@@ -418,7 +418,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     return <span style={{ paddingBottom: '1px' }}>{suffix}</span>;
   }
 
-  private get _errorMessage(): TextFieldErrorMessage | undefined {
+  private get _errorMessage(): string | JSX.Element | undefined {
     let { errorMessage } = this.state;
     if (!errorMessage && this.props.errorMessage) {
       errorMessage = this.props.errorMessage;
@@ -530,7 +530,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       } else {
         const currentValidation: number = ++this._lastValidation;
 
-        result.then((errorMessage: TextFieldErrorMessage) => {
+        result.then((errorMessage: string | JSX.Element) => {
           if (this._isMounted && currentValidation === this._lastValidation) {
             this.setState({ errorMessage } as ITextFieldState);
           }
@@ -542,7 +542,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     }
   }
 
-  private _notifyAfterValidate(value: string | undefined, errorMessage: TextFieldErrorMessage): void {
+  private _notifyAfterValidate(value: string | undefined, errorMessage: string | JSX.Element): void {
     if (this._isMounted && value === this.state.value && this.props.onNotifyValidationResult) {
       this.props.onNotifyValidationResult(errorMessage, value);
     }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -16,7 +16,7 @@ import {
   warnDeprecations,
   warnMutuallyExclusive
 } from '../../Utilities';
-import { ITextField, ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
+import { ITextField, ITextFieldProps, ITextFieldStyleProps, ITextFieldStyles, TextFieldErrorMessage } from './TextField.types';
 
 const getClassNames = classNamesFunction<ITextFieldStyleProps, ITextFieldStyles>();
 
@@ -32,7 +32,7 @@ export interface ITextFieldState {
    * - If there is no validation error or we have not validated the input value, errorMessage is an empty string.
    * - If we have done the validation and there is validation error, errorMessage is the validation error message.
    */
-  errorMessage: string;
+  errorMessage: TextFieldErrorMessage;
 }
 
 const DEFAULT_STATE_VALUE = '';
@@ -418,7 +418,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     return <span style={{ paddingBottom: '1px' }}>{suffix}</span>;
   }
 
-  private get _errorMessage(): string | undefined {
+  private get _errorMessage(): TextFieldErrorMessage | undefined {
     let { errorMessage } = this.state;
     if (!errorMessage && this.props.errorMessage) {
       errorMessage = this.props.errorMessage;
@@ -524,13 +524,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     const result = onGetErrorMessage(value || '');
 
     if (result !== undefined) {
-      if (typeof result === 'string') {
+      if (typeof result === 'string' || !('then' in result)) {
         this.setState({ errorMessage: result } as ITextFieldState);
         this._notifyAfterValidate(value, result);
       } else {
         const currentValidation: number = ++this._lastValidation;
 
-        result.then((errorMessage: string) => {
+        result.then((errorMessage: TextFieldErrorMessage) => {
           if (this._isMounted && currentValidation === this._lastValidation) {
             this.setState({ errorMessage } as ITextFieldState);
           }
@@ -542,7 +542,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     }
   }
 
-  private _notifyAfterValidate(value: string | undefined, errorMessage: string): void {
+  private _notifyAfterValidate(value: string | undefined, errorMessage: TextFieldErrorMessage): void {
     if (this._isMounted && value === this.state.value && this.props.onNotifyValidationResult) {
       this.props.onNotifyValidationResult(errorMessage, value);
     }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -9,7 +9,7 @@ import { resetIds } from '../../Utilities';
 
 import { TextField } from './TextField';
 import { TextFieldBase } from './TextField.base';
-import { ITextFieldStyles, ITextField, TextFieldErrorMessage } from './TextField.types';
+import { ITextFieldStyles, ITextField } from './TextField.types';
 import { mockEvent, renderIntoDocument } from '../../common/testUtilities';
 
 describe('TextField', () => {
@@ -215,7 +215,7 @@ describe('TextField', () => {
       </span>
     );
 
-    function assertErrorMessage(renderedDOM: Element, expectedErrorMessage: TextFieldErrorMessage | boolean): void {
+    function assertErrorMessage(renderedDOM: Element, expectedErrorMessage: string | JSX.Element | boolean): void {
       const errorMessageDOM = renderedDOM.querySelector('[data-automation-id=error-message]');
 
       if (expectedErrorMessage === false) {
@@ -245,7 +245,7 @@ describe('TextField', () => {
     });
 
     it('should render error message when onGetErrorMessage returns a JSX.Element', () => {
-      function validator(value: string): TextFieldErrorMessage {
+      function validator(value: string): string | JSX.Element {
         return value.length > 3 ? errorMessageJSX : '';
       }
 
@@ -277,7 +277,7 @@ describe('TextField', () => {
     });
 
     it('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
-      function validator(value: string): Promise<TextFieldErrorMessage> {
+      function validator(value: string): Promise<string | JSX.Element> {
         return Promise.resolve(value.length > 3 ? errorMessageJSX : '');
       }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -3,12 +3,13 @@ import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import { resetIds } from '../../Utilities';
 
 import { TextField } from './TextField';
 import { TextFieldBase } from './TextField.base';
-import { ITextFieldStyles, ITextField } from './TextField.types';
+import { ITextFieldStyles, ITextField, TextFieldErrorMessage } from './TextField.types';
 import { mockEvent, renderIntoDocument } from '../../common/testUtilities';
 
 describe('TextField', () => {
@@ -206,14 +207,24 @@ describe('TextField', () => {
 
   describe('error message', () => {
     const errorMessage = 'The string is too long, should not exceed 3 characters.';
+    const errorMessageJSX = (
+      <span>
+        The string is too long,
+        <br />
+        should not exceed 3 characters.
+      </span>
+    );
 
-    function assertErrorMessage(renderedDOM: Element, expectedErrorMessage: string | boolean): void {
+    function assertErrorMessage(renderedDOM: Element, expectedErrorMessage: TextFieldErrorMessage | boolean): void {
       const errorMessageDOM = renderedDOM.querySelector('[data-automation-id=error-message]');
 
       if (expectedErrorMessage === false) {
         expect(errorMessageDOM).toBeNull(); // element not exists
-      } else {
+      } else if (typeof expectedErrorMessage === 'string') {
         expect(errorMessageDOM!.textContent).toEqual(expectedErrorMessage);
+      } else if (typeof expectedErrorMessage !== 'boolean') {
+        const xhtml = errorMessageDOM!.innerHTML.replace(/<br>/g, '<br/>');
+        expect(xhtml).toEqual(renderToStaticMarkup(expectedErrorMessage));
       }
     }
 
@@ -233,6 +244,22 @@ describe('TextField', () => {
       return delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
     });
 
+    it('should render error message when onGetErrorMessage returns a JSX.Element', () => {
+      function validator(value: string): TextFieldErrorMessage {
+        return value.length > 3 ? errorMessageJSX : '';
+      }
+
+      const textField = mount(
+        <TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />
+      );
+
+      const inputDOM = textField.getDOMNode().querySelector('input');
+      ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
+
+      // The value is delayed to validate, so it must to query error message after a while.
+      return delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessageJSX));
+    });
+
     it('should render error message when onGetErrorMessage returns a Promise<string>', () => {
       function validator(value: string): Promise<string> {
         return Promise.resolve(value.length > 3 ? errorMessage : '');
@@ -247,6 +274,22 @@ describe('TextField', () => {
 
       // The value is delayed to validate, so it must to query error message after a while.
       return delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessage));
+    });
+
+    it('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
+      function validator(value: string): Promise<TextFieldErrorMessage> {
+        return Promise.resolve(value.length > 3 ? errorMessageJSX : '');
+      }
+
+      const textField = mount(
+        <TextField label="text-field-label" value="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />
+      );
+
+      const inputDOM = textField.getDOMNode().querySelector('input');
+      ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
+
+      // The value is delayed to validate, so it must to query error message after a while.
+      return delay(20).then(() => assertErrorMessage(textField.getDOMNode(), errorMessageJSX));
     });
 
     it('should render error message on first render when onGetErrorMessage returns a string', () => {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -2,6 +2,8 @@ import { IStyle, IStyleSet, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IIconProps } from '../../Icon';
 
+export type TextFieldErrorMessage = string | JSX.Element;
+
 /**
  * {@docCategory TextField}
  */
@@ -166,7 +168,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * change the error message displayed (if any) based on the current value. `errorMessage` and
    * `onGetErrorMessage` are mutually exclusive (`errorMessage` takes precedence).
    */
-  errorMessage?: string;
+  errorMessage?: TextFieldErrorMessage;
 
   /**
    * Callback for when the input value changes.
@@ -192,22 +194,22 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   /**
    * Function called after validation completes.
    */
-  onNotifyValidationResult?: (errorMessage: string, value: string | undefined) => void;
+  onNotifyValidationResult?: (errorMessage: TextFieldErrorMessage, value: string | undefined) => void;
 
   /**
    * Function used to determine whether the input value is valid and get an error message if not.
    * Mutually exclusive with the static string `errorMessage` (it will take precedence over this).
    *
-   * When it returns string:
+   * When it returns TextFieldErrorMessage:
    * - If valid, it returns empty string.
-   * - If invalid, it returns the error message string and the text field will
+   * - If invalid, it returns the error message and the text field will
    *   show a red border and show an error message below the text field.
    *
-   * When it returns Promise<string>:
+   * When it returns Promise<TextFieldErrorMessage>:
    * - The resolved value is displayed as the error message.
    * - If rejected, the value is thrown away.
    */
-  onGetErrorMessage?: (value: string) => string | PromiseLike<string> | undefined;
+  onGetErrorMessage?: (value: string) => TextFieldErrorMessage | PromiseLike<TextFieldErrorMessage> | undefined;
 
   /**
    * Text field will start to validate after users stop typing for `deferredValidationTime` milliseconds.

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -2,8 +2,6 @@ import { IStyle, IStyleSet, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IIconProps } from '../../Icon';
 
-export type TextFieldErrorMessage = string | JSX.Element;
-
 /**
  * {@docCategory TextField}
  */
@@ -168,7 +166,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * change the error message displayed (if any) based on the current value. `errorMessage` and
    * `onGetErrorMessage` are mutually exclusive (`errorMessage` takes precedence).
    */
-  errorMessage?: TextFieldErrorMessage;
+  errorMessage?: string | JSX.Element;
 
   /**
    * Callback for when the input value changes.
@@ -194,22 +192,22 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   /**
    * Function called after validation completes.
    */
-  onNotifyValidationResult?: (errorMessage: TextFieldErrorMessage, value: string | undefined) => void;
+  onNotifyValidationResult?: (errorMessage: string | JSX.Element, value: string | undefined) => void;
 
   /**
    * Function used to determine whether the input value is valid and get an error message if not.
    * Mutually exclusive with the static string `errorMessage` (it will take precedence over this).
    *
-   * When it returns TextFieldErrorMessage:
+   * When it returns string | JSX.Element:
    * - If valid, it returns empty string.
    * - If invalid, it returns the error message and the text field will
    *   show a red border and show an error message below the text field.
    *
-   * When it returns Promise<TextFieldErrorMessage>:
+   * When it returns Promise<string | JSX.Element>:
    * - The resolved value is displayed as the error message.
    * - If rejected, the value is thrown away.
    */
-  onGetErrorMessage?: (value: string) => TextFieldErrorMessage | PromiseLike<TextFieldErrorMessage> | undefined;
+  onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
 
   /**
    * Text field will start to validate after users stop typing for `deferredValidationTime` milliseconds.

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -203,7 +203,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * - If invalid, it returns the error message and the text field will
    *   show a red border and show an error message below the text field.
    *
-   * When it returns Promise<string | JSX.Element>:
+   * When it returns Promise\<string | JSX.Element\>:
    * - The resolved value is displayed as the error message.
    * - If rejected, the value is thrown away.
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add TextField multiple-line errorMessage support by making error msg type accept JSX element as well.

#### Focus areas to test

It should render error message when onGetErrorMessage returns a JSX.Element.
It should render error message when onGetErrorMessage returns a Promise<JSX.Element>.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9080)