### PR TITLE
Updated theme designer stack usage

### DIFF
--- a/apps/theming-designer/src/components/AccessibilityChecker.tsx
+++ b/apps/theming-designer/src/components/AccessibilityChecker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AccessibilityDetailsList } from './AccessibilityDetailsList';
-import { BaseSlots, FabricSlots, IThemeRules } from 'office-ui-fabric-react/lib/ThemeGenerator';
+import { BaseSlots, FabricSlots, IThemeRules, Text } from 'office-ui-fabric-react';
 import { getContrastRatio, isDark } from 'office-ui-fabric-react/lib/utilities/color/shades';
 import { IColor } from 'office-ui-fabric-react/lib/utilities/color/interfaces';
 import { MainPanelInnerContent } from '../shared/MainPanelStyles';
@@ -59,7 +59,7 @@ export const AccessibilityChecker: React.StatelessComponent<IAccessibilityChecke
   loadAllContrastRatioPairsList();
   return (
     <div className={MainPanelInnerContent}>
-      <h1>Accessibility checker</h1>
+      <Text variant={'xxLarge'}>Accessibility checker</Text>
       <AccessibilityDetailsList theme={props.theme!} accessiblePairs={accessiblePairs} nonAccessiblePairs={nonAccessiblePairs} />
     </div>
   );

--- a/apps/theming-designer/src/components/AccessibilityChecker.tsx
+++ b/apps/theming-designer/src/components/AccessibilityChecker.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { AccessibilityDetailsList } from './AccessibilityDetailsList';
-import { BaseSlots, FabricSlots, IThemeRules, Text } from 'office-ui-fabric-react';
+import { BaseSlots, FabricSlots, IThemeRules, Text, ITextProps } from 'office-ui-fabric-react';
 import { getContrastRatio, isDark } from 'office-ui-fabric-react/lib/utilities/color/shades';
 import { IColor } from 'office-ui-fabric-react/lib/utilities/color/interfaces';
 import { MainPanelInnerContent } from '../shared/MainPanelStyles';
 import { ITheme } from 'office-ui-fabric-react/lib/Styling';
+import { TitleText } from '../shared/Typography';
 
 export interface IAccessibilityCheckerProps {
   theme?: ITheme;

--- a/apps/theming-designer/src/components/AccessibilityChecker.tsx
+++ b/apps/theming-designer/src/components/AccessibilityChecker.tsx
@@ -60,7 +60,7 @@ export const AccessibilityChecker: React.StatelessComponent<IAccessibilityChecke
   loadAllContrastRatioPairsList();
   return (
     <div className={MainPanelInnerContent}>
-      <Text variant={'xxLarge'}>Accessibility checker</Text>
+      <TitleText>Accessibility checker</TitleText>
       <AccessibilityDetailsList theme={props.theme!} accessiblePairs={accessiblePairs} nonAccessiblePairs={nonAccessiblePairs} />
     </div>
   );

--- a/apps/theming-designer/src/components/FabricPalette.tsx
+++ b/apps/theming-designer/src/components/FabricPalette.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FabricSlots, IThemeRules } from 'office-ui-fabric-react/lib/ThemeGenerator';
 import { MainPanelInnerContent } from '../shared/MainPanelStyles';
 import { mergeStyles } from '@uifabric/merge-styles';
