### PR TITLE
TextField: remove unecessary font override for ::placeholder

### DIFF
--- a/common/changes/office-ui-fabric-react/tf-font-size_2019-05-23-15-17.json
+++ b/common/changes/office-ui-fabric-react/tf-font-size_2019-05-23-15-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: remove unecessary font override for ::placeholder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -278,14 +278,12 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             display: 'none'
           },
           '::placeholder': [
-            theme.fonts.medium,
             {
               color: semanticColors.inputPlaceholderText,
               opacity: 1
             }
           ],
           ':-ms-input-placeholder': [
-            theme.fonts.medium,
             {
               color: semanticColors.inputPlaceholderText,
               opacity: 1


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9181 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

I think we added some fixed font sizes here:  #8018. However, we can simply use the inherited font size for a default for TextField placeholders as a default. This restores the font definitions while retaining the placeholder coloring. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9193)