### PR TITLE
Added value to ChoiceGroupOption

### DIFF
--- a/common/changes/office-ui-fabric-react/feat-choice-group-option-value_2019-05-20-21-20.json
+++ b/common/changes/office-ui-fabric-react/feat-choice-group-option-value_2019-05-20-21-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "added value to ChoiceGroupOption",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rayknight@genui.co"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2203,6 +2203,7 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
     onFocus?: OnFocusCallback;
     required?: boolean;
     theme?: ITheme;
+    value?: string;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -117,6 +117,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
                 id: `${this._id}-${option.key}`,
                 labelId: `${this._labelId}-${option.key}`,
                 name: name || this._id,
+                value: option.key,
                 required
               };
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -28,6 +28,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       id,
       styles,
       name,
+      value,
       onRenderField = this._onRenderField,
       ...rest
     } = this.props;
@@ -57,6 +58,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
             disabled={disabled}
             checked={checked}
             required={required}
+            value={value}
             onChange={this._onChange.bind(this, this.props)}
             onFocus={this._onFocus.bind(this, this.props)}
             onBlur={this._onBlur.bind(this, this.props)}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -57,6 +57,11 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
    * This value is used to group each ChoiceGroupOption into the same logical ChoiceGroup
    */
   name?: string;
+
+  /**
+   * Value is an alias to key that sets a value on the input. Key is unavailable due to being a React protected prop name.
+   */
+  value?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -112,6 +112,7 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             onFocus={[Function]}
             required={true}
             type="radio"
+            value="1"
           />
           <label
             className=
@@ -232,6 +233,7 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             onFocus={[Function]}
             required={true}
             type="radio"
+            value="2"
           />
           <label
             className=
@@ -352,6 +354,7 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             onFocus={[Function]}
             required={true}
             type="radio"
+            value="3"
           />
           <label
             className=
@@ -502,6 +505,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             onFocus={[Function]}
             required={true}
             type="radio"
+            value="1"
           />
           <label
             className=
@@ -622,6 +626,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             onFocus={[Function]}
             required={true}
             type="radio"
+            value="2"
           />
           <label
             className=
@@ -742,6 +747,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             onFocus={[Function]}
             required={true}
             type="radio"
+            value="3"
           />
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -113,6 +113,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="A"
             />
             <label
               className=
@@ -233,6 +234,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="B"
             />
             <label
               className=
@@ -366,6 +368,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="C"
             />
             <label
               className=
@@ -484,6 +487,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="D"
             />
             <label
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -113,6 +113,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="A"
             />
             <div
               className=""
@@ -409,6 +410,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="B"
             />
             <label
               className=
@@ -542,6 +544,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="C"
             />
             <label
               className=
@@ -659,6 +662,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="D"
             />
             <label
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -114,6 +114,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             onChange={[Function]}
             onFocus={[Function]}
             type="radio"
+            value="day"
           />
           <label
             className=
@@ -338,6 +339,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             onChange={[Function]}
             onFocus={[Function]}
             type="radio"
+            value="week"
           />
           <label
             className=
@@ -551,6 +553,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             onChange={[Function]}
             onFocus={[Function]}
             type="radio"
+            value="month"
           />
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -115,6 +115,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
               onChange={[Function]}
               onFocus={[Function]}
               type="radio"
+              value="bar"
             />
             <label
               className=
@@ -428,6 +429,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
               onChange={[Function]}
               onFocus={[Function]}
               type="radio"
+              value="pie"
             />
             <label
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -113,6 +113,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="A"
             />
             <label
               className=
@@ -233,6 +234,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="B"
             />
             <label
               className=
@@ -366,6 +368,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="C"
             />
             <label
               className=
@@ -484,6 +487,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               onFocus={[Function]}
               required={true}
               type="radio"
+              value="D"
             />
             <label
               className=


### PR DESCRIPTION
#### Description of changes

Added value to ChoiceGroupOption, so that the Synthetic onChange Event that traverses up the DOM can be listened to and `event.target.value` is equal to the option key. Chose to use key due to the parent using the `defaultSelectedKey` or `selectedKey` as the unique identifier/selected option identifier.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9157)