### PR TITLE
Button: Migration for text, iconProps, menuProps and split deprecated props

### DIFF
--- a/common/changes/@uifabric/migration/buttonCodeMods_2019-06-05-23-01.json
+++ b/common/changes/@uifabric/migration/buttonCodeMods_2019-06-05-23-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/migration",
+      "comment": "Button: Migration for text, iconProps, menuProps and split deprecated props.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/migration",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/migration/fixtures/7.0.0/button.tsx
+++ b/packages/migration/fixtures/7.0.0/button.tsx
@@ -1,11 +1,26 @@
 import { Button } from '@uifabric/experiments';
 import { Fabric } from 'office-ui-fabric-react';
 
+const menuProps = {
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
+};
+
 class ButtonExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Fabric className={wrapperClassName}>
         <Button text="This is a button" iconProps={{ iconName: 'Emoji2' }} />
+        <Button text="This is a button" iconProps={{ iconName: 'Emoji2' }} menuProps={menuProps} />
+        <Button split text="This is a button" iconProps={{ iconName: 'Emoji2' }} menuProps={menuProps} />
       </Fabric>
     );
   }

--- a/packages/migration/fixtures/7.0.0/button.tsx
+++ b/packages/migration/fixtures/7.0.0/button.tsx
@@ -1,0 +1,12 @@
+import { Button } from '@uifabric/experiments';
+import { Fabric } from 'office-ui-fabric-react';
+
+class ButtonExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    return (
+      <Fabric className={wrapperClassName}>
+        <Button text="This is a button" iconProps={{ iconName: 'Emoji2' }} />
+      </Fabric>
+    );
+  }
+}

--- a/packages/migration/src/mods/7.0.0/buttonIconPropsPropChange.ts
+++ b/packages/migration/src/mods/7.0.0/buttonIconPropsPropChange.ts
@@ -1,0 +1,12 @@
+import { IMigrationOptions, migration, ModResult } from '../../migration';
+import { mod } from 'riceburn';
+import { renameJsxProp } from 'riceburn/lib/mods/renameJsxProp';
+
+export default migration(
+  'rename deprecated Button props from iconProps to icon',
+  (opts: IMigrationOptions): ModResult[] => {
+    return mod('**/*.tsx', opts).asTypescript((node, modder) => {
+      return renameJsxProp('Button', 'iconProps', 'icon')(node, modder);
+    }).files;
+  }
+);

--- a/packages/migration/src/mods/7.0.0/buttonMenuPropsPropChange.ts
+++ b/packages/migration/src/mods/7.0.0/buttonMenuPropsPropChange.ts
@@ -1,0 +1,12 @@
+import { IMigrationOptions, migration, ModResult } from '../../migration';
+import { mod } from 'riceburn';
+import { renameJsxProp } from 'riceburn/lib/mods/renameJsxProp';
+
+export default migration(
+  'rename deprecated Button props from menuProps to menu',
+  (opts: IMigrationOptions): ModResult[] => {
+    return mod('**/*.tsx', opts).asTypescript((node, modder) => {
+      return renameJsxProp('Button', 'menuProps', 'menu')(node, modder);
+    }).files;
+  }
+);

--- a/packages/migration/src/mods/7.0.0/buttonTextPropChange.ts
+++ b/packages/migration/src/mods/7.0.0/buttonTextPropChange.ts
@@ -1,0 +1,12 @@
+import { IMigrationOptions, migration, ModResult } from '../../migration';
+import { mod } from 'riceburn';
+import { renameJsxProp } from 'riceburn/lib/mods/renameJsxProp';
+
+export default migration(
+  'rename deprecated Button props from text to content',
+  (opts: IMigrationOptions): ModResult[] => {
+    return mod('**/*.tsx', opts).asTypescript((node, modder) => {
+      return renameJsxProp('Button', 'text', 'content')(node, modder);
+    }).files;
+  }
+);

