### PR TITLE
Update file type icons README with note about opting in to the Fluent assets

### DIFF
--- a/common/changes/@uifabric/file-type-icons/jahnp-update-file-type-icons-readme_2019-05-15-04-00.json
+++ b/common/changes/@uifabric/file-type-icons/jahnp-update-file-type-icons-readme_2019-05-15-04-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Update README with note about how to use the new Fluent file type icons",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "pejahn@microsoft.com"
+}

--- a/packages/file-type-icons/README.md
+++ b/packages/file-type-icons/README.md
@@ -29,6 +29,16 @@ import { getFileTypeIconProps } from '@uifabric/file-type-icons';
 <Icon {...getFileTypeIconProps({extension: 'docx', size: 16}) />
 ```
 
+# Fluent file type icons
+
+You can use the new Fluent file type icons as they become available by passing the following path to `initializeFileTypeIcons`:
+
+```tsx
+initializeFileTypeIcons('https://spoprod-a.akamaihd.net/files/fabric/assets/item-types-fluent/');
+```
+
+In Fabric 7, the new Fluent file type icons will be the default.
+
 # Notes
 
 See [Office UI Fabric React](http://github.com/OfficeDev/office-ui-fabric-react) for more details on the UI Fabric project and packages within.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9090
- [x] Include a change request file using `$ npm run change`

#### Description of changes
This PR targets **Fabric 6** and provides a note in the `file-type-icons` README about how to opt in to using the new Fluent-style file type icons.

In **Fabric 7**, those assets will be the default, which is why the code change is captured in #9104 but this README change is not–as it won't make sense for Fabric 7 users.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9105)