### PR TITLE
Callout/refactor dismiss on mouse event handlers

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-refactorDismissOnMouseEventHandlers_2019-05-29-14-28.json
+++ b/common/changes/office-ui-fabric-react/callout-refactorDismissOnMouseEventHandlers_2019-05-29-14-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Refactor common logic out of _dismissOnLostFocus to a generalized function in order to decouple handling of _dismissOnScroll from _dismissOnLostFocus",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rpsenski@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -261,7 +261,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   protected _dismissOnScroll = (ev: Event) => {
     const { preventDismissOnScroll } = this.props;
     if (this.state.positions && !preventDismissOnScroll) {
-      this._dismissOnClickOrScroll(ev, preventDismissOnScroll);
+      this._dismissOnClickOrScroll(ev);
     }
   };
 
@@ -273,7 +273,10 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   };
 
   protected _dismissOnLostFocus = (ev: Event) => {
-    this._dismissOnClickOrScroll(ev, this.props.preventDismissOnLostFocus);
+    const { preventDismissOnLostFocus } = this.props;
+    if (!preventDismissOnLostFocus) {
+      this._dismissOnClickOrScroll(ev);
+    }
   };
 
   protected _setInitialFocus = (): void => {
@@ -294,17 +297,16 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     this._setHeightOffsetEveryFrame();
   };
 
-  private _dismissOnClickOrScroll(ev: Event, preventDismiss?: boolean) {
+  private _dismissOnClickOrScroll(ev: Event) {
     const target = ev.target as HTMLElement;
     const isEventTargetOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);
 
     if (
-      !preventDismiss &&
-      ((!this._target && isEventTargetOutsideCallout) ||
-        (ev.target !== this._targetWindow &&
-          isEventTargetOutsideCallout &&
-          ((this._target as MouseEvent).stopPropagation ||
-            (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target))))))
+      (!this._target && isEventTargetOutsideCallout) ||
+      (ev.target !== this._targetWindow &&
+        isEventTargetOutsideCallout &&
+        ((this._target as MouseEvent).stopPropagation ||
+          (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target)))))
     ) {
       this.dismiss(ev);
     }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -261,7 +261,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   protected _dismissOnScroll = (ev: Event) => {
     const { preventDismissOnScroll } = this.props;
     if (this.state.positions && !preventDismissOnScroll) {
-      this._dismissOnLostFocus(ev);
+      this._dismissOnClickOrScroll(ev, preventDismissOnScroll);
     }
   };
 
@@ -273,20 +273,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   };
 
   protected _dismissOnLostFocus = (ev: Event) => {
-    const target = ev.target as HTMLElement;
-    const clickedOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);
-    const { preventDismissOnLostFocus } = this.props;
-
-    if (
-      !preventDismissOnLostFocus &&
-      ((!this._target && clickedOutsideCallout) ||
-        (ev.target !== this._targetWindow &&
-          clickedOutsideCallout &&
-          ((this._target as MouseEvent).stopPropagation ||
-            (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target))))))
-    ) {
-      this.dismiss(ev);
-    }
+    this._dismissOnClickOrScroll(ev, this.props.preventDismissOnLostFocus);
   };
 
   protected _setInitialFocus = (): void => {
@@ -306,6 +293,22 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     this._updateAsyncPosition();
     this._setHeightOffsetEveryFrame();
   };
+
+  private _dismissOnClickOrScroll(ev: Event, preventDismiss?: boolean) {
+    const target = ev.target as HTMLElement;
+    const isEventTargetOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);
+
+    if (
+      !preventDismiss &&
+      ((!this._target && isEventTargetOutsideCallout) ||
+        (ev.target !== this._targetWindow &&
+          isEventTargetOutsideCallout &&
+          ((this._target as MouseEvent).stopPropagation ||
+            (!this._target || (target !== this._target && !elementContains(this._target as HTMLElement, target))))))
+    ) {
+      this.dismiss(ev);
+    }
+  }
 
   private _addListeners() {
     // This is added so the callout will dismiss when the window is scrolled


### PR DESCRIPTION
#### Pull request checklist

- [ x ] Addresses an existing issue: Fixes #9259
- [ x ] Include a change request file using `$ npm run change`

#### Description of changes

_dismissOnScroll was calling _dismissOnLostFocus. The latter checks for preventDismissOnLostFocus, which means _dismissOnScroll can be disabled by preventDismissOnLostFocus being set to true. Undesireable coupling.

My fix extracts the reusable code from _dismissOnLostFocus into a separate, private function that both _dismissOnScroll and _dismissOnLostFocus now call, passing along the event that fired AND the relevant, optional preventDismissOn* prop value.

#### Focus areas to test

dismiss on lost focus and dismiss on scroll with different values for corresponding preventDismissOn* props. These are the steps I performed by temporarily doctoring one of the examples in the demo page.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9260)