### PR TITLE
Changed commandBar cacheKey creation logic for farItems to include th…

### DIFF
--- a/common/changes/office-ui-fabric-react/momahesh-command-bar-ie-menu-items-overlap-issue_2019-06-06-16-04.json
+++ b/common/changes/office-ui-fabric-react/momahesh-command-bar-ie-menu-items-overlap-issue_2019-06-06-16-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": " Changed commandBar cacheKey creation logic for farItems to include the Name along with the key while creating the cacheKey",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "momahesh@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -196,8 +196,16 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       return acc + cacheKey;
     };
 
+    // This will handle the case when only the name of the farItems got changed and key remains the same
+    // In this case we should invalidate the cache as farItems name is contributing to the width
+    // of the container. Thus we are keeping the name as part of cacheKey creation.
+    const returnFarItemsKey = (acc: string, current: ICommandBarItemProps): string => {
+      const { displayText = current.name || current.text } = current;
+      return returnKey(acc, current) + displayText.replace(/\s/g, '');
+    };
+
     const primaryKey = primaryItems.reduce(returnKey, '');
-    const farKey = farItems.reduce(returnKey, '');
+    const farKey = farItems.reduce(returnFarItemsKey, '');
     const overflowKey = !!overflowItems.length ? 'overflow' : '';
 
     return [primaryKey, farKey, overflowKey].join(' ');

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -200,8 +200,9 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     // In this case we should invalidate the cache as farItems name is contributing to the width
     // of the container. Thus we are keeping the name as part of cacheKey creation.
     const returnFarItemsKey = (acc: string, current: ICommandBarItemProps): string => {
-      const { displayText = current.name || current.text } = current;
-      return returnKey(acc, current) + displayText ? displayText.replace(/\s/g, '') : '';
+      const { cacheKey = current.key, displayText = current.name || current.text } = current;
+      const displayTextKey = displayText ? displayText.replace(/\s/g, '') : '';
+      return acc + cacheKey + displayTextKey;
     };
 
     const primaryKey = primaryItems.reduce(returnKey, '');

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -201,7 +201,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     // of the container. Thus we are keeping the name as part of cacheKey creation.
     const returnFarItemsKey = (acc: string, current: ICommandBarItemProps): string => {
       const { displayText = current.name || current.text } = current;
-      return returnKey(acc, current) + displayText.replace(/\s/g, '');
+      return returnKey(acc, current) + displayText ? displayText.replace(/\s/g, '') : '';
     };
 
     const primaryKey = primaryItems.reduce(returnKey, '');


### PR DESCRIPTION


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Changed commandBar cacheKey creation logic for farItems to include the Name along with the key while creating the cacheKey

REpro steps:
Create a modern page;
Add a section with 3 columns or one-third left column;
Add a Document library webpart;
Publish the page.

Root cause of this issue is that the cacheKey stays same before "All Documents" text is added in "Switch View Options" and enve after it update the name to "All Documents"

Because of this second shrink call takes the width from cache which is not changed and because of this primary items do not shrink.

#### Focus areas to test
CommandBar
(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9363)