### PR TITLE
MessageBar: add back lineHeight

### DIFF
--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -139,7 +139,8 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
       classNames.content,
       {
         display: 'flex',
-        width: '100%'
+        width: '100%',
+        lineHeight: 'normal'
       }
     ],
     iconContainer: [

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
           ms-MessageBar-content
           {
             display: flex;
+            line-height: normal;
             width: 100%;
           }
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -106,6 +106,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -272,6 +273,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -583,6 +585,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -1028,6 +1031,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -1447,6 +1451,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -1874,6 +1879,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -2322,6 +2328,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
@@ -106,6 +106,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -273,6 +274,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               {
                 background: rgba(50, 20, 90, 0.2);
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -585,6 +587,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -1035,6 +1038,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -1455,6 +1459,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -1885,6 +1890,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               {
                 background: rgba(234, 67, 0, 0.2);
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >
@@ -2336,6 +2342,7 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
               ms-MessageBar-content
               {
                 display: flex;
+                line-height: normal;
                 width: 100%;
               }
         >


### PR DESCRIPTION

#### Description of changes
 Previously when I made style changes to `MessageBar` for `fabric-7` branch I removed some of the styles that didn't make sense when running locally. This caused some of the global styles coming from the `UHF` messing up the `line-height` of the `MessageBar` content as @ecraig12345 mentioned to me offline. I am adding back the line-height but this could be another case that would tilt the scale towards moving the website to our own domain and constantly have to fight specificity wars.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9326)