### PR TITLE
Prevent Callout from being dismissed after mouse pressed inside but released outside

### DIFF
--- a/common/changes/office-ui-fabric-react/jiangwan-calloutdismiss_2019-06-11-22-02.json
+++ b/common/changes/office-ui-fabric-react/jiangwan-calloutdismiss_2019-06-11-22-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Prevent the callout from being dismissed when the mouse is pressed inside, but then moved outside (while keeping pressed) and released. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jiaw@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -78,6 +78,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   private _hasListeners = false;
   private _maxHeight: number | undefined;
   private _blockResetHeight: boolean;
+  private _isMouseDownOnPopup: boolean;
 
   private _async: Async;
   private _disposables: (() => void)[] = [];
@@ -241,6 +242,8 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
             onScroll={onScroll}
             shouldRestoreFocus={true}
             style={overflowStyle}
+            onMouseDown={this._mouseDownOnPopup}
+            onMouseUp={this._mouseUpOnPopup}
           >
             {children}
           </Popup>
@@ -301,6 +304,12 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   private _dismissOnClickOrScroll(ev: Event) {
     const target = ev.target as HTMLElement;
     const isEventTargetOutsideCallout = this._hostElement.current && !elementContains(this._hostElement.current, target);
+
+    // If mouse is pressed down on callout but moved outside then released, don't dismiss the callout.
+    if (isEventTargetOutsideCallout && this._isMouseDownOnPopup) {
+      this._isMouseDownOnPopup = false;
+      return;
+    }
 
     if (
       (!this._target && isEventTargetOutsideCallout) ||
@@ -516,4 +525,12 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     const { target } = props;
     return target!;
   }
+
+  private _mouseDownOnPopup = () => {
+    this._isMouseDownOnPopup = true;
+  };
+
+  private _mouseUpOnPopup = () => {
+    this._isMouseDownOnPopup = false;
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Callout/__snapshots__/Callout.test.tsx.snap
@@ -51,6 +51,8 @@ exports[`Callout renders Callout correctly 1`] = `
             position: relative;
           }
       onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
       style={
         Object {
           "maxHeight": 750,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -235,6 +235,8 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                     position: relative;
                   }
               onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
               onScroll={[Function]}
               style={
                 Object {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -103,6 +103,8 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
                 position: relative;
               }
           onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
           style={
             Object {
               "maxHeight": 718,
@@ -265,6 +267,8 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
                 position: relative;
               }
           onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
           style={
             Object {
               "maxHeight": 718,

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -62,6 +62,8 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
             position: relative;
           }
       onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
       style={
         Object {
           "maxHeight": 750,

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -103,6 +103,8 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
                 position: relative;
               }
           onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
           style={
             Object {
               "maxHeight": 750,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
@@ -241,6 +241,8 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
                   position: relative;
                 }
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
             role="alertdialog"
             style={
               Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -1532,6 +1532,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                     position: relative;
                   }
               onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
               onScroll={[Function]}
               style={
                 Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -778,6 +778,8 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
                           position: relative;
                         }
                     onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
                     role="alertdialog"
                     style={
                       Object {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When user pressed the mouse inside callout (mouseDown), moved it outside while keeping it pressed, and then released (mouseUp), it was treated as a click outside the callout which made the callout dismissed. However, in practice users often accidentally dismissed callout in this way while drag and select text inside callout with mouse but unintentionally move outside the boundary.

Before change:
![BeforeChange](https://user-images.githubusercontent.com/5481393/59311045-07125580-8c5d-11e9-9324-c34605737b6f.gif)

After change:
![AfterChange](https://user-images.githubusercontent.com/5481393/59311043-07125580-8c5d-11e9-931d-b615a23adf31.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9415)