### PR TITLE
DetailsList on header key down should only select the first item if selection doesn't already exist

### DIFF
--- a/common/changes/office-ui-fabric-react/dl-downkey_2019-05-22-18-26.json
+++ b/common/changes/office-ui-fabric-react/dl-downkey_2019-05-22-18-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailList: only select the first item on keydown from header if there isn't already something selected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -586,7 +586,11 @@ export class DetailsListBase extends BaseComponent<IDetailsListProps, IDetailsLi
     if (ev.which === KeyCodes.down) {
       if (this._focusZone.current && this._focusZone.current.focus()) {
         // select the first item in list after down arrow key event
-        this._selection.setIndexSelected(0, true, false);
+        // only if nothing was selected; otherwise start with the already-selected item
+        if (this._selection.getSelectedIndices().length === 0) {
+          this._selection.setIndexSelected(0, true, false);
+        }
+
         ev.preventDefault();
         ev.stopPropagation();
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9176 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

After #5966, pressing down key from header will auto select the first item. This is okay if the selection doesn't already exist. If it does, that behavior exhibits the bug described in #9176.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9180)