### PR TITLE
Override more UHF styles

### DIFF
--- a/apps/fabric-website/src/components/Nav/Nav.module.scss
+++ b/apps/fabric-website/src/components/Nav/Nav.module.scss
@@ -161,7 +161,8 @@ $nav-group-header-height: 32px;
       padding: 8px 0;
       @include ms-text-align(left);
       height: auto;
-      align-items: flex-start;
+      align-items: center;
+      line-height: normal;
 
       span {
         color: $ms-color-neutralPrimary;
@@ -170,8 +171,6 @@ $nav-group-header-height: 32px;
       }
 
       i {
-        margin-top: 2px;
-        margin-bottom: 0;
         @include ms-margin-right(16px);
         @include ms-margin-left(8px);
         color: $ms-color-neutralSecondary;

--- a/apps/fabric-website/src/styles/_base.scss
+++ b/apps/fabric-website/src/styles/_base.scss
@@ -60,4 +60,9 @@
       @include ms-fontSize-16;
     }
   }
+
+  // Feedback section styles
+  .Feedback-button .ms-Button-label { // Feedback button color overridden by UHF
+    @include ms-fontColor-white;
+  }
 }

--- a/apps/fabric-website/src/styles/_base.scss
+++ b/apps/fabric-website/src/styles/_base.scss
@@ -65,4 +65,16 @@
   .Feedback-button .ms-Button-label { // Feedback button color overridden by UHF
     @include ms-fontColor-white;
   }
+
+  @media screen and (min-width: $uhf-screen-min-mobile) {
+    // Align logo with left nav
+    .c-uhfh > div {
+      padding: 0 $App-padding-right-sm 0 $App-padding-left-sm;
+    }
+
+    #uhfLogo {
+      padding: 16px 6px 16px 0;
+      width: 125px;
+    }
+  }
 }

--- a/common/changes/@uifabric/fabric-website/override-uhf-styles_2019-05-29-23-02.json
+++ b/common/changes/@uifabric/fabric-website/override-uhf-styles_2019-05-29-23-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix more UHF style overrides",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "v-jojanz@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Attempt to fix:
- Feedback button text color is black, should be white
    ![image](https://user-images.githubusercontent.com/7110658/58595870-e8589b80-8226-11e9-93f8-6593fb091c2f.png) ![image](https://user-images.githubusercontent.com/7110658/58596128-c01d6c80-8227-11e9-8ef4-5799ee6e014a.png)
- Left nav sections line height
   ![image](https://user-images.githubusercontent.com/7110658/58596184-f4912880-8227-11e9-98ed-e781a13ee57e.png) ![image](https://user-images.githubusercontent.com/7110658/58596208-12f72400-8228-11e9-84ad-62621cd8a8ee.png)
- Align the logo with the left nav
   ![image](https://user-images.githubusercontent.com/7110658/58596255-3de17800-8228-11e9-9d67-42ddd1bc1df6.png)
   ![image](https://user-images.githubusercontent.com/7110658/58596342-826d1380-8228-11e9-8444-3dddbadf601b.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9274)