### PR TITLE
Fix Data Viz 'Legends' is not accessible using keyboard tab navigation

### DIFF
--- a/common/changes/@uifabric/charting/LegendsAccesability_2019-05-30-07-22.json
+++ b/common/changes/@uifabric/charting/LegendsAccesability_2019-05-30-07-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Data Viz 'Legends' is not accessible using keyboard tab navigation ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "v-ragor@microsoft.com"
+}

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -236,7 +236,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         onMouseOut={onMouseOut}
         onFocus={onHoverHandler}
         onBlur={onMouseOut}
-        data-is-focusable={'true'}
+        data-is-focusable={true}
       >
         <div className={classNames.rect} />
         <div className={classNames.text}>{legend.title}</div>

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -228,7 +228,16 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       this._onLeave(legend);
     };
     return (
-      <div key={index} className={classNames.legend} onClick={onClickHandler} onMouseOver={onHoverHandler} onMouseOut={onMouseOut}>
+      <div
+        key={index}
+        className={classNames.legend}
+        onClick={onClickHandler}
+        onMouseOver={onHoverHandler}
+        onMouseOut={onMouseOut}
+        onFocus={onHoverHandler}
+        onBlur={onMouseOut}
+        data-is-focusable={'true'}
+      >
         <div className={classNames.rect} />
         <div className={classNames.text}>{legend.title}</div>
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Fix Data Viz 'Legends' is not accessible using keyboard tab navigation

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9281)


######Sceenshot
![legends](https://user-images.githubusercontent.com/13463251/58615972-18ad4200-82da-11e9-849f-25d1fc936208.png)
 