### PR TITLE
Calendar bug fixes

### DIFF
--- a/common/changes/@uifabric/date-time/lorejoh-fixTextOverflowDatetimeCalendar_2019-06-04-00-11.json
+++ b/common/changes/@uifabric/date-time/lorejoh-fixTextOverflowDatetimeCalendar_2019-06-04-00-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "add tooltips to Calendar buttons without text and fix text overflow bug in calendar header button with long names",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/lorejoh-fixTextOverflowDatetimeCalendar_2019-06-04-00-11.json
+++ b/common/changes/office-ui-fabric-react/lorejoh-fixTextOverflowDatetimeCalendar_2019-06-04-00-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add tooltips to Calendar buttons without text",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -155,7 +155,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
           onClick={prevMonthInBounds ? this._onSelectPrevMonth : undefined}
           onKeyDown={prevMonthInBounds ? this._onButtonKeyDown(this._onSelectPrevMonth) : undefined}
           aria-controls={dayPickerId}
-          aria-label={
+          title={
             strings.prevMonthAriaLabel
               ? strings.prevMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, -1).getMonth()]
               : undefined
@@ -173,7 +173,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
           onClick={nextMonthInBounds ? this._onSelectNextMonth : undefined}
           onKeyDown={nextMonthInBounds ? this._onButtonKeyDown(this._onSelectNextMonth) : undefined}
           aria-controls={dayPickerId}
-          aria-label={
+          title={
             strings.nextMonthAriaLabel
               ? strings.nextMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, 1).getMonth()]
               : undefined
@@ -187,7 +187,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
             className={css(classNames.headerIconButton)}
             onClick={this._onClose}
             onKeyDown={this._onButtonKeyDown(this._onClose)}
-            aria-label={strings.closeButtonAriaLabel}
+            title={strings.closeButtonAriaLabel}
             type="button"
           >
             <Icon iconName={closeNavigationIcon} />

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -104,7 +104,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
             onKeyDown={this._onButtonKeyDown(this._onHeaderSelect)}
             type="button"
           >
