### PR TITLE
Theme Designer: fix Samples card Text components' color

### DIFF
--- a/apps/theming-designer/src/components/Samples/index.tsx
+++ b/apps/theming-designer/src/components/Samples/index.tsx
@@ -18,6 +18,7 @@ import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 
 export interface ISamplesProps {
   backgroundColor: string;
+  textColor: string;
 }
 
 export interface ISamplesState {
@@ -43,6 +44,9 @@ const sampleColumn = mergeStyles({
 });
 const iconButtonStyles = mergeStyles({
   color: '#0078D4'
+});
+const storiesTextStyles = mergeStyles({
+  color: '#ffffff'
 });
 
 const commandBarItems = [
@@ -170,9 +174,13 @@ export class Samples extends React.Component<ISamplesProps, ISamplesState> {
               <Stack.Item className={sampleColumn} grow={1}>
                 <Stack gap={32}>
                   <Stack gap={20}>
-                    <Text variant="small">STORIES</Text>
-                    <Text variant="xxLarge">Make an impression</Text>
-                    <Text variant="medium">
+                    <Text variant="small" styles={{ root: { color: this.props.textColor } }}>
+                      STORIES
+                    </Text>
+                    <Text variant="xxLarge" styles={{ root: { color: this.props.textColor } }}>
+                      Make an impression
+                    </Text>
+                    <Text variant="medium" styles={{ root: { color: this.props.textColor } }}>
                       Make a big impression with this clean, modern, and mobile-friendly site. Use it to communicate information to people
                       inside or outisde your team. Share your ideas, results, and more in this visually compelling format.
                     </Text>

--- a/apps/theming-designer/src/components/Samples/index.tsx
+++ b/apps/theming-designer/src/components/Samples/index.tsx
@@ -45,9 +45,6 @@ const sampleColumn = mergeStyles({
 const iconButtonStyles = mergeStyles({
   color: '#0078D4'
 });
-const storiesTextStyles = mergeStyles({
-  color: '#ffffff'
-});
 
 const commandBarItems = [
   {

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -95,7 +95,7 @@ export class ThemingDesigner extends BaseComponent<{}, IThemingDesignerState> {
           <Stack.Item grow={1} disableShrink className={cardsBlockStyles}>
             <Stack>
               <ThemeProvider theme={this.state.theme}>
-                <Samples backgroundColor={this.state.backgroundColor.str} />
+                <Samples backgroundColor={this.state.backgroundColor.str} textColor={this.state.textColor.str} />
               </ThemeProvider>
               <AccessibilityChecker theme={this.state.theme} themeRules={this.state.themeRules} />
               <FabricPalette themeRules={this.state.themeRules} />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Samples card Text components weren't changing their color with the Theme Designer's text color input so resulted in bad experiences like this: 
![image](https://user-images.githubusercontent.com/4161791/58665293-63808700-82e5-11e9-8066-e8e4645a9ff9.png)

Fixed it so their color now changes accordingly:
![image](https://user-images.githubusercontent.com/4161791/58665239-49df3f80-82e5-11e9-91f1-221c2ab6af52.png)

#### Focus areas to test

Play around with the text input in the left hand nav on the theme designer site and make sure the samples card text is changing accordingly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9291)