### PR TITLE
Nav accessibility: Update expand button's aria label to include link name

### DIFF
--- a/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
+++ b/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Nav: Add expandButtonAriaLabelUseName prop, use link name as default aria label for expand button",
-      "type": "minor"
+      "comment": "Nav: Prepend link name to aria label for expand button and set it as default if no label is provided",
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
+++ b/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "Nav: Set link name as default aria-label for chevron",
+      "comment": "Nav: Add expandButtonAriaLabelUseName prop, use link name as default aria label for expand button",
       "type": "minor"
     }
   ],

--- a/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
+++ b/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Nav: Set link name as default aria-label for chevron",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
+++ b/common/changes/office-ui-fabric-react/nav-accessibility_2019-05-20-21-11.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Nav: Set link name as default aria-label for chevron",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5377,7 +5377,6 @@ export interface INavProps {
     collapsedStateText?: string;
     componentRef?: IRefObject<INav>;
     expandButtonAriaLabel?: string;
-    expandButtonAriaLabelUseName?: boolean;
     // @deprecated
     expandedStateText?: string;
     groups: INavLinkGroup[] | null;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5377,6 +5377,7 @@ export interface INavProps {
     collapsedStateText?: string;
     componentRef?: IRefObject<INav>;
     expandButtonAriaLabel?: string;
+    expandButtonAriaLabelUseName?: boolean;
     // @deprecated
     expandedStateText?: string;
     groups: INavLinkGroup[] | null;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -138,7 +138,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
   private _renderCompositeLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
     const divProps: React.HTMLProps<HTMLDivElement> = { ...getNativeProps(link, divProperties, ['onClick']) };
-    const { styles, groups, theme } = this.props;
+    const { expandButtonAriaLabel, expandButtonAriaLabelUseName, styles, groups, theme } = this.props;
     const classNames = getClassNames(styles!, {
       theme: theme!,
       isExpanded: !!link.isExpanded,
@@ -149,13 +149,19 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
       groups
     });
 
+    const submenuArialLabel = expandButtonAriaLabel
+      ? expandButtonAriaLabelUseName
+        ? `${link.name} ${expandButtonAriaLabel}`
+        : expandButtonAriaLabel
+      : link.name;
+
     return (
       <div {...divProps} key={link.key || linkIndex} className={classNames.compositeLink}>
         {link.links && link.links.length > 0 ? (
           <button
             className={classNames.chevronButton}
             onClick={this._onLinkExpandClicked.bind(this, link)}
-            aria-label={this.props.expandButtonAriaLabel || link.name}
+            aria-label={submenuArialLabel || link.name}
             aria-expanded={link.isExpanded ? 'true' : 'false'}
           >
             <Icon className={classNames.chevronIcon} iconName="ChevronDown" />

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -138,7 +138,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
   private _renderCompositeLink(link: INavLink, linkIndex: number, nestingLevel: number): React.ReactElement<{}> {
     const divProps: React.HTMLProps<HTMLDivElement> = { ...getNativeProps(link, divProperties, ['onClick']) };
-    const { expandButtonAriaLabel, expandButtonAriaLabelUseName, styles, groups, theme } = this.props;
+    const { expandButtonAriaLabel, styles, groups, theme } = this.props;
     const classNames = getClassNames(styles!, {
       theme: theme!,
       isExpanded: !!link.isExpanded,
@@ -149,11 +149,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
       groups
     });
 
-    const expandBtnArialLabel = expandButtonAriaLabel
-      ? expandButtonAriaLabelUseName
-        ? `${link.name} ${expandButtonAriaLabel}`
-        : expandButtonAriaLabel
-      : link.name;
+    const finalExpandBtnAriaLabel = expandButtonAriaLabel ? `${link.name} ${expandButtonAriaLabel}` : link.name;
 
     return (
       <div {...divProps} key={link.key || linkIndex} className={classNames.compositeLink}>
@@ -161,7 +157,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
           <button
             className={classNames.chevronButton}
             onClick={this._onLinkExpandClicked.bind(this, link)}
-            aria-label={expandBtnArialLabel || link.name}
+            aria-label={finalExpandBtnAriaLabel}
             aria-expanded={link.isExpanded ? 'true' : 'false'}
           >
             <Icon className={classNames.chevronIcon} iconName="ChevronDown" />

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -149,7 +149,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
       groups
     });
 
-    const submenuArialLabel = expandButtonAriaLabel
+    const expandBtnArialLabel = expandButtonAriaLabel
       ? expandButtonAriaLabelUseName
         ? `${link.name} ${expandButtonAriaLabel}`
         : expandButtonAriaLabel
@@ -161,7 +161,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
           <button
             className={classNames.chevronButton}
             onClick={this._onLinkExpandClicked.bind(this, link)}
-            aria-label={submenuArialLabel || link.name}
+            aria-label={expandBtnArialLabel || link.name}
             aria-expanded={link.isExpanded ? 'true' : 'false'}
           >
             <Icon className={classNames.chevronIcon} iconName="ChevronDown" />

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -155,7 +155,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
           <button
             className={classNames.chevronButton}
             onClick={this._onLinkExpandClicked.bind(this, link)}
-            aria-label={this.props.expandButtonAriaLabel}
+            aria-label={this.props.expandButtonAriaLabel || link.name}
             aria-expanded={link.isExpanded ? 'true' : 'false'}
           >
             <Icon className={classNames.chevronIcon} iconName="ChevronDown" />

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -97,14 +97,10 @@ export interface INavProps {
   ariaLabel?: string;
 
   /**
-   * (Optional) The nav container aria label. If not provided, the aria label will default to the link name.
+   * (Optional) The nav container aria label. The link name is prepended to this label.
+   * If not provided, the aria label will default to the link name.
    */
   expandButtonAriaLabel?: string;
-
-  /**
-   * (Optional) If true, the link name will be prepended to `expandButtonAriaLabel`.
-   */
-  expandButtonAriaLabelUseName?: boolean;
 
   /**
    * Deprecated at v0.68.1 and will be removed at \>= v1.0.0.

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -97,7 +97,7 @@ export interface INavProps {
   ariaLabel?: string;
 
   /**
-   * (Optional) The nav container aria label.
+   * (Optional) The nav container aria label. If not provided, the aria label will default to the link name.
    */
   expandButtonAriaLabel?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -102,6 +102,11 @@ export interface INavProps {
   expandButtonAriaLabel?: string;
 
   /**
+   * (Optional) If true, the link name will be prepended to `expandButtonAriaLabel`.
+   */
+  expandButtonAriaLabelUseName?: boolean;
+
+  /**
    * Deprecated at v0.68.1 and will be removed at \>= v1.0.0.
    * @deprecated Removed at v1.0.0.
    **/

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -87,7 +87,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
             >
               <button
                 aria-expanded="true"
-                aria-label="Expand or collapse"
+                aria-label="Home Expand or collapse"
                 className=
                     ms-Nav-chevronButton
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -82,7 +82,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
             >
               <button
                 aria-expanded="false"
-                aria-label="Expand or collapse"
+                aria-label="Parent link 1 Expand or collapse"
                 className=
                     ms-Nav-chevronButton
                     {
@@ -336,7 +336,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
             >
               <button
                 aria-expanded="false"
-                aria-label="Expand or collapse"
+                aria-label="Parent link 2 Expand or collapse"
                 className=
                     ms-Nav-chevronButton
                     {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- If `expandButtonAriaLabel` is not provided, aria-label will default to the link name
- Set link name as default value for `expandButtonAriaLabel`

Per accessibility requirement, functionality and navigation of the content must be exposed. Screenreader should indicate which control is in focus and provide instructions for navigation. Currently, when focused on the expand button, Narrator will read the `expandButtonAriaLabel` if provided but does not give context on which nav item is focused. If `expandButtonAriaLabel` is not provided, Narrator will only read "Button collapsed."

With this change, given link "Home" with sublinks:
- If `expandButtonAriaLabel` is not provided, Narrator will read "Home button collapsed" when the expand button is focused. (Previously just "Button collapsed.")
- If `expandButtonAriaLabel` is provided, Narrator will read "Home {expandButtonAriaLabel}. Button collapsed.", e.g. "Home submenu button.  Use arrow keys and enter to navigate. Button collapsed." 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9163)