### PR TITLE
Run lint-imports after ts

### DIFF
--- a/scripts/just.config.js
+++ b/scripts/just.config.js
@@ -76,11 +76,8 @@ module.exports = function preset() {
       'clean',
       'copy',
       'sass',
-      parallel(
-        condition('validate', () => !argv().min),
-        condition('lint-imports', () => argv().production && !argv().min),
-        series('ts', condition('webpack', () => !argv().min))
-      )
+      parallel(condition('validate', () => !argv().min), series('ts', condition('webpack', () => !argv().min))),
+      condition('lint-imports', () => argv().production && !argv().min)
     )
   );
 };


### PR DESCRIPTION
Fix the build by running `lint-imports` after `ts`. Otherwise lots of files won't exist yet, which makes `lint-imports` fail.

For some reason the existing code worked okay in PR and master builds, but failed on the release build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9204)