### PR TITLE
Searchbox: fix it so that searchbox only calls prevent default when we handle an event

### DIFF
--- a/common/changes/office-ui-fabric-react/searchbox-preventdefault_2019-06-03-18-30.json
+++ b/common/changes/office-ui-fabric-react/searchbox-preventdefault_2019-06-03-18-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Searchbox: Stop preventing default if we don't handle the keypress\"",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -187,8 +187,10 @@ export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxStat
       case KeyCodes.enter:
         if (this.props.onSearch) {
           this.props.onSearch(this.state.value);
+          break;
         }
-        break;
+        // if we don't handle the enter press then we shouldn't prevent default
+        return;
 
       default:
         this.props.onKeyDown && this.props.onKeyDown(ev);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #8703
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Searchbox: fix it so that searchbox only calls prevent default when we handle an event

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9319)