### PR TITLE
Codeowner updates and other small cleanup changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,8 @@ azure-pipelines.yml @ecraig12345 @kenotron
 
 #### Apps
 # component-demo/
-fabric-website/ @jordandrako
+fabric-website/ @jordandrako @ecraig12345
+fabric-website-resources/ @ecraig12345
 # ssr-tests/
 # test-bundle-button/ @dzearing
 # todo-app/
@@ -43,7 +44,7 @@ fabric-website/ @jordandrako
 packages/charting/ @Raghurk @veeray @chankev
 packages/codepen-loader/ @ecraig12345 @kenotron
 packages/foundation/ @JasonGore
-# packages/example-app-base/
+packages/example-app-base/ @ecraig12345
 packages/file-type-icons/  @KatherineThayerMicrosoft @jahnp @bigbadcapers
 # packages/icons/
 # packages/jest-serializer-merge-styles/
@@ -82,14 +83,14 @@ Checkbox/ @cliffkoh
 ChoiceGroup/ @srideshpande
 CollapsibleSection/ @JasonGore
 ColorPicker/ @ecraig12345
-ComboBox/ @ecraig12345
+ComboBox/ @joschect
 CommandBar/ @micahgodbolt @joschect
 ContextualMenu/ @joschect
 DatePicker/ @OfficeDev/uifabric-calendar
 DetailsList/ @KevinTCoughlin
 Dialog/ @kkjeer
 DocumentCard/ @yiminwu
-Dropdown/ @ecraig12345
+Dropdown/ @joschect
 Fabric/ @dzearing
 FacePile/ @markionium
 FolderCover/ @ThomasMichon
@@ -106,7 +107,7 @@ List/ @KevinTCoughlin
 MarqueeSelection/ @dzearing
 MessageBar/ @ecraig12345
 Modal/ @JasonGore
-Nav/ @jdhuntington
+office-ui-fabric-react/src/components/Nav/ @jdhuntington
 OverflowSet/ @micahgodbolt
 Overlay/ @kkjeer
 Pagination/ @caradong

--- a/apps/dom-tests/src/index.tsx
+++ b/apps/dom-tests/src/index.tsx
@@ -5,6 +5,7 @@ import * as ReactDOM from 'react-dom';
 import { Router, Route } from 'office-ui-fabric-react/lib/utilities/router/index';
 import { setBaseUrl } from 'office-ui-fabric-react/lib/Utilities';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
+import { IRouteProps } from '../../../packages/office-ui-fabric-react/lib/utilities/router/Route';
 
 setBaseUrl('./dist/');
 
@@ -23,15 +24,16 @@ function _onLoad(): void {
 
 function _getRoutes(): JSX.Element[] {
   return require('./pages/pageList')
-    .map((page: string) => {
-      return {
-        component: (require(`./pages/${page}`) as any).default,
-        key: page,
-        name: page,
-        url: `#/${page}`
-      };
-    })
-    .map((page: any) => <Route key={page.key} path={page.url} component={page.component} />);
+    .map(
+      (page: string): IRouteProps => {
+        return {
+          component: require(`./pages/${page}`).default,
+          key: page,
+          path: `#/${page}`
+        };
+      }
+    )
+    .map((page: IRouteProps) => <Route key={page.key} {...page} />);
 }
 
 function _onUnload(): void {

--- a/apps/dom-tests/src/pages/pageList.ts
+++ b/apps/dom-tests/src/pages/pageList.ts
@@ -1,1 +1,2 @@
-module.exports = ['FocusZone.example1'];
+const pages: string[] = ['FocusZone.example1'];
+module.exports = pages;

--- a/apps/dom-tests/src/test/FocusZone.test.dom.ts
+++ b/apps/dom-tests/src/test/FocusZone.test.dom.ts
@@ -1,7 +1,7 @@
 import * as puppeteer from 'puppeteer';
 
 describe('FocusZone', () => {
-  let browser: any;
+  let browser: puppeteer.Browser;
 
   beforeAll(async () => {
     browser = await puppeteer.launch({ headless: true });
@@ -19,9 +19,9 @@ describe('FocusZone', () => {
     // Act
     // 'Nesting FocusZons in list rows'
     const focusZone = await page.$('#fz');
-    await focusZone.focus();
+    await focusZone!.focus();
 
     // Assert
-    expect(await page.$eval('#a', (button: any) => document.activeElement === button));
+    expect(await page.$eval('#a', (button: Element) => document.activeElement === button));
   });
 });

--- a/apps/dom-tests/tslint.json
+++ b/apps/dom-tests/tslint.json
@@ -1,6 +1,4 @@
 {
   "extends": ["@uifabric/tslint-rules"],
-  "rules": {
-    "no-any": false
-  }
+  "rules": {}
 }

--- a/common/changes/@uifabric/example-app-base/website-bugs2_2019-05-14-20-19.json
+++ b/common/changes/@uifabric/example-app-base/website-bugs2_2019-05-14-20-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "PlatformContext: improve types, add displayName",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/PlatformContext.tsx
+++ b/packages/example-app-base/src/utilities/PlatformContext.tsx
@@ -6,12 +6,14 @@ export interface IWithPlatformProps<TPlatforms extends string = string> {
   platform?: TPlatforms;
 }
 
-export function withPlatform<TPlatforms extends string = string>(
-  Component: React.ComponentType
-): React.StatelessComponent<IWithPlatformProps<TPlatforms>> {
-  // tslint:disable-next-line no-any
-  const ComponentWithPlatform = (props: any) => (
+export function withPlatform<
+  TPlatforms extends string = string,
+  TProps extends IWithPlatformProps<TPlatforms> = IWithPlatformProps<TPlatforms>
+>(Component: React.ComponentType<TProps>): React.StatelessComponent<IWithPlatformProps<TPlatforms>> {
+  const ComponentWithPlatform: React.StatelessComponent = (props: TProps & { children?: React.ReactNode }) => (
     <PlatformContext.Consumer>{(platform: string) => <Component {...props} platform={platform} />}</PlatformContext.Consumer>
   );
+  // tslint:disable no-any
+  ComponentWithPlatform.displayName = (Component.displayName || (Component as any).name) + 'WithPlatform';
   return ComponentWithPlatform;
 }

--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -7,7 +7,6 @@ const path = require('path');
 exports.jest = () =>
   jestTask({
     ...(process.env.TF_BUILD && { runInBand: true }),
-    ...(process.env.TF_BUILD || argv().production ? { coverage: true } : undefined),
     ...(argv().u || argv().updateSnapshot ? { updateSnapshot: true } : undefined)
   });
 
@@ -15,7 +14,6 @@ exports.jestWatch = () => {
   const args = argv();
   return jestTask({
     ...(process.env.TF_BUILD && { runInBand: true }),
-    ...(process.env.TF_BUILD || args.production ? { coverage: true } : undefined),
     ...(args.u || args.updateSnapshot ? { updateSnapshot: true } : undefined),
     watch: true,
     _: ['-i', ...(args._ || []).filter(arg => arg !== 'jest-watch')]


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

A few small cleanup-type changes:

- Fix some typings in dom-tests

- Turn off code coverage in PR/prod builds since we don't actually use the data and it slows down the build

- PlatformContext (example-app-base): typing improvements, add `displayName`

- Codeowner updates:
  - Add myself for fabric-website and example-app-base
  - Make path to the Nav that @jdhuntington owns more specific (to avoid capturing the Nav from the website)
  - Transfer ComboBox and Dropdown to @joschect since he's working on the replacement

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9098)