### PR TITLE
Minor website code and codeowner updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@ azure-pipelines.yml @ecraig12345 @kenotron
 
 #### Apps
 # component-demo/
-fabric-website/ @jordandrako @ecraig12345
+fabric-website/ @jordandrako @ecraig12345 @Jahnp
 fabric-website-resources/ @ecraig12345
 # ssr-tests/
 # test-bundle-button/ @dzearing
@@ -45,7 +45,7 @@ Controls/web.tsx @Vitalius1 @natalieethell
 packages/charting/ @Raghurk @veeray @chankev
 packages/codepen-loader/ @ecraig12345 @kenotron
 packages/foundation/ @JasonGore
-packages/example-app-base/ @ecraig12345
+packages/example-app-base/ @ecraig12345 @jordandrako
 packages/file-type-icons/  @KatherineThayerMicrosoft @jahnp @bigbadcapers
 # packages/icons/
 # packages/jest-serializer-merge-styles/

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -12,11 +12,12 @@ import {
   DirectionalHint,
   ActionButton,
   Stack,
-  IRawStyle
+  IRawStyle,
+  css
 } from 'office-ui-fabric-react';
 import { trackEvent, EventNames, getSiteArea, MarkdownHeader } from '@uifabric/example-app-base/lib/index2';
 import { platforms } from '../../SiteDefinition/SiteDefinition.platforms';
-import { AndroidLogo, AppleLogo, WebLogo, getParameterByName } from '../../utilities/index';
+import { AndroidLogo, AppleLogo, WebLogo } from '../../utilities/index';
 import { IHomePageProps, IHomePageStyles, IHomePageStyleProps } from './HomePage.types';
 import { monoFont } from './HomePage.styles';
 const reactPackageData = require<any>('office-ui-fabric-react/package.json');
@@ -58,6 +59,13 @@ const fabricVersionOptions: IContextualMenuItem[] = [
     text: 'Fabric 5'
   }
 ];
+
+interface IRenderLinkOptions {
+  disabled?: boolean;
+  isCTA?: boolean;
+  icon?: string;
+  dark?: boolean;
+}
 
 export interface IHomePageState {
   isMounted: boolean;
@@ -125,7 +133,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
               seamlessly into a broad range of Microsoft products.
             </p>
             <p>Connect with the cross-platform styles, controls and resources you need to do amazing things.</p>
-            <p>{this._renderLink('#/get-started', 'Get started', false, true)}</p>
+            <p>{this._renderLink('#/get-started', 'Get started', { isCTA: true, dark: false })}</p>
           </div>
         </div>
       </section>
@@ -262,7 +270,7 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
           <div className={this._classNames.oneFourth}>
             <h2 className={this._classNames.resourcesTitle}>Discover resources</h2>
             <p>Find design, inclusive and developer onboarding resources, and learn about how to become a contributor.</p>
-            <p>{this._renderLink('#/resources', 'See resources')}</p>
+            <p>{this._renderLink('#/resources', 'See resources', { dark: false })}</p>
           </div>
         </div>
       </section>
@@ -290,10 +298,11 @@ export class HomePageBase extends React.Component<IHomePageProps, IHomePageState
   };
 
   /**Renders a link with an icon */
