### PR TITLE
Passing through calendar props to CalendarDay and CalendarMonth

### DIFF
--- a/common/changes/@uifabric/date-time/lorejoh12-passingThroughCalendarProps_2019-05-31-23-39.json
+++ b/common/changes/@uifabric/date-time/lorejoh12-passingThroughCalendarProps_2019-05-31-23-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "passing through props as the api expects them to be",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -142,8 +142,8 @@ export interface ICalendarMonthProps extends IBaseProps_2<ICalendarMonth> {
 // @public (undocumented)
 export interface ICalendarProps extends IBaseProps<ICalendar> {
     allFocusable?: boolean;
-    calendarDayProps?: ICalendarDayProps;
-    calendarMonthProps?: ICalendarMonthProps;
+    calendarDayProps?: Partial<ICalendarDayProps>;
+    calendarMonthProps?: Partial<ICalendarMonthProps>;
     className?: string;
     componentRef?: IRefObject<ICalendar>;
     dateRangeType?: DateRangeType;

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -157,7 +157,9 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
       allFocusable,
       styles,
       showWeekNumbers,
-      theme
+      theme,
+      calendarDayProps,
+      calendarMonthProps
     } = this.props;
     const { selectedDate, navigatedDayDate, navigatedMonthDate, isMonthPickerVisible, isDayPickerVisible } = this.state;
     const onHeaderSelect = showMonthPickerAsOverlay ? this._onHeaderSelect : undefined;
@@ -202,6 +204,7 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
             componentRef={this._dayPicker}
             showCloseButton={showCloseButton}
             allFocusable={allFocusable}
+            {...calendarDayProps} // at end of list so consumer's custom functions take precedence
           />
         )}
         {isDayPickerVisible && isMonthPickerVisible && <div className={classes.divider} />}
@@ -221,6 +224,7 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
               minDate={minDate}
               maxDate={maxDate}
               componentRef={this._monthPicker}
+              {...calendarMonthProps} // at end of list so consumer's custom functions take precedence
             />
             {this._renderGoToTodayButton(classes)}
           </div>

--- a/packages/date-time/src/components/Calendar/Calendar.types.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.types.ts
@@ -26,12 +26,12 @@ export interface ICalendarProps extends IBaseProps<ICalendar> {
   /**
    * Customized props for the calendar day
    */
-  calendarDayProps?: ICalendarDayProps;
+  calendarDayProps?: Partial<ICalendarDayProps>;
 
   /**
    * Customized props for the calendar month
    */
-  calendarMonthProps?: ICalendarMonthProps;
+  calendarMonthProps?: Partial<ICalendarMonthProps>;
 
   /**
    * Theme provided by High-Order Component.

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -54,7 +54,8 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
         padding: '0 4px 0 10px',
         border: 'none',
         backgroundColor: 'transparent',
-        borderRadius: 2
+        borderRadius: 2,
+        lineHeight: 0
       },
       headerIsClickable && {
         selectors: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

passing through the CalendarDay and calendarMonth props to their respective components. The API took in those props but didn't actually pass them along, so if the consumer wanted to override something it wouldn't work. This wasn't that noticeable before, but with mergestyles now if the consumer tried to override the styles, it wouldn't work.

While I'm here, also fixing a line height bug in the header text of the CalendarDay component. If the CalendarDay gets stuck with "line-height: inherit" instead of the default (which can happen for apps with default <button> styles on them), it inherits the 44px from the container, which breaks the alignment. Specifying 0 allows flex to center the text.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9308)