### PR TITLE
Styled: Fixed wrapped styled component regression

### DIFF
--- a/common/changes/@uifabric/utilities/jg-fix-nested-styled-regression_2019-05-23-20-06.json
+++ b/common/changes/@uifabric/utilities/jg-fix-nested-styled-regression_2019-05-23-20-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Fix wrapped styled regression caused by nested style arrays.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "jagore@microsoft.com"
+}

--- a/packages/utilities/src/__snapshots__/styled.test.tsx.snap
+++ b/packages/utilities/src/__snapshots__/styled.test.tsx.snap
@@ -52,13 +52,14 @@ exports[`styled can wrap components and merge styling functions for both 1`] = `
 />
 `;
 
-exports[`styled can wrap components and merge styling objects for both 1`] = `
+exports[`styled can wrap components and merge styling objects for all 1`] = `
 <div
   className=
 
       {
         background: blue;
         color: green;
+        line-height: 19px;
       }
 />
 `;

--- a/packages/utilities/src/__snapshots__/styled.test.tsx.snap
+++ b/packages/utilities/src/__snapshots__/styled.test.tsx.snap
@@ -41,13 +41,14 @@ exports[`styled can process style props (background blue) 1`] = `
 />
 `;
 
-exports[`styled can wrap components and merge styling functions for both 1`] = `
+exports[`styled can wrap components and merge styling functions for all 1`] = `
 <div
   className=
 
       {
         background: blue;
         color: green;
+        line-height: 29px;
       }
 />
 `;

--- a/packages/utilities/src/__snapshots__/styled.test.tsx.snap
+++ b/packages/utilities/src/__snapshots__/styled.test.tsx.snap
@@ -41,6 +41,68 @@ exports[`styled can process style props (background blue) 1`] = `
 />
 `;
 
