### PR TITLE
[DatePicker] keep validation errors after noop

### DIFF
--- a/common/changes/@uifabric/date-time/fix-date-picker-9050_2019-05-17-21-54.json
+++ b/common/changes/@uifabric/date-time/fix-date-picker-9050_2019-05-17-21-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "DatePicker: keep validation errors after noop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "jdh@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fix-date-picker-9050_2019-05-15-22-26.json
+++ b/common/changes/office-ui-fabric-react/fix-date-picker-9050_2019-05-15-22-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DatePicker: keep validation errors after noop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -168,7 +168,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       calendarAs: CalendarType = Calendar,
       tabIndex
     } = this.props;
-    const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
+    const { isDatePickerShown, formattedDate, selectedDate } = this.state;
 
     const classNames = getClassNames(styles, {
       theme: theme!,
@@ -197,7 +197,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             aria-controls={isDatePickerShown ? calloutId : undefined}
             required={isRequired}
             disabled={disabled}
-            errorMessage={errorMessage}
+            errorMessage={this._getErrorMessage()}
             placeholder={placeholder}
             borderless={borderless}
             value={formattedDate}
@@ -388,8 +388,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     if (!this.state.isDatePickerShown) {
       this._preventFocusOpeningPicker = true;
       this.setState({
-        isDatePickerShown: true,
-        errorMessage: ''
+        isDatePickerShown: true
       });
     }
   }
@@ -509,5 +508,12 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
   private _isDateOutOfBounds(date: Date, minDate?: Date, maxDate?: Date): boolean {
     return (!!minDate && compareDatePart(minDate!, date) > 0) || (!!maxDate && compareDatePart(maxDate!, date) < 0);
+  }
+
+  private _getErrorMessage(): string | undefined {
+    if (this.state.isDatePickerShown) {
+      return undefined;
+    }
+    return this.state.errorMessage;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -163,7 +163,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       calendarAs: CalendarType = Calendar,
       tabIndex
     } = this.props;
-    const { isDatePickerShown, formattedDate, selectedDate, errorMessage } = this.state;
+    const { isDatePickerShown, formattedDate, selectedDate } = this.state;
 
     const classNames = getClassNames(styles, {
       theme: theme!,
@@ -192,7 +192,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             aria-controls={isDatePickerShown ? calloutId : undefined}
             required={isRequired}
             disabled={disabled}
-            errorMessage={errorMessage}
+            errorMessage={this._getErrorMessage()}
             placeholder={placeholder}
             borderless={borderless}
             value={formattedDate}
@@ -383,8 +383,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     if (!this.state.isDatePickerShown) {
       this._preventFocusOpeningPicker = true;
       this.setState({
-        isDatePickerShown: true,
-        errorMessage: ''
+        isDatePickerShown: true
       });
     }
   }
@@ -506,5 +505,12 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
   private _isDateOutOfBounds(date: Date, minDate?: Date, maxDate?: Date): boolean {
     return (!!minDate && compareDatePart(minDate!, date) > 0) || (!!maxDate && compareDatePart(maxDate!, date) < 0);
+  }
+
+  private _getErrorMessage(): string | undefined {
+    if (this.state.isDatePickerShown) {
+      return undefined;
+    }
+    return this.state.errorMessage;
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9050
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When focusing on a date time picker, the error message is cleared in order to give a clean experience. However, the dates are not re-parsed in case there are difficulties with the formatting. This change makes error messages conditionally render only when the picker is not open.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9113)