### PR TITLE
ShimmedDetailsList: export missing APIs to the surface

### DIFF
--- a/common/changes/office-ui-fabric-react/vibraga-exportsShimmeredDetailsList_2019-05-14-03-05.json
+++ b/common/changes/office-ui-fabric-react/vibraga-exportsShimmeredDetailsList_2019-05-14-03-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ShimmeredDetailsList: export to the surface missing API items.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6681,11 +6681,19 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
     onRenderCustomPlaceholder?: (rowProps: IDetailsRowProps) => React_2.ReactNode;
     removeFadingOverlay?: boolean;
     shimmerLines?: number;
-    // Warning: (ae-forgotten-export) The symbol "IShimmeredDetailsListStyleProps" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "IShimmeredDetailsListStyles" needs to be exported by the entry point index.d.ts
-    // 
     // @deprecated
     styles?: IStyleFunctionOrObject<IShimmeredDetailsListStyleProps, IShimmeredDetailsListStyles>;
+}
+
+// @public
+export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsListProps, 'theme'>> & {
+    className?: string;
+    enableShimmer?: boolean;
+};
+
+// @public
+export interface IShimmeredDetailsListStyles {
+    root: IStyle;
 }
 
 // @public

--- a/packages/office-ui-fabric-react/src/ShimmeredDetailsList.ts
+++ b/packages/office-ui-fabric-react/src/ShimmeredDetailsList.ts
@@ -1,3 +1,3 @@
 export * from './components/DetailsList/ShimmeredDetailsList';
 export * from './components/DetailsList/ShimmeredDetailsList.base';
-export { IShimmeredDetailsListProps } from './components/DetailsList/ShimmeredDetailsList.types';
+export * from './components/DetailsList/ShimmeredDetailsList.types';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.types.ts
@@ -50,7 +50,6 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
 
 /**
  * Defines props needed to construct styles. This represents the simplified set of immutable things which control the class names.
- * @internal
  */
 export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsListProps, 'theme'>> & {
   /**
@@ -68,7 +67,6 @@ export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsLis
 
 /**
  * Represents the stylable areas of the control.
- * @internal
  */
 export interface IShimmeredDetailsListStyles {
   /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.types.ts
@@ -5,7 +5,7 @@ import { IStyleFunctionOrObject } from '../../Utilities';
 
 /**
  * ShimmeredDetailsList props interface
- * {@docCategory ShimmeredDetailsList}
+ * {@docCategory DetailsList}
  */
 export interface IShimmeredDetailsListProps extends IDetailsListProps {
   /**
@@ -50,6 +50,7 @@ export interface IShimmeredDetailsListProps extends IDetailsListProps {
 
 /**
  * Defines props needed to construct styles. This represents the simplified set of immutable things which control the class names.
+ * {@docCategory DetailsList}
  */
 export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsListProps, 'theme'>> & {
   /**
@@ -67,6 +68,7 @@ export type IShimmeredDetailsListStyleProps = Required<Pick<IShimmeredDetailsLis
 
 /**
  * Represents the stylable areas of the control.
+ * {@docCategory DetailsList}
  */
 export interface IShimmeredDetailsListStyles {
   /**


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Exporting to the surface the missing API items for `ShimmeredDetailsList`. Also, changed the `docCategory` tag to `DetailsList`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9087)