### PR TITLE
Button: Conditionally rendering KeytipData

### DIFF
--- a/common/changes/@uifabric/experiments/buttonKeytip_2019-05-29-23-51.json
+++ b/common/changes/@uifabric/experiments/buttonKeytip_2019-05-29-23-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Conditionally rendering KeytipData.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/buttonKeytip_2019-05-29-23-51.json
+++ b/common/changes/office-ui-fabric-react/buttonKeytip_2019-05-29-23-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Button: Conditionally rendering KeytipData.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -52,7 +52,7 @@ export const ButtonView: IButtonComponent['view'] = props => {
 
   return keytipProps ? (
     <KeytipData keytipProps={keytipProps} disabled={disabled && !allowDisabledFocus}>
-      {(keytipAttributes: any): JSX.Element => <Button keytipAttributes={keytipAttributes} />}
+      {(keytipAttributes: any): JSX.Element => Button(keytipAttributes)}
     </KeytipData>
   ) : (
     <Button />

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -29,7 +29,7 @@ export const ButtonView: IButtonComponent['view'] = props => {
     }
   };
 
-  const Button = (keytipAttributes: any): JSX.Element => (
+  const Button = (keytipAttributes?: any): JSX.Element => (
     <Slots.root
       type="button" // stack doesn't take in native button props
       role="button"
@@ -55,7 +55,7 @@ export const ButtonView: IButtonComponent['view'] = props => {
       {(keytipAttributes: any): JSX.Element => Button(keytipAttributes)}
     </KeytipData>
   ) : (
-    <Button />
+    Button()
   );
 };
 

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -29,29 +29,33 @@ export const ButtonView: IButtonComponent['view'] = props => {
     }
   };
 
-  return (
+  const Button = (keytipAttributes: any): JSX.Element => (
+    <Slots.root
+      type="button" // stack doesn't take in native button props
+      role="button"
+      onClick={_onClick}
+      {...buttonProps}
+      {...keytipAttributes}
+      disabled={disabled && !allowDisabledFocus}
+      aria-disabled={disabled}
+      tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
+      aria-label={ariaLabel}
+      ref={buttonRef}
+    >
+      <Slots.stack horizontal as="span" tokens={{ childrenGap: 8 }} verticalAlign="center" horizontalAlign="center" verticalFill>
+        <Slots.icon />
+        <Slots.content />
+        {children}
+      </Slots.stack>
+    </Slots.root>
+  );
+
+  return keytipProps ? (
     <KeytipData keytipProps={keytipProps} disabled={disabled && !allowDisabledFocus}>
-      {(keytipAttributes: any): JSX.Element => (
-        <Slots.root
-          type="button" // stack doesn't take in native button props
-          role="button"
-          onClick={_onClick}
-          {...buttonProps}
-          {...keytipAttributes}
-          disabled={disabled && !allowDisabledFocus}
-          aria-disabled={disabled}
-          tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
-          aria-label={ariaLabel}
-          ref={buttonRef}
-        >
-          <Slots.stack horizontal as="span" tokens={{ childrenGap: 8 }} verticalAlign="center" horizontalAlign="center" verticalFill>
-            <Slots.icon />
-            <Slots.content />
-            {children}
-          </Slots.stack>
-        </Slots.root>
-      )}
+      {(keytipAttributes: any): JSX.Element => <Button keytipAttributes={keytipAttributes} />}
     </KeytipData>
+  ) : (
+    <Button />
   );
 };
 

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -274,7 +274,20 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       };
     }
 
-    const Content = (
+    const Button = () => (
+      <div className={this._classNames.flexContainer}>
+        {onRenderIcon(props, this._onRenderIcon)}
+        {this._onRenderTextContents()}
+        {onRenderAriaDescription(props, this._onRenderAriaDescription)}
+        {onRenderChildren(props, this._onRenderChildren)}
+        {!this._isSplitButton &&
+          (menuProps || menuIconProps || this.props.onRenderMenuIcon) &&
+          onRenderMenuIcon(this.props, this._onRenderMenuIcon)}
+        {this.state.menuProps && !this.state.menuProps.doNotLayer && onRenderMenu(menuProps, this._onRenderMenu)}
+      </div>
+    );
+
+    const Content = keytipProps ? (
       // If we're making a split button, we won't put the keytip here
       <KeytipData
         keytipProps={!this._isSplitButton ? keytipProps : undefined}
@@ -283,19 +296,14 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       >
         {(keytipAttributes: any): JSX.Element => (
           <Tag {...buttonProps} {...keytipAttributes}>
-            <div className={this._classNames.flexContainer}>
-              {onRenderIcon(props, this._onRenderIcon)}
-              {this._onRenderTextContents()}
-              {onRenderAriaDescription(props, this._onRenderAriaDescription)}
-              {onRenderChildren(props, this._onRenderChildren)}
-              {!this._isSplitButton &&
-                (menuProps || menuIconProps || this.props.onRenderMenuIcon) &&
-                onRenderMenuIcon(this.props, this._onRenderMenuIcon)}
-              {this.state.menuProps && !this.state.menuProps.doNotLayer && onRenderMenu(menuProps, this._onRenderMenu)}
-            </div>
+            <Button />
           </Tag>
         )}
       </KeytipData>
+    ) : (
+      <Tag {...buttonProps}>
+        <Button />
+      </Tag>
     );
 
     if (menuProps && menuProps.doNotLayer) {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -274,17 +274,19 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       };
     }
 
