### PR TITLE
SplitButton: Fixing some styling bugs related to the divider

### DIFF
--- a/common/changes/@uifabric/experiments/splitButtonStyles_2019-05-28-21-45.json
+++ b/common/changes/@uifabric/experiments/splitButtonStyles_2019-05-28-21-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "SplitButton: Fixing some styling bugs related to the divider.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.styles.ts
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.styles.ts
@@ -64,6 +64,9 @@ export const MenuButtonStyles: IMenuButtonComponent['styles'] = (props, theme, t
   const { className } = props;
 
   return {
+    root: {
+      display: 'inline-flex'
+    },
     button: [
       {
         backgroundColor: props.expanded ? tokens.backgroundColorExpanded : tokens.backgroundColor,

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -136,7 +136,7 @@ export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme,
       borderRightWidth: 0,
       borderTopWidth: props.primaryActionDisabled ? 0 : tokens.borderWidth,
       boxSizing: 'border-box',
-      height: '100%',
+      height: 'auto',
       width: 'auto',
 
       selectors: {
@@ -154,9 +154,8 @@ export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme,
     },
     splitDivider: {
       backgroundColor: props.primaryActionDisabled ? semanticColors.menuDivider : tokens.dividerColor,
-      boxSizing: 'border-box',
       display: 'inline-block',
-      height: 'calc(100% - 14px)',
+      height: '100%',
       margin: '7px 0px',
       width: '1px'
     },

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -65,6 +65,7 @@ export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme,
     root: {
       borderRadius: tokens.borderRadius,
       boxSizing: 'border-box',
+      display: 'inline-flex',
       zIndex: 1,
 
       selectors: {

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -1,4 +1,4 @@
-import { IStackSlot, IStackItemSlot } from 'office-ui-fabric-react';
+import { IStackSlot } from 'office-ui-fabric-react';
 import { IComponent, IComponentStyles, IHTMLSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../../Foundation';
 import { IBaseProps } from '../../../Utilities';
 import { INativeButtonProps } from '../Button.types';
@@ -50,7 +50,7 @@ export interface ISplitButtonSlots extends IMenuButtonSlots {
   /**
    * Defines the container for the divider that is used for styling purposes.
    */
-  splitDividerContainer?: IStackItemSlot;
+  splitDividerContainer?: IStackSlot;
 
   /**
    * Defines the divider that separates the left and right parts of a SplitButton.

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -43,7 +43,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     content: Text,
     menu: ContextualMenu,
     menuIcon: Icon,
-    splitDividerContainer: Stack.Item,
+    splitDividerContainer: Stack,
     splitDivider: 'span'
   });
 
@@ -54,12 +54,15 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     backgroundColor,
     backgroundColorHovered,
     backgroundColorPressed,
+    borderColor,
+    borderColorHovered,
+    borderColorPressed,
     color,
     colorHovered,
     colorPressed,
     ...nonColoredButtonTokens
   } = splitButtonTokens;
-  const buttonTokens = primaryActionDisabled ? { contentPadding, contentPaddingFocused, nonColoredButtonTokens } : tokens;
+  const buttonTokens = primaryActionDisabled ? { contentPadding, contentPaddingFocused, ...nonColoredButtonTokens } : tokens;
   const menuButtonTokens = { contentPadding: secondaryPadding, ...splitButtonTokens };
 
   return (

--- a/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
@@ -105,6 +105,9 @@ const SplitMenuButtonVerticalStyles: ISplitRibbonMenuButtonProps['styles'] = (pr
       borderLeftWidth: tokens.borderWidth,
       borderRightWidth: tokens.borderWidth,
       borderTopWidth: 0
+    },
+    splitDividerContainer: {
+      borderWidth: 0
     }
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

While writing VR tests and testing `Button` perf I realized that the styling for the `SplitButton` divider was wrong:

![image](https://user-images.githubusercontent.com/7798177/58514800-c512eb00-8157-11e9-8a36-fb885ae02329.png)

However, this did not repro on the component example page. After investigating it became apparent that the use of `Stack` in the example code was masking this issue. This PR fixes that styling issue so that the divider now looks correctly both in the component example page and in its independent use:

![image](https://user-images.githubusercontent.com/7798177/58514867-f390c600-8157-11e9-9d03-e8d7c1643b96.png)

Once this PR merges, this will also serve to unblock #9159, which was not being merged because `SplitButton` vr tests didn't look right.

Finally, this PR also adds `display: inline-flex` to the `root` of both `MenuButton` and `SplitButton`, so that they render `inline` like HTML `buttons` do (this issue was highlighted by perf-tests that rendered a large number of these `Buttons`).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9246)