### PR TITLE
Remove circular imports in ContextualMenu.tsx

### DIFF
--- a/common/changes/office-ui-fabric-react/master_2019-05-17-07-56.json
+++ b/common/changes/office-ui-fabric-react/master_2019-05-17-07-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove circular imports in ContextualMenu.tsx",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xinychen@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -711,7 +711,7 @@ export enum ConstrainMode {
 }
 
 // @public
-export const ContextualMenu: React_2.StatelessComponent<IContextualMenuProps>;
+export const ContextualMenu: React.StatelessComponent<IContextualMenuProps>;
 
 // @public (undocumented)
 export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, IContextualMenuState> {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -390,8 +390,11 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     return focusZoneProps && focusZoneProps.direction !== undefined ? focusZoneProps.direction : FocusZoneDirection.vertical;
   }
 
-  private _onRenderSubMenu(subMenuProps: IContextualMenuProps) {
-    return <ContextualMenuBase {...subMenuProps} />;
+  private _onRenderSubMenu(subMenuProps: IContextualMenuProps, defaultRenderer: any) {
+    throw Error(
+      'ContextualMenuBase: onRenderSubMenu callback is null or undefined. ' +
+        'Please ensure to set `onRenderSubMenu` property either manually or with `styled` helper.'
+    );
   }
 
   private _onRenderMenuList = (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -34,7 +34,6 @@ import {
 import { hasSubmenu, getIsChecked, isItemDisabled } from '../../utilities/contextualMenu/index';
 import { withResponsiveMode, ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import { Callout, ICalloutContentStyleProps, ICalloutContentStyles } from '../../Callout';
-import { ContextualMenu } from './ContextualMenu';
 import { ContextualMenuItem } from './ContextualMenuItem';
 import { ContextualMenuSplitButton, ContextualMenuButton, ContextualMenuAnchor } from './ContextualMenuItemWrapper/index';
 import { IProcessedStyleSet, mergeStyleSets } from '../../Styling';
@@ -392,7 +391,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   }
 
   private _onRenderSubMenu(subMenuProps: IContextualMenuProps) {
-    return <ContextualMenu {...subMenuProps} />;
+    return <ContextualMenuBase {...subMenuProps} />;
   }
 
   private _onRenderMenuList = (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -390,7 +390,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     return focusZoneProps && focusZoneProps.direction !== undefined ? focusZoneProps.direction : FocusZoneDirection.vertical;
   }
 
-  private _onRenderSubMenu(subMenuProps: IContextualMenuProps, defaultRenderer: any) {
+  private _onRenderSubMenu(subMenuProps: IContextualMenuProps, defaultRender?: IRenderFunction<IContextualMenuProps>): JSX.Element {
     throw Error(
       'ContextualMenuBase: onRenderSubMenu callback is null or undefined. ' +
         'Please ensure to set `onRenderSubMenu` property either manually or with `styled` helper.'

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -1,13 +1,28 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IContextualMenuProps, IContextualMenuStyleProps, IContextualMenuStyles } from './ContextualMenu.types';
 import { ContextualMenuBase } from './ContextualMenu.base';
 import { getStyles } from './ContextualMenu.styles';
 
+// This is to prevent cyclic import with ContextualMenu.base.tsx.
+let LocalContextualMenu: React.StatelessComponent<IContextualMenuProps>;
+
+function onRenderSubMenu(subMenuProps: IContextualMenuProps, _: any) {
+  return <LocalContextualMenu {...subMenuProps} />;
+}
+
+LocalContextualMenu = styled<IContextualMenuProps, IContextualMenuStyleProps, IContextualMenuStyles>(
+  ContextualMenuBase,
+  getStyles,
+  _ => {
+    return {
+      onRenderSubMenu: onRenderSubMenu
+    };
+  },
+  { scope: 'ContextualMenu' }
+);
+
 /**
  * ContextualMenu description
  */
-export const ContextualMenu: React.StatelessComponent<IContextualMenuProps> = styled<
-  IContextualMenuProps,
-  IContextualMenuStyleProps,
-  IContextualMenuStyles
->(ContextualMenuBase, getStyles, undefined, { scope: 'ContextualMenu' });
+export const ContextualMenu: React.StatelessComponent<IContextualMenuProps> = LocalContextualMenu;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -16,7 +16,7 @@ LocalContextualMenu = styled<IContextualMenuProps, IContextualMenuStyleProps, IC
   getStyles,
   () => {
     return {
-      onRenderSubMenu: onRenderSubMenu
+      onRenderSubMenu
     };
   },
   { scope: 'ContextualMenu' }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.tsx
@@ -7,14 +7,14 @@ import { getStyles } from './ContextualMenu.styles';
 // This is to prevent cyclic import with ContextualMenu.base.tsx.
 let LocalContextualMenu: React.StatelessComponent<IContextualMenuProps>;
 
-function onRenderSubMenu(subMenuProps: IContextualMenuProps, _: any) {
+function onRenderSubMenu(subMenuProps: IContextualMenuProps) {
   return <LocalContextualMenu {...subMenuProps} />;
 }
 
 LocalContextualMenu = styled<IContextualMenuProps, IContextualMenuStyleProps, IContextualMenuStyles>(
   ContextualMenuBase,
   getStyles,
-  _ => {
+  () => {
     return {
       onRenderSubMenu: onRenderSubMenu
     };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9122 
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Removed circular dependency between `ContextualMenu.tsx` and `ContextualMenu.base.tsx` by setting `onRenderSubMenu` maunally in `ContextualMenu.tsx`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9130)