### PR TITLE
Change the office-ui-fabric-react imports to be from root

### DIFF
--- a/common/changes/@uifabric/fluent-theme/fluent-jest_2019-05-20-22-03.json
+++ b/common/changes/@uifabric/fluent-theme/fluent-jest_2019-05-20-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Replaced all import specifiers of OUFR to the root to allow commonjs environments",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fluent-jest_2019-05-20-22-03.json
+++ b/common/changes/office-ui-fabric-react/fluent-jest_2019-05-20-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adds ReactangleEdge export from positioning",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -30,9 +30,7 @@
     "@uifabric/tslint-rules": "^1.0.2"
   },
   "dependencies": {
-    "@uifabric/merge-styles": "^6.17.3",
     "@uifabric/set-version": "^1.1.3",
-    "@uifabric/styling": "^6.47.6",
     "@uifabric/variants": "^6.14.2",
     "office-ui-fabric-react": "^6.183.0",
     "tslib": "^1.7.1"

--- a/packages/fluent-theme/src/fluent/FluentMotion.ts
+++ b/packages/fluent-theme/src/fluent/FluentMotion.ts
@@ -1,4 +1,4 @@
-import { keyframes } from '@uifabric/merge-styles';
+import { keyframes } from 'office-ui-fabric-react';
 
 const fadeInAnimationName: string = keyframes({
   from: { opacity: 0 },

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,4 +1,4 @@
-import { createTheme, ITheme } from '@uifabric/styling';
+import { createTheme, ITheme } from 'office-ui-fabric-react';
 import { NeutralColors, SharedColors } from './FluentColors';
 import { Depths } from './FluentDepths';
 

--- a/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/BasePicker.styles.ts
@@ -1,4 +1,4 @@
-import { IBasePickerStyleProps, IBasePickerStyles } from 'office-ui-fabric-react/lib/Pickers';
+import { IBasePickerStyleProps, IBasePickerStyles } from 'office-ui-fabric-react';
 
 export const BasePickerStyles = (props: IBasePickerStyleProps): Partial<IBasePickerStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Breadcrumb.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Breadcrumb.styles.ts
@@ -1,5 +1,4 @@
-import { IBreadcrumbStyleProps, IBreadcrumbStyles } from 'office-ui-fabric-react/lib/Breadcrumb';
-import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
+import { IBreadcrumbStyleProps, IBreadcrumbStyles, FontWeights } from 'office-ui-fabric-react';
 import { FontSizes } from '../FluentType';
 import { MediumScreenSelector, MinimumScreenSelector } from './styleConstants';
 

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -1,4 +1,4 @@
-import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react/lib/Callout';
+import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react';
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Checkbox.styles.ts
@@ -1,4 +1,4 @@
-import { ICheckboxStyleProps, ICheckboxStyles } from 'office-ui-fabric-react/lib/Checkbox';
+import { ICheckboxStyleProps, ICheckboxStyles } from 'office-ui-fabric-react';
 
 export const CheckboxStyles = (props: ICheckboxStyleProps): Partial<ICheckboxStyles> => {
   const { disabled, checked, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/ChoiceGroupOption.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ChoiceGroupOption.styles.ts
@@ -1,4 +1,4 @@
-import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from 'office-ui-fabric-react';
 
 export const ChoiceGroupOptionStyles = (props: IChoiceGroupOptionStyleProps): Partial<IChoiceGroupOptionStyles> => {
   const { checked, disabled, theme, hasIcon, hasImage } = props;

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -5,7 +5,7 @@ import {
   IColorRectangleStyles,
   IColorSliderStyleProps,
   IColorSliderStyles
-} from 'office-ui-fabric-react/lib/ColorPicker';
+} from 'office-ui-fabric-react';
 
 export const ColorPickerStyles = (props: IColorPickerStyleProps): Partial<IColorPickerStyles> => {
   return {

--- a/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPickerGridCell.styles.ts
@@ -1,4 +1,4 @@
-import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from 'office-ui-fabric-react/lib/SwatchColorPicker';
+import { IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from 'office-ui-fabric-react';
 
 export const ColorPickerGridCellStyles = (props: IColorPickerGridCellStyleProps): Partial<IColorPickerGridCellStyles> => {
   return {};

--- a/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ComboBox.styles.ts
@@ -1,4 +1,4 @@
-import { IComboBoxStyles, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
+import { IComboBoxStyles, IComboBoxProps } from 'office-ui-fabric-react';
 
 export const ComboBoxStyles = (props: IComboBoxProps): Partial<IComboBoxStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/CommandBar.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBar.styles.ts
@@ -1,4 +1,4 @@
-import { ICommandBarStyleProps, ICommandBarStyles } from 'office-ui-fabric-react/lib/CommandBar';
+import { ICommandBarStyleProps, ICommandBarStyles } from 'office-ui-fabric-react';
 
 export const CommandBarStyles = (props: ICommandBarStyleProps): Partial<ICommandBarStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CommandBarButton.styles.ts
@@ -1,5 +1,4 @@
-import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { getFocusStyle, IButtonStyles, IButtonProps } from 'office-ui-fabric-react';
 
 export const CommandBarButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/CompoundButton.styles.ts
@@ -1,5 +1,4 @@
-import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { getFocusStyle, IButtonStyles, IButtonProps } from 'office-ui-fabric-react';
 
 export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
@@ -2,9 +2,9 @@ import {
   IContextualMenuStyleProps,
   IContextualMenuStyles,
   IContextualMenuItemStyleProps,
-  IContextualMenuItemStyles
-} from 'office-ui-fabric-react/lib/ContextualMenu';
-import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
+  IContextualMenuItemStyles,
+  IsFocusVisibleClassName
+} from 'office-ui-fabric-react';
 import { MinimumScreenSelector } from './styleConstants';
 import { FontSizes } from '../FluentType';
 

--- a/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DatePicker.styles.ts
@@ -1,4 +1,4 @@
-import { IDatePickerStyleProps, IDatePickerStyles } from 'office-ui-fabric-react/lib/DatePicker';
+import { IDatePickerStyleProps, IDatePickerStyles } from 'office-ui-fabric-react';
 
 export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePickerStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -1,5 +1,4 @@
-import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { getFocusStyle, IButtonStyles, IButtonProps } from 'office-ui-fabric-react';
 
 export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/DetailsColumn.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DetailsColumn.styles.ts
@@ -1,6 +1,5 @@
 import { FontSizes } from '../FluentType';
-import { FontWeights } from '@uifabric/styling';
-import { IDetailsColumnStyles } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn.types';
+import { FontWeights, IDetailsColumnStyles } from 'office-ui-fabric-react';
 
 export const DetailsColumnStyles = (): Partial<IDetailsColumnStyles> => {
   return {

--- a/packages/fluent-theme/src/fluent/styles/DetailsList.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DetailsList.styles.ts
@@ -1,6 +1,4 @@
-import { ICheckStyleProps, ICheckStyles } from 'office-ui-fabric-react/lib/Check';
-import { IDetailsRowStyleProps, IDetailsRowStyles } from 'office-ui-fabric-react/lib/DetailsList';
-import { FontWeights } from '@uifabric/styling';
+import { ICheckStyleProps, ICheckStyles, IDetailsRowStyleProps, IDetailsRowStyles, FontWeights } from 'office-ui-fabric-react';
 
 export const CheckStyles = (props: ICheckStyleProps): Partial<ICheckStyles> => {
   const { theme, checked } = props;

--- a/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dialog.styles.ts
@@ -2,9 +2,9 @@ import {
   IDialogContentStyleProps,
   IDialogContentStyles,
   IDialogFooterStyleProps,
-  IDialogFooterStyles
-} from 'office-ui-fabric-react/lib/Dialog';
-import { FontWeights } from '@uifabric/styling';
+  IDialogFooterStyles,
+  FontWeights
+} from 'office-ui-fabric-react';
 import { FontSizes } from '../FluentType';
 
 export const DialogContentStyles = (props: IDialogContentStyleProps): Partial<IDialogContentStyles> => {

--- a/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Dropdown.styles.ts
@@ -1,6 +1,4 @@
-import { IDropdownStyleProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
-import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
-import { IStyle } from '@uifabric/styling';
+import { IStyle, IDropdownStyleProps, IDropdownStyles, RectangleEdge } from 'office-ui-fabric-react';
 
 export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownStyles> => {
   const { disabled, hasError, isOpen, calloutRenderEdge, theme, isRenderingPlaceholder } = props;

--- a/packages/fluent-theme/src/fluent/styles/Facepile.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Facepile.styles.ts
@@ -1,4 +1,4 @@
-import { IFacepileStyleProps, IFacepileStyles } from 'office-ui-fabric-react/lib/Facepile';
+import { IFacepileStyleProps, IFacepileStyles } from 'office-ui-fabric-react';
 
 export const FacepileStyles = (props: IFacepileStyleProps): Partial<IFacepileStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/HoverCard.styles.ts
@@ -1,9 +1,4 @@
-import {
-  IExpandingCardStyleProps,
-  IExpandingCardStyles,
-  IPlainCardStyleProps,
-  IPlainCardStyles
-} from 'office-ui-fabric-react/lib/HoverCard';
+import { IExpandingCardStyleProps, IExpandingCardStyles, IPlainCardStyleProps, IPlainCardStyles } from 'office-ui-fabric-react';
 
 const commonCardStyles = (props: IExpandingCardStyleProps | IPlainCardStyleProps) => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/IconButton.styles.ts
@@ -1,4 +1,4 @@
-import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react';
 
 export const IconButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Label.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Label.styles.ts
@@ -1,5 +1,4 @@
-import { ILabelStyleProps, ILabelStyles } from 'office-ui-fabric-react/lib/Label';
-import { FontWeights } from '@uifabric/styling';
+import { ILabelStyleProps, ILabelStyles, FontWeights } from 'office-ui-fabric-react';
 
 export const LabelStyles = (props: ILabelStyleProps): Partial<ILabelStyles> => {
   const { theme, disabled } = props;

--- a/packages/fluent-theme/src/fluent/styles/Link.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Link.styles.ts
@@ -1,4 +1,4 @@
-import { ILinkStyleProps, ILinkStyles } from 'office-ui-fabric-react/lib/Link';
+import { ILinkStyleProps, ILinkStyles } from 'office-ui-fabric-react';
 
 export const LinkStyles = (props: ILinkStyleProps): Partial<ILinkStyles> => {
   const { isDisabled } = props;

--- a/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Modal.styles.ts
@@ -1,4 +1,4 @@
-import { IModalStyles, IModalProps } from 'office-ui-fabric-react/lib/Modal';
+import { IModalStyles, IModalProps } from 'office-ui-fabric-react';
 
 export const ModalStyles = (props: IModalProps): Partial<IModalStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Panel.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Panel.styles.ts
@@ -1,6 +1,5 @@
-import { IPanelStyleProps, IPanelStyles } from 'office-ui-fabric-react/lib/Panel';
+import { FontWeights, IPanelStyleProps, IPanelStyles } from 'office-ui-fabric-react';
 import { FontSizes } from '../FluentType';
-import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 export const PanelStyles = (props: IPanelStyleProps): Partial<IPanelStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/PeoplePicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PeoplePicker.styles.ts
@@ -1,4 +1,4 @@
-import { IPeoplePickerItemSelectedStyleProps, IPeoplePickerItemSelectedStyles } from 'office-ui-fabric-react/lib/Pickers';
+import { IPeoplePickerItemSelectedStyleProps, IPeoplePickerItemSelectedStyles } from 'office-ui-fabric-react';
 
 export const PeoplePickerItemStyles = (props: IPeoplePickerItemSelectedStyleProps): Partial<IPeoplePickerItemSelectedStyles> => {
   const { selected, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Persona.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Persona.styles.ts
@@ -1,6 +1,5 @@
-import { IPersonaStyleProps, IPersonaStyles, PersonaSize, sizeBoolean } from 'office-ui-fabric-react/lib/Persona';
+import { IPersonaStyleProps, IPersonaStyles, PersonaSize, sizeBoolean, FontWeights } from 'office-ui-fabric-react';
 import { FontSizes } from '../FluentType';
-import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
 
 export const PersonaStyles = (props: IPersonaStyleProps): Partial<IPersonaStyles> => {
   const size = sizeBoolean(props.size as PersonaSize);

--- a/packages/fluent-theme/src/fluent/styles/PickerSuggestions.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PickerSuggestions.styles.ts
@@ -1,9 +1,4 @@
-import {
-  ISuggestionsItemStyleProps,
-  ISuggestionsItemStyles,
-  ISuggestionsStyleProps,
-  ISuggestionsStyles
-} from 'office-ui-fabric-react/lib/Pickers';
+import { ISuggestionsItemStyleProps, ISuggestionsItemStyles, ISuggestionsStyleProps, ISuggestionsStyles } from 'office-ui-fabric-react';
 
 export const SuggestionItemStyles = (props: ISuggestionsItemStyleProps): Partial<ISuggestionsItemStyles> => {
   return {

--- a/packages/fluent-theme/src/fluent/styles/Pivot.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Pivot.styles.ts
@@ -1,5 +1,4 @@
-import { IPivotStyleProps, IPivotStyles } from 'office-ui-fabric-react/lib/Pivot';
-import { AnimationVariables } from 'office-ui-fabric-react/lib/Styling';
+import { AnimationVariables, IPivotStyleProps, IPivotStyles } from 'office-ui-fabric-react';
 
 export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
   const { theme, rootIsTabs } = props;

--- a/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/PrimaryButton.styles.ts
@@ -1,4 +1,4 @@
-import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react';
 
 export const PrimaryButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Rating.styles.ts
@@ -1,4 +1,4 @@
-import { IRatingStyleProps, IRatingStyles } from 'office-ui-fabric-react/lib/Rating';
+import { IRatingStyleProps, IRatingStyles } from 'office-ui-fabric-react';
 
 export const RatingStyles = (props: IRatingStyleProps): Partial<IRatingStyles> => {
   const { disabled, readOnly, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/SearchBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SearchBox.styles.ts
@@ -1,4 +1,4 @@
-import { ISearchBoxStyleProps, ISearchBoxStyles } from 'office-ui-fabric-react/lib/SearchBox';
+import { ISearchBoxStyleProps, ISearchBoxStyles } from 'office-ui-fabric-react';
 
 export const SearchBoxStyles = (props: ISearchBoxStyleProps): Partial<ISearchBoxStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Slider.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Slider.styles.ts
@@ -1,4 +1,4 @@
-import { ISliderStyleProps, ISliderStyles } from 'office-ui-fabric-react/lib/Slider';
+import { ISliderStyleProps, ISliderStyles } from 'office-ui-fabric-react';
 
 export const SliderStyles = (props: ISliderStyleProps): Partial<ISliderStyles> => {
   const { disabled, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SpinButton.styles.ts
@@ -1,4 +1,4 @@
-import { ISpinButtonStyles, ISpinButtonProps } from 'office-ui-fabric-react/lib/SpinButton';
+import { ISpinButtonStyles, ISpinButtonProps } from 'office-ui-fabric-react';
 
 export const SpinButtonStyles = (props: ISpinButtonProps): Partial<ISpinButtonStyles> => {
   const SPIN_BUTTON_WIDTH = 23;

--- a/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TagPicker.styles.ts
@@ -1,4 +1,4 @@
-import { ITagItemStyleProps, ITagItemStyles } from 'office-ui-fabric-react/lib/Pickers';
+import { ITagItemStyleProps, ITagItemStyles } from 'office-ui-fabric-react';
 
 export const TagItemStyles = (props: ITagItemStyleProps): Partial<ITagItemStyles> => {
   const { theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TeachingBubble.styles.ts
@@ -1,6 +1,5 @@
 import { FontSizes } from '../FluentType';
-import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react/lib/TeachingBubble';
+import { FontWeights, ITeachingBubbleStyleProps, ITeachingBubbleStyles } from 'office-ui-fabric-react';
 
 export const TeachingBubbleStyles = (props: ITeachingBubbleStyleProps): Partial<ITeachingBubbleStyles> => {
   const { hasCondensedHeadline, hasSmallHeadline, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/TextField.styles.ts
@@ -1,4 +1,4 @@
-import { ITextFieldStyleProps, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
+import { ITextFieldStyleProps, ITextFieldStyles } from 'office-ui-fabric-react';
 
 export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextFieldStyles> => {
   const { focused, disabled, hasErrorMessage, multiline, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/Toggle.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Toggle.styles.ts
@@ -1,5 +1,4 @@
-import { FontWeights } from 'office-ui-fabric-react/lib/Styling';
-import { IToggleStyleProps, IToggleStyles } from 'office-ui-fabric-react/lib/Toggle';
+import { FontWeights, IToggleStyleProps, IToggleStyles } from 'office-ui-fabric-react';
 
 export const ToggleStyles = (props: IToggleStyleProps): Partial<IToggleStyles> => {
   const { disabled, checked, theme } = props;

--- a/packages/fluent-theme/src/fluent/styles/styleConstants.ts
+++ b/packages/fluent-theme/src/fluent/styles/styleConstants.ts
@@ -1,4 +1,4 @@
-import { ScreenWidthMaxMedium, ScreenWidthMaxSmall, ScreenWidthMinMedium, getScreenSelector } from '@uifabric/styling';
+import { ScreenWidthMaxMedium, ScreenWidthMaxSmall, ScreenWidthMinMedium, getScreenSelector } from 'office-ui-fabric-react';
 
 export const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMaxSmall);
 export const MediumScreenSelector = getScreenSelector(ScreenWidthMinMedium, ScreenWidthMaxMedium);

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2353,7 +2353,6 @@ export interface ICoachmarkState {
     isMeasured: boolean;
     isMeasuring: boolean;
     isMouseInProximity: boolean;
-    // Warning: (ae-forgotten-export) The symbol "RectangleEdge" needs to be exported by the entry point index.d.ts
     targetAlignment?: RectangleEdge;
     targetPosition?: RectangleEdge;
     transformOrigin?: string;
@@ -8465,6 +8464,18 @@ export enum RatingSize {
     Large = 1,
     // (undocumented)
     Small = 0,
+}
+
+// @public (undocumented)
+export enum RectangleEdge {
+    // (undocumented)
+    bottom = -1,
+    // (undocumented)
+    left = 2,
+    // (undocumented)
+    right = -2,
+    // (undocumented)
+    top = 1,
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/Utilities.ts
+++ b/packages/office-ui-fabric-react/src/Utilities.ts
@@ -1,2 +1,3 @@
 import './version';
 export * from '@uifabric/utilities';
+export { RectangleEdge } from './utilities/positioning/index';

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -1,9 +1,8 @@
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { getScrollbarWidth, getRTL, Rectangle as FullRectangle, IRectangle } from '../../Utilities';
+import { getScrollbarWidth, getRTL, Rectangle as FullRectangle, IRectangle, IPoint } from '../../Utilities';
 import {
   IPositionDirectionalHintData,
   IPositionedData,
-  IPoint,
   ICalloutPositionedInfo,
   ICalloutBeakPositionedInfo,
   IPositionProps,

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.types.ts
@@ -1,6 +1,5 @@
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { IPoint } from './positioning.types';
-import { IRectangle } from '../../Utilities';
+import { IRectangle, IPoint } from '../../Utilities';
 
 export enum RectangleEdge {
   top = 1,
@@ -99,11 +98,6 @@ export interface IPosition {
   bottom?: number;
   right?: number;
   [key: string]: number | undefined;
-}
-
-export interface IPoint {
-  x: number;
-  y: number;
 }
 
 export interface IPositionDirectionalHintData {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9150
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This removes the extra deps - everything should come in through oufr and variants. The import specifiers are changed to point to root so that it's consistent and can work with commonjs environments. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9158)