--- a/packages/migration/src/mods/7.0.0/buttonToMenuButtonNodeChange.ts
+++ b/packages/migration/src/mods/7.0.0/buttonToMenuButtonNodeChange.ts
@@ -1,0 +1,12 @@
+import { IMigrationOptions, migration, ModResult } from '../../migration';
+import { mod } from 'riceburn';
+import { renameJsxNodeIfHasProp } from '../../util/CustomMods';
+
+export default migration(
+  'rename Button to MenuButton if menu prop exists',
+  (opts: IMigrationOptions): ModResult[] => {
+    return mod('**/*.tsx', opts).asTypescript((node, modder) => {
+      return renameJsxNodeIfHasProp('Button', 'MenuButton', 'menu')(node, modder);
+    }).files;
+  }
+);

--- a/packages/migration/src/mods/7.0.0/buttonToSplitButtonNodeChange.ts
+++ b/packages/migration/src/mods/7.0.0/buttonToSplitButtonNodeChange.ts
@@ -1,0 +1,12 @@
+import { IMigrationOptions, migration, ModResult } from '../../migration';
+import { mod } from 'riceburn';
+import { renameJsxNodeIfHasProp } from '../../util/CustomMods';
+
+export default migration(
+  'rename Button to SplitButton if split prop exists',
+  (opts: IMigrationOptions): ModResult[] => {
+    return mod('**/*.tsx', opts).asTypescript((node, modder) => {
+      return renameJsxNodeIfHasProp('Button', 'SplitButton', 'split')(node, modder);
+    }).files;
+  }
+);

--- a/packages/migration/src/mods/7.0.0/splitButtonSplitPropRemovalChange.ts
+++ b/packages/migration/src/mods/7.0.0/splitButtonSplitPropRemovalChange.ts
@@ -1,0 +1,12 @@
+import { IMigrationOptions, migration, ModResult } from '../../migration';
+import { mod } from 'riceburn';
+import { removeProp } from '../../util/CustomMods';
+
+export default migration(
+  'remove deprecated split prop from SplitButton',
+  (opts: IMigrationOptions): ModResult[] => {
+    return mod('**/*.tsx', opts).asTypescript((node, modder) => {
+      return removeProp('SplitButton', 'split')(node, modder);
+    }).files;
+  }
+);

--- a/packages/migration/src/tests/mods/7.0.0/__snapshots__/buttonPropsChange.test.ts.snap
+++ b/packages/migration/src/tests/mods/7.0.0/__snapshots__/buttonPropsChange.test.ts.snap
@@ -2,13 +2,30 @@
 
 exports[`buttonPropsChange transforms deprecated props to the corresponding non-deprecated ones 1`] = `
 "import { Button } from '@uifabric/experiments';
+import { MenuButton } from '@uifabric/experiments';
+import { SplitButton } from '@uifabric/experiments';
 import { Fabric } from 'office-ui-fabric-react';
+
+const menuProps = {
+  items: [
+    {
+      key: 'a',
+      name: 'Item a'
+    },
+    {
+      key: 'b',
+      name: 'Item b'
+    }
+  ]
+};
 
 class ButtonExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <Fabric className={wrapperClassName}>
         <Button content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} />
+        <MenuButton content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} menu={menuProps} />
+        <SplitButton content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} menu={menuProps} />
       </Fabric>
     );
   }

--- a/packages/migration/src/tests/mods/7.0.0/__snapshots__/buttonPropsChange.test.ts.snap
+++ b/packages/migration/src/tests/mods/7.0.0/__snapshots__/buttonPropsChange.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buttonPropsChange transforms deprecated props to the corresponding non-deprecated ones 1`] = `
+"import { Button } from '@uifabric/experiments';
+import { Fabric } from 'office-ui-fabric-react';
+
+class ButtonExample extends React.Component<{}, {}> {
+  public render(): JSX.Element {
+    return (
+      <Fabric className={wrapperClassName}>
+        <Button content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} />
+      </Fabric>
+    );
+  }
+}
+"
+`;

