### PR TITLE
Making ComboBox onResolveOptions pass the correct argument type

### DIFF
--- a/common/changes/office-ui-fabric-react/combobox-options_2019-05-20-17-42.json
+++ b/common/changes/office-ui-fabric-react/combobox-options_2019-05-20-17-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fixed: ComboBox onResolveOptions should have array not object as argument",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -937,7 +937,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   private _onResolveOptions = (): void => {
     if (this.props.onResolveOptions) {
       // get the options
-      const newOptions = this.props.onResolveOptions({ ...this.state.currentOptions });
+      const newOptions = this.props.onResolveOptions([...this.state.currentOptions]);
 
       // Check to see if the returned value is an array, if it is update the state
       // If the returned value is not an array then check to see if it's a promise or PromiseLike. If it is then resolve it asynchronously.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9149
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Even though the consuming code can handle the argument from `onResolveOptions` as an object with numeric keys, it is actually more accurate to use an array as is the actual type definition of the args.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9151)