### PR TITLE
Autofill: makes sure the fresh input is retrieved at the time of composition end

### DIFF
--- a/common/changes/office-ui-fabric-react/android-autofill_2019-05-23-20-53.json
+++ b/common/changes/office-ui-fabric-react/android-autofill_2019-05-23-20-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Autofill: makes sure the fresh input is retrieved at the time of composition end",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -159,7 +159,8 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     const isKorean = (ev.nativeEvent as any).locale === 'ko';
     // Due to timing, this needs to be async, otherwise no text will be selected.
     this._async.setTimeout(() => {
-      const updatedInputValue = isKorean ? this.value : inputValue;
+      // Call getCurrentInputValue here again since there can be a race condition where this value has changed during the async call
+      const updatedInputValue = isKorean ? this.value : this._getCurrentInputValue();
       this._updateValue(updatedInputValue);
     }, 0);
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #9175
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Due to async timing, compositionend would end up getting stale data in autofill. We need to re-retrieve this so that it can prevent bugs like #9175 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9205)