### PR TITLE
Run lint-imports as part of regular build

### DIFF
--- a/scripts/just.config.js
+++ b/scripts/just.config.js
@@ -76,8 +76,10 @@ module.exports = function preset() {
       'clean',
       'copy',
       'sass',
-      parallel(condition('validate', () => !argv().min), series('ts', condition('webpack', () => !argv().min))),
-      condition('lint-imports', () => argv().production && !argv().min)
+      parallel(
+        condition('validate', () => !argv().min),
+        series('ts', parallel(condition('webpack', () => !argv().min), condition('lint-imports', () => !argv().min)))
+      )
     )
   );
 };


### PR DESCRIPTION
The `lint-imports` task was only getting run on `--production` builds, which meant that errors would usually go unnoticed until the PR build and unnecessarily delay PRs.

Instead, this PR changes `lint-imports` to run parallel to `webpack` unless `--min` is given.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9275)