### PR TITLE
Exclude yml from prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "node ./scripts/lint-staged/tslint",
         "git add"
       ],
-      "*.{js,jsx,json,scss,html,yml,md}": [
+      "*.{js,jsx,json,scss,html,md}": [
         "node ./scripts/lint-staged/prettier",
         "git add"
       ]

--- a/scripts/prettier/prettier-helpers.js
+++ b/scripts/prettier/prettier-helpers.js
@@ -58,7 +58,7 @@ function runPrettier(files, configPath, runAsync) {
 function runPrettierForProject(projectPath) {
   init();
 
-  const sourcePath = path.join(projectPath, '**', '*.{ts,tsx,js,jsx,json,scss,html,yml,md}');
+  const sourcePath = path.join(projectPath, '**', '*.{ts,tsx,js,jsx,json,scss,html,md}');
   const configPath = projectsWithPrettierConfig.includes(projectPath) ? path.join(projectPath, prettierConfig) : prettierRulesConfig;
   return runPrettier([sourcePath], configPath, true);
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Exclude yml files from prettier.

YML is a space-sensitive file format. We presently use it for build definitions. Prettier is often a hindrance than a help, esp. when yml file changes are sometimes made from external sources (Azure Pipelines).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9179)