### PR TITLE
Update file type icons to use new Fluent assets by default

### DIFF
--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types-fluent/';
 const ICON_SIZES: number[] = [16, 20, 32, 40, 48, 64, 96];
 
 // Due to CDN cache, images updated in place may take up to a year to appear for some users


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9090
- [ ] Include a change request file using `$ npm run change`
  - Not done yet–need to determine version-bumping approach.

#### Description of changes
This PR updates the file type icons to use new Fluent assets by default. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9104)