-import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, Text } from 'office-ui-fabric-react';
 
 export interface IFabricPaletteProps {
   themeRules?: IThemeRules;
@@ -56,82 +56,182 @@ export const FabricPalette: React.StatelessComponent<IFabricPaletteProps> = (pro
 
   return (
     <div className={MainPanelInnerContent}>
-      <h1>Fabric palette</h1>
+      <Text variant="xxLarge">Fabric palette</Text>
       <table className={tableClassName}>
         <thead>
           <tr>
-            <th>Primary</th>
-            <th>Hex</th>
-            <th>Foreground</th>
-            <th>Hex</th>
-            <th>Background</th>
-            <th>Hex</th>
+            <th>
+              <Text> Primary</Text>
+            </th>
+            <th>
+              <Text> Hex</Text>
+            </th>
+            <th>
+              <Text> Foreground</Text>
+            </th>
+            <th>
+              <Text> Hex</Text>
+            </th>
+            <th>
+              <Text> Background</Text>
+            </th>
+            <th>
+              <Text> Hex</Text>
+            </th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeDarker)}</td> {/*fabricThemeSlots*/}
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeDarker]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.black)}</td> {/*fabricNeutralForegroundSlots*/}
-            <td>{props.themeRules![FabricSlots[FabricSlots.black]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralTertiaryAlt)}</td> {/*fabricNeutralBackgroundSlots*/}
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeDarker)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeDarker]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.black)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.black]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralTertiaryAlt)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeDark)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeDark]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralDark)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralDark]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralQuaternary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralQuaternary]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeDark)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeDark]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralDark)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralDark]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralQuaternary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralQuaternary]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeDarkAlt)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeDarkAlt]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralPrimary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralPrimary]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralQuaternaryAlt)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralQuaternaryAlt]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeDarkAlt)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeDarkAlt]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralPrimary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralPrimary]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralQuaternaryAlt)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralQuaternaryAlt]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themePrimary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themePrimary]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralPrimaryAlt)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralPrimaryAlt]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralLight)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralLight]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themePrimary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themePrimary]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralPrimaryAlt)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralPrimaryAlt]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralLight)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralLight]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeSecondary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeSecondary]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralSecondary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralSecondary]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralLighter)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralLighter]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeSecondary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeSecondary]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralSecondary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralSecondary]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralLighter)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralLighter]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeTertiary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeTertiary]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralTertiary)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</td>
-            <td>{fabricSlotWidget(FabricSlots.neutralLighterAlt)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.neutralLighterAlt]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeTertiary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeTertiary]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralTertiary)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</Text>
+            </td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.neutralLighterAlt)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralLighterAlt]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeLight)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeLight]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeLight)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeLight]].color!.str}</Text>
+            </td>
             <td />
             <td />
-            <td>{fabricSlotWidget(FabricSlots.white)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.white]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.white)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.white]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeLighter)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeLighter]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeLighter)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeLighter]].color!.str}</Text>
+            </td>
           </tr>
           <tr>
-            <td>{fabricSlotWidget(FabricSlots.themeLighterAlt)}</td>
-            <td>{props.themeRules![FabricSlots[FabricSlots.themeLighterAlt]].color!.str}</td>
+            <td>
+              <Text>{fabricSlotWidget(FabricSlots.themeLighterAlt)}</Text>
+            </td>
+            <td>
+              <Text>{props.themeRules![FabricSlots[FabricSlots.themeLighterAlt]].color!.str}</Text>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/apps/theming-designer/src/components/FabricPalette.tsx
+++ b/apps/theming-designer/src/components/FabricPalette.tsx
@@ -18,9 +18,13 @@ const tableClassName = mergeStyles({
       padding: 80,
       textAlign: 'left'
     },
+    th: {
+      display: 'table-cell'
+    },
     td: {
       padding: 10,
-      textAlign: 'left'
+      textAlign: 'left',
+      display: 'table-cell'
     }
   }
 });
@@ -56,182 +60,79 @@ export const FabricPalette: React.StatelessComponent<IFabricPaletteProps> = (pro
 
   return (
     <div className={MainPanelInnerContent}>
-      <Text variant="xxLarge">Fabric palette</Text>
       <table className={tableClassName}>
         <thead>
           <tr>
-            <th>
-              <Text> Primary</Text>
-            </th>
-            <th>
-              <Text> Hex</Text>
-            </th>
-            <th>
-              <Text> Foreground</Text>
-            </th>
-            <th>
-              <Text> Hex</Text>
-            </th>
-            <th>
-              <Text> Background</Text>
-            </th>
-            <th>
-              <Text> Hex</Text>
-            </th>
+            <Text as="th"> Primary</Text>
+            <Text as="th"> Hex</Text>
+            <Text as="th"> Foreground</Text>
+            <Text as="th"> Hex</Text>
+            <Text as="th"> Background</Text>
+            <Text as="th"> Hex</Text>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeDarker)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeDarker]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.black)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.black]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralTertiaryAlt)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeDarker)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeDarker]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.black)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.black]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralTertiaryAlt)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeDark)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeDark]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralDark)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralDark]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralQuaternary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralQuaternary]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeDark)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeDark]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralDark)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralDark]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralQuaternary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralQuaternary]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeDarkAlt)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeDarkAlt]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralPrimary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralPrimary]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralQuaternaryAlt)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralQuaternaryAlt]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeDarkAlt)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeDarkAlt]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralPrimary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralPrimary]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralQuaternaryAlt)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralQuaternaryAlt]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themePrimary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themePrimary]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralPrimaryAlt)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralPrimaryAlt]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralLight)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralLight]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themePrimary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themePrimary]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralPrimaryAlt)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralPrimaryAlt]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralLight)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralLight]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeSecondary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeSecondary]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralSecondary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralSecondary]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralLighter)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralLighter]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeSecondary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeSecondary]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralSecondary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralSecondary]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralLighter)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralLighter]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeTertiary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeTertiary]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralTertiary)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</Text>
-            </td>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.neutralLighterAlt)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.neutralLighterAlt]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeTertiary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeTertiary]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralTertiary)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralTertiaryAlt]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.neutralLighterAlt)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.neutralLighterAlt]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeLight)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeLight]].color!.str}</Text>
-            </td>
-            <td />
-            <td />
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.white)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.white]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeLight)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeLight]].color!.str}</Text>
+            <Text as="td">{fabricSlotWidget(FabricSlots.white)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.white]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeLighter)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeLighter]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeLighter)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeLighter]].color!.str}</Text>
           </tr>
           <tr>
