### PR TITLE
Dropdown className should be applied to root

### DIFF
--- a/common/changes/office-ui-fabric-react/dropdown-class_2019-06-10-20-11.json
+++ b/common/changes/office-ui-fabric-react/dropdown-class_2019-06-10-20-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown className should be applied to the root",
+      "type": "major"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
@@ -99,7 +99,6 @@ const classNameSelectors: { [key: string]: string } = {
   Callout: 'ms-Callout',
   ContextualMenu: 'ms-ContextualMenu',
   DetailsList: 'ms-DetailsList',
-  Dropdown: 'ms-Dropdown',
   ExpandingCard: 'ms-Callout',
   Modal: 'ms-Modal',
   Nav: 'ms-Nav',

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -175,7 +175,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       : `${effects.roundedCorner2} ${effects.roundedCorner2} 0 0`;
 
   return {
-    root: globalClassnames.root,
+    root: [globalClassnames.root, className],
     label: globalClassnames.label,
     dropdown: [
       globalClassnames.dropdown,
@@ -223,7 +223,6 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
           ['&:focus .' + globalClassnames.titleHasError]: borderColorError
         }
       },
-      className,
       isOpen && 'is-open',
       disabled && 'is-disabled',
       required && 'is-required',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9096
- [x] Include a change request file using `$ npm run change`

#### Description of changes

To match other components, Dropdown's `className` prop should be applied to the root of the component (wrapper of the label+dropdown) rather than the dropdown itself.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9396)