### PR TITLE
Card: Extending HTMLElement attributes in ICardProps

### DIFF
--- a/common/changes/@uifabric/react-cards/cardDivAttr_2019-06-10-22-03.json
+++ b/common/changes/@uifabric/react-cards/cardDivAttr_2019-06-10-22-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/react-cards",
+      "comment": "Card: Extending HTMLElement attributes in ICardProps.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/react-cards/src/components/Card/Card.types.ts
+++ b/packages/react-cards/src/components/Card/Card.types.ts
@@ -19,7 +19,11 @@ export interface ICardSlots {
   root?: IStackSlot;
 }
 
-export interface ICardProps extends ICardSlots, IStyleableComponentProps<ICardProps, ICardTokens, ICardStyles>, IBaseProps<ICard> {
+export interface ICardProps
+  extends ICardSlots,
+    IStyleableComponentProps<ICardProps, ICardTokens, ICardStyles>,
+    IBaseProps<ICard>,
+    React.AllHTMLAttributes<HTMLElement> {
   /**
    * Defines whether to render a regular or a compact Card.
    * @defaultvalue false

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import { withSlots, getSlots } from '@uifabric/foundation';
 import { getNativeProps, htmlElementProperties } from '@uifabric/utilities';
-import { Stack } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, IStackComponent } from 'office-ui-fabric-react/lib/Stack';
 
 import { ICardComponent, ICardProps, ICardSlots } from './Card.types';
 
@@ -12,13 +12,13 @@ export const CardView: ICardComponent['view'] = props => {
 
   const { styles, tokens, compact, ...rest } = props;
 
-  const nativeProps = getNativeProps(rest, htmlElementProperties);
+  const nativeProps = getNativeProps<React.HTMLAttributes<HTMLElement>>(rest, htmlElementProperties);
 
   return (
     <Slots.root
       {...nativeProps}
       horizontal={compact}
-      tokens={tokens}
+      tokens={tokens as IStackComponent['tokens']}
       verticalFill
       verticalAlign="space-between"
       horizontalAlign="space-between"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

A recent partner ask for tabbable cards made us realize that `ICardProps` should be extending `HTMLElement` attributes. This PR takes care of that.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9402)