--- a/packages/migration/src/tests/mods/7.0.0/buttonPropsChange.test.ts
+++ b/packages/migration/src/tests/mods/7.0.0/buttonPropsChange.test.ts
@@ -1,0 +1,11 @@
+import textMigration from '../../../mods/7.0.0/buttonTextPropChange';
+import iconPropsMigration from '../../../mods/7.0.0/buttonIconPropsPropChange';
+import { runMigration } from '../utils';
+
+describe('buttonPropsChange', () => {
+  it('transforms deprecated props to the corresponding non-deprecated ones', async () => {
+    const result = await runMigration([iconPropsMigration, textMigration], 'button.tsx');
+    expect(result.warnings).toEqual([]);
+    expect(result.contents).toMatchSnapshot();
+  });
+});

--- a/packages/migration/src/tests/mods/7.0.0/buttonPropsChange.test.ts
+++ b/packages/migration/src/tests/mods/7.0.0/buttonPropsChange.test.ts
@@ -1,10 +1,24 @@
 import textMigration from '../../../mods/7.0.0/buttonTextPropChange';
 import iconPropsMigration from '../../../mods/7.0.0/buttonIconPropsPropChange';
+import buttonMenuPropsMigration from '../../../mods/7.0.0/buttonMenuPropsPropChange';
+import buttonToMenuButtonMigration from '../../../mods/7.0.0/buttonToMenuButtonNodeChange';
+import buttonToSplitButtonMigration from '../../../mods/7.0.0/buttonToSplitButtonNodeChange';
+import splitButtonSplitPropRemovalMigration from '../../../mods/7.0.0/splitButtonSplitPropRemovalChange';
 import { runMigration } from '../utils';
 
 describe('buttonPropsChange', () => {
   it('transforms deprecated props to the corresponding non-deprecated ones', async () => {
-    const result = await runMigration([iconPropsMigration, textMigration], 'button.tsx');
+    const result = await runMigration(
+      [
+        textMigration,
+        iconPropsMigration,
+        buttonMenuPropsMigration,
+        buttonToSplitButtonMigration,
+        buttonToMenuButtonMigration,
+        splitButtonSplitPropRemovalMigration
+      ],
+      'button.tsx'
+    );
     expect(result.warnings).toEqual([]);
     expect(result.contents).toMatchSnapshot();
   });

--- a/packages/migration/src/tests/mods/utils/index.ts
+++ b/packages/migration/src/tests/mods/utils/index.ts
@@ -47,11 +47,17 @@ interface IMigrationResult {
   warnings: string[];
 }
 
-export async function runMigration(migration: IMigration, filename: string): Promise<IMigrationResult> {
+export async function runMigration(migration: IMigration | IMigration[], filename: string): Promise<IMigrationResult> {
   await setup();
   const result: IMigrationResult = { contents: '', warnings: [] };
   try {
-    migration.step({ dryRun: false, warn: (msg: string) => result.warnings.push(msg) });
+    if (Array.isArray(migration)) {
+      for (const mig of migration) {
+        mig.step({ dryRun: false, warn: (msg: string) => result.warnings.push(msg) });
+      }
+    } else {
+      migration.step({ dryRun: false, warn: (msg: string) => result.warnings.push(msg) });
+    }
     const contents = await readFileAsync(path.join('_root', filename));
     teardown();
     result.contents = contents.toString();

--- a/packages/migration/src/util/CustomMods.ts
+++ b/packages/migration/src/util/CustomMods.ts
@@ -1,0 +1,71 @@
+import os from 'os';
+import ts from 'typescript';
+import { Modder, TypescriptMod } from 'riceburn/lib/interfaces';
+import { generateImport } from './MoveImports';
+
+export function renameJsxNodeIfHasProp(
+  nodePrevName: string,
+  nodeNewName: string,
+  prop: string
+): (node: ts.Node, modder: Modder) => TypescriptMod | TypescriptMod[] | undefined {
+  return (node: ts.Node, modder: Modder) => {
+    let nodeHasImport: boolean = false;
+    let nodeHasProp: boolean = false;
+
+    // Append new node name in imports.
+    if (
+      ts.isImportDeclaration(node) &&
+      node.importClause &&
+      node.importClause.namedBindings &&
+      ts.isNamedImports(node.importClause.namedBindings)
+    ) {
+      let importPackage = node.moduleSpecifier.getText();
+      importPackage = importPackage.substr(1, importPackage.length - 2);
+      const namedBindings = node.importClause.namedBindings;
+      const imports: string[] = [];
+      namedBindings.forEachChild(binding => {
+        if (binding.getText() === nodePrevName) {
+          nodeHasImport = true;
+          imports.push(binding.getText());
+        }
+      });
+      if (nodeHasImport) {
+        return modder.replace(
+          node,
+          [generateImport(importPackage, imports), generateImport(importPackage, [nodeNewName])].filter(s => s !== undefined).join(os.EOL)
+        );
+      }
+    }
+
+    // Replace the previous node name with the new one.
+    if (ts.isJsxOpeningLikeElement(node)) {
+      if (node.tagName.getText() === nodePrevName && node.attributes && node.attributes.properties) {
+        for (const p of node.attributes.properties) {
+          if (p && ts.isJsxAttribute(p) && p.name && p.name.getText() === prop) {
+            nodeHasProp = true;
+            break;
+          }
+        }
+
+        if (nodeHasProp) {
+          return modder.replace(node.tagName, nodeNewName);
+        }
+      }
+    }
+  };
+}
+
+export function removeProp(nodeName: string, prop: string): (node: ts.Node, modder: Modder) => TypescriptMod | undefined {
+  return (node: ts.Node, modder: Modder) => {
+    // Replace the previous node name with the new one.
+    if (ts.isJsxOpeningLikeElement(node)) {
+      if (node.tagName.getText() === nodeName && node.attributes && node.attributes.properties) {
+        for (const p of node.attributes.properties) {
+          if (p && ts.isJsxAttribute(p) && p.name && p.name.getText() === prop) {
+            return modder.removeFull(p);
+          }
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR creates code mods for some `Button` props to aid in the transition of people using the old `Button` in Fabric 7. The code mods do the following things:
- Rename the deprecated `text` prop to `content`.
- Rename the deprecated `iconProps` prop to `icon`.
- Rename the deprecated `menuProps` prop to `menu`.
- For `Buttons` that have the `menuProps` prop, rename `Button` to `MenuButton` and add `MenuButton` as an import.
- For `Buttons` that have the `split` prop, rename `Button` to `SplitButton`, remove the `split` prop and add `SplitButton` as an import.

In order to do this two custom reusable code mods have been created, one to rename a JSX node to a new name if it has a prop and another one to remove a prop from a JSX node.

`index.ts` has also been modified to include accept an array of code mods that are applied in sequence instead of only accepting one code mod at a time.

With these code mods applied, the file:

```ts
import { Button } from '@uifabric/experiments';
import { Fabric } from 'office-ui-fabric-react';

const menuProps = {
  items: [
    {
      key: 'a',
      name: 'Item a'
    },
    {
      key: 'b',
      name: 'Item b'
    }
  ]
};

class ButtonExample extends React.Component<{}, {}> {
  public render(): JSX.Element {
    return (
      <Fabric className={wrapperClassName}>
        <Button text="This is a button" iconProps={{ iconName: 'Emoji2' }} />
        <Button text="This is a button" iconProps={{ iconName: 'Emoji2' }} menuProps={menuProps} />
        <Button split text="This is a button" iconProps={{ iconName: 'Emoji2' }} menuProps={menuProps} />
      </Fabric>
    );
  }
}
```

Is transformed into:

```ts
import { Button } from '@uifabric/experiments';
import { MenuButton } from '@uifabric/experiments';
import { SplitButton } from '@uifabric/experiments';
import { Fabric } from 'office-ui-fabric-react';

const menuProps = {
  items: [
    {
      key: 'a',
      name: 'Item a'
    },
    {
      key: 'b',
      name: 'Item b'
    }
  ]
};

class ButtonExample extends React.Component<{}, {}> {
  public render(): JSX.Element {
    return (
      <Fabric className={wrapperClassName}>
        <Button content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} />
        <MenuButton content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} menu={menuProps} />
        <SplitButton content=\\"This is a button\\" icon={{ iconName: 'Emoji2' }} menu={menuProps} />
      </Fabric>
    );
  }
}
```

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9354)