-    const Button = () => (
-      <div className={this._classNames.flexContainer}>
-        {onRenderIcon(props, this._onRenderIcon)}
-        {this._onRenderTextContents()}
-        {onRenderAriaDescription(props, this._onRenderAriaDescription)}
-        {onRenderChildren(props, this._onRenderChildren)}
-        {!this._isSplitButton &&
-          (menuProps || menuIconProps || this.props.onRenderMenuIcon) &&
-          onRenderMenuIcon(this.props, this._onRenderMenuIcon)}
-        {this.state.menuProps && !this.state.menuProps.doNotLayer && onRenderMenu(menuProps, this._onRenderMenu)}
-      </div>
+    const Button = (keytipAttributes?: any): JSX.Element => (
+      <Tag {...buttonProps} {...keytipAttributes}>
+        <div className={this._classNames.flexContainer}>
+          {onRenderIcon(props, this._onRenderIcon)}
+          {this._onRenderTextContents()}
+          {onRenderAriaDescription(props, this._onRenderAriaDescription)}
+          {onRenderChildren(props, this._onRenderChildren)}
+          {!this._isSplitButton &&
+            (menuProps || menuIconProps || this.props.onRenderMenuIcon) &&
+            onRenderMenuIcon(this.props, this._onRenderMenuIcon)}
+          {this.state.menuProps && !this.state.menuProps.doNotLayer && onRenderMenu(menuProps, this._onRenderMenu)}
+        </div>
+      </Tag>
     );
 
     const Content = keytipProps ? (
@@ -294,16 +296,10 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         ariaDescribedBy={(buttonProps as any)['aria-describedby']}
         disabled={disabled}
       >
-        {(keytipAttributes: any): JSX.Element => (
-          <Tag {...buttonProps} {...keytipAttributes}>
-            <Button />
-          </Tag>
-        )}
+        {(keytipAttributes: any): JSX.Element => Button(keytipAttributes)}
       </KeytipData>
     ) : (
-      <Tag {...buttonProps}>
-        <Button />
-      </Tag>
+      Button()
     );
 
     if (menuProps && menuProps.doNotLayer) {
@@ -500,36 +496,41 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     const containerProps = getNativeProps(buttonProps, [], ['disabled']);
-    return (
+
+    const SplitButton = (keytipAttributes?: any): JSX.Element => (
+      <div
+        {...containerProps}
+        data-ktp-target={keytipAttributes ? keytipAttributes['data-ktp-target'] : undefined}
+        role={'button'}
+        aria-disabled={disabled}
+        aria-haspopup={true}
+        aria-expanded={this._isExpanded}
+        aria-pressed={toggle ? !!checked : undefined} // aria-pressed attribute should only be present for toggle buttons
+        aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes ? keytipAttributes['aria-describedby'] : undefined)}
+        className={classNames && classNames.splitButtonContainer}
+        onKeyDown={this._onSplitButtonContainerKeyDown}
+        onTouchStart={this._onTouchStart}
+        ref={this._splitButtonContainer}
+        data-is-focusable={true}
+        onClick={!disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined}
+        tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
+        aria-roledescription={buttonProps['aria-roledescription']}
+        onFocusCapture={this._onSplitContainerFocusCapture}
+      >
+        <span style={{ display: 'flex' }}>
+          {this._onRenderContent(tag, buttonProps)}
+          {this._onRenderSplitButtonMenuButton(classNames, keytipAttributes)}
+          {this._onRenderSplitButtonDivider(classNames)}
+        </span>
+      </div>
+    );
+
+    return keytipProps ? (
       <KeytipData keytipProps={keytipProps} disabled={disabled}>
-        {(keytipAttributes: any): JSX.Element => (
-          <div
-            {...containerProps}
-            data-ktp-target={keytipAttributes['data-ktp-target']}
-            role={'button'}
-            aria-disabled={disabled}
-            aria-haspopup={true}
-            aria-expanded={this._isExpanded}
-            aria-pressed={toggle ? !!checked : undefined} // aria-pressed attribute should only be present for toggle buttons
-            aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}
-            className={classNames && classNames.splitButtonContainer}
-            onKeyDown={this._onSplitButtonContainerKeyDown}
-            onTouchStart={this._onTouchStart}
-            ref={this._splitButtonContainer}
-            data-is-focusable={true}
-            onClick={!disabled && !primaryDisabled ? this._onSplitButtonPrimaryClick : undefined}
-            tabIndex={!disabled || allowDisabledFocus ? 0 : undefined}
-            aria-roledescription={buttonProps['aria-roledescription']}
-            onFocusCapture={this._onSplitContainerFocusCapture}
-          >
-            <span style={{ display: 'flex' }}>
-              {this._onRenderContent(tag, buttonProps)}
-              {this._onRenderSplitButtonMenuButton(classNames, keytipAttributes)}
-              {this._onRenderSplitButtonDivider(classNames)}
-            </span>
-          </div>
-        )}
+        {(keytipAttributes: any): JSX.Element => SplitButton(keytipAttributes)}
       </KeytipData>
+    ) : (
+      SplitButton()
     );
   }
 
@@ -595,7 +596,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     return (
       <BaseButton
         {...splitButtonProps}
-        data-ktp-execute-target={keytipAttributes['data-ktp-execute-target']}
+        data-ktp-execute-target={keytipAttributes ? keytipAttributes['data-ktp-execute-target'] : keytipAttributes}
         onMouseDown={this._onMouseDown}
         tabIndex={-1}
       />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adding a conditional render of `KeytipData` only if `keytipProps` are present in `Button` in both `office-ui-fabric-react` and `experiments`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9276)