### PR TITLE
Callout/role role description

### DIFF
--- a/common/changes/office-ui-fabric-react/callout-role_roleDescription_2019-05-29-19-43.json
+++ b/common/changes/office-ui-fabric-react/callout-role_roleDescription_2019-05-29-19-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Remove extra role attribute from callout root element, support aria-roledescription on callout main where role already resides",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rpsenski@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -45,7 +45,7 @@ const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 // filter needs to be added as an additional way to set opacity.
 const OFF_SCREEN_STYLE = { opacity: 0, filter: 'opacity(0)' };
 // role and role description go hand-in-hand. Both would be included by spreading getNativeProps for a basic element
-// This constant array can be used to filter these out of native props spread on calloutRoot and apply them together on
+// This constant array can be used to filter these out of native props spread on callout root and apply them together on
 // calloutMain (the Popup component within the callout)
 const ARIA_ROLE_ATTRIBUTES = ['role', 'aria-roledescription'];
 

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -44,6 +44,10 @@ const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 // To help ensure that edge will respect the offscreen style opacity
 // filter needs to be added as an additional way to set opacity.
 const OFF_SCREEN_STYLE = { opacity: 0, filter: 'opacity(0)' };
+// role and role description go hand-in-hand. Both would be included by spreading getNativeProps for a basic element
+// This constant array can be used to filter these out of native props spread on calloutRoot and apply them together on
+// calloutMain (the Popup component within the callout)
+const ARIA_ROLE_ATTRIBUTES = ['role', 'aria-roledescription'];
 
 export interface ICalloutState {
   positions?: ICalloutPositionedInfo;
@@ -174,7 +178,6 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     const {
       styles,
       style,
-      role,
       ariaLabel,
       ariaDescribedBy,
       ariaLabelledBy,
@@ -221,7 +224,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     const content = (
       <div ref={this._hostElement} className={this._classNames.container} style={visibilityStyle}>
         <div
-          {...getNativeProps(this.props, divProperties)}
+          {...getNativeProps(this.props, divProperties, ARIA_ROLE_ATTRIBUTES)}
           className={css(this._classNames.root, positions && positions.targetEdge && ANIMATIONS[positions.targetEdge!])}
           style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
           tabIndex={-1} // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
@@ -231,7 +234,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
           {beakVisible && <div className={this._classNames.beak} style={this._getBeakPosition()} />}
           {beakVisible && <div className={this._classNames.beakCurtain} />}
           <Popup
-            role={role}
+            {...getNativeProps(this.props, ARIA_ROLE_ATTRIBUTES)}
             ariaLabel={ariaLabel}
             ariaDescribedBy={ariaDescribedBy}
             ariaLabelledBy={ariaLabelledBy}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
@@ -221,7 +221,6 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
                 border: 0px;
               }
           hidden={true}
-          role="alertdialog"
           style={
             Object {
               "filter": "opacity(0)",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -758,7 +758,6 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                         border: 0px;
                       }
                   hidden={true}
-                  role="alertdialog"
                   style={
                     Object {
                       "filter": "opacity(0)",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Does not address, but may be related to or have bearing on, #1655
- [x] Include a change request file using `$ npm run change`

#### Description of changes

role attribute is currently being placed on two elements within the callout component. It gets included on the root element by getNativeProps and it is explicitly placed on the Popup component rendered within the callout (considered callout main element). aria-roledescription is supplemental to the aria role attribute, so the two should be on the same element when both are provided in the ICalloutProps. The redundant addition was causing a screen reader to provide redundant information AND, since aria-roledescription wasn't manually propagated to the Popup component, it wasn't successfully masking the role from the screen reader (as it is supposed to, [per the spec](https://www.w3.org/TR/wai-aria-1.1/#aria-roledescription)).

My change filters role and aria-roledescription from the getNativeProps call that gets spread on the root element, and then explictly propagates these two props onto the Popup component, if specified.

Required updating two test snapshot files

#### Focus areas to test

Examine the markup directly in the rendered HTML. Verify the redundancy is removed and that one prop, the other, or both, find their way to the Popup component (the one with css class callout-main)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9269)