### PR TITLE
Fonts: Add additional font steps

### DIFF
--- a/common/changes/@uifabric/styling/phkuo-addFontSteps_2019-06-04-00-23.json
+++ b/common/changes/@uifabric/styling/phkuo-addFontSteps_2019-06-04-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add font steps so that Fabric 7's Fluent theme will be backwards compatible",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "odbuild@microsoft.com"
+}

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -87,7 +87,11 @@ export namespace FontSizes {
     const // (undocumented)
     xLarge: string;
     const // (undocumented)
+    xLargePlus: string;
+    const // (undocumented)
     xxLarge: string;
+    const // (undocumented)
+    xxLargePlus: string;
     const // (undocumented)
     superLarge: string;
     const // (undocumented)
@@ -298,10 +302,14 @@ export interface IFontStyles {
     tiny: IRawStyle;
     // (undocumented)
     xLarge: IRawStyle;
+    // @deprecated (undocumented)
+    xLargePlus: IRawStyle;
     // (undocumented)
     xSmall: IRawStyle;
     // (undocumented)
     xxLarge: IRawStyle;
+    // @deprecated (undocumented)
+    xxLargePlus: IRawStyle;
 }
 
 export { IFontWeight }

--- a/packages/styling/src/interfaces/IFontStyles.ts
+++ b/packages/styling/src/interfaces/IFontStyles.ts
@@ -13,7 +13,17 @@ export interface IFontStyles {
   mediumPlus: IRawStyle;
   large: IRawStyle;
   xLarge: IRawStyle;
+  /**
+   * @deprecated Exists for forward compatibility with Fabric 7's Fluent theme.
+   * Not recommended for use with Fabric 6.
+   */
+  xLargePlus: IRawStyle;
   xxLarge: IRawStyle;
+  /**
+   * @deprecated Exists for forward compatibility with Fabric 7's Fluent theme
+   * Not recommended for use with Fabric 6.
+   */
+  xxLargePlus: IRawStyle;
   superLarge: IRawStyle;
   mega: IRawStyle;
 }

--- a/packages/styling/src/styles/__snapshots__/fonts.test.ts.snap
+++ b/packages/styling/src/styles/__snapshots__/fonts.test.ts.snap
@@ -65,6 +65,13 @@ Object {
     "fontSize": "21px",
     "fontWeight": 100,
   },
+  "xLargePlus": Object {
+    "MozOsxFontSmoothing": "grayscale",
+    "WebkitFontSmoothing": "antialiased",
+    "fontFamily": "'Segoe UI Web (Arabic)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
+    "fontSize": "21px",
+    "fontWeight": 100,
+  },
   "xSmall": Object {
     "MozOsxFontSmoothing": "grayscale",
     "WebkitFontSmoothing": "antialiased",
@@ -73,6 +80,13 @@ Object {
     "fontWeight": 400,
   },
   "xxLarge": Object {
+    "MozOsxFontSmoothing": "grayscale",
+    "WebkitFontSmoothing": "antialiased",
+    "fontFamily": "'Segoe UI Web (Arabic)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
+    "fontSize": "28px",
+    "fontWeight": 100,
+  },
+  "xxLargePlus": Object {
     "MozOsxFontSmoothing": "grayscale",
     "WebkitFontSmoothing": "antialiased",
     "fontFamily": "'Segoe UI Web (Arabic)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
@@ -147,6 +161,13 @@ Object {
     "fontSize": "21px",
     "fontWeight": 100,
   },
+  "xLargePlus": Object {
+    "MozOsxFontSmoothing": "grayscale",
+    "WebkitFontSmoothing": "antialiased",
+    "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
+    "fontSize": "21px",
+    "fontWeight": 100,
+  },
   "xSmall": Object {
     "MozOsxFontSmoothing": "grayscale",
     "WebkitFontSmoothing": "antialiased",
@@ -155,6 +176,13 @@ Object {
     "fontWeight": 400,
   },
   "xxLarge": Object {
+    "MozOsxFontSmoothing": "grayscale",
+    "WebkitFontSmoothing": "antialiased",
+    "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
+    "fontSize": "28px",
+    "fontWeight": 100,
+  },
+  "xxLargePlus": Object {
     "MozOsxFontSmoothing": "grayscale",
     "WebkitFontSmoothing": "antialiased",
     "fontFamily": "'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
@@ -229,6 +257,13 @@ Object {
     "fontSize": "21px",
     "fontWeight": 100,
   },
+  "xLargePlus": Object {
+    "MozOsxFontSmoothing": "grayscale",
+    "WebkitFontSmoothing": "antialiased",
+    "fontFamily": "'Yu Gothic UI', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
+    "fontSize": "21px",
+    "fontWeight": 100,
+  },
   "xSmall": Object {
     "MozOsxFontSmoothing": "grayscale",
     "WebkitFontSmoothing": "antialiased",
@@ -237,6 +272,13 @@ Object {
     "fontWeight": 400,
   },
   "xxLarge": Object {
+    "MozOsxFontSmoothing": "grayscale",
+    "WebkitFontSmoothing": "antialiased",
+    "fontFamily": "'Yu Gothic UI', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",
+    "fontSize": "28px",
+    "fontWeight": 100,
+  },
+  "xxLargePlus": Object {
     "MozOsxFontSmoothing": "grayscale",
     "WebkitFontSmoothing": "antialiased",
     "fontFamily": "'Yu Gothic UI', 'Meiryo UI', Meiryo, 'MS Pgothic', Osaka, 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif",

--- a/packages/styling/src/styles/fonts.ts
+++ b/packages/styling/src/styles/fonts.ts
@@ -78,7 +78,9 @@ export namespace FontSizes {
   export const icon: string = '16px';
   export const large: string = '17px';
   export const xLarge: string = '21px';
+  export const xLargePlus: string = '21px';
   export const xxLarge: string = '28px';
+  export const xxLargePlus: string = '28px';
   export const superLarge: string = '42px';
   export const mega: string = '72px';
 }
@@ -123,7 +125,9 @@ export function createFontStyles(localeCode: string | null): IFontStyles {
     mediumPlus: _createFont(FontSizes.mediumPlus, FontWeights.regular, fontFamilyWithFallback),
     large: _createFont(FontSizes.large, FontWeights.semilight, semilightFontFamilyWithFallback),
     xLarge: _createFont(FontSizes.xLarge, FontWeights.light, fontFamilyWithFallback),
+    xLargePlus: _createFont(FontSizes.xLargePlus, FontWeights.light, fontFamilyWithFallback),
     xxLarge: _createFont(FontSizes.xxLarge, FontWeights.light, fontFamilyWithFallback),
+    xxLargePlus: _createFont(FontSizes.xxLargePlus, FontWeights.light, fontFamilyWithFallback),
     superLarge: _createFont(FontSizes.superLarge, FontWeights.light, fontFamilyWithFallback),
     mega: _createFont(FontSizes.mega, FontWeights.light, fontFamilyWithFallback)
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Adds additional font steps that will be used in Fabric 7's Fluent theme. This is to insure that Fabric 7's Fluent theme is backwards compatible with components coded against Fabric 6's theme API.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9329)