### PR TITLE
Fabric Website: Add section under "Developer resources" with link to versioned release notes and demos

### DIFF
--- a/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
+++ b/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
@@ -9,7 +9,7 @@ Get started with React and learn how to build your first projects.
 
 ### Release notes and demos
 
-View Fabric's versioned release notes and component demos.
+View Fabric React's versioned release notes and component demos.
 
 <ul class="md-list--flex">
   <li class="mdut--full">[Release notes and demos](https://aka.ms/FabricDemo)</li>

--- a/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
+++ b/apps/fabric-website/src/pages/Overviews/ResourcesPage/docs/default/ResourcesDeveloperResources.md
@@ -7,6 +7,14 @@ Get started with React and learn how to build your first projects.
   <li class="mdut--full">[Fabric React tutorial](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Getting-Started-with-UI-Fabric)</li>
 </ul>
 
+### Release notes and demos
+
+View Fabric's versioned release notes and component demos.
+
+<ul class="md-list--flex">
+  <li class="mdut--full">[Release notes and demos](https://aka.ms/FabricDemo)</li>
+</ul>
+
 <h3 id="sharepoint-framework-dev">SharePoint Framework</h3>
 
 SharePoint uses Fabric, so if you’re building on top of or within a SharePoint experience, you can be sure that your UI will blend in.

--- a/common/changes/@uifabric/fabric-website/keco-release-notes-link_2019-05-15-22-25.json
+++ b/common/changes/@uifabric/fabric-website/keco-release-notes-link_2019-05-15-22-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Add versioned release notes and demo section",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds section under "Developer resources" which links to https://aka.ms/FabricDemo. We want to use this section to educate third-party developers, specifically SharePoint developers about:

1. Versioned release notes
1. Versioned component demos
1. Versioned TypeScript compatibility (Coming soon to https://aka.ms/FabricDemo)

I defer to area owners re: page structure and language. I can clump under a different section if deemed appropriate.

Also whether or not we use aka.ms link vs absolute. The current aka.ms vanity URL is a bit confusing so I can see us preferring absolute URL if we bless this.

#### Focus areas to test

![image](https://user-images.githubusercontent.com/706967/57813809-4b760880-7726-11e9-9e23-d2dae83608f1.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9112)