### PR TITLE
Fluent-theme: fix IconButton disabled background color

### DIFF
--- a/common/changes/@uifabric/fluent-theme/vibraga-IconButton_2019-05-18-03-20.json
+++ b/common/changes/@uifabric/fluent-theme/vibraga-IconButton_2019-05-18-03-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "IconButton: change the background color when in diabled state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "vibraga@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
@@ -25,7 +25,7 @@ export const IconButtonStyles = (props: IButtonProps): Partial<IButtonStyles> =>
       color: palette.themeDark
     },
     rootDisabled: {
-      backgroundColor: palette.white,
+      backgroundColor: 'transparent',
       color: palette.neutralTertiary
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9131
- [X] Include a change request file using `$ npm run change`

#### Description of changes

IconButton is supposed to take in the background color of the element its rendered on by specifying it as `transparent` in rest state. In disabled state it should behave the same.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9142)