### PR TITLE
Mutually exclusive warnings should not be shown if the prop exists but the value is undefined

### DIFF
--- a/common/changes/@uifabric/utilities/warning.mutually.exclusive.undefined.check_2019-05-15-02-26.json
+++ b/common/changes/@uifabric/utilities/warning.mutually.exclusive.undefined.check_2019-05-15-02-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Mutually exclusive warnings are not displayed if value of the prop is undefined",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "42455391+canmenekse@users.noreply.github.com"
+}

--- a/packages/utilities/src/warn/warn.test.ts
+++ b/packages/utilities/src/warn/warn.test.ts
@@ -55,8 +55,7 @@ describe('warnMutuallyExclusive', () => {
   });
 
   it('does not warn unnecessarily both of them are undefined', () => {
-    // tslint:disable-next-line:no-any
-    warnMutuallyExclusive('Foo', { foo: undefined, bar: undefined }, { foo: 'bar' } as any);
+    warnMutuallyExclusive('Foo', { foo: undefined, bar: undefined }, { foo: 'bar' });
     expect(_lastWarning).toEqual(undefined);
   });
 
@@ -67,38 +66,32 @@ describe('warnMutuallyExclusive', () => {
   });
 
   it('does not warn unnecessarily when the matching prop of the exclusive map is implicitly undefined', () => {
-    // tslint:disable-next-line:no-any
     warnMutuallyExclusive('Foo', { foo: 1 }, { foo: 'bar' });
     expect(_lastWarning).toEqual(undefined);
   });
 
   it('does not warn unnecessarily when both of the props are implicitly undefined ', () => {
-    // tslint:disable-next-line:no-any
-    warnMutuallyExclusive('Foo', {}, {} as any);
+    warnMutuallyExclusive('Foo', {}, {});
     expect(_lastWarning).toEqual(undefined);
   });
 
   it('can warn on mutual exclusive props', () => {
-    // tslint:disable-next-line:no-any
-    warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { foo: 'bar' } as any);
+    warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { foo: 'bar' });
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 
   it('can warn if the exclusive props with the key in the map is null', () => {
-    // tslint:disable-next-line:no-any
-    warnMutuallyExclusive('Foo', { foo: null, bar: 1 }, { foo: 'bar' } as any);
+    warnMutuallyExclusive('Foo', { foo: null, bar: 1 }, { foo: 'bar' });
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 
   it('can warn if the matching key in exclusive map is null', () => {
-    // tslint:disable-next-line:no-any
-    warnMutuallyExclusive('Foo', { foo: 1, bar: null }, { foo: 'bar' } as any);
+    warnMutuallyExclusive('Foo', { foo: 1, bar: null }, { foo: 'bar' });
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 
   it('can warn if both of the exclusive props are null', () => {
-    // tslint:disable-next-line:no-any
-    warnMutuallyExclusive('Foo', { foo: null, bar: null }, { foo: 'bar' } as any);
+    warnMutuallyExclusive('Foo', { foo: null, bar: null }, { foo: 'bar' });
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 });

--- a/packages/utilities/src/warn/warn.test.ts
+++ b/packages/utilities/src/warn/warn.test.ts
@@ -44,7 +44,17 @@ describe('warnMutuallyExclusive', () => {
     expect(_lastWarning).toEqual(undefined);
   });
 
-  it('can warn on mutual exlusive props', () => {
+  it('does not warn unnecessarily when the key of the exclusive map has undefined value in props', () => {
+    warnMutuallyExclusive('Foo', { foo: undefined, bar: 1 }, { foo: 'bar' });
+    expect(_lastWarning).toEqual(undefined);
+  });
+
+  it('does not warn unnecessarily when the matching prop of the exclusive map key has undefined value in props', () => {
+    warnMutuallyExclusive('Foo', { foo: 1, bar: undefined }, { foo: 'bar' });
+    expect(_lastWarning).toEqual(undefined);
+  });
+
+  it('can warn on mutual exclusive props', () => {
     // tslint:disable-next-line:no-any
     warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { foo: 'bar' } as any);
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);

--- a/packages/utilities/src/warn/warn.test.ts
+++ b/packages/utilities/src/warn/warn.test.ts
@@ -54,7 +54,7 @@ describe('warnMutuallyExclusive', () => {
     expect(_lastWarning).toEqual(undefined);
   });
 
-  it('does not warn unnecessarily both of them are undefined', () => {
+  it('does not warn unnecessarily when both of them are explicitly undefined', () => {
     warnMutuallyExclusive('Foo', { foo: undefined, bar: undefined }, { foo: 'bar' });
     expect(_lastWarning).toEqual(undefined);
   });
@@ -90,7 +90,7 @@ describe('warnMutuallyExclusive', () => {
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 
-  it('can warn if both of the exclusive props are null', () => {
+  it('can warn if both of the props are null', () => {
     warnMutuallyExclusive('Foo', { foo: null, bar: null }, { foo: 'bar' });
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });

--- a/packages/utilities/src/warn/warn.test.ts
+++ b/packages/utilities/src/warn/warn.test.ts
@@ -44,19 +44,61 @@ describe('warnMutuallyExclusive', () => {
     expect(_lastWarning).toEqual(undefined);
   });
 
-  it('does not warn unnecessarily when the key of the exclusive map has undefined value in props', () => {
+  it('does not warn unnecessarily when the key of the exclusive map is explicitly undefined', () => {
     warnMutuallyExclusive('Foo', { foo: undefined, bar: 1 }, { foo: 'bar' });
     expect(_lastWarning).toEqual(undefined);
   });
 
-  it('does not warn unnecessarily when the matching prop of the exclusive map key has undefined value in props', () => {
+  it('does not warn unnecessarily when the matching prop of the exclusive map key is explicitly undefined', () => {
     warnMutuallyExclusive('Foo', { foo: 1, bar: undefined }, { foo: 'bar' });
+    expect(_lastWarning).toEqual(undefined);
+  });
+
+  it('does not warn unnecessarily both of them are undefined', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', { foo: undefined, bar: undefined }, { foo: 'bar' } as any);
+    expect(_lastWarning).toEqual(undefined);
+  });
+
+  it('does not warn unnecessarily when the key of the exclusive map is implicitly undefined', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', { bar: 1 }, { foo: 'bar' } as any);
+    expect(_lastWarning).toEqual(undefined);
+  });
+
+  it('does not warn unnecessarily when the matching prop of the exclusive map is implicitly undefined', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', { foo: 1 }, { foo: 'bar' });
+    expect(_lastWarning).toEqual(undefined);
+  });
+
+  it('does not warn unnecessarily when both of the props are implicitly undefined ', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', {}, {} as any);
     expect(_lastWarning).toEqual(undefined);
   });
 
   it('can warn on mutual exclusive props', () => {
     // tslint:disable-next-line:no-any
     warnMutuallyExclusive('Foo', { foo: 1, bar: 1 }, { foo: 'bar' } as any);
+    expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
+  });
+
+  it('can warn if the exclusive props with the key in the map is null', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', { foo: null, bar: 1 }, { foo: 'bar' } as any);
+    expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
+  });
+
+  it('can warn if the matching key in exclusive map is null', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', { foo: 1, bar: null }, { foo: 'bar' } as any);
+    expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
+  });
+
+  it('can warn if both of the exclusive props are null', () => {
+    // tslint:disable-next-line:no-any
+    warnMutuallyExclusive('Foo', { foo: null, bar: null }, { foo: 'bar' } as any);
     expect(_lastWarning).toEqual(`Foo property 'foo' is mutually exclusive with 'bar'. Use one or the other.`);
   });
 });

--- a/packages/utilities/src/warn/warnMutuallyExclusive.ts
+++ b/packages/utilities/src/warn/warnMutuallyExclusive.ts
@@ -10,7 +10,7 @@ import { ISettingsMap, warn } from './warn';
 export function warnMutuallyExclusive<P>(componentName: string, props: P, exclusiveMap: ISettingsMap<P>): void {
   if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
     for (const propName in exclusiveMap) {
-      if (props && propName in props) {
+      if (props && propName in props &&  props[propName] !== undefined) {
         let propInExclusiveMapValue = exclusiveMap[propName];
         if (propInExclusiveMapValue && propInExclusiveMapValue in props) {
           warn(`${componentName} property '${propName}' is mutually exclusive with '${exclusiveMap[propName]}'. Use one or the other.`);

--- a/packages/utilities/src/warn/warnMutuallyExclusive.ts
+++ b/packages/utilities/src/warn/warnMutuallyExclusive.ts
@@ -10,9 +10,9 @@ import { ISettingsMap, warn } from './warn';
 export function warnMutuallyExclusive<P>(componentName: string, props: P, exclusiveMap: ISettingsMap<P>): void {
   if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
     for (const propName in exclusiveMap) {
-      if (props && propName in props &&  props[propName] !== undefined) {
+      if (props && propName in props && props[propName] !== undefined) {
         let propInExclusiveMapValue = exclusiveMap[propName];
-        if (propInExclusiveMapValue && propInExclusiveMapValue in props) {
+        if (propInExclusiveMapValue && props[propInExclusiveMapValue as keyof P] !== undefined) {
           warn(`${componentName} property '${propName}' is mutually exclusive with '${exclusiveMap[propName]}'. Use one or the other.`);
         }
       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Mutually exclusive warnings currently only check the existence of the prop, but not the value of it. This causes unnecessary warnings when extending Fabric Components.

Here is an example of such a problem : [https://codepen.io/anon/pen/BepLGr](https://codepen.io/anon/pen/BepLGr)

Although undefined is passed to the SelectedKey, we still get a warning on the console about SelectedKey & DefaultSelectedKey being not mutually exclusive.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9103)