+exports[`styled can wrap components and merge styling functions for both 1`] = `
+<div
+  className=
+
+      {
+        background: blue;
+        color: green;
+      }
+/>
+`;
+
+exports[`styled can wrap components and merge styling objects for both 1`] = `
+<div
+  className=
+
+      {
+        background: blue;
+        color: green;
+      }
+/>
+`;
+
+exports[`styled gives styles function user prop priority 1`] = `
+<div
+  className=
+
+      {
+        background: purple;
+      }
+/>
+`;
+
+exports[`styled gives styles object user prop priority 1`] = `
+<div
+  className=
+
+      {
+        background: purple;
+      }
+/>
+`;
+
+exports[`styled gives wrapped styles function priority 1`] = `
+<div
+  className=
+
+      {
+        background: grey;
+      }
+/>
+`;
+
+exports[`styled gives wrapped styles object priority 1`] = `
+<div
+  className=
+
+      {
+        background: grey;
+      }
+/>
+`;
+
 exports[`styled renders base styles (background red) 1`] = `
 <div
   className=

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -185,6 +185,54 @@ describe('styled', () => {
     });
   });
 
+  it('can wrap components and merge styling objects for both', () => {
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { color: 'green' } }, undefined, { scope: 'WrappedTest' });
+    safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  it('can wrap components and merge styling functions for both', () => {
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { color: 'green' } }), undefined, {
+      scope: 'WrappedTest'
+    });
+    safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  it('gives wrapped styles object priority', () => {
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { background: 'grey' } }, undefined, { scope: 'WrappedTest' });
+    safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  it('gives wrapped styles function priority', () => {
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { background: 'grey' } }), undefined, {
+      scope: 'WrappedTest'
+    });
+    safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  it('gives styles object user prop priority', () => {
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { background: 'grey' } }, undefined, { scope: 'WrappedTest' });
+    safeCreate(<TestWrapped cool styles={{ root: { background: 'purple' } }} />, (component: renderer.ReactTestRenderer) => {
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  it('gives styles function user prop priority', () => {
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { background: 'grey' } }), undefined, {
+      scope: 'WrappedTest'
+    });
+    safeCreate(<TestWrapped cool styles={{ root: { background: 'purple' } }} />, (component: renderer.ReactTestRenderer) => {
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+
   it('can re-render on customization mutations', () => {
     safeCreate(<Test />, () => {
       expect(_renderCount).toEqual(1);

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -185,9 +185,10 @@ describe('styled', () => {
     });
   });
 
-  it('can wrap components and merge styling objects for both', () => {
-    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { color: 'green' } }, undefined, { scope: 'WrappedTest' });
-    safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
+  it('can wrap components and merge styling objects for all', () => {
+    const TestInner = styled<ITestProps, {}, ITestStyles>(Test, { root: { color: 'green' } }, undefined, { scope: 'TestInner' });
+    const TestOuter = styled<ITestProps, {}, ITestStyles>(TestInner, { root: { lineHeight: '19px' } }, undefined, { scope: 'TestOuter' });
+    safeCreate(<TestOuter cool />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });
   });

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -186,49 +186,44 @@ describe('styled', () => {
   });
 
   it('can wrap components and merge styling objects for all', () => {
-    const TestInner = styled<ITestProps, {}, ITestStyles>(Test, { root: { color: 'green' } }, undefined, { scope: 'TestInner' });
-    const TestOuter = styled<ITestProps, {}, ITestStyles>(TestInner, { root: { lineHeight: '19px' } }, undefined, { scope: 'TestOuter' });
+    const TestInner = styled<ITestProps, {}, ITestStyles>(Test, { root: { color: 'green' } }, undefined);
+    const TestOuter = styled<ITestProps, {}, ITestStyles>(TestInner, { root: { lineHeight: '19px' } }, undefined);
     safeCreate(<TestOuter cool />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });
   });
 
-  it('can wrap components and merge styling functions for both', () => {
-    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { color: 'green' } }), undefined, {
-      scope: 'WrappedTest'
-    });
-    safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
+  it('can wrap components and merge styling functions for all', () => {
+    const TestInner = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { color: 'green' } }), undefined);
+    const TestOuter = styled<ITestProps, {}, ITestStyles>(TestInner, () => ({ root: { lineHeight: '29px' } }), undefined);
+    safeCreate(<TestOuter cool />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });
   });
 
   it('gives wrapped styles object priority', () => {
-    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { background: 'grey' } }, undefined, { scope: 'WrappedTest' });
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { background: 'grey' } }, undefined);
     safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });
   });
 
   it('gives wrapped styles function priority', () => {
-    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { background: 'grey' } }), undefined, {
-      scope: 'WrappedTest'
-    });
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { background: 'grey' } }), undefined);
     safeCreate(<TestWrapped cool />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });
   });
 
   it('gives styles object user prop priority', () => {
-    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { background: 'grey' } }, undefined, { scope: 'WrappedTest' });
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, { root: { background: 'grey' } }, undefined);
     safeCreate(<TestWrapped cool styles={{ root: { background: 'purple' } }} />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });
   });
 
   it('gives styles function user prop priority', () => {
-    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { background: 'grey' } }), undefined, {
-      scope: 'WrappedTest'
-    });
+    const TestWrapped = styled<ITestProps, {}, ITestStyles>(Test, () => ({ root: { background: 'grey' } }), undefined);
     safeCreate(<TestWrapped cool styles={{ root: { background: 'purple' } }} />, (component: renderer.ReactTestRenderer) => {
       expect(component.toJSON()).toMatchSnapshot();
     });

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { flatten } from './array';
 import { concatStyleSets, IStyleSet, IStyleFunctionOrObject, IConcatenatedStyleSet } from '@uifabric/merge-styles';
 import { Customizations } from './customizations/Customizations';
 import { CustomizerContext, ICustomizerContext } from './customizations/CustomizerContext';
@@ -97,7 +98,9 @@ export function styled<
 
     private _updateStyles(customizedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>): void {
       if (!this._styles || customizedStyles !== this._styles[1] || !!this.props.styles) {
-        this._styles = [baseStyles, customizedStyles, this.props.styles];
+        // Using styled components as the Component arg will result in nested styling arrays.
+        // Use flatten to ensure that the _styles array remains flat when styled components are wrapped.
+        this._styles = flatten([baseStyles, customizedStyles, this.props.styles]);
       }
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9189
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The root cause of this issue is that wrapped styled components end up creating nested style arrays per #8761:

```
this._styles = [
  Link's base styles,
  Link's customized styles,
  [
    StyledLink's base styles,
    StyledLink's customized styles,
    StyledLink's styles prop
  ]
]
```

Since `classNamesFunction` does not recurse into style arrays, `StyledLink`'s styling was never processed.

This PR just adds `flatten` use to `styled` to ensure that wrapped component styling gets flattened and processed:

```
this._styles = [
  Link's base styles,
  Link's customized styles,
  StyledLink's base styles,
  StyledLink's customized styles,
  StyledLink's styles prop
]
```

#### Focus areas to test

Added unit tests that reproduced the issue and confirm it remains fixed moving forward.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9203)