### PR TITLE
Fixes the fabric-website deployment baseCDNUrl

### DIFF
--- a/apps/fabric-website/scripts/createFlightConfig.js
+++ b/apps/fabric-website/scripts/createFlightConfig.js
@@ -48,7 +48,7 @@ module.exports.createPublicFlightConfigTask = function() {
 
     let configData = {
       version: process.env.BUILD_BUILDNUMBER || '0',
-      baseCDNUrl: path.join(argv().baseCDNUrl, process.env.BUILD_BUILDNUMBER) + '/',
+      baseCDNUrl: argv().baseCDNUrl,
       buildName: process.env.BUILD_DEFINITIONNAME || 'localbuild',
       createdDate: today
     };

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -88,7 +88,7 @@ steps:
     displayName: 'Publish Artifact: oufr-version.txt'
 
   - script: |
-      npm run create-public-flight-config -- --baseCDNUrl https://fabricweb.azureedge.net/fabric-website/
+      npm run create-public-flight-config -- --baseCDNUrl https://fabricweb.azureedge.net/fabric-website/$(Build.BuildNumber)/
     workingDirectory: apps/fabric-website
     displayName: 'Generate Fabric Website Flight Manifest Files'
 

--- a/common/changes/@uifabric/fabric-website/buildnum_2019-05-16-16-32.json
+++ b/common/changes/@uifabric/fabric-website/buildnum_2019-05-16-16-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "fixed the way it creates a flight baseCDNUrl",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9121
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

There was an issue with the fabric baseCDNUrl that came up where the `path.join` ate one of the `/`'s

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9123)