### PR TITLE
Fix Vertical bar chart x-axis descriptor cut off issue

### DIFF
--- a/common/changes/@uifabric/charting/virticalBarChartCutOffIssue_2019-06-10-10-33.json
+++ b/common/changes/@uifabric/charting/virticalBarChartCutOffIssue_2019-06-10-10-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Fix verticalBarChart x-axis description cut off issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "v-ragor@microsoft.com"
+}

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -103,7 +103,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     const yMax = d3Max(this._points, (point: IDataPoint) => point.y)!;
     const yAxisScale = d3ScaleLinear()
       .domain([0, yMax])
-      .range([this._height, 0]);
+      .range([this._height, 10]);
     const yAxis = d3AxisLeft(yAxisScale).ticks(this._yAxisTickCount);
     return yAxis;
   }
@@ -117,7 +117,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
       .range([0, this._width - this._barWidth]);
     const yBarScale = d3ScaleLinear()
       .domain([0, yMax])
-      .range([0, this._height]);
+      .range([0, this._height - 10]);
 
     const colorScale = this._createColors(yMax);
 

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.styles.ts
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.styles.ts
@@ -3,11 +3,11 @@ import { IVerticalBarChartStyleProps, IVerticalBarChartStyles } from './Vertical
 export const getStyles = (props: IVerticalBarChartStyleProps): IVerticalBarChartStyles => {
   const { className, theme, width, height } = props;
 
-  const chartWidth = width + 30;
+  const chartWidth = width + 50;
   const chartPadding = 20;
-  const chartHeight = height + 10;
+  const chartHeight = height + 50;
   const xOffset = 30;
-  const yOffset = 20;
+  const yOffset = 23;
 
   return {
     root: [

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
         font-weight: 400;
-        width: 670px;
+        width: 690px;
       }
 >
   <svg
@@ -18,12 +18,12 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
 
         {
           box-sizing: content-box;
-          height: 360px;
+          height: 400px;
           padding-bottom: 20px;
           padding-left: 20px;
           padding-right: 20px;
           padding-top: 20px;
-          width: 630px;
+          width: 650px;
         }
   >
     <g
@@ -37,7 +37,7 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
       className=
 
           {
-            transform: translate(20px, 0px);
+            transform: translate(23px, 0px);
           }
     />
     <g
@@ -56,10 +56,10 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
       />
       <rect
         fill="rgb(0, 32, 80)"
-        height={350}
+        height={340}
         width={15}
         x={585}
-        y={0}
+        y={10}
       />
     </g>
   </svg>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Fix Vertical bar chart x-axis descriptor cut off issue

(give an overview)

#### Focus areas to test

(optional)

####screenshot
![verticalBarchart](https://user-images.githubusercontent.com/13463251/59190631-d538ba80-8b9a-11e9-9e82-a6aa1c85b17b.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9388)