-            <td>
-              <Text>{fabricSlotWidget(FabricSlots.themeLighterAlt)}</Text>
-            </td>
-            <td>
-              <Text>{props.themeRules![FabricSlots[FabricSlots.themeLighterAlt]].color!.str}</Text>
-            </td>
+            <Text as="td">{fabricSlotWidget(FabricSlots.themeLighterAlt)}</Text>
+            <Text as="td">{props.themeRules![FabricSlots[FabricSlots.themeLighterAlt]].color!.str}</Text>
           </tr>
         </tbody>
       </table>

--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -1,7 +1,18 @@
 import * as React from 'react';
 import { Card } from '@uifabric/react-cards';
-import { Stack, Text } from 'office-ui-fabric-react';
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import {
+  Stack,
+  Text,
+  styled,
+  Link,
+  Image,
+  ITextProps,
+  ILinkStyleProps,
+  ILinkStyles,
+  PrimaryButton,
+  ITheme,
+  IStackProps
+} from 'office-ui-fabric-react';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
 import { IThemeRules, ThemeGenerator } from 'office-ui-fabric-react/lib/ThemeGenerator';
@@ -32,15 +43,24 @@ const textAreaClassName = mergeStyles({
 });
 
 const microsoftLogo = mergeStyles({
-  width: '120px'
+  width: '120px',
+  display: 'block'
 });
 