-  private _renderLink = (url: string, text: React.ReactNode, disabled?: boolean, isCTA?: boolean, icon = 'Forward'): JSX.Element => {
+  private _renderLink = (url: string, text: React.ReactNode, options: IRenderLinkOptions = {}): JSX.Element => {
+    const { disabled, isCTA, icon = 'Forward', dark = true } = options;
     return (
       <Link
-        className={this._classNames.link}
+        className={css(this._classNames.link, dark && this._classNames.linkDark)}
         href={url}
         disabled={!!disabled}
         // tslint:disable-next-line jsx-no-lambda

--- a/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
@@ -30,6 +30,7 @@ const GlobalClassNames: { [key in keyof IHomePageStyles]: string } = {
   cardListItem: 'ms-HomePage-cardListItem',
   cardIcon: 'ms-HomePage-cardIcon',
   link: 'ms-HomePage-link',
+  linkDark: 'ms-HomePage-linkDark',
   linkIcon: 'ms-HomePage-linkIcon',
   linkText: 'ms-HomePage-linkText',
   illustration: 'ms-HomePage-illustration'
@@ -38,6 +39,8 @@ const GlobalClassNames: { [key in keyof IHomePageStyles]: string } = {
 export const monoFont =
   '"Segoe UI Mono",Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono",' +
   '"Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace';
+
+const allLinkStatesSelector = '&:hover, &:active, &:active:hover, &:link';
 
 export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
   const { theme, className, isMountedOffset, isInverted, beforeColor, afterColor } = props;
@@ -326,10 +329,6 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
         minWidth: 300,
 
         selectors: {
-          'a, a:hover, a:active, p': {
-            color: palette.black
-          },
-
           [mediaQuery.maxLarge]: {
             flex: '1 0 25%'
           }
@@ -395,12 +394,14 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
         fontFamily: monoFont,
         display: 'flex',
         alignItems: 'center',
-        color: 'inherit',
+        color: theme.palette.white,
 
         selectors: {
-          '&:hover, &:active, &:active:hover': {
+          // Override default link styles and UHF styles
+          // (due to UHF styles, we have to use a specific color rather than 'inherit')
+          [allLinkStatesSelector]: {
             textDecoration: 'none',
-            color: 'inherit'
+            color: theme.palette.white
           },
 
           [`
@@ -409,6 +410,18 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
             &:not(.is-disabled):active:hover .${classNames.linkText}
           `]: {
             borderColor: 'inherit'
+          }
+        }
+      }
+    ],
+
+    linkDark: [
+      classNames.linkDark,
+      {
+        color: theme.palette.black,
+        selectors: {
+          [allLinkStatesSelector]: {
+            color: theme.palette.black
           }
         }
       }

--- a/apps/fabric-website/src/pages/HomePage/HomePage.types.ts
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.types.ts
@@ -10,6 +10,7 @@ export interface IHomePageStyleProps {
   theme: ITheme;
   className?: string;
   isMountedOffset: boolean;
+  /** On this page, a *light* background is inverted and a dark background is normal. */
   isInverted?: boolean;
   beforeColor?: string;
   afterColor?: string;
@@ -40,6 +41,7 @@ export interface IHomePageStyles {
   cardListItem: IStyle;
   cardIcon: IStyle;
   link: IStyle;
+  linkDark: IStyle;
   linkIcon: IStyle;
   linkText: IStyle;
   illustration: IStyle;

--- a/common/changes/@uifabric/example-app-base/website-codeowners_2019-05-15-05-55.json
+++ b/common/changes/@uifabric/example-app-base/website-codeowners_2019-05-15-05-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Update withPlatform return type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/website-codeowners_2019-05-15-06-12.json
+++ b/common/changes/@uifabric/fabric-website/website-codeowners_2019-05-15-06-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix home page card link color",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/utilities/PlatformContext.tsx
+++ b/packages/example-app-base/src/utilities/PlatformContext.tsx
@@ -9,7 +9,7 @@ export interface IWithPlatformProps<TPlatforms extends string = string> {
 export function withPlatform<
   TPlatforms extends string = string,
   TProps extends IWithPlatformProps<TPlatforms> = IWithPlatformProps<TPlatforms>
->(Component: React.ComponentType<TProps>): React.StatelessComponent<IWithPlatformProps<TPlatforms>> {
+>(Component: React.ComponentType<TProps>): React.StatelessComponent<TProps> {
   const ComponentWithPlatform: React.StatelessComponent = (props: TProps & { children?: React.ReactNode }) => (
     <PlatformContext.Consumer>{(platform: string) => <Component {...props} platform={platform} />}</PlatformContext.Consumer>
   );


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add additional codeowners as requested on #9098 (which auto-merged before I saw the comments).

Update example-app-base `withPlatform` to return `React.StatelessComponent<TProps>`.

Fix link colors on home page: the links were showing up light gray instead of black (seemingly due to UHF styles), which resulted in a non-accessible color combination.

(This is a follow-up for #9107, which for some reason I seem to have closed instead of merging?)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9165)