### PR TITLE
Fabric 7.0: remove the deprecated API items in ShimmeredDetailsList

### DIFF
--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6410,17 +6410,13 @@ export interface IShimmerColors {
 
 // @public
 export interface IShimmeredDetailsListProps extends IDetailsListProps {
-    // @deprecated
-    detailsListStyles?: IDetailsListProps['styles'];
     enableShimmer?: boolean;
     onRenderCustomPlaceholder?: (rowProps: IDetailsRowProps) => React_2.ReactNode;
     removeFadingOverlay?: boolean;
     shimmerLines?: number;
     // Warning: (ae-forgotten-export) The symbol "IShimmeredDetailsListStyleProps" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "IShimmeredDetailsListStyles" needs to be exported by the entry point index.d.ts
-    // 
-    // @deprecated
-    styles?: IStyleFunctionOrObject<IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>;
+    shimmerOverlayStyles?: IStyleFunctionOrObject<IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>;
 }
 
 // @public

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { BaseComponent, classNamesFunction, css } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { SelectionMode } from '../../utilities/selection/interfaces';
 import { DetailsList } from './DetailsList';
@@ -29,14 +29,13 @@ export class ShimmeredDetailsListBase extends BaseComponent<IShimmeredDetailsLis
 
   public render(): JSX.Element {
     const {
-      detailsListStyles,
       enableShimmer,
       items,
       listProps,
       onRenderCustomPlaceholder,
       removeFadingOverlay,
       shimmerLines,
-      styles,
+      shimmerOverlayStyles: styles,
       theme,
       ...restProps
     } = this.props;
@@ -44,15 +43,13 @@ export class ShimmeredDetailsListBase extends BaseComponent<IShimmeredDetailsLis
     const listClassName = listProps && listProps.className;
 
     this._classNames = getClassNames(styles, {
-      theme: theme!,
-      className: listClassName,
-      enableShimmer
+      theme: theme!
     });
 
     const newListProps = {
       ...listProps,
-      // Adds to the optional listProp className a fading out overlay className only when shimmer enabled.
-      className: enableShimmer && !removeFadingOverlay ? this._classNames.root : listClassName
+      // Adds to the optional listProp className a fading out overlay className only when shimmer enabled and not disabled.
+      className: enableShimmer && !removeFadingOverlay ? css(this._classNames.root, listClassName) : undefined
     };
 
     return (
@@ -61,7 +58,6 @@ export class ShimmeredDetailsListBase extends BaseComponent<IShimmeredDetailsLis
         items={enableShimmer ? this._shimmerItems : items}
         onRenderMissingItem={this._onRenderShimmerPlaceholder}
         listProps={newListProps}
-        styles={detailsListStyles}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.styles.ts
@@ -1,13 +1,13 @@
 import { IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles } from './ShimmeredDetailsList.types';
 
 export const getStyles = (props: IShimmeredDetailsListStyleProps): IShimmeredDetailsListStyles => {
-  const { theme, className, enableShimmer } = props;
+  const { theme } = props;
   const { palette } = theme;
 
   return {
     root: [
       theme.fonts.xSmall,
-      enableShimmer && {
+      {
         selectors: {
           ':after': {
             content: '""',
@@ -19,8 +19,7 @@ export const getStyles = (props: IShimmeredDetailsListStyleProps): IShimmeredDet
             backgroundImage: `linear-gradient(to bottom, transparent 30%, ${palette.whiteTranslucent40} 65%,${palette.white} 100%)`
           }
         }
-      },
-      className
+      }
     ]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.types.ts
@@ -9,14 +9,6 @@ import { IStyleFunctionOrObject } from '../../Utilities';
  */
 export interface IShimmeredDetailsListProps extends IDetailsListProps {
   /**
-   * DetailsList `styles` to pass through.
-   * Due to ShimmeredDetailsList overriding the extended `styles` prop with its own one
-   * we temporary introduce this one slot to allow `DetailsList` styles customization.
-   * @deprecated Will be removed in Fabric 7.0 in favor of `styles` prop that will have its typing adjusted
-   */
-  detailsListStyles?: IDetailsListProps['styles'];
-
-  /**
    * Boolean flag to control when to render placeholders vs real items.
    * It's up to the consumer app to know when fetching of the data is done to toggle this prop.
    */
@@ -36,10 +28,8 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
 
   /**
    * Custom styles to override the styles specific to the ShimmeredDetailsList root area.
-   * To override DetailsList styles, temporary use `detailsListStyles` prop instead.
-   * @deprecated Types will be adjusted in Fabric 7.0 to allow direct pass through of `DetailsList` styles.
    */
-  styles?: IStyleFunctionOrObject<IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>;
+  shimmerOverlayStyles?: IStyleFunctionOrObject<IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>;
 
   /**
    * Number of shimmer placeholder lines to render.
@@ -52,19 +42,7 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
  * Defines props needed to construct styles. This represents the simplified set of immutable things which control the class names.
  * @internal
  */
-export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsListProps, 'theme'>> & {
-  /**
-   * Class name passed to `List` component.
-   * @deprecated In Fabric 7.0 a different logic will be applied to pass the className to `List`.
-   */
-  className?: string;
-
-  /**
-   * Whether the shimmer placeholder is enabled. Used to render a fade-out to bottom overlay over the shimmer placeholders.
-   * @deprecated In Fabric 7.0 a different logic will be applied to control the application of the overlay.
-   */
-  enableShimmer?: boolean;
-};
+export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsListProps, 'theme'>>;
 
 /**
  * Represents the stylable areas of the control.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -31,6 +31,15 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
           min-height: 38px;
           word-break: break-word;
         }
+        &:after {
+          background-image: linear-gradient(to bottom, transparent 30%, rgba(255,255,255,.4) 65%,#ffffff 100%);
+          bottom: 0px;
+          content: "";
+          left: 0px;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
     data-automationid="DetailsList"
     data-is-scrollable="false"
   >
@@ -346,24 +355,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
             role="presentation"
           >
             <div
-              className=
-                  ms-List
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 12px;
-                    font-weight: 400;
-                  }
-                  &:after {
-                    background-image: linear-gradient(to bottom, transparent 30%, rgba(255,255,255,.4) 65%,#ffffff 100%);
-                    bottom: 0px;
-                    content: "";
-                    left: 0px;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                  }
+              className="ms-List"
               role="presentation"
             >
               <div


### PR DESCRIPTION


#### Description of changes

I recently added in current master some deprecation tags in the attempt to fix some issues introduced by css-in-js conversion. Now, I am removing them and cleaning up some code in order to make `ShimmeredDetailsList` a true pass through component.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9086)