### PR TITLE
Persona: rename and export function to get color

### DIFF
--- a/common/changes/@uifabric/experiments/persona_2019-04-19-03-07.json
+++ b/common/changes/@uifabric/experiments/persona_2019-04-19-03-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "PersonaCoin: use renamed persona color function",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/persona_2019-04-19-03-07.json
+++ b/common/changes/office-ui-fabric-react/persona_2019-04-19-03-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Persona: rename and export function to get color",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.styles.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.styles.ts
@@ -1,6 +1,6 @@
 import { IPersonaProps } from 'office-ui-fabric-react';
 import { IPersonaCoinComponent, IPersonaCoinStylesReturnType } from './PersonaCoin.types';
-import { initialsColorPropToColorCode } from 'office-ui-fabric-react/lib/components/Persona/PersonaInitialsColor';
+import { getPersonaInitialsColor } from 'office-ui-fabric-react/lib/Persona';
 
 export const DEFAULT_PERSONA_COIN_SIZE = 48;
 
@@ -10,7 +10,7 @@ export const PersonaCoinStyles: IPersonaCoinComponent['styles'] = (props, theme,
     initialsColor: props.initialsColor
   };
 
-  const { size = DEFAULT_PERSONA_COIN_SIZE, coinColor = initialsColorPropToColorCode(personaProps), initialsColor = 'white' } = props;
+  const { size = DEFAULT_PERSONA_COIN_SIZE, coinColor = getPersonaInitialsColor(personaProps), initialsColor = 'white' } = props;
 
   return {
     root: {

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1301,6 +1301,9 @@ export const getNextResizeGroupStateProvider: (measurementCache?: {
 };
 
 // @public
+export function getPersonaInitialsColor(props: Pick<IPersonaProps, 'primaryText' | 'text' | 'initialsColor'>): string;
+
+// @public
 export function getShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -12,7 +12,7 @@ import {
   PersonaPresence as PersonaPresenceEnum,
   PersonaSize
 } from '../Persona.types';
-import { initialsColorPropToColorCode } from '../PersonaInitialsColor';
+import { getPersonaInitialsColor } from '../PersonaInitialsColor';
 import { sizeToPixels } from '../PersonaConsts';
 
 const getClassNames = classNamesFunction<IPersonaCoinStyleProps, IPersonaCoinStyles>();
@@ -103,7 +103,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
               <div
                 className={mergeStyles(
                   classNames.initials,
-                  !showUnknownPersonaCoin && { backgroundColor: initialsColorPropToColorCode(this.props) }
+                  !showUnknownPersonaCoin && { backgroundColor: getPersonaInitialsColor(this.props) }
                 )}
                 style={coinSizeStyle}
                 aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -1,22 +1,22 @@
-import { initialsColorPropToColorCode } from './PersonaInitialsColor';
+import { getPersonaInitialsColor } from './PersonaInitialsColor';
 import { PersonaInitialsColor } from './Persona.types';
 
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
-    const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
+    const colorCode = getPersonaInitialsColor({ text: 'Kat Larrson' });
     expect(colorCode).toEqual('#5E4B8B');
 
-    const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
+    const colorCode2 = getPersonaInitialsColor({ text: 'Annie Lindqvist' });
     expect(colorCode2).toEqual('#00A300');
   });
 
   it('uses provided enum initialsColor if one was specified', () => {
-    const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson', initialsColor: PersonaInitialsColor.red });
+    const colorCode = getPersonaInitialsColor({ text: 'Kat Larrson', initialsColor: PersonaInitialsColor.red });
     expect(colorCode).toEqual('#EE1111');
   });
 
   it('uses provided string initialsColor if one was specified', () => {
-    const colorCode = initialsColorPropToColorCode({ text: 'Christian Gonzalez', initialsColor: 'violet' });
+    const colorCode = getPersonaInitialsColor({ text: 'Christian Gonzalez', initialsColor: 'violet' });
     expect(colorCode).toEqual('violet');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -83,7 +83,18 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
   }
 }
 
+/** @deprecated Use `getPersonaInitialsColor` */
 export function initialsColorPropToColorCode(props: IPersonaProps): string {
+  return getPersonaInitialsColor(props);
+}
+
+/**
+ * Gets the hex color string (prefixed with #) for the given persona props.
+ * This is the logic used internally by the Persona control.
+ * @param props - Current persona props
+ * @returns Hex color string prefixed with #
+ */
+export function getPersonaInitialsColor(props: Pick<IPersonaProps, 'primaryText' | 'text' | 'initialsColor'>): string {
   const { primaryText, text } = props;
   let { initialsColor } = props;
   let initialsColorCode: string;

--- a/packages/office-ui-fabric-react/src/components/Persona/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/index.ts
@@ -3,3 +3,5 @@ export * from './Persona.base';
 export * from './Persona.types';
 export * from './PersonaCoin/index';
 export * from './PersonaConsts';
+// Exporting in case someone would like to track the current color of a persona
+export { getPersonaInitialsColor } from './PersonaInitialsColor';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #8770
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Currently there's no "public" way to get the color which is automatically assigned to a Persona based on the user's initials. This PR renames the existing function for calculating the color from `initialsColorPropToColorCode` to `getPersonaInitialsColor` and exports it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9225)