### PR TITLE
Improving perf. of customized components

### DIFF
--- a/common/changes/@uifabric/utilities/customizablePerf_2019-06-10-19-37.json
+++ b/common/changes/@uifabric/utilities/customizablePerf_2019-06-10-19-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Setting the styles props only when either of defaultProps or componentProps have it defined",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "kushaly@microsoft.com"
+}

--- a/packages/utilities/src/customizations/customizable.tsx
+++ b/packages/utilities/src/customizations/customizable.tsx
@@ -48,7 +48,8 @@ export function customizable(
                 defaultProps.styles = defaultProps.styles({ ...defaultProps, ...componentProps });
               }
 
-              if (concatStyles) {
+              // If concatStyles is true and custom styles have been defined compute those styles
+              if (concatStyles && (defaultProps.styles || componentProps.styles)) {
                 const mergedStyles = concatStyleSets(defaultProps.styles, componentProps.styles);
                 return <ComposedComponent {...defaultProps} {...componentProps} styles={mergedStyles} />;
               }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Setting the styles prop in the customized component only when either of defaultProps or componentProps have it defined.

Otherwise, `concatStyleSets` returns an empty object even when all of its argument styleSets are `undefined`. This messes up all the memoization when we compute classNames in an customized component because the styles prop will be a new reference for every instance of the component. This impacts perf. when we need to render a large number of say ActionButtons with no difference in styling at once.

With this change, rendering around 150 icon buttons has an improvement of around **17%** in React dev mode. ColorPickers which use Customized Action Buttons also see similar improvements (they have other bugs which do not let the perf. improvements surface right now, but I will fix them in a different PR). We should see similar improvement for every customized component.

Raw Time taken to mount a component with 154 Icon buttons tested using ChromeDevTools

Without fix - 
248.15
260.86
251.20
252.15
264.36
265.92
251.86
254.31
253.55
250.62
Avg = 255.298

With fix - 
216.99
205.66
210.14
213.72
210.21
205.59
212.49
207.23
204.26
215.56
Avg = 210.185


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9395)