### PR TITLE
ColorPicker: remove decimals from alpha value

### DIFF
--- a/common/changes/office-ui-fabric-react/color-decimal_2019-06-10-21-14.json
+++ b/common/changes/office-ui-fabric-react/color-decimal_2019-06-10-21-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ColorPicker: remove decimals from alpha value",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -57,9 +57,6 @@ export class ActivityItem extends React.Component<IActivityItemProps, {}> {
 // @public
 export type Alignment = 'start' | 'end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'baseline' | 'stretch';
 
-// @public
-export const ALPHA_REGEX: RegExp;
-
 // Warning: (ae-forgotten-export) The symbol "React" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
@@ -7922,7 +7919,7 @@ export const MAX_COLOR_VALUE = 100;
 export const MAX_HEX_LENGTH = 6;
 
 // @public
-export const MAX_RGB_LENGTH = 3;
+export const MAX_RGBA_LENGTH = 3;
 
 // @public (undocumented)
 export const MeasuredContext: React.Context<{
@@ -7967,7 +7964,7 @@ export enum MessageBarType {
 export const MIN_HEX_LENGTH = 3;
 
 // @public
-export const MIN_RGB_LENGTH = 1;
+export const MIN_RGBA_LENGTH = 1;
 
 // @public (undocumented)
 export const Modal: React_2.StatelessComponent<IModalProps>;
@@ -8464,7 +8461,7 @@ export function rgb2hex(r: number, g: number, b: number): string;
 export function rgb2hsv(r: number, g: number, b: number): IHSV;
 
 // @public
-export const RGB_REGEX: RegExp;
+export const RGBA_REGEX: RegExp;
 
 // @public (undocumented)
 export const ScrollablePane: React_2.StatelessComponent<IScrollablePaneProps>;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -191,10 +191,9 @@ describe('ColorPicker', () => {
 
     const alphaInput = inputs[4];
     ReactTestUtils.Simulate.input(alphaInput, mockEvent('50'));
-    expect(onChange).toHaveBeenCalledTimes(2); // onChange not called until blur
     ReactTestUtils.Simulate.blur(alphaInput);
     validateChange({ calls: 3, prop: 'str', value: 'rgba(0, 255, 0, 0.5)' });
-    validateChange({ calls: 3, prop: 'a', value: 50, input: alphaInput, inputValue: '50.0' });
+    validateChange({ calls: 3, prop: 'a', value: 50 });
   });
 
   // This has repeatedly broken in the past (really)
@@ -219,7 +218,7 @@ describe('ColorPicker', () => {
     validateChange({ calls: 2, prop: 'str', value: '#00ff00' });
   });
 
-  it('ignores non-numeric RGB input', () => {
+  it('ignores non-numeric RGBA input', () => {
     wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
     const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
@@ -227,6 +226,10 @@ describe('ColorPicker', () => {
     // valid value => accepted
     ReactTestUtils.Simulate.input(redInput, mockEvent('12'));
     validateChange({ calls: 1, prop: 'r', value: 12, input: redInput });
+
+    // decimal added to valid value => totally ignored
+    ReactTestUtils.Simulate.input(redInput, mockEvent('12.'));
+    validateChange({ calls: 1, prop: 'r', value: 12 });
 
     // non-number added to valid value => totally ignored
     ReactTestUtils.Simulate.input(redInput, mockEvent('12x'));
@@ -241,7 +244,7 @@ describe('ColorPicker', () => {
     validateChange({ calls: 1, prop: 'r', value: 12, input: redInput, inputValue: '' });
   });
 
-  it('reverts to previous valid RGB value on blur if field is empty', () => {
+  it('reverts to previous valid RGBA value on blur if field is empty', () => {
     wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
     const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
@@ -276,7 +279,24 @@ describe('ColorPicker', () => {
     validateChange({ calls: 2, prop: 'r', value: 255, input: redInput });
   });
 
-  it('handles RGB input too long', () => {
+  it('clamps alpha input too large', () => {
+    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
+
+    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
+
+    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50'));
+    validateChange({ calls: 1, prop: 'a', value: 50, input: alphaInput });
+
+    // value too large => allowed in field but onChange not called
+    ReactTestUtils.Simulate.input(alphaInput, mockEvent('123'));
+    validateChange({ calls: 1, prop: 'a', value: 50, input: alphaInput, inputValue: '123' });
+
+    // blur => value clamped
+    ReactTestUtils.Simulate.blur(alphaInput);
+    validateChange({ calls: 2, prop: 'a', value: 100, input: alphaInput });
+  });
+
+  it('handles RGBA input too long', () => {
     wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
 
     const redInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[1] as HTMLInputElement;
@@ -296,116 +316,6 @@ describe('ColorPicker', () => {
     // invalid new value too long "pasted" => use substring but don't call onChange
     ReactTestUtils.Simulate.input(redInput, mockEvent('4567'));
     validateChange({ calls: 2, prop: 'r', value: 100, input: redInput, inputValue: '456' });
-  });
-
-  it('allows variations of alpha input', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
-
-    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
-
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('5'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '5' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 1, prop: 'a', value: 5, input: alphaInput, inputValue: '5.0' });
-
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50'));
-    validateChange({ calls: 1, prop: 'a', value: 5, input: alphaInput, inputValue: '50' });
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50.'));
-    validateChange({ calls: 1, prop: 'a', value: 5, input: alphaInput, inputValue: '50.' });
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('50.8'));
-    validateChange({ calls: 1, prop: 'a', value: 5, input: alphaInput, inputValue: '50.8' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 2, prop: 'a', value: 50.8 });
-
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('.'));
-    validateChange({ calls: 2, prop: 'a', value: 50.8, input: alphaInput, inputValue: '.' });
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('.9'));
-    validateChange({ calls: 2, prop: 'a', value: 50.8, input: alphaInput, inputValue: '.9' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 3, prop: 'a', value: 0.9 });
-  });
-
-  it('corrects alpha input on blur', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
-
-    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
-
-    // empty string isn't a number, so revert it on blur
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent(''));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '100.0' });
-
-    // . isn't a number, so revert it on blur
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('.'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '.' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '100.0' });
-  });
-
-  it('prevents invalid alpha input', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
-
-    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
-
-    // letters not accepted
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('x'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '100.0' });
-
-    // pasting input with numbers and letters not accepted
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('12x'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '100.0' });
-
-    // second decimal point trimmed off
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('1.2.3'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '1.2' });
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('4.56.7'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '4.5' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 1, prop: 'a', value: 4.5 });
-
-    // valid input followed by letter => preserve valid part
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('12'));
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(alphaInput.value).toBe('12');
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('12x'));
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(alphaInput.value).toBe('12');
-  });
-
-  it('prevents alpha input too long', () => {
-    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" componentRef={colorPickerRef} />);
-
-    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
-
-    // too many numbers before decimal not accepted
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('1234'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '100.0' });
-
-    // technically not valid but accepted as an intermediate value
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('123'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '123' });
-    // extra digit not accepted
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('1234'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '123' });
-
-    // too many numbers after decimal not accepted
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('12.0'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '12.0' });
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('12.09'));
-    validateChange({ calls: 0, prop: 'a', value: 100, input: alphaInput, inputValue: '12.0' });
-  });
-
-  it('corrects alpha input on blur', () => {
-    // start this input at alpha=50
-    wrapper = mount(<ColorPicker onChange={onChange} color="rgba(0,0,0,0.5)" componentRef={colorPickerRef} />);
-
-    const alphaInput = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input')[4] as HTMLInputElement;
-
-    ReactTestUtils.Simulate.input(alphaInput, mockEvent('255'));
-    validateChange({ calls: 0, prop: 'a', value: 50, input: alphaInput, inputValue: '255' });
-    ReactTestUtils.Simulate.blur(alphaInput);
-    validateChange({ calls: 1, prop: 'a', value: 100, input: alphaInput, inputValue: '100.0' });
   });
 
   it('handles 3-char hex value', () => {

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -994,7 +994,7 @@ exports[`ColorPicker renders correctly 1`] = `
                     onInput={[Function]}
                     spellCheck={false}
                     type="text"
-                    value="100.0"
+                    value="100"
                   />
                 </div>
               </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1001,7 +1001,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                       onInput={[Function]}
                       spellCheck={false}
                       type="text"
-                      value="100.0"
+                      value="100"
                     />
                   </div>
                 </div>

--- a/packages/office-ui-fabric-react/src/utilities/color/consts.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/consts.ts
@@ -10,17 +10,12 @@ export const MAX_COLOR_ALPHA = 100;
 export const MIN_HEX_LENGTH = 3;
 /** Maximum length for a hexadecimal color string (not including the #) */
 export const MAX_HEX_LENGTH = 6;
-/** Minimum length for a string of an RGB color component */
-export const MIN_RGB_LENGTH = 1;
-/** Maximum length for a string of an RGB color component */
-export const MAX_RGB_LENGTH = 3;
+/** Minimum length for a string of an RGBA color component */
+export const MIN_RGBA_LENGTH = 1;
+/** Maximum length for a string of an RGBA color component */
+export const MAX_RGBA_LENGTH = 3;
 
 /** Regular expression matching only valid hexadecimal chars */
 export const HEX_REGEX = /^[\da-f]{0,6}$/i;
-/** Regular expression matching only valid RGB chars */
-export const RGB_REGEX = /^\d{0,3}$/;
-/**
- * Regular expression matching only potentially-valid alpha (transparency) strings based on the
- * type of characters and string length. We allow alpha strings to have one decimal place.
- */
-export const ALPHA_REGEX = /^\d{0,3}(\.\d?)?$/;
+/** Regular expression matching only numbers */
+export const RGBA_REGEX = /^\d{0,3}$/;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Remove decimal places from the ColorPicker's alpha value, to be consistent with the other values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9399)