### PR TITLE
Add TypeScript 2.8 to compatibility tests build definition

### DIFF
--- a/scripts/typescript-compatibility-build.yml
+++ b/scripts/typescript-compatibility-build.yml
@@ -71,6 +71,8 @@ jobs:
           TypeScriptVersion: 2.4
         'TypeScript 2.7':
           TypeScriptVersion: 2.7
+        'TypeScript 2.8':
+          TypeScriptVersion: 2.8
         'TypeScript 2.9':
           TypeScriptVersion: 2.9
         'TypeScript 3.0':


### PR DESCRIPTION
#### Description of changes

Adds a TypeScript `2.8` test to the existing compatibility build definition to better represent current compatibility with `office-ui-fabric-react@6` which has a TypeScript minbar of `2.8`.

Related PR: https://github.com/microsoft/ui-fabric-ts-validation/pull/2.

#### Focus areas to test

None. CI is passing for the above linked CI which explicitly tests OUFR compat, see https://github.com/microsoft/ui-fabric-ts-validation/pull/2/checks?check_run_id=132265885.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9145)