### PR TITLE
Fix npm start in fabric-website

### DIFF
--- a/apps/fabric-website-resources/webpack.config.js
+++ b/apps/fabric-website-resources/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = [
 
     resolve: {
       alias: {
+        'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
         'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
         'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
         '@uifabric/api-docs/lib': path.resolve(__dirname, 'node_modules/@uifabric/api-docs/lib'),

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -44,9 +44,9 @@ module.exports = function(env) {
         alias: {
           '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
           '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
+          'office-ui-fabric-react$': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
           'office-ui-fabric-react/src': path.join(__dirname, 'node_modules/office-ui-fabric-react/src'),
           'office-ui-fabric-react/lib': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
-          'office-ui-fabric-react$': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
           '@uifabric/api-docs/lib': path.join(__dirname, 'node_modules/@uifabric/api-docs/lib')
         }
       }

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -26,6 +26,7 @@ module.exports = resources.createServeConfig({
     alias: {
       '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
       '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
+      'office-ui-fabric-react$': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
       'office-ui-fabric-react/src': path.join(__dirname, 'node_modules/office-ui-fabric-react/src'),
       'office-ui-fabric-react/lib': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
       '@uifabric/example-app-base$': path.join(__dirname, '../../packages/example-app-base/src'),

--- a/apps/fabric-website/webpack.uhf.serve.config.js
+++ b/apps/fabric-website/webpack.uhf.serve.config.js
@@ -39,6 +39,7 @@ module.exports = resources.createServeConfig({
     alias: {
       '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
       '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
+      'office-ui-fabric-react$': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
       'office-ui-fabric-react/src': path.join(__dirname, 'node_modules/office-ui-fabric-react/src'),
       'office-ui-fabric-react/lib': path.join(__dirname, 'node_modules/office-ui-fabric-react/lib'),
       'Props.ts.js': 'Props',

--- a/common/changes/@uifabric/fabric-website-resources/website-serve_2019-05-24-23-56.json
+++ b/common/changes/@uifabric/fabric-website-resources/website-serve_2019-05-24-23-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website-resources",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website/website-serve_2019-05-24-23-49.json
+++ b/common/changes/@uifabric/fabric-website/website-serve_2019-05-24-23-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/fabric-website",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/website-serve_2019-05-24-23-56.json
+++ b/common/changes/office-ui-fabric-react/website-serve_2019-05-24-23-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/webpack.codepen.config.js
+++ b/packages/office-ui-fabric-react/webpack.codepen.config.js
@@ -17,8 +17,9 @@ module.exports = resources.createServeConfig({
 
   resolve: {
     alias: {
-      'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
-      'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
+      'office-ui-fabric-react$': path.join(__dirname, 'src'),
+      'office-ui-fabric-react/src': path.join(__dirname, 'src'),
+      'office-ui-fabric-react/lib': path.join(__dirname, 'src'),
       'Props.ts.js': 'Props',
       'Example.tsx.js': 'Example'
     }

--- a/packages/office-ui-fabric-react/webpack.config.js
+++ b/packages/office-ui-fabric-react/webpack.config.js
@@ -27,6 +27,7 @@ function createConfig(config, onlyProduction) {
 
       resolve: {
         alias: {
+          'office-ui-fabric-react$': path.join(__dirname, 'lib'),
           'office-ui-fabric-react/src': path.join(__dirname, 'src'),
           'office-ui-fabric-react/lib': path.join(__dirname, 'lib'),
           'Props.ts.js': 'Props',


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Recent changes to make examples import from the root of `office-ui-fabric-react` broke `npm start` for the website. Fix by adding an alias for `office-ui-fabric-react$` to the website's webpack serve config.

Also add aliases for `office-ui-fabric-react$` to other webpack configs which didn't have it already.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9226)