### PR TITLE
Add a new prop to enable Slider origin from zero

### DIFF
--- a/common/changes/office-ui-fabric-react/anihan-slider-prop_2019-05-17-00-23.json
+++ b/common/changes/office-ui-fabric-react/anihan-slider-prop_2019-05-17-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add a new prop to enable Slider origin from zero",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6848,6 +6848,7 @@ export interface ISliderProps extends React.ClassAttributes<SliderBase> {
     min?: number;
     onChange?: (value: number) => void;
     onChanged?: (event: MouseEvent | TouchEvent, value: number) => void;
+    originFromZero?: boolean;
     showValue?: boolean;
     step?: number;
     styles?: IStyleFunctionOrObject<ISliderStyleProps, ISliderStyles>;
@@ -6894,6 +6895,8 @@ export interface ISliderStyles {
     titleLabel: IStyle;
     // (undocumented)
     valueLabel: IStyle;
+    // (undocumented)
+    zeroTick: IStyle;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6875,27 +6875,16 @@ export type ISliderStyleProps = Required<Pick<ISliderProps, 'theme'>> & Pick<ISl
 
 // @public (undocumented)
 export interface ISliderStyles {
-    // (undocumented)
     activeSection: IStyle;
-    // (undocumented)
     container: IStyle;
-    // (undocumented)
     inactiveSection: IStyle;
-    // (undocumented)
     line: IStyle;
-    // (undocumented)
     lineContainer: IStyle;
-    // (undocumented)
     root: IStyle;
-    // (undocumented)
     slideBox: IStyle;
-    // (undocumented)
     thumb: IStyle;
-    // (undocumented)
     titleLabel: IStyle;
-    // (undocumented)
     valueLabel: IStyle;
-    // (undocumented)
     zeroTick: IStyle;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -129,7 +129,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
               )}
               <span ref={this._thumb} className={classNames.thumb} style={this._getStyleUsingOffsetPercent(vertical, thumbOffsetPercent)} />
               {originFromZero ? (
-                <React.Fragment>
+                <>
                   <span
                     className={css(classNames.lineContainer, classNames.inactiveSection)}
                     style={{ [lengthString]: Math.min(thumbOffsetPercent, zeroOffsetPercent) + '%' }}
@@ -142,9 +142,9 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
                     className={css(classNames.lineContainer, classNames.inactiveSection)}
                     style={{ [lengthString]: Math.min(100 - thumbOffsetPercent, 100 - zeroOffsetPercent) + '%' }}
                   />
-                </React.Fragment>
+                </>
               ) : (
-                <React.Fragment>
+                <>
                   <span
                     className={css(classNames.lineContainer, classNames.activeSection)}
                     style={{ [lengthString]: thumbOffsetPercent + '%' }}
@@ -153,7 +153,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
                     className={css(classNames.lineContainer, classNames.inactiveSection)}
                     style={{ [lengthString]: 100 - thumbOffsetPercent + '%' }}
                   />
-                </React.Fragment>
+                </>
               )}
             </div>
           </div>

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -16,7 +16,8 @@ const GlobalClassNames = {
   inactiveSection: 'ms-Slider-inactive',
   valueLabel: 'ms-Slider-value',
   showValue: 'ms-Slider-showValue',
-  showTransitions: 'ms-Slider-showTransitions'
+  showTransitions: 'ms-Slider-showTransitions',
+  zeroTick: 'ms-Slider-zeroTick'
 };
 
 export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
@@ -46,6 +47,15 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
     selectors: {
       [HighContrastSelector]: {
         borderColor: 'Highlight'
+      }
+    }
+  };
+
+  const slideBoxActiveZeroTickStyles = !props.disabled && {
+    backgroundColor: theme.palette.themeLight,
+    selectors: {
+      [HighContrastSelector]: {
+        backgroundColor: 'Highlight'
       }
     }
   };
