### PR TITLE
Update ColorPicker thumb style

### DIFF
--- a/common/changes/@uifabric/fluent-theme/anihan-color-picker-thumb_2019-05-16-00-39.json
+++ b/common/changes/@uifabric/fluent-theme/anihan-color-picker-thumb_2019-05-16-00-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Update ColorPicker thumb style",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -48,8 +48,7 @@ export const ColorRectangleStyles = (props: IColorRectangleStyleProps): Partial<
       borderRadius: effects.roundedCorner2
     },
     thumb: {
-      borderColor: palette.neutralTertiary,
-      boxShadow: effects.elevation8
+      boxShadow: effects.elevation16
     }
   };
 };
@@ -64,7 +63,7 @@ export const ColorSliderStyles = (props: IColorSliderStyleProps): Partial<IColor
       marginBottom: 8
     },
     sliderThumb: {
-      borderColor: palette.neutralTertiary,
+      borderColor: palette.neutralSecondaryAlt,
       boxShadow: effects.elevation8
     }
   };

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -48,7 +48,7 @@ export const ColorRectangleStyles = (props: IColorRectangleStyleProps): Partial<
       borderRadius: effects.roundedCorner2
     },
     thumb: {
-      boxShadow: effects.elevation16
+      boxShadow: effects.elevation8
     }
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8917
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Remove border color of thumb in the color rectangle to fall back to `white`.
- Update border color of slider thumb to `neutralSecondaryAlt`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9116)