-            <span>{dateTimeFormatter.formatMonthYear(navigatedDate, strings)}</span>
+            {dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
           </button>
           {this.renderMonthNavigationButtons(classNames, dayPickerId)}
         </div>

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -104,7 +104,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
             onKeyDown={this._onButtonKeyDown(this._onHeaderSelect)}
             type="button"
           >
-            {dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
+            <span>{dateTimeFormatter.formatMonthYear(navigatedDate, strings)}</span>
           </button>
           {this.renderMonthNavigationButtons(classNames, dayPickerId)}
         </div>

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -48,14 +48,18 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
         alignItems: 'center',
         fontSize: FontSizes.medium,
         color: palette.neutralPrimary,
-        display: 'inline-flex',
+        display: 'inline-block',
         flexGrow: 1,
         fontWeight: FontWeights.semibold,
         padding: '0 4px 0 10px',
         border: 'none',
         backgroundColor: 'transparent',
         borderRadius: 2,
-        lineHeight: 0
+        lineHeight: 28,
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textAlign: 'start',
+        textOverflow: 'ellipsis'
       },
       headerIsClickable && {
         selectors: {

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -145,7 +145,7 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
               disabled={!allFocusable && !isPrevYearInBounds}
               onClick={isPrevYearInBounds ? this._onSelectPrevYear : undefined}
               onKeyDown={isPrevYearInBounds ? this._onButtonKeyDown(this._onSelectPrevYear) : undefined}
-              aria-label={
+              title={
                 strings.prevYearAriaLabel
                   ? strings.prevYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, -1))
                   : undefined
@@ -161,7 +161,7 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
               disabled={!allFocusable && !isNextYearInBounds}
               onClick={isNextYearInBounds ? this._onSelectNextYear : undefined}
               onKeyDown={isNextYearInBounds ? this._onButtonKeyDown(this._onSelectNextYear) : undefined}
-              aria-label={
+              title={
                 strings.nextYearAriaLabel
                   ? strings.nextYearAriaLabel + ' ' + dateFormatter.formatYear(addYears(navigatedDate, 1))
                   : undefined

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -226,7 +226,7 @@ class CalendarYearNavPrev extends React.Component<ICalendarYearHeaderProps, {}> 
         onClick={!disabled && onSelectPrev ? this._onSelectPrev : undefined}
         onKeyDown={!disabled && onSelectPrev ? this._onKeyDown : undefined}
         type="button"
-        aria-label={prevAriaLabel}
+        title={prevAriaLabel}
         disabled={disabled}
       >
         <Icon iconName={getRTL() ? iconStrings.rightNavigation : iconStrings.leftNavigation} />
@@ -280,7 +280,7 @@ class CalendarYearNavNext extends React.Component<ICalendarYearHeaderProps, {}> 
         onClick={!disabled && onSelectNext ? this._onSelectNext : undefined}
         onKeyDown={!disabled && onSelectNext ? this._onKeyDown : undefined}
         type="button"
-        aria-label={nextAriaLabel}
+        title={nextAriaLabel}
         disabled={this.isDisabled}
       >
         <Icon iconName={getRTL() ? iconStrings.leftNavigation : iconStrings.rightNavigation} />

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -167,7 +167,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 onClick={prevMonthInBounds ? this._onSelectPrevMonth : undefined}
                 onKeyDown={prevMonthInBounds ? this._onPrevMonthKeyDown : undefined}
                 aria-controls={dayPickerId}
-                aria-label={
+                title={
                   strings.prevMonthAriaLabel
                     ? strings.prevMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, -1).getMonth()]
                     : undefined
@@ -186,7 +186,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 onClick={nextMonthInBounds ? this._onSelectNextMonth : undefined}
                 onKeyDown={nextMonthInBounds ? this._onNextMonthKeyDown : undefined}
                 aria-controls={dayPickerId}
-                aria-label={
+                title={
                   strings.nextMonthAriaLabel
                     ? strings.nextMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate, 1).getMonth()]
                     : undefined
@@ -201,7 +201,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                   className={css('ms-DatePicker-closeButton js-closeButton', styles.closeButton)}
                   onClick={this._onClose}
                   onKeyDown={this._onCloseButtonKeyDown}
-                  aria-label={strings.closeButtonAriaLabel}
+                  title={strings.closeButtonAriaLabel}
                   role="button"
                   type="button"
                 >

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -150,7 +150,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
                 disabled={!isPrevYearInBounds}
                 onClick={isPrevYearInBounds ? this._onSelectPrevYear : undefined}
                 onKeyDown={isPrevYearInBounds ? this._onSelectPrevYearKeyDown : undefined}
-                aria-label={
+                title={
                   strings.prevYearAriaLabel
                     ? strings.prevYearAriaLabel + ' ' + dateTimeFormatter.formatYear(addYears(navigatedDate, -1))
                     : undefined
@@ -167,7 +167,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
                 disabled={!isNextYearInBounds}
                 onClick={isNextYearInBounds ? this._onSelectNextYear : undefined}
                 onKeyDown={isNextYearInBounds ? this._onSelectNextYearKeyDown : undefined}
-                aria-label={
+                title={
                   strings.nextYearAriaLabel
                     ? strings.nextYearAriaLabel + ' ' + dateTimeFormatter.formatYear(addYears(navigatedDate, 1))
                     : undefined

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarYear.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarYear.tsx
@@ -201,7 +201,7 @@ class CalendarYearNavPrev extends React.Component<ICalendarYearHeaderProps, any>
         onKeyDown={!disabled && onSelectPrev ? this._onKeyDown : undefined}
         type="button"
         tabIndex={0}
-        aria-label={prevAriaLabel}
+        title={prevAriaLabel}
         disabled={disabled}
       >
         <Icon iconName={getRTL() ? iconStrings.rightNavigation : iconStrings.leftNavigation} />
@@ -249,7 +249,7 @@ class CalendarYearNavNext extends React.Component<ICalendarYearHeaderProps, any>
         onKeyDown={!disabled && onSelectNext ? this._onKeyDown : undefined}
         type="button"
         tabIndex={0}
-        aria-label={nextAriaLabel}
+        title={nextAriaLabel}
         disabled={this.isDisabled}
       >
         <Icon iconName={getRTL() ? iconStrings.leftNavigation : iconStrings.rightNavigation} />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9324 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1) fixing text overflow bug in date-time Calendar component when user inputs text that is very long. Before there was no overflow behavior so text overlaps itself. Now the text hides overflow and adds ellipsis.

2) in both OUFR and date-time calendars, adding tooltips for buttons that have no text in them. Note that Narrator is slightly slower in reading this text out than before with it being an aria-label, but as noted here: https://github.com/nvaccess/nvda/issues/7841, we generally don't want to have the same aria-label and title text because screen readers will read it twice, and title text does get read.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9328)