-const pipeFabricClassName = mergeStyles({
-  fontSize: '15px',
-  fontWeight: 'bold',
-  color: '#000000',
-  textDecoration: 'none',
-  marginTop: '10px'
+const pipeFabricStyles = (p: ILinkStyleProps): ILinkStyles => ({
+  root: {
+    textDecoration: 'none',
+    color: p.theme.semanticColors.bodyText
+  }
+});
+
+const headerStackStyles = (p: IStackProps, theme: ITheme) => ({
+  root: {
+    backgroundColor: theme.semanticColors.bodyBackground,
+    minHeight: 47,
+    padding: '0 32px',
+    boxShadow: theme.effects.elevation16
+  }
 });
 
 const codeHeader = "import { loadTheme } from 'office-ui-fabric-react';\n\n";
@@ -65,64 +85,51 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
 
   public render(): JSX.Element {
     return (
-      <Card
-        styles={{
-          root: { flexGrow: 0, backgroundColor: 'white', maxWidth: 'none', height: 'auto' }
-        }}
-      >
-        <Stack horizontal tokens={{ childrenGap: 1200 }}>
-          <Stack horizontal>
-            <a href="https://www.microsoft.com" title="Microsoft Home Page" aria-label="Microsoft Home Page" className={microsoftLogo}>
-              <img src="https://themingdesigner.blob.core.windows.net/$web/MicrosoftLogo.png" className={microsoftLogo} />
-            </a>
-            <a
-              href="https://www.aka.ms/themedesigner"
-              title="Microsoft Theme Designer page"
-              aria-label="Microsoft Fabric Theme Designer page"
-              className={pipeFabricClassName}
-            >
-              <Text> | UI Fabric Theme Designer </Text>
-            </a>
-          </Stack>
-          <Stack horizontal styles={{ root: { position: 'absolute', right: '25px' } }}>
-            <PrimaryButton text="Export theme" onClick={this.showPanel} styles={{ root: { width: '130px', height: '35px' } }} />
-            <Panel
-              isOpen={this.state.showPanel}
-              type={PanelType.smallFixedFar}
-              onDismiss={this.hidePanel}
-              headerText="Export theme"
-              closeButtonAriaLabel="Close"
-              onRenderFooterContent={this.onRenderFooterContent}
-            >
-              <span>
-                <p>
-                  This code block initializes the theme you have configured above and loads it using the loadTheme utility function. Calling
-                  loadTheme will automatically apply the configured theming to any Fabric controls used within the same app. You can also
-                  export this example to CodePen with a few component examples below.
-                </p>
-              </span>
-              <div className={outputPanelClassName}>
-                <Pivot>
-                  <PivotItem headerText="Code">
-                    <textarea
-                      className={textAreaClassName}
-                      readOnly={true}
-                      spellCheck={false}
-                      value={codeHeader + this.state.themeAsCode}
-                    />
-                  </PivotItem>
-                  <PivotItem headerText="JSON">
-                    <textarea className={textAreaClassName} readOnly={true} spellCheck={false} value={this.state.jsonTheme} />
-                  </PivotItem>
-                  <PivotItem headerText="PowerShell">
-                    <textarea className={textAreaClassName} readOnly={true} spellCheck={false} value={this.state.powershellTheme} />
-                  </PivotItem>
-                </Pivot>
-              </div>
-            </Panel>
-          </Stack>
+      <Stack horizontal verticalAlign="center" grow={0} styles={headerStackStyles}>
+        <Stack horizontal grow={1} verticalAlign="center">
+          <a href="https://www.microsoft.com" title="Microsoft Home Page" aria-label="Microsoft Home Page" className={microsoftLogo}>
+            <img src="https://themingdesigner.blob.core.windows.net/$web/MicrosoftLogo.png" className={microsoftLogo} />
+          </a>
+          <Link
+            href="https://www.aka.ms/themedesigner"
+            title="Microsoft Theme Designer page"
+            aria-label="Microsoft Fabric Theme Designer page"
+            styles={pipeFabricStyles}
+          >
+            | UI Fabric Theme Designer
+          </Link>
         </Stack>
-      </Card>
+        <PrimaryButton text="Export theme" onClick={this.showPanel} />
+        <Panel
+          isOpen={this.state.showPanel}
+          type={PanelType.smallFixedFar}
+          onDismiss={this.hidePanel}
+          headerText="Export theme"
+          closeButtonAriaLabel="Close"
+          onRenderFooterContent={this.onRenderFooterContent}
+        >
+          <span>
+            <p>
+              This code block initializes the theme you have configured above and loads it using the loadTheme utility function. Calling
+              loadTheme will automatically apply the configured theming to any Fabric controls used within the same app. You can also export
+              this example to CodePen with a few component examples below.
+            </p>
+          </span>
+          <div className={outputPanelClassName}>
+            <Pivot>
+              <PivotItem headerText="Code">
+                <textarea className={textAreaClassName} readOnly={true} spellCheck={false} value={codeHeader + this.state.themeAsCode} />
+              </PivotItem>
+              <PivotItem headerText="JSON">
+                <textarea className={textAreaClassName} readOnly={true} spellCheck={false} value={this.state.jsonTheme} />
+              </PivotItem>
+              <PivotItem headerText="PowerShell">
+                <textarea className={textAreaClassName} readOnly={true} spellCheck={false} value={this.state.powershellTheme} />
+              </PivotItem>
+            </Pivot>
+          </div>
+        </Panel>
+      </Stack>
     );
   }
 

--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -50,7 +50,9 @@ const microsoftLogo = mergeStyles({
 const pipeFabricStyles = (p: ILinkStyleProps): ILinkStyles => ({
   root: {
     textDecoration: 'none',
-    color: p.theme.semanticColors.bodyText
+    color: p.theme.semanticColors.bodyText,
+    fontWeight: '600',
+    fontSize: p.theme.fonts.medium.fontSize
   }
 });
 

--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Card } from '@uifabric/react-cards';
-import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, Text } from 'office-ui-fabric-react';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
@@ -25,7 +25,7 @@ const outputPanelClassName = mergeStyles({
 
 const textAreaClassName = mergeStyles({
   height: 350,
-  width: 280,
+  width: '100%',
   marginRight: 28,
   backgroundColor: 'white',
   color: '#333'
@@ -67,7 +67,7 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
     return (
       <Card
         styles={{
-          root: { backgroundColor: 'white', minWidth: '99%', height: '35px', position: 'fixed', left: '0', top: '0', zIndex: 600 }
+          root: { flexGrow: 0, backgroundColor: 'white', maxWidth: 'none', height: 'auto' }
         }}
       >
         <Stack horizontal tokens={{ childrenGap: 1200 }}>
@@ -81,7 +81,7 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
               aria-label="Microsoft Fabric Theme Designer page"
               className={pipeFabricClassName}
             >
-              <span> | UI Fabric Theme Designer </span>
+              <Text> | UI Fabric Theme Designer </Text>
             </a>
           </Stack>
           <Stack horizontal styles={{ root: { position: 'absolute', right: '25px' } }}>

--- a/apps/theming-designer/src/components/SemanticSlots.tsx
+++ b/apps/theming-designer/src/components/SemanticSlots.tsx
@@ -462,7 +462,6 @@ export const SemanticSlots: React.StatelessComponent<ISemanticSlotsProps> = (pro
 
   return (
     <div className={MainPanelInnerContent}>
-      <Text variant="xxLarge">Semantic slots</Text>
       <SemanticSlotsDetailsList
         slotNames={slotNames}
         noneSlots={noneSlots}

--- a/apps/theming-designer/src/components/SemanticSlots.tsx
+++ b/apps/theming-designer/src/components/SemanticSlots.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ITheme } from 'office-ui-fabric-react/lib/Styling';
-import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, Text } from 'office-ui-fabric-react';
 import { mergeStyles } from '@uifabric/merge-styles';
 import { SemanticSlotsDetailsList } from './SemanticSlotsDetailsList';
 import { MainPanelInnerContent } from '../shared/MainPanelStyles';
@@ -462,7 +462,7 @@ export const SemanticSlots: React.StatelessComponent<ISemanticSlotsProps> = (pro
 
   return (
     <div className={MainPanelInnerContent}>
-      <h1>Semantic slots</h1>
+      <Text variant="xxLarge">Semantic slots</Text>
       <SemanticSlotsDetailsList
         slotNames={slotNames}
         noneSlots={noneSlots}

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -13,8 +13,9 @@ import { Samples } from './Samples/index';
 import { SemanticSlots } from './SemanticSlots';
 import { Stack, IStackProps } from 'office-ui-fabric-react/lib/Stack';
 import { ThemeDesignerColorPicker } from './ThemeDesignerColorPicker';
-import { ThemeProvider, Text } from 'office-ui-fabric-react';
+import { ThemeProvider, Text, Pivot, PivotItem } from 'office-ui-fabric-react';
 import { MainPanelWidth } from '../shared/MainPanelStyles';
+import { TitleText } from '../shared/Typography';
 
 export interface IThemingDesignerState {
   primaryColor: IColor;
@@ -84,11 +85,11 @@ export class ThemingDesigner extends BaseComponent<{}, IThemingDesignerState> {
         <Header themeRules={this.state.themeRules} />
         <Content>
           <Sidebar>
-            <Text variant={'xxLarge'}>
+            <Text variant={'xLarge'} styles={{ root: { fontWeight: 600, marginLeft: 20 } }}>
               <IconButton
                 disabled={false}
                 checked={false}
-                iconProps={{ iconName: 'Color', styles: { root: { fontSize: '20px' } } }}
+                iconProps={{ iconName: 'Color', styles: { root: { fontSize: '20px', marginRight: 12 } } }}
                 title="Colors"
                 ariaLabel="Colors"
               />
@@ -112,8 +113,15 @@ export class ThemingDesigner extends BaseComponent<{}, IThemingDesignerState> {
               <Samples backgroundColor={this.state.backgroundColor.str} textColor={this.state.textColor.str} />
             </ThemeProvider>
             <AccessibilityChecker theme={this.state.theme} themeRules={this.state.themeRules} />
-            <FabricPalette themeRules={this.state.themeRules} />
-            <SemanticSlots theme={this.state.theme} />;
+            <TitleText>Theme Slots</TitleText>
+            <Pivot>
+              <PivotItem headerText="Fabric palette slots">
+                <FabricPalette themeRules={this.state.themeRules} />
+              </PivotItem>
+              <PivotItem headerText="Semantic slots">
+                <SemanticSlots theme={this.state.theme} />
+              </PivotItem>
+            </Pivot>
           </Main>
         </Content>
       </Page>

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -11,9 +11,9 @@ import { isDark } from 'office-ui-fabric-react/lib/utilities/color/shades';
 import { mergeStyles } from '@uifabric/merge-styles';
 import { Samples } from './Samples/index';
 import { SemanticSlots } from './SemanticSlots';
-import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, IStackProps } from 'office-ui-fabric-react/lib/Stack';
 import { ThemeDesignerColorPicker } from './ThemeDesignerColorPicker';
-import { ThemeProvider } from 'office-ui-fabric-react/lib/Foundation';
+import { ThemeProvider, Text } from 'office-ui-fabric-react';
 import { MainPanelWidth } from '../shared/MainPanelStyles';
 
 export interface IThemingDesignerState {
@@ -24,29 +24,50 @@ export interface IThemingDesignerState {
   themeRules?: IThemeRules;
 }
 
-const outerMostStack = mergeStyles({
-  width: '100%'
-});
+const Page = (props: IStackProps) => (
+  <Stack
+    gap={10}
+    className={mergeStyles({
+      height: '100vh',
+      overflow: 'hidden',
+      selectors: {
+        ':global(body)': {
+          padding: 0,
+          margin: 0
+        }
+      }
+    })}
+    {...props}
+  />
+);
 
-const sidebarStyles = mergeStyles({
-  marginTop: '35px',
-  width: '300px'
-});
+const Content = (props: IStackProps) => <Stack horizontal gap={10} className={mergeStyles({ overflow: 'hidden' })} {...props} />;
 
-const sidebarContentStyles = mergeStyles({
-  borderRight: '1px solid #ddd',
-  minHeight: '100%',
-  paddingRight: '1rem',
-  position: 'fixed',
-  top: '60px',
-  left: '10px',
-  width: '300px'
-});
+const Sidebar = (props: IStackProps) => (
+  <Stack
+    disableShrink
+    gap={20}
+    grow={0}
+    className={mergeStyles({
+      borderRight: '1px solid #ddd',
+      paddingRight: '1rem'
+    })}
+    {...props}
+  />
+);
 
-const cardsBlockStyles = mergeStyles({
-  minWidth: MainPanelWidth,
-  marginTop: '35px'
-});
+const Main = (props: IStackProps) => (
+  <Stack
+    grow={1}
+    disableShrink
+    className={mergeStyles({
+      minWidth: MainPanelWidth,
+      overflow: 'scroll',
+      marginTop: '35px'
+    })}
+    {...props}
+  />
+);
 
 let colorChangeTimeout: number;
 
@@ -55,69 +76,61 @@ export class ThemingDesigner extends BaseComponent<{}, IThemingDesignerState> {
     super(props);
 
     this.state = this._buildInitialState();
-
-    this._onPrimaryColorPickerChange = this._onPrimaryColorPickerChange.bind(this);
-    this._onTextColorPickerChange = this._onTextColorPickerChange.bind(this);
-    this._onBkgColorPickerChange = this._onBkgColorPickerChange.bind(this);
   }
 
   public render() {
     return (
-      <Stack gap={10} className={outerMostStack}>
+      <Page>
         <Header themeRules={this.state.themeRules} />
-        <Stack horizontal gap={10}>
-          <Stack.Item shrink={false} grow={false} className={sidebarStyles}>
-            <Stack gap={20} className={sidebarContentStyles}>
-              <h1>
-                <IconButton
-                  disabled={false}
-                  checked={false}
-                  iconProps={{ iconName: 'Color', styles: { root: { fontSize: '20px' } } }}
-                  title="Colors"
-                  ariaLabel="Colors"
-                />
-                Color
-              </h1>
-              {/* the three base slots, prominently displayed at the top of the page */}
-              <ThemeDesignerColorPicker
-                color={this.state.primaryColor}
-                onColorChange={this._onPrimaryColorPickerChange}
-                label={'Primary color'}
+        <Content>
+          <Sidebar>
+            <Text variant={'xxLarge'}>
+              <IconButton
+                disabled={false}
+                checked={false}
+                iconProps={{ iconName: 'Color', styles: { root: { fontSize: '20px' } } }}
+                title="Colors"
+                ariaLabel="Colors"
               />
-              <ThemeDesignerColorPicker color={this.state.textColor} onColorChange={this._onTextColorPickerChange} label={'Text color'} />
-              <ThemeDesignerColorPicker
-                color={this.state.backgroundColor}
-                onColorChange={this._onBkgColorPickerChange}
-                label={'Background color'}
-              />
-            </Stack>
-          </Stack.Item>
-          <Stack.Item grow={1} disableShrink className={cardsBlockStyles}>
-            <Stack>
-              <ThemeProvider theme={this.state.theme}>
-                <Samples backgroundColor={this.state.backgroundColor.str} textColor={this.state.textColor.str} />
-              </ThemeProvider>
-              <AccessibilityChecker theme={this.state.theme} themeRules={this.state.themeRules} />
-              <FabricPalette themeRules={this.state.themeRules} />
-              <SemanticSlots theme={this.state.theme} />;
-            </Stack>
-          </Stack.Item>
-        </Stack>
-      </Stack>
+              Color
+            </Text>
+            {/* the three base slots, prominently displayed at the top of the page */}
+            <ThemeDesignerColorPicker
+              color={this.state.primaryColor}
+              onColorChange={this._onPrimaryColorPickerChange}
+              label={'Primary color'}
+            />
+            <ThemeDesignerColorPicker color={this.state.textColor} onColorChange={this._onTextColorPickerChange} label={'Text color'} />
+            <ThemeDesignerColorPicker
+              color={this.state.backgroundColor}
+              onColorChange={this._onBkgColorPickerChange}
+              label={'Background color'}
+            />
+          </Sidebar>
+          <Main>
+            <ThemeProvider theme={this.state.theme}>
+              <Samples backgroundColor={this.state.backgroundColor.str} textColor={this.state.textColor.str} />
+            </ThemeProvider>
+            <AccessibilityChecker theme={this.state.theme} themeRules={this.state.themeRules} />
+            <FabricPalette themeRules={this.state.themeRules} />
+            <SemanticSlots theme={this.state.theme} />;
+          </Main>
+        </Content>
+      </Page>
     );
   }
 
-  private _onPrimaryColorPickerChange(newColor: IColor | undefined) {
+  private _onPrimaryColorPickerChange = (newColor: IColor | undefined) => {
     this._onColorChange(this.state.primaryColor, BaseSlots.primaryColor, newColor);
-  }
+  };
 
-  private _onTextColorPickerChange(newColor: IColor | undefined) {
+  private _onTextColorPickerChange = (newColor: IColor | undefined) => {
     this._onColorChange(this.state.textColor, BaseSlots.foregroundColor, newColor);
-  }
+  };
 
-  private _onBkgColorPickerChange(newColor: IColor | undefined) {
+  private _onBkgColorPickerChange = (newColor: IColor | undefined) => {
     this._onColorChange(this.state.backgroundColor, BaseSlots.backgroundColor, newColor);
-  }
+  };
 
   private _makeNewTheme = (): void => {
     if (this.state.themeRules) {

--- a/apps/theming-designer/src/index.tsx
+++ b/apps/theming-designer/src/index.tsx
@@ -13,12 +13,7 @@ function start(): void {
     _rootDiv = document.createElement('div');
     document.body.appendChild(_rootDiv);
   }
-  ReactDOM.render(
-    <Fabric>
-      <ThemingDesigner />
-    </Fabric>,
-    _rootDiv
-  );
+  ReactDOM.render(<ThemingDesigner />, _rootDiv);
 }
 
 // Start the application.

--- a/apps/theming-designer/src/shared/Typography.tsx
+++ b/apps/theming-designer/src/shared/Typography.tsx
@@ -1,0 +1,14 @@
+import { ITextProps, Text } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+const titleTextStyles: ITextProps['styles'] = (p, theme) => ({
+  root: {
+    display: 'block',
+    fontWeight: 600,
+    color: theme.palette.neutralPrimary,
+    fontSize: 20,
+    marginBottom: 20
+  }
+});
+
+export const TitleText = (p: ITextProps) => <Text styles={titleTextStyles} {...p} />;


### PR DESCRIPTION
Hacking on the Theme Designer stack usage. Cleaned up a bunch of unnecessary stacks, moved sections into easier to read pieces, and updated styling to avoid fixed layouts. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9347)