### PR TITLE
Fix button page imports

### DIFF
--- a/apps/fabric-website/src/pages/Controls/ButtonPage/ButtonPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ButtonPage/ButtonPage.tsx
@@ -3,8 +3,8 @@ import { Checkbox } from 'office-ui-fabric-react';
 import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
 import { ButtonPageProps } from './ButtonPage.doc';
 import * as exampleStylesImport from 'office-ui-fabric-react/lib/common/_exampleStyles.scss';
-import { Platforms } from 'src/interfaces/Platforms';
-import { IPageSectionProps, Markdown } from '../../../../../../packages/example-app-base/lib/index2';
+import { Platforms } from '../../../interfaces/Platforms';
+import { IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 
 const exampleStyles: any = exampleStylesImport;
 const baseUrl = 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/apps/fabric-website/src/pages/Controls/ButtonPage/';
@@ -50,10 +50,10 @@ export class ButtonPage extends React.Component<
     return (
       <ControlsAreaPage
         {...this.props}
+        title="Button"
         {...buttonPageProps[this.props.platform]}
         exampleKnobs={this.renderKnobs()}
         otherSections={this._otherSections(this.props.platform)}
-        title="Button"
       />
     );
   }

--- a/common/changes/@uifabric/fabric-website/fix-button-page_2019-05-16-00-02.json
+++ b/common/changes/@uifabric/fabric-website/fix-button-page_2019-05-16-00-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix Button page imports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "v-jojanz@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

I noticed the Button page had relative imports to example-app-base and that would break importing this page from the package.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9115)