### PR TITLE
Remove deprecated unused Nav props

### DIFF
--- a/apps/vr-tests/src/stories/Nav.stories.tsx
+++ b/apps/vr-tests/src/stories/Nav.stories.tsx
@@ -107,12 +107,7 @@ storiesOf('Nav', module)
     'Root',
     () => (
       <div style={{ width: '208px' }}>
-        <Nav
-          groups={[{ links: links }]}
-          expandedStateText={'expanded'}
-          collapsedStateText={'collapsed'}
-          selectedKey={'key3'}
-        />
+        <Nav groups={[{ links: links }]} selectedKey="key3" />
       </div>
     ),
     { rtl: true }
@@ -121,12 +116,7 @@ storiesOf('Nav', module)
     'Disabled',
     () => (
       <div style={{ width: '208px' }}>
-        <Nav
-          groups={[{ links: disabledLinks }]}
-          expandedStateText={'expanded'}
-          collapsedStateText={'collapsed'}
-          selectedKey={'key3'}
-        />
+        <Nav groups={[{ links: disabledLinks }]} selectedKey="key3" />
       </div>
     ),
     { rtl: true }

--- a/common/changes/@uifabric/legacy/nav-props_2019-05-29-18-07.json
+++ b/common/changes/@uifabric/legacy/nav-props_2019-05-29-18-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/legacy",
+      "comment": "Remove deprecated unused Nav props",
+      "type": "major"
+    }
+  ],
+  "packageName": "@uifabric/legacy",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/legacy/etc/legacy.api.md
+++ b/packages/legacy/etc/legacy.api.md
@@ -24,13 +24,9 @@ export interface INav {
 // @public (undocumented)
 export interface INavLink {
     [propertyName: string]: any;
-    // @deprecated
-    altText?: string;
     ariaLabel?: string;
     automationId?: string;
     disabled?: boolean;
-    // @deprecated
-    engagementName?: string;
     forceAnchor?: boolean;
     icon?: string;
     // @deprecated
@@ -41,8 +37,6 @@ export interface INavLink {
     links?: INavLink[];
     name: string;
     onClick?: (ev?: React_2.MouseEvent<HTMLElement>, item?: INavLink) => void;
-    // @deprecated (undocumented)
-    parentId?: string;
     target?: string;
     title?: string;
     url: string;
@@ -61,12 +55,8 @@ export interface INavLinkGroup {
 export interface INavProps {
     ariaLabel?: string;
     className?: string;
-    // @deprecated
-    collapsedStateText?: string;
     componentRef?: IRefObject<INav>;
     expandButtonAriaLabel?: string;
-    // @deprecated
-    expandedStateText?: string;
     groups: INavLinkGroup[] | null;
     initialSelectedKey?: string;
     isOnTop?: boolean;
@@ -129,7 +119,7 @@ export interface INavStyles {
 export function isRelativeUrl(url: string): boolean;
 
 // Warning: (ae-forgotten-export) The symbol "React" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export const Nav: React.StatelessComponent<INavProps>;
 

--- a/packages/legacy/src/components/Nav/Nav.doc.tsx
+++ b/packages/legacy/src/components/Nav/Nav.doc.tsx
@@ -17,7 +17,7 @@ const NavCustomGroupHeadersExampleCodepen = require('!@uifabric/codepen-loader!@
 export const NavPageProps: IDocPageProps = {
   title: 'Nav',
   componentName: 'Nav',
-  componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Nav',
+  componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/legacy/src/components/Nav',
   examples: [
     {
       title: 'Basic nav with sample links',

--- a/packages/legacy/src/components/Nav/Nav.types.ts
+++ b/packages/legacy/src/components/Nav/Nav.types.ts
@@ -100,18 +100,6 @@ export interface INavProps {
    * (Optional) The nav container aria label.
    */
   expandButtonAriaLabel?: string;
-
-  /**
-   * Deprecated at v0.68.1 and will be removed at \>= v1.0.0.
-   * @deprecated Removed at v1.0.0.
-   **/
-  expandedStateText?: string;
-
-  /**
-   * Deprecated at v0.68.1 and will be removed at \>= v1.0.0.
-   * @deprecated Removed at v1.0.0.
-   **/
-  collapsedStateText?: string;
 }
 
 /**
@@ -192,18 +180,6 @@ export interface INavLink {
   iconProps?: IIconProps;
 
   /**
-   * Deprecated at v0.68.1 and will be removed at \>= v1.0.0.
-   * @deprecated Removed at v1.0.0.
-   */
-  engagementName?: string;
-
-  /**
-   * Deprecated at v0.68.1 and will be removed at \>= v1.0.0.
-   * @deprecated Removed at v1.0.0.
-   */
-  altText?: string;
-
-  /**
    * The name to use for functional automation tests
    */
   automationId?: string;
@@ -232,11 +208,6 @@ export interface INavLink {
    * Whether or not the link is disabled.
    */
   disabled?: boolean;
-
-  /**
-   * @deprecated Not used in the Nav control or anywhere else in office-ui-fabric-react.
-   */
-  parentId?: string;
 
   /**
    * (Optional) By default, any link with onClick defined will render as a button.

--- a/packages/legacy/src/components/Nav/examples/Nav.Basic.Example.tsx
+++ b/packages/legacy/src/components/Nav/examples/Nav.Basic.Example.tsx
@@ -5,8 +5,6 @@ export const NavBasicExample: React.StatelessComponent = () => {
   return (
     <Nav
       onLinkClick={_onLinkClick}
-      expandedStateText="expanded"
-      collapsedStateText="collapsed"
       selectedKey="key3"
       expandButtonAriaLabel="Expand or collapse"
       styles={{


### PR DESCRIPTION
Remove Nav props `expandedStateText` and `collapsedStateText`, which are unused within the component and were marked as deprecated a long time ago. Since these have been deprecated and unused for so long, I'm not sure a codemod is very important.

Remove `INavLink` props `altText`, `engagementName`, and `parentId`, which were also deprecated a long time ago and are unused within the component. If people are using these props for custom renderers or something, it actually will still succeed to compile because `INavLink` has an index signature.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9257)