@@ -103,6 +113,8 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
           ':hover $inactiveSection': slideBoxInactiveSectionStyles,
           ':active $thumb': slideBoxActiveThumbStyles,
           ':hover $thumb': slideBoxActiveThumbStyles,
+          ':active $zeroTick': slideBoxActiveZeroTickStyles,
+          ':hover $zeroTick': slideBoxActiveZeroTickStyles,
           $thumb: [
             {
               borderWidth: 2,
@@ -230,11 +242,41 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
         background: theme.palette.neutralLight,
         selectors: {
           [HighContrastSelector]: {
-            backgroundColor: 'GrayText',
             borderColor: 'GrayText'
           }
         }
       }
+    ],
+    zeroTick: [
+      classNames.zeroTick,
+      {
+        position: 'absolute',
+        background: theme.palette.neutralTertiaryAlt,
+        selectors: {
+          [HighContrastSelector]: {
+            backgroundColor: 'WindowText'
+          }
+        }
+      },
+      props.disabled && {
+        background: theme.palette.neutralLight,
+        selectors: {
+          [HighContrastSelector]: {
+            backgroundColor: 'GrayText'
+          }
+        }
+      },
+      props.vertical
+        ? {
+            width: '16px',
+            height: '1px',
+            transform: getRTL() ? 'translateX(6px)' : 'translateX(-6px)'
+          }
+        : {
+            width: '1px',
+            height: '16px',
+            transform: 'translateY(-6px)'
+          }
     ],
     valueLabel: [
       classNames.valueLabel,

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
@@ -117,6 +117,12 @@ export interface ISliderProps extends React.ClassAttributes<SliderBase> {
    * Optional function to format the slider value.
    */
   valueFormat?: (value: number) => string;
+
+  /**
+   * Optional flag to attach the origin of slider to zero. Helpful when the range include negatives.
+   * @defaultvalue false
+   */
+  originFromZero?: boolean;
 }
 
 /**
@@ -143,4 +149,5 @@ export interface ISliderStyles {
   activeSection: IStyle;
   inactiveSection: IStyle;
   valueLabel: IStyle;
+  zeroTick: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
@@ -139,15 +139,58 @@ export type ISliderStyleProps = Required<Pick<ISliderProps, 'theme'>> &
  * {@docCategory Slider}
  */
 export interface ISliderStyles {
+  /**
+   * Style set for the root element.
+   */
   root: IStyle;
+
+  /**
+   * Style set for the title label above the slider.
+   */
   titleLabel: IStyle;
+
+  /**
+   * Style set for the container of the slider.
+   */
   container: IStyle;
+
+  /**
+   * Style set for the actual box containting interactive elements of the slider.
+   */
   slideBox: IStyle;
+
+  /**
+   * Style set for element that contains all the lines.
+   */
   line: IStyle;
+
+  /**
+   * Style set for thumb of the slider.
+   */
   thumb: IStyle;
+
+  /**
+   * Style set for both active and inactive sections of the line.
+   */
   lineContainer: IStyle;
+
+  /**
+   * Style set for active portion of the line.
+   */
   activeSection: IStyle;
+
+  /**
+   * Style set for inactive portion of the line.
+   */
   inactiveSection: IStyle;
+
+  /**
+   * Style set for value label on right/below of the slider.
+   */
   valueLabel: IStyle;
+
+  /**
+   * Style set for tick on 0 on number line. This element only shows up when originFromZero prop is true.
+   */
   zeroTick: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -128,6 +128,18 @@ exports[`Slider renders correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover $thumb {
             border-color: Highlight;
           }
+          &:active $zeroTick {
+            background-color: #c7e0f4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+            background-color: Highlight;
+          }
+          &:hover $zeroTick {
+            background-color: #c7e0f4;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+            background-color: Highlight;
+          }
           & $thumb {
             background: #ffffff;
             border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/Slider/examples/Slider.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/examples/Slider.Basic.Example.tsx
@@ -33,6 +33,7 @@ export class SliderBasicExample extends React.Component<{}, ISliderBasicExampleS
           showValue={true}
         />
         <Slider label="Example with formatted value" max={100} valueFormat={(value: number) => `${value}%`} showValue={true} />
+        <Slider label="Origin from zero" min={-5} max={5} step={1} defaultValue={2} showValue originFromZero />
       </Stack>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Slider/examples/Slider.Vertical.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/examples/Slider.Vertical.Example.tsx
@@ -44,6 +44,16 @@ export const SliderVerticalExample: React.StatelessComponent = () => {
         showValue
         vertical
       />
+      <Slider // prettier-ignore
+        label="Origin from zero"
+        min={-5}
+        max={15}
+        step={1}
+        defaultValue={5}
+        showValue
+        vertical
+        originFromZero
+      />
     </Stack>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -278,6 +278,18 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
               @media screen and (-ms-high-contrast: active){&:hover $thumb {
                 border-color: Highlight;
               }
+              &:active $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                background-color: Highlight;
+              }
+              &:hover $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                background-color: Highlight;
+              }
               & $thumb {
                 background: #ffffff;
                 border-color: #666666;
@@ -522,6 +534,18 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
               }
               @media screen and (-ms-high-contrast: active){&:hover $thumb {
                 border-color: Highlight;
+              }
+              &:active $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                background-color: Highlight;
+              }
+              &:hover $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                background-color: Highlight;
               }
               & $thumb {
                 background: #ffffff;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-479:hover + .headerDividerBar-480 {
+      & .headerDivider-480:hover + .headerDividerBar-481 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -596,6 +596,18 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover $thumb {
                 border-color: Highlight;
               }
+              &:active $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                background-color: Highlight;
+              }
+              &:hover $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                background-color: Highlight;
+              }
               & $thumb {
                 background: #ffffff;
                 border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -790,6 +790,18 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               @media screen and (-ms-high-contrast: active){&:hover $thumb {
                 border-color: Highlight;
               }
+              &:active $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                background-color: Highlight;
+              }
+              &:hover $zeroTick {
+                background-color: #c7e0f4;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                background-color: Highlight;
+              }
               & $thumb {
                 background: #ffffff;
                 border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -150,6 +150,18 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;
@@ -433,7 +445,6 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active){& {
-                  background-color: GrayText;
                   border-color: GrayText;
                   border: 1px solid WindowText;
                 }
@@ -605,6 +616,18 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
+            }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
             }
             & $thumb {
               background: #ffffff;
@@ -851,6 +874,18 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;
@@ -966,6 +1001,299 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             }
       >
         0%
+      </label>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Slider
+        ms-Slider-enabled
+        ms-Slider-row
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          user-select: none;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            word-wrap: break-word;
+          }
+      htmlFor="Slider4"
+    >
+      Origin from zero
+    </label>
+    <div
+      className=
+          ms-Slider-container
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+          }
+    >
+      <div
+        aria-disabled={false}
+        aria-label="Origin from zero"
+        aria-valuemax={5}
+        aria-valuemin={-5}
+        aria-valuenow={2}
+        className=
+            ms-Slider-slideBox
+            ms-Slider-showValue
+            ms-Slider-showTransitions
+            {
+              align-items: center;
+              background: transparent;
+              border: none;
+              display: flex;
+              flex-grow: 1;
+              height: 28px;
+              line-height: 28px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              width: auto;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:active $activeSection {
+              background-color: #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $activeSection {
+              background-color: Highlight;
+            }
+            &:hover $activeSection {
+              background-color: #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $activeSection {
+              background-color: Highlight;
+            }
+            &:active $inactiveSection {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $inactiveSection {
+              border-color: Highlight;
+            }
+            &:hover $inactiveSection {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $inactiveSection {
+              border-color: Highlight;
+            }
+            &:active $thumb {
+              border: 2px solid #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $thumb {
+              border-color: Highlight;
+            }
+            &:hover $thumb {
+              border: 2px solid #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $thumb {
+              border-color: Highlight;
+            }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
+            & $thumb {
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 10px;
+              border-style: solid;
+              border-width: 2px;
+              box-sizing: border-box;
+              display: block;
+              height: 16px;
+              position: absolute;
+              top: -6px;
+              transform: translateX(-50%);
+              transition: left 0.367s cubic-bezier(.1,.9,.2,1);
+              width: 16px;
+            }
+        data-is-focusable={true}
+        id="Slider4"
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+        role="slider"
+        tabIndex={0}
+      >
+        <div
+          className=
+              ms-Slider-line
+              {
+                display: flex;
+                position: relative;
+                width: 100%;
+              }
+              & $lineContainer {
+                border-radius: 4px;
+                box-sizing: border-box;
+                height: 4px;
+                width: 100%;
+              }
+        >
+          <span
+            className=
+                ms-Slider-zeroTick
+                {
+                  background: #c8c8c8;
+                  height: 16px;
+                  position: absolute;
+                  transform: translateY(-6px);
+                  width: 1px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: WindowText;
+                }
+            style={
+              Object {
+                "left": "50%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-thumb
+
+            style={
+              Object {
+                "left": "70%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-inactive
+
+                {
+                  background: #c8c8c8;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: 1px solid WindowText;
+                }
+            style={
+              Object {
+                "width": "50%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-active
+
+                {
+                  background: #666666;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: WindowText;
+                }
+            style={
+              Object {
+                "width": "20%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-inactive
+
+                {
+                  background: #c8c8c8;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: 1px solid WindowText;
+                }
+            style={
+              Object {
+                "width": "30%",
+              }
+            }
+          />
+        </div>
+      </div>
+      <label
+        className=
+            ms-Label
+            ms-Slider-value
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              flex-shrink: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              line-height: 1;
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              white-space: nowrap;
+              width: 40px;
+              word-wrap: break-word;
+            }
+      >
+        2
       </label>
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
@@ -157,6 +157,18 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;
@@ -468,7 +480,6 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
                   transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                 }
                 @media screen and (-ms-high-contrast: active){& {
-                  background-color: GrayText;
                   border-color: GrayText;
                   border: 1px solid WindowText;
                 }
@@ -648,6 +659,18 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             }
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
+            }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
             }
             & $thumb {
               background: #ffffff;
@@ -912,6 +935,18 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;
@@ -1037,6 +1072,317 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             }
       >
         0%
+      </label>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Slider
+        ms-Slider-enabled
+        ms-Slider-column
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-right: 8px;
+          user-select: none;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            word-wrap: break-word;
+          }
+      htmlFor="Slider4"
+    >
+      Origin from zero
+    </label>
+    <div
+      className=
+          ms-Slider-container
+          {
+            align-items: center;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: nowrap;
+            height: 100%;
+            margin-bottom: 8px;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 8px;
+            text-align: center;
+          }
+    >
+      <div
+        aria-disabled={false}
+        aria-label="Origin from zero"
+        aria-valuemax={15}
+        aria-valuemin={-5}
+        aria-valuenow={5}
+        className=
+            ms-Slider-slideBox
+            ms-Slider-showValue
+            ms-Slider-showTransitions
+            {
+              align-items: center;
+              background: transparent;
+              border: none;
+              display: flex;
+              flex-grow: 1;
+              height: 100%;
+              line-height: 28px;
+              outline: transparent;
+              padding-bottom: 8px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 8px;
+              position: relative;
+              width: 28px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: 1px;
+              content: "";
+              left: 1px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: 1px;
+              top: 1px;
+              z-index: 1;
+            }
+            &:active $activeSection {
+              background-color: #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $activeSection {
+              background-color: Highlight;
+            }
+            &:hover $activeSection {
+              background-color: #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $activeSection {
+              background-color: Highlight;
+            }
+            &:active $inactiveSection {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $inactiveSection {
+              border-color: Highlight;
+            }
+            &:hover $inactiveSection {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $inactiveSection {
+              border-color: Highlight;
+            }
+            &:active $thumb {
+              border: 2px solid #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $thumb {
+              border-color: Highlight;
+            }
+            &:hover $thumb {
+              border: 2px solid #0078d4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $thumb {
+              border-color: Highlight;
+            }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
+            & $thumb {
+              background: #ffffff;
+              border-color: #666666;
+              border-radius: 10px;
+              border-style: solid;
+              border-width: 2px;
+              box-sizing: border-box;
+              display: block;
+              height: 16px;
+              left: -6px;
+              margin-bottom: 0;
+              margin-left: auto;
+              margin-right: auto;
+              margin-top: 0;
+              position: absolute;
+              transform: translateY(8px);
+              transition: left 0.367s cubic-bezier(.1,.9,.2,1);
+              width: 16px;
+            }
+        data-is-focusable={true}
+        id="Slider4"
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+        role="slider"
+        tabIndex={0}
+      >
+        <div
+          className=
+              ms-Slider-line
+              {
+                display: flex;
+                flex-direction: column-reverse;
+                height: 100%;
+                margin-bottom: 0;
+                margin-left: auto;
+                margin-right: auto;
+                margin-top: 0;
+                position: relative;
+                width: 4px;
+              }
+              & $lineContainer {
+                border-radius: 4px;
+                box-sizing: border-box;
+                height: 100%;
+                width: 4px;
+              }
+        >
+          <span
+            className=
+                ms-Slider-zeroTick
+                {
+                  background: #c8c8c8;
+                  height: 1px;
+                  position: absolute;
+                  transform: translateX(-6px);
+                  width: 16px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: WindowText;
+                }
+            style={
+              Object {
+                "bottom": "25%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-thumb
+
+            style={
+              Object {
+                "bottom": "50%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-inactive
+
+                {
+                  background: #c8c8c8;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: 1px solid WindowText;
+                }
+            style={
+              Object {
+                "height": "25%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-active
+
+                {
+                  background: #666666;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: WindowText;
+                }
+            style={
+              Object {
+                "height": "25%",
+              }
+            }
+          />
+          <span
+            className=
+                ms-Slider-inactive
+
+                {
+                  background: #c8c8c8;
+                  transition: width 0.367s cubic-bezier(.1,.9,.2,1);
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: 1px solid WindowText;
+                }
+            style={
+              Object {
+                "height": "50%",
+              }
+            }
+          />
+        </div>
+      </div>
+      <label
+        className=
+            ms-Label
+            ms-Slider-value
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              flex-shrink: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              line-height: 1;
+              margin-bottom: 0;
+              margin-left: auto;
+              margin-right: auto;
+              margin-top: 0;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              white-space: nowrap;
+              width: 40px;
+              word-wrap: break-word;
+            }
+      >
+        5
       </label>
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -205,6 +205,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -1063,6 +1075,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     @media screen and (-ms-high-contrast: active){&:hover $thumb {
                       border-color: Highlight;
                     }
+                    &:active $zeroTick {
+                      background-color: #c7e0f4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                      background-color: Highlight;
+                    }
+                    &:hover $zeroTick {
+                      background-color: #c7e0f4;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                      background-color: Highlight;
+                    }
                     & $thumb {
                       background: #ffffff;
                       border-color: #666666;
@@ -1368,6 +1392,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -1612,6 +1648,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   }
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
+                  }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
                   }
                   & $thumb {
                     background: #ffffff;
@@ -1895,6 +1943,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -2139,6 +2199,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   }
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
+                  }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
                   }
                   & $thumb {
                     background: #ffffff;
@@ -2422,6 +2494,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -2666,6 +2750,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   }
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
+                  }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
                   }
                   & $thumb {
                     background: #ffffff;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
@@ -149,6 +149,18 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
@@ -149,6 +149,18 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -185,6 +185,18 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 @media screen and (-ms-high-contrast: active){&:hover $thumb {
                   border-color: Highlight;
                 }
+                &:active $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                  background-color: Highlight;
+                }
+                &:hover $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                  background-color: Highlight;
+                }
                 & $thumb {
                   background: #ffffff;
                   border-color: #666666;
@@ -445,6 +457,18 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 }
                 @media screen and (-ms-high-contrast: active){&:hover $thumb {
                   border-color: Highlight;
+                }
+                &:active $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                  background-color: Highlight;
+                }
+                &:hover $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                  background-color: Highlight;
                 }
                 & $thumb {
                   background: #ffffff;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
@@ -149,6 +149,18 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -206,6 +206,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -1068,7 +1080,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         transition: width 0.367s cubic-bezier(.1,.9,.2,1);
                       }
                       @media screen and (-ms-high-contrast: active){& {
-                        background-color: GrayText;
                         border-color: GrayText;
                         border: 1px solid WindowText;
                       }
@@ -1444,6 +1455,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
+                  }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
                   }
                   & $thumb {
                     background: #ffffff;
@@ -2515,6 +2538,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -2759,6 +2794,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
+                  }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
                   }
                   & $thumb {
                     background: #ffffff;
@@ -3043,6 +3090,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
                   }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
+                  }
                   & $thumb {
                     background: #ffffff;
                     border-color: #666666;
@@ -3287,6 +3346,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
                   @media screen and (-ms-high-contrast: active){&:hover $thumb {
                     border-color: Highlight;
+                  }
+                  &:active $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                    background-color: Highlight;
+                  }
+                  &:hover $zeroTick {
+                    background-color: #c7e0f4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                    background-color: Highlight;
                   }
                   & $thumb {
                     background: #ffffff;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
@@ -149,6 +149,18 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
@@ -149,6 +149,18 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -185,6 +185,18 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 @media screen and (-ms-high-contrast: active){&:hover $thumb {
                   border-color: Highlight;
                 }
+                &:active $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                  background-color: Highlight;
+                }
+                &:hover $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                  background-color: Highlight;
+                }
                 & $thumb {
                   background: #ffffff;
                   border-color: #666666;
@@ -445,6 +457,18 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 }
                 @media screen and (-ms-high-contrast: active){&:hover $thumb {
                   border-color: Highlight;
+                }
+                &:active $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+                  background-color: Highlight;
+                }
+                &:hover $zeroTick {
+                  background-color: #c7e0f4;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+                  background-color: Highlight;
                 }
                 & $thumb {
                   background: #ffffff;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
@@ -149,6 +149,18 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
             @media screen and (-ms-high-contrast: active){&:hover $thumb {
               border-color: Highlight;
             }
+            &:active $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:active $zeroTick {
+              background-color: Highlight;
+            }
+            &:hover $zeroTick {
+              background-color: #c7e0f4;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover $zeroTick {
+              background-color: Highlight;
+            }
             & $thumb {
               background: #ffffff;
               border-color: #666666;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8873, #9128
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add a new prop to enable Slider origin from zero. This slider helps in settings values in case the range starts from a negative number.

Horizontal
<img width="282" alt="Capture1" src="https://user-images.githubusercontent.com/785361/57895159-17224b00-77ff-11e9-84bd-929d2d836424.PNG">

Vertical
<img width="104" alt="Capture2" src="https://user-images.githubusercontent.com/785361/57895164-1b4e6880-77ff-11e9-9661-729fd1de7d48.PNG">

High contrast
<img width="430" alt="Capture" src="https://user-images.githubusercontent.com/785361/57895172-243f3a00-77ff-11e9-9227-129a406b01d9.PNG">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9126)