### PR TITLE
 Only run KeytipManager update when relevant keytip props have changed

### DIFF
--- a/common/changes/office-ui-fabric-react/KeytipDataPerf_2019-06-11-18-53.json
+++ b/common/changes/office-ui-fabric-react/KeytipDataPerf_2019-06-11-18-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Only run KeytipManager update when relevant keytip props have changed in KeytipData.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7763,7 +7763,7 @@ export class KeytipData extends React.Component<IKeytipDataProps & IRenderCompon
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentDidUpdate(): void;
+    componentDidUpdate(prevProps: IKeytipDataProps & IRenderComponent<{}>): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -19,6 +19,8 @@ import { IButtonProps, IButton } from './Button.types';
 import { IButtonClassNames, getBaseButtonClassNames } from './BaseButton.classNames';
 import { getClassNames as getBaseSplitButtonClassNames, ISplitButtonClassNames } from './SplitButton/SplitButton.classNames';
 import { KeytipData } from '../../KeytipData';
+import { memoizeFunction } from '@uifabric/utilities';
+import { IKeytipProps } from '../Keytip';
 
 /**
  * {@docCategory Button}
@@ -65,6 +67,13 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   private _processingTouch: boolean;
   private _lastTouchTimeoutId: number | undefined;
   private _renderedPersistentMenu: boolean = false;
+
+  private _getMemoizedMenuButtonKeytipProps = memoizeFunction((keytipProps: IKeytipProps) => {
+    return {
+      ...keytipProps,
+      hasMenu: true
+    };
+  });
 
   constructor(props: IBaseButtonProps, rootClassName: string) {
     super(props);
@@ -265,10 +274,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     } = props;
     let { keytipProps } = props;
     if (keytipProps && menuProps) {
-      keytipProps = {
-        ...keytipProps,
-        hasMenu: true
-      };
+      keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
 
     const Content = (
@@ -487,10 +493,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     const ariaDescribedBy = buttonProps.ariaDescription;
 
     if (keytipProps && menuProps) {
-      keytipProps = {
-        ...keytipProps,
-        hasMenu: true
-      };
+      keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
 
     const containerProps = getNativeProps(buttonProps, [], ['disabled']);

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -20,7 +20,7 @@ import { IButtonClassNames, getBaseButtonClassNames } from './BaseButton.classNa
 import { getClassNames as getBaseSplitButtonClassNames, ISplitButtonClassNames } from './SplitButton/SplitButton.classNames';
 import { KeytipData } from '../../KeytipData';
 import { memoizeFunction } from '@uifabric/utilities';
-import { IKeytipProps } from '../Keytip';
+import { IKeytipProps } from '../Keytip/Keytip.types';
 
 /**
  * {@docCategory Button}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
-import { anchorProperties, getNativeProps } from '../../../Utilities';
+import { anchorProperties, getNativeProps, memoizeFunction } from '../../../Utilities';
 import { ContextualMenuItemWrapper } from './ContextualMenuItemWrapper';
 import { KeytipData } from '../../../KeytipData';
 import { isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
+import { IKeytipProps } from '../../Keytip';
 
 export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
   private _anchor = React.createRef<HTMLAnchorElement>();
+
+  private _getMemoizedMenuButtonKeytipProps = memoizeFunction((keytipProps: IKeytipProps) => {
+    return {
+      ...keytipProps,
+      hasMenu: true
+    };
+  });
 
   public render() {
     const {
@@ -39,10 +47,7 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
 
     let { keytipProps } = item;
     if (keytipProps && itemHasSubmenu) {
-      keytipProps = {
-        ...keytipProps,
-        hasMenu: true
-      };
+      keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -5,7 +5,7 @@ import { KeytipData } from '../../../KeytipData';
 import { isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
-import { IKeytipProps } from '../../Keytip';
+import { IKeytipProps } from '../../Keytip/Keytip.types';
 
 export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
   private _anchor = React.createRef<HTMLAnchorElement>();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -1,13 +1,21 @@
 import * as React from 'react';
-import { buttonProperties, getNativeProps } from '../../../Utilities';
+import { buttonProperties, getNativeProps, memoizeFunction } from '../../../Utilities';
 import { ContextualMenuItemWrapper } from './ContextualMenuItemWrapper';
 import { KeytipData } from '../../../KeytipData';
 import { getIsChecked, isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
+import { IKeytipProps } from '../../Keytip';
 
 export class ContextualMenuButton extends ContextualMenuItemWrapper {
   private _btn = React.createRef<HTMLButtonElement>();
+
+  private _getMemoizedMenuButtonKeytipProps = memoizeFunction((keytipProps: IKeytipProps) => {
+    return {
+      ...keytipProps,
+      hasMenu: true
+    };
+  });
 
   public render() {
     const {
@@ -63,10 +71,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
 
     let { keytipProps } = item;
     if (keytipProps && itemHasSubmenu) {
-      keytipProps = {
-        ...keytipProps,
-        hasMenu: true
-      };
+      keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -5,7 +5,7 @@ import { KeytipData } from '../../../KeytipData';
 import { getIsChecked, isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
-import { IKeytipProps } from '../../Keytip';
+import { IKeytipProps } from '../../Keytip/Keytip.types';
 
 export class ContextualMenuButton extends ContextualMenuItemWrapper {
   private _btn = React.createRef<HTMLButtonElement>();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { buttonProperties, getNativeProps, KeyCodes, mergeAriaAttributeValues } from '../../../Utilities';
+import { buttonProperties, getNativeProps, KeyCodes, mergeAriaAttributeValues, memoizeFunction } from '../../../Utilities';
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IContextualMenuItem } from '../ContextualMenu.types';
 import { IMenuItemClassNames, getSplitButtonVerticalDividerClassNames } from '../ContextualMenu.classNames';
@@ -7,6 +7,7 @@ import { KeytipData } from '../../../KeytipData';
 import { isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
 import { VerticalDivider } from '../../../Divider';
 import { ContextualMenuItemWrapper } from './ContextualMenuItemWrapper';
+import { IKeytipProps } from '../../Keytip';
 
 export interface IContextualMenuSplitButtonState {}
 
@@ -16,6 +17,13 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
   private _splitButton: HTMLDivElement;
   private _lastTouchTimeoutId: number | undefined;
   private _processingTouch: boolean;
+
+  private _getMemoizedMenuButtonKeytipProps = memoizeFunction((keytipProps: IKeytipProps) => {
+    return {
+      ...keytipProps,
+      hasMenu: true
+    };
+  });
 
   public componentDidMount() {
     if (this._splitButton && 'onpointerdown' in this._splitButton) {
@@ -40,10 +48,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
 
     let { keytipProps } = item;
     if (keytipProps) {
-      keytipProps = {
-        ...keytipProps,
-        hasMenu: true
-      };
+      keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -7,7 +7,7 @@ import { KeytipData } from '../../../KeytipData';
 import { isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
 import { VerticalDivider } from '../../../Divider';
 import { ContextualMenuItemWrapper } from './ContextualMenuItemWrapper';
-import { IKeytipProps } from '../../Keytip';
+import { IKeytipProps } from '../../Keytip/Keytip.types';
 
 export interface IContextualMenuSplitButtonState {}
 

--- a/packages/office-ui-fabric-react/src/components/KeytipData/KeytipData.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/KeytipData.tsx
@@ -25,9 +25,11 @@ export class KeytipData extends React.Component<IKeytipDataProps & IRenderCompon
     this.props.keytipProps && this._keytipManager.unregister(this._getKtpProps(), this._uniqueId);
   }
 
-  public componentDidUpdate() {
-    // Update Keytip in KeytipManager
-    this.props.keytipProps && this._keytipManager.update(this._getKtpProps(), this._uniqueId);
+  public componentDidUpdate(prevProps: IKeytipDataProps & IRenderComponent<{}>) {
+    if (prevProps.keytipProps !== this.props.keytipProps || prevProps.disabled !== this.props.disabled) {
+      // If keytipProps or disabled has changed update Keytip in KeytipManager
+      this.props.keytipProps && this._keytipManager.update(this._getKtpProps(), this._uniqueId);
+    }
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes
I notice this whenever I open the profile of a button when clicked or when a button's state changes. The actual perf. impact is pretty minor (around 3-4ms in total)

Testing this more revealed that we also generate a new reference to `keytipProps` in a few components. I also made the changes to memoize them. 

Smoke tested that keytips work in the keytips demo page. Also, observed in the dev tools profile that we do not update the KeytipManager unnecessarily.

NOTE: Keeping the memoize helper as a method instead of a util method because cache will be filled with all keytip props from all buttons in the app which is probably something we do not want.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9414)