### PR TITLE
Hide UHF back to top button

### DIFF
--- a/apps/fabric-website/src/components/Site/Site.module.scss
+++ b/apps/fabric-website/src/components/Site/Site.module.scss
@@ -1,9 +1,9 @@
 @import '../../styles/variables';
 @import '../../styles/mixins';
 
-// #headerWrapper is the UHF header wrapper. The p, ul, ol style in _typography.scss was making
-// the header links larger than they should be, so reset that here.
 :global {
+  // #headerWrapper is the UHF header wrapper. The p, ul, ol style in _typography.scss was making
+  // the header links larger than they should be, so reset that here.
   #headerWrapper,
   #footerWrapper,
   #socialMediaContainer,
@@ -13,6 +13,11 @@
     ol {
       font-size: inherit;
     }
+  }
+
+  // Hide UHF back to top button that attempts to go to a nonexistent #main-content page
+  a.m-back-to-top {
+    display: none !important;
   }
 }
 

--- a/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.styles.ts
@@ -404,11 +404,9 @@ export const getStyles = (props: IHomePageStyleProps): IHomePageStyles => {
             color: theme.palette.white
           },
 
-          [`
-            &:not(.is-disabled):hover .${classNames.linkText},
-            &:not(.is-disabled):active .${classNames.linkText},
-            &:not(.is-disabled):active:hover .${classNames.linkText}
-          `]: {
+          [`&:not(.is-disabled):hover .${classNames.linkText}, ` +
+          `&:not(.is-disabled):active .${classNames.linkText}, ` +
+          `&:not(.is-disabled):active:hover .${classNames.linkText}`]: {
             borderColor: 'inherit'
           }
         }

--- a/common/changes/@uifabric/fabric-website/back-to-top_2019-05-22-20-53.json
+++ b/common/changes/@uifabric/fabric-website/back-to-top_2019-05-22-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Hide UHF back to top button",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Hide back to top arrow button which the UHF makes show up in certain cases--it attempts to scroll to the `#main-content` element by changing the hash, which on our site means it navigates to https://developer.microsoft.com/en-us/fabric#main-content which doesn't exist.

Also converted a multiline string with a bunch of whitespace in a style function to use string concatenation, to slightly reduce minified size.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9183)