### PR TITLE
Dropdown: Add required visual hint when no label is present

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/TextField.test.ts.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/TextField.test.ts.snap
@@ -48,7 +48,25 @@ Array [
     },
     "ruleId": "label",
   },
+  Object {
+    "level": "error",
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
 ]
 `;
 
-exports[`runs Axe on TextField 2`] = `"Found 3 a11y errors for TextField. Please check 'Scan' tab in 'office-ui-fabric-react' on Azure DevOps"`;
+exports[`runs Axe on TextField 2`] = `"Found 4 a11y errors for TextField. Please check 'Scan' tab in 'office-ui-fabric-react' on Azure DevOps"`;

--- a/common/changes/office-ui-fabric-react/jg-9119-dropdown-required_2019-05-20-20-11.json
+++ b/common/changes/office-ui-fabric-react/jg-9119-dropdown-required_2019-05-20-20-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown: Add required visual hint when label is not provided.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-9119-dropdown-required_2019-05-20-20-11.json
+++ b/common/changes/office-ui-fabric-react/jg-9119-dropdown-required_2019-05-20-20-11.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Dropdown: Add required visual hint when label is not provided.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4278,6 +4278,7 @@ export interface IDropdownState {
 // @public
 export type IDropdownStyleProps = Pick<IDropdownProps, 'theme' | 'className' | 'disabled' | 'required'> & {
     hasError: boolean;
+    hasLabel: boolean;
     isOpen: boolean;
     isRenderingPlaceholder: boolean;
     panelClassName?: string;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -236,6 +236,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       theme,
       className,
       hasError: !!(errorMessage && errorMessage.length > 0),
+      hasLabel: !!label,
       isOpen,
       required,
       disabled,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -67,7 +67,18 @@ const highContrastBorderState: IRawStyle = {
 const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMinMedium);
 
 export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = props => {
-  const { theme, hasError, className, isOpen, disabled, required, isRenderingPlaceholder, panelClassName, calloutClassName } = props;
+  const {
+    theme,
+    hasError,
+    hasLabel,
+    className,
+    isOpen,
+    disabled,
+    required,
+    isRenderingPlaceholder,
+    panelClassName,
+    calloutClassName
+  } = props;
 
   if (!theme) {
     throw new Error('theme is undefined or null in base Dropdown getStyles function.');
@@ -173,7 +184,26 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       className,
       isOpen && 'is-open',
       disabled && 'is-disabled',
-      required && 'is-required'
+      required && 'is-required',
+      required &&
+        !hasLabel && {
+          selectors: {
+            ':after': {
+              content: `'*'`,
+              color: semanticColors.errorText,
+              position: 'absolute',
+              top: -5,
+              right: -10
+            },
+            [HighContrastSelector]: {
+              selectors: {
+                ':after': {
+                  right: -14 // moving the * 4 pixel to right to alleviate border clipping in HC mode.
+                }
+              }
+            }
+          }
+        }
     ],
     title: [
       globalClassnames.title,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -166,6 +166,11 @@ export type IDropdownStyleProps = Pick<IDropdownProps, 'theme' | 'className' | '
   hasError: boolean;
 
   /**
+   * Specifies if the dropdown has label content.
+   */
+  hasLabel: boolean;
+
+  /**
    * Whether the dropdown is in an opened state.
    */
   isOpen: boolean;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Required.Example.tsx
@@ -10,11 +10,26 @@ export const DropdownRequiredExample: React.StatelessComponent = () => {
   const stackTokens: IStackTokens = { childrenGap: 20 };
 
   return (
-    <Stack horizontal tokens={stackTokens} verticalAlign="end">
+    <Stack tokens={stackTokens} verticalAlign="end">
+      <Stack horizontal tokens={stackTokens} verticalAlign="end">
+        <Dropdown
+          componentRef={dropdownRef}
+          placeholder="Select an option"
+          label="Required dropdown example"
+          options={[
+            { key: 'A', text: 'Option a', title: 'I am option a.' },
+            { key: 'B', text: 'Option b' },
+            { key: 'C', text: 'Option c', disabled: true },
+            { key: 'D', text: 'Option d' },
+            { key: 'E', text: 'Option e' }
+          ]}
+          required={true}
+          styles={{ dropdown: { width: 300 } }}
+        />
+        <PrimaryButton text="Set focus" onClick={onSetFocus} />
+      </Stack>
       <Dropdown
-        componentRef={dropdownRef}
-        placeholder="Select an option"
-        label="Required dropdown example"
+        placeholder="Required with no label"
         options={[
           { key: 'A', text: 'Option a', title: 'I am option a.' },
           { key: 'B', text: 'Option b' },
@@ -25,7 +40,6 @@ export const DropdownRequiredExample: React.StatelessComponent = () => {
         required={true}
         styles={{ dropdown: { width: 300 } }}
       />
-      <PrimaryButton text="Set focus" onClick={onSetFocus} />
     </Stack>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Basic.Example.tsx
@@ -16,6 +16,7 @@ export const TextFieldBasicExample: React.StatelessComponent = () => {
         <TextField label="Disabled" disabled defaultValue="I am disabled" />
         <TextField label="Read-only" readOnly defaultValue="I am read-only" />
         <TextField label="Required " required />
+        <TextField required />
         <TextField label="With error message" errorMessage="Error message" />
       </Stack>
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -5,19 +5,19 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
   className=
       ms-Stack
       {
-        align-items: flex-end;
         box-sizing: border-box;
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
         flex-wrap: nowrap;
         height: auto;
+        justify-content: flex-end;
         width: auto;
       }
       & > * {
         text-overflow: ellipsis;
       }
       & > *:not(:first-child) {
-        margin-left: 20px;
+        margin-top: 20px;
       }
       & > *:not(.ms-StackItem) {
         flex-shrink: 1;
@@ -25,49 +25,383 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
 >
   <div
     className=
-        ms-Dropdown-container
-
+        ms-Stack
+        {
+          align-items: flex-end;
+          box-sizing: border-box;
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          height: auto;
+          width: auto;
+        }
+        & > * {
+          text-overflow: ellipsis;
+        }
+        & > *:not(:first-child) {
+          margin-left: 20px;
+        }
+        & > *:not(.ms-StackItem) {
+          flex-shrink: 1;
+        }
   >
-    <label
+    <div
       className=
-          ms-Label
-          ms-Dropdown-label
+          ms-Dropdown-container
+
+    >
+      <label
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            &::after {
+              color: #a80000;
+              content: ' *';
+              padding-right: 12px;
+            }
+        htmlFor="Dropdown0"
+        id="Dropdown0-label"
+        required={true}
+      >
+        Required dropdown example
+      </label>
+      <div
+        aria-describedby="Dropdown0-option"
+        aria-expanded="false"
+        aria-labelledby="Dropdown0-label"
+        aria-required={true}
+        className=
+            ms-Dropdown
+            is-required
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              user-select: none;
+              width: 300px;
+            }
+            &:hover .ms-Dropdown-title {
+              border-color: #212121;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
+              border-color: Highlight;
+            }
+            &:focus .ms-Dropdown-title {
+              border-color: #0078d4;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
+              color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
+              -ms-high-contrast-adjust: none;
+            }
+            &:active .ms-Dropdown-title {
+              border-color: #005a9e;
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
+              border-color: Highlight;
+            }
+            &:hover .ms-Dropdown-caretDown {
+              color: #212121;
+            }
+            &:focus .ms-Dropdown-caretDown {
+              color: #212121;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
+              color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
+              -ms-high-contrast-adjust: none;
+            }
+            &:active .ms-Dropdown-caretDown {
+              color: #212121;
+            }
+            &:hover .ms-Dropdown-titleIsPlaceHolder {
+              color: #666666;
+            }
+            &:focus .ms-Dropdown-titleIsPlaceHolder {
+              color: #666666;
+            }
+            &:active .ms-Dropdown-titleIsPlaceHolder {
+              color: #666666;
+            }
+            &:hover .ms-Dropdown-title--hasError {
+              border-color: #a80000;
+            }
+            &:active .ms-Dropdown-title--hasError {
+              border-color: #a80000;
+            }
+            &:focus .ms-Dropdown-title--hasError {
+              border-color: #a80000;
+            }
+        data-is-focusable={true}
+        id="Dropdown0"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        placeholder="Select an option"
+        required={true}
+        role="listbox"
+        tabIndex={0}
+      >
+        <span
+          aria-atomic={true}
+          aria-label="Select an option"
+          aria-live="off"
+          aria-setsize={5}
+          className=
+              ms-Dropdown-title
+              ms-Dropdown-titleIsPlaceHolder
+              {
+                background-color: #ffffff;
+                border-color: #a6a6a6;
+                border-style: solid;
+                border-width: 1px;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #666666;
+                cursor: pointer;
+                display: block;
+                height: 32px;
+                line-height: 30px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow: hidden;
+                padding-bottom: 0;
+                padding-left: 12px;
+                padding-right: 32px;
+                padding-top: 0;
+                position: relative;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+          id="Dropdown0-option"
+          role="option"
+        >
+          <span>
+            Select an option
+          </span>
+        </span>
+        <span
+          className=
+              ms-Dropdown-caretDownWrapper
+              {
+                cursor: pointer;
+                height: 32px;
+                line-height: 30px;
+                position: absolute;
+                right: 12px;
+                top: 1px;
+              }
+        >
+          <i
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #666666;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  pointer-events: none;
+                  speak: none;
+                }
+            data-icon-name="ChevronDown"
+            role="presentation"
+          >
+            
+          </i>
+        </span>
+      </div>
+    </div>
+    <button
+      className=
+          ms-Button
+          ms-Button--primary
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: #0078d4;
+            border-radius: 0px;
+            border: 1px solid transparent;
             box-sizing: border-box;
-            color: #333333;
+            color: #ffffff;
+            cursor: pointer;
             display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
+            height: 32px;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
+            min-width: 80px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 16px;
+            padding-right: 16px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
           }
-          &::after {
-            color: #a80000;
-            content: ' *';
-            padding-right: 12px;
+          &::-moz-focus-inner {
+            border: 0;
           }
-      htmlFor="Dropdown0"
-      id="Dropdown0-label"
-      required={true}
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            outline: 1px solid #666666;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+            background-color: WindowText;
+            color: Window;
+          }
+          &:hover {
+            background-color: #106ebe;
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            background-color: Highlight;
+            color: Window;
+          }
+          &:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: WindowText;
+            color: Window;
+          }
+      data-is-focusable={true}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      type="button"
     >
-      Required dropdown example
-    </label>
+      <div
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: center;
+            }
+      >
+        <div
+          className=
+              ms-Button-textContainer
+              {
+                flex-grow: 1;
+              }
+        >
+          <div
+            className=
+                ms-Button-label
+                {
+                  font-weight: 600;
+                  line-height: 100%;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                }
+            id="id__1"
+          >
+            Set focus
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+  <div
+    className=
+        ms-Dropdown-container
+
+  >
     <div
-      aria-describedby="Dropdown0-option"
+      aria-describedby="Dropdown4-option"
       aria-expanded="false"
-      aria-labelledby="Dropdown0-label"
       aria-required={true}
       className=
           ms-Dropdown
@@ -156,21 +490,31 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
           &:focus .ms-Dropdown-title--hasError {
             border-color: #a80000;
           }
+          &:after {
+            color: #a80000;
+            content: '*';
+            position: absolute;
+            right: -10px;
+            top: -5px;
+          }
+          @media screen and (-ms-high-contrast: active){&:after {
+            right: -14px;
+          }
       data-is-focusable={true}
-      id="Dropdown0"
+      id="Dropdown4"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
-      placeholder="Select an option"
+      placeholder="Required with no label"
       required={true}
       role="listbox"
       tabIndex={0}
     >
       <span
         aria-atomic={true}
-        aria-label="Select an option"
+        aria-label="Required with no label"
         aria-live="off"
         aria-setsize={5}
         className=
@@ -201,11 +545,11 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
               text-overflow: ellipsis;
               white-space: nowrap;
             }
-        id="Dropdown0-option"
+        id="Dropdown4-option"
         role="option"
       >
         <span>
-          Select an option
+          Required with no label
         </span>
       </span>
       <span
@@ -243,133 +587,5 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
       </span>
     </div>
   </div>
-  <button
-    className=
-        ms-Button
-        ms-Button--primary
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: #0078d4;
-          border-radius: 0px;
-          border: 1px solid transparent;
-          box-sizing: border-box;
-          color: #ffffff;
-          cursor: pointer;
-          display: inline-block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          min-width: 80px;
-          outline: transparent;
-          padding-bottom: 0;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-          position: relative;
-          text-align: center;
-          text-decoration: none;
-          user-select: none;
-          vertical-align: top;
-        }
-        &::-moz-focus-inner {
-          border: 0;
-        }
-        .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid #ffffff;
-          bottom: 0px;
-          content: "";
-          left: 0px;
-          outline: 1px solid #666666;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-          z-index: 1;
-        }
-        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-          border: none;
-          bottom: -2px;
-          left: -2px;
-          outline-color: ButtonText;
-          right: -2px;
-          top: -2px;
-        }
-        &:active > * {
-          left: 0px;
-          position: relative;
-          top: 0px;
-        }
-        @media screen and (-ms-high-contrast: active){& {
-          -ms-high-contrast-adjust: none;
-          background-color: WindowText;
-          color: Window;
-        }
-        &:hover {
-          background-color: #106ebe;
-          color: #ffffff;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover {
-          background-color: Highlight;
-          color: Window;
-        }
-        &:active {
-          background-color: #005a9e;
-          color: #ffffff;
-        }
-        @media screen and (-ms-high-contrast: active){&:active {
-          -ms-high-contrast-adjust: none;
-          background-color: WindowText;
-          color: Window;
-        }
-    data-is-focusable={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    type="button"
-  >
-    <div
-      className=
-          ms-Button-flexContainer
-          {
-            align-items: center;
-            display: flex;
-            flex-wrap: nowrap;
-            height: 100%;
-            justify-content: center;
-          }
-    >
-      <div
-        className=
-            ms-Button-textContainer
-            {
-              flex-grow: 1;
-            }
-      >
-        <div
-          className=
-              ms-Button-label
-              {
-                font-weight: 600;
-                line-height: 100%;
-                margin-bottom: 0;
-                margin-left: 4px;
-                margin-right: 4px;
-                margin-top: 0;
-              }
-          id="id__1"
-        >
-          Set focus
-        </div>
-      </div>
-    </div>
-  </button>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -660,6 +660,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
     <div
       className=
           ms-TextField
+          is-required
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -684,41 +685,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             ms-TextField-wrapper
 
       >
-        <label
-          className=
-              ms-Label
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #333333;
-                display: block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow-wrap: break-word;
-                padding-bottom: 5px;
-                padding-left: 0;
-                padding-right: 0;
-                padding-top: 5px;
-                word-wrap: break-word;
-              }
-          htmlFor="TextField8"
-        >
-          With error message
-        </label>
         <div
           className=
               ms-TextField-fieldGroup
               {
                 align-items: stretch;
                 background: #ffffff;
-                border-color: #a80000;
                 border: 1px solid #a6a6a6;
                 box-shadow: none;
                 box-sizing: border-box;
@@ -742,13 +714,19 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
-              &:focus, &:hover {
-                border-color: #a80000;
+              &:after {
+                color: #a80000;
+                content: '*';
+                position: absolute;
+                right: -10px;
+                top: -5px;
+              }
+              @media screen and (-ms-high-contrast: active){&:after {
+                right: -14px;
               }
         >
           <input
-            aria-describedby="TextFieldDescription9"
-            aria-invalid={true}
+            aria-invalid={false}
             className=
                 ms-TextField-field
                 {
@@ -806,13 +784,169 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
             onChange={[Function]}
             onFocus={[Function]}
             onInput={[Function]}
+            required={true}
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-TextField
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-TextField-wrapper
+
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #333333;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          htmlFor="TextField10"
+        >
+          With error message
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-color: #a80000;
+                border: 1px solid #a6a6a6;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: text;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #333333;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
+              &:focus, &:hover {
+                border-color: #a80000;
+              }
+        >
+          <input
+            aria-describedby="TextFieldDescription11"
+            aria-invalid={true}
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  background: none;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #333333;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 12px;
+                  padding-right: 12px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #666666;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #666666;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+            id="TextField10"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
             type="text"
             value=""
           />
         </div>
       </div>
       <span
-        id="TextFieldDescription9"
+        id="TextFieldDescription11"
       >
         <div
           role="alert"
@@ -892,7 +1026,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField10"
+          htmlFor="TextField12"
         >
           With input mask
         </label>
@@ -980,7 +1114,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
-            id="TextField10"
+            id="TextField12"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -1046,7 +1180,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField12"
+          htmlFor="TextField14"
         >
           With an icon
         </label>
@@ -1134,7 +1268,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
-            id="TextField12"
+            id="TextField14"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -1220,7 +1354,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
-          htmlFor="TextField14"
+          htmlFor="TextField16"
         >
           With placeholder
         </label>
@@ -1308,7 +1442,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
-            id="TextField14"
+            id="TextField16"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -1375,7 +1509,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               @media screen and (-ms-high-contrast: active){& {
                 color: GrayText;
               }
-          htmlFor="TextField16"
+          htmlFor="TextField18"
         >
           Disabled with placeholder
         </label>
@@ -1464,7 +1598,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   opacity: 1;
                 }
             disabled={true}
-            id="TextField16"
+            id="TextField18"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9119
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Similar to TextField, this PR adds a visual hint to Dropdown when label is not present.

![image](https://user-images.githubusercontent.com/26070760/58049135-f90b6200-7b00-11e9-898d-55de4cb2430e.png)

#### Focus areas to test

Updated examples and example snapshots.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9154)