### PR TITLE
Minor website code and codeowner updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@ azure-pipelines.yml @ecraig12345 @kenotron
 
 #### Apps
 # component-demo/
-fabric-website/ @jordandrako @ecraig12345
+fabric-website/ @jordandrako @ecraig12345 @Jahnp
 fabric-website-resources/ @ecraig12345
 # ssr-tests/
 # test-bundle-button/ @dzearing
@@ -45,7 +45,7 @@ Controls/web.tsx @Vitalius1 @natalieethell
 packages/charting/ @Raghurk @veeray @chankev
 packages/codepen-loader/ @ecraig12345 @kenotron
 packages/foundation/ @JasonGore
-packages/example-app-base/ @ecraig12345
+packages/example-app-base/ @ecraig12345 @jordandrako
 packages/file-type-icons/  @KatherineThayerMicrosoft @jahnp @bigbadcapers
 # packages/icons/
 # packages/jest-serializer-merge-styles/

--- a/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
@@ -48,6 +48,7 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
   const beforeAlt = beforeColorObj && getShade(beforeColorObj, Shade.Shade6).str;
   const afterColorObj = afterColor && getColorFromString(afterColor);
   const afterAlt = afterColorObj && getShade(afterColorObj, Shade.Shade6).str;
+  const textColor = isInverted ? palette.white : palette.black;
 
   const sectionAnimation: IStyle = [
     {
@@ -139,7 +140,7 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
 
         selectors: {
           p: {
-            color: isInverted ? palette.black : palette.white
+            color: textColor
           }
         }
       }
@@ -395,12 +396,13 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
         fontFamily: monoFont,
         display: 'flex',
         alignItems: 'center',
-        color: 'inherit',
+        color: textColor,
 
         selectors: {
-          '&:hover, &:active, &:active:hover': {
+          // Override default link styles and UHF styles
+          '&:hover, &:active, &:active:hover, &:link': {
             textDecoration: 'none',
-            color: 'inherit'
+            color: textColor
           },
 
           [`

--- a/common/changes/@uifabric/example-app-base/website-codeowners_2019-05-15-05-55.json
+++ b/common/changes/@uifabric/example-app-base/website-codeowners_2019-05-15-05-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Update withPlatform return type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/website-codeowners_2019-05-15-06-12.json
+++ b/common/changes/@uifabric/fabric-website/website-codeowners_2019-05-15-06-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix home page card link color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/PlatformContext.tsx
+++ b/packages/example-app-base/src/utilities/PlatformContext.tsx
@@ -9,7 +9,7 @@ export interface IWithPlatformProps<TPlatforms extends string = string> {
 export function withPlatform<
   TPlatforms extends string = string,
   TProps extends IWithPlatformProps<TPlatforms> = IWithPlatformProps<TPlatforms>
->(Component: React.ComponentType<TProps>): React.StatelessComponent<IWithPlatformProps<TPlatforms>> {
+>(Component: React.ComponentType<TProps>): React.StatelessComponent<TProps> {
   const ComponentWithPlatform: React.StatelessComponent = (props: TProps & { children?: React.ReactNode }) => (
     <PlatformContext.Consumer>{(platform: string) => <Component {...props} platform={platform} />}</PlatformContext.Consumer>
   );


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add additional codeowners as requested on #9098 (which auto-merged before I saw the comments).

Update example-app-base `withPlatform` to return `React.StatelessComponent<TProps>`.

Fix link colors on home page: the links were showing up light gray instead of black (seemingly due to UHF styles), which resulted in a non-accessible color combination.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9107)