### PR TITLE
fabric-website: Fixing type on categories object

### DIFF
--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.pages/Controls/web.tsx
@@ -13,7 +13,7 @@ export interface ICategory {
 // Exporting this object to be used in generating a TOC (table of content) for docs.microsoft documentation repo.
 // Any changes to this object need to be communicated to avoid accidental breaking of the documentation
 // and to allow the appropriate actions to be taken to mitigate this.
-export const categories: { Other?: ICategory; [name: string]: ICategory } = {
+export const categories: { [name: string]: ICategory } = {
   'Basic Inputs': {
     Button: {},
     Checkbox: {},

--- a/common/changes/@uifabric/fabric-website/vibraga-fixTypeInCategories_2019-05-14-07-23.json
+++ b/common/changes/@uifabric/fabric-website/vibraga-fixTypeInCategories_2019-05-14-07-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fixes the type on controls/web categories object.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "vibraga@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes

Using the `categories` object as an import revealed a type error:
`Property 'Other' of type 'ICategory | undefined' is not assignable to string index type 'ICategory'.`
Having an indexer includes the possibility to have the `Other` if needed so I removed the optional `Other` property.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9089)