### PR TITLE
Styled: Improved perf via getClassNames memoization

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -564,7 +564,7 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -599,7 +599,7 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -634,7 +634,7 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -688,7 +688,7 @@ Array [
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
+        "fullyQualifiedLogicalName": ".prefix-15 > span",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -698,151 +698,11 @@ Array [
     ],
     "message": Object {
       "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.21 (foreground color: #a6a6a6, background color: #f4f4f4, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.21 (foreground color: #a6a6a6, background color: #f4f4f4, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
-    "ruleId": "color-contrast",
-  },
-  Object {
-    "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<span style=\\"padding-bottom:1px\\">https://</span>",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".prefix-16 > span",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".prefix-16 > span",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
-    "ruleId": "color-contrast",
-  },
-  Object {
-    "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<span style=\\"padding-bottom:1px\\">.com</span>",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
-    "ruleId": "color-contrast",
-  },
-  Object {
-    "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<span style=\\"padding-bottom:1px\\">https://</span>",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
-    "ruleId": "color-contrast",
-  },
-  Object {
-    "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<span style=\\"padding-bottom:1px\\">.com</span>",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
+      "fullyQualifiedLogicalName": ".prefix-15 > span",
       "ruleId": "color-contrast",
     },
     "properties": Object {

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -564,42 +564,7 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
-            },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\"",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
-    },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField2",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
-    "ruleId": "aria-valid-attr-value",
-  },
-  Object {
-    "level": "error",
-    "locations": Array [
-      Object {
-        "annotations": Array [
-          Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -634,7 +599,7 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -688,7 +653,7 @@ Array [
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".prefix-15 > span",
+        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -698,11 +663,151 @@ Array [
     ],
     "message": Object {
       "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.21 (foreground color: #a6a6a6, background color: #f4f4f4, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.21 (foreground color: #a6a6a6, background color: #f4f4f4, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".prefix-15 > span",
+      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<span style=\\"padding-bottom:1px\\">https://</span>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".prefix-16 > span",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".prefix-16 > span",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<span style=\\"padding-bottom:1px\\">.com</span>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(1) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<span style=\\"padding-bottom:1px\\">https://</span>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .prefix-10.ms-TextField-prefix > span",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<span style=\\"padding-bottom:1px\\">.com</span>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.43 (foreground color: #a6a6a6, background color: #ffffff, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-TextField.root-3:nth-child(2) > .ms-TextField-wrapper.wrapper-4 > .fieldGroup-5.ms-TextField-fieldGroup > .ms-TextField-suffix.suffix-11 > span",
       "ruleId": "color-contrast",
     },
     "properties": Object {

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -564,7 +564,42 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#TextField2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#TextField2",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -599,7 +634,7 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         ],

--- a/common/changes/@uifabric/example-app-base/jg-memoize-part-deux_2019-06-13-00-43.json
+++ b/common/changes/@uifabric/example-app-base/jg-memoize-part-deux_2019-06-13-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Addressing a variety of problems related to style recalculations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/jg-memoize-part-deux_2019-06-13-00-43.json
+++ b/common/changes/@uifabric/experiments/jg-memoize-part-deux_2019-06-13-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button example updated.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/@uifabric/utilities/jg-memoize-part-deux_2019-06-13-00-43.json
+++ b/common/changes/@uifabric/utilities/jg-memoize-part-deux_2019-06-13-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "The `getClassNames` function now returns memoized classnames, resulting in improved performance in high repeat scenarios (like lists rendering checks.) Reintroduction of #8761.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "jagore@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/jg-memoize-part-deux_2019-06-13-00-43.json
+++ b/common/changes/office-ui-fabric-react/jg-memoize-part-deux_2019-06-13-00-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Addressing a variety of problems related to style recalculations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com"
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "create-component": "node scripts/create-component.js",
     "create-package": "node scripts/create-package.js",
     "create-page": "node scripts/create-page.js",
-    "checkchange": "node common/scripts/install-run-rush.js change -v",
+    "checkchange": "node common/scripts/install-run-rush.js change -v -b origin/6.0",
     "update-api": "cd packages/office-ui-fabric-react && npm run update-api",
     "update-snapshots": "cd packages/office-ui-fabric-react && npm run update-snapshots",
     "check-for-changed-files": "cd scripts && npx just-scripts check-for-modified-files",

--- a/packages/example-app-base/src/components/PropertiesTable/PropertiesTableSet.tsx
+++ b/packages/example-app-base/src/components/PropertiesTable/PropertiesTableSet.tsx
@@ -6,7 +6,7 @@ import { getStyles } from './PropertiesTableSet.styles';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 
 const PropertiesTableSetBase: React.StatelessComponent<IPropertiesTableSetProps> = props => {
-  const { componentName, componentPath, sources, styles } = props;
+  const { componentName, componentPath, sources } = props;
   let src: string;
   let properties: IProperty[] = [];
 
@@ -34,7 +34,6 @@ const PropertiesTableSetBase: React.StatelessComponent<IPropertiesTableSetProps>
           title={item.name === 'I' + props.componentName ? props.componentName + ' class' : item.propertyName}
           properties={item.property}
           renderAsEnum={item.propertyType === PropertyType.enum}
-          styles={styles}
         />
       ))}
     </div>

--- a/packages/experiments/src/components/Button/Button.styles.ts
+++ b/packages/experiments/src/components/Button/Button.styles.ts
@@ -145,16 +145,14 @@ export const ButtonTokens: IButtonComponent['tokens'] = (props, theme): IButtonT
   props.disabled && disabledTokens
 ];
 
+const GlobalClassNames = {
+  icon: 'ms-Icon'
+};
+
 export const ButtonStyles: IButtonComponent['styles'] = (props, theme, tokens): IButtonStylesReturnType => {
   const { className, circular } = props;
 
-  const globalClassNames = getGlobalClassNames(
-    {
-      icon: 'ms-Icon'
-    },
-    theme,
-    true
-  );
+  const globalClassNames = getGlobalClassNames(GlobalClassNames, theme, true);
 
   return {
     root: [

--- a/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -214,16 +214,16 @@ exports[`Button view renders a disabled primary Button with content correctly 1`
         border-color: GrayText;
         color: GrayText;
       }
-      &:hover .ms-Icon-56 {
+      &:hover .ms-Icon-47 {
         color: #a6a6a6;
       }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-56 {
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-47 {
         color: GrayText;
       }
-      &:active .ms-Icon-56 {
+      &:active .ms-Icon-47 {
         color: #a6a6a6;
       }
-      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-56 {
+      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-47 {
         color: GrayText;
       }
   disabled={true}
@@ -357,16 +357,16 @@ exports[`Button view renders a primary Button with content correctly 1`] = `
         border-color: Highlight;
         color: Window;
       }
-      &:hover .ms-Icon-54 {
+      &:hover .ms-Icon-47 {
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-54 {
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-47 {
         color: Window;
       }
-      &:active .ms-Icon-54 {
+      &:active .ms-Icon-47 {
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-54 {
+      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-47 {
         color: Window;
       }
   onClick={[Function]}

--- a/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -214,16 +214,16 @@ exports[`Button view renders a disabled primary Button with content correctly 1`
         border-color: GrayText;
         color: GrayText;
       }
-      &:hover .ms-Icon-47 {
+      &:hover .ms-Icon-46 {
         color: #a6a6a6;
       }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-47 {
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-46 {
         color: GrayText;
       }
-      &:active .ms-Icon-47 {
+      &:active .ms-Icon-46 {
         color: #a6a6a6;
       }
-      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-47 {
+      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-46 {
         color: GrayText;
       }
   disabled={true}
@@ -357,16 +357,16 @@ exports[`Button view renders a primary Button with content correctly 1`] = `
         border-color: Highlight;
         color: Window;
       }
-      &:hover .ms-Icon-47 {
+      &:hover .ms-Icon-46 {
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-47 {
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Icon-46 {
         color: Window;
       }
-      &:active .ms-Icon-47 {
+      &:active .ms-Icon-46 {
         color: #ffffff;
       }
-      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-47 {
+      @media screen and (-ms-high-contrast: active){&:active .ms-Icon-46 {
         color: Window;
       }
   onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -9,7 +9,7 @@ import { IconButton } from './IconButton/IconButton';
 import { ActionButton } from './ActionButton/ActionButton';
 import { CommandBarButton } from './CommandBarButton/CommandBarButton';
 import { CompoundButton } from './CompoundButton/CompoundButton';
-import { KeyCodes } from '../../Utilities';
+import { KeyCodes, resetIds } from '../../Utilities';
 import { renderIntoDocument } from '../../common/testUtilities';
 import { IContextualMenuProps } from '../ContextualMenu/index';
 
@@ -18,6 +18,21 @@ const alertClicked = (): void => {
 };
 
 describe('Button', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    resetIds();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container) {
+      ReactDOM.unmountComponentAtNode(container);
+    }
+    document.body.innerHTML = '';
+  });
+
   it('renders DefaultButton correctly', () => {
     const component = renderer.create(<DefaultButton text="Button" />);
     const tree = component.toJSON();
@@ -79,7 +94,7 @@ describe('Button', () => {
 
   describe('DefaultButton', () => {
     it('can render without an onClick.', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(<DefaultButton>Hello</DefaultButton>);
+      const button = ReactDOM.render(<DefaultButton>Hello</DefaultButton>, container);
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       expect(renderedDOM.tagName).toEqual('BUTTON');
     });
@@ -87,16 +102,17 @@ describe('Button', () => {
     it('can render with an onClick.', () => {
       const onClick: () => null = () => null;
 
-      const button = ReactTestUtils.renderIntoDocument<any>(<DefaultButton onClick={onClick}>Hello</DefaultButton>);
+      const button = ReactDOM.render(<DefaultButton onClick={onClick}>Hello</DefaultButton>, container);
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       expect(renderedDOM.tagName).toEqual('BUTTON');
     });
 
     it('can render with an href', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton href="http://www.microsoft.com" target="_blank">
           Hello
-        </DefaultButton>
+        </DefaultButton>,
+        container
       );
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       expect(renderedDOM.tagName).toEqual('A');
@@ -104,10 +120,11 @@ describe('Button', () => {
 
     describe('aria attributes', () => {
       it('does not apply aria attributes that are not passed in', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton href="http://www.microsoft.com" target="_blank">
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -118,10 +135,11 @@ describe('Button', () => {
       });
 
       it('overrides native aria-label with Button ariaLabel', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton href="http://www.microsoft.com" target="_blank" aria-label="NativeLabel" ariaLabel="ButtonLabel">
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -131,10 +149,11 @@ describe('Button', () => {
       });
 
       it('applies aria-label', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton href="http://www.microsoft.com" target="_blank" aria-label="MyLabel">
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -144,10 +163,11 @@ describe('Button', () => {
       });
 
       it('applies aria-labelledby', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton href="http://www.microsoft.com" target="_blank" aria-labelledby="someid">
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -156,8 +176,9 @@ describe('Button', () => {
       });
 
       it('does not apply aria-labelledby to a button with no text', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
-          <DefaultButton href="http://www.microsoft.com" target="_blank" aria-describedby="someid" />
+        const button: any = ReactDOM.render(
+          <DefaultButton href="http://www.microsoft.com" target="_blank" aria-describedby="someid" />,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -166,7 +187,7 @@ describe('Button', () => {
       });
 
       it('applies aria-labelledby and aria-describedby', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton
             href="http://www.microsoft.com"
             target="_blank"
@@ -174,7 +195,8 @@ describe('Button', () => {
             styles={{ screenReaderText: 'some-screenreader-class' }}
           >
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -188,12 +210,13 @@ describe('Button', () => {
       });
 
       it('applies aria-describedby to an IconButton', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <IconButton
             iconProps={{ iconName: 'Emoji2' }}
             ariaDescription="Description on icon button"
             styles={{ screenReaderText: 'some-screenreader-class' }}
-          />
+          />,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -207,14 +230,15 @@ describe('Button', () => {
       });
 
       it('applies aria-labelledby and aria-describedby to a CompoundButton with ariaDescription', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <CompoundButton
             secondaryText="Some awesome description"
             ariaDescription="Description on icon button"
             styles={{ screenReaderText: 'some-screenreader-class' }}
           >
             And this is the label
-          </CompoundButton>
+          </CompoundButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -228,8 +252,9 @@ describe('Button', () => {
       });
 
       it('applies aria-labelledby and aria-describedby to a CompoundButton with secondaryText and no ariaDescription', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
-          <CompoundButton secondaryText="Some awesome description">And this is the label</CompoundButton>
+        const button: any = ReactDOM.render(
+          <CompoundButton secondaryText="Some awesome description">And this is the label</CompoundButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -243,17 +268,18 @@ describe('Button', () => {
       });
 
       it('does not apply aria-pressed to an unchecked button', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(<DefaultButton toggle={true}>Hello</DefaultButton>);
+        const button: any = ReactDOM.render(<DefaultButton toggle={true}>Hello</DefaultButton>, container);
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
         expect(renderedDOM.getAttribute('aria-pressed')).toEqual('false');
       });
 
       it('applies aria-pressed to a checked button', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton toggle={true} checked={true}>
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -261,7 +287,7 @@ describe('Button', () => {
       });
 
       it('does not apply aria-pressed to an unchecked split button', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton
             toggle={true}
             split={true}
@@ -277,7 +303,8 @@ describe('Button', () => {
             }}
           >
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -295,10 +322,11 @@ describe('Button', () => {
             }
           ]
         };
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton toggle={true} split={true} onClick={alertClicked} persistMenu={true} menuProps={menuProps}>
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
 
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
@@ -307,7 +335,7 @@ describe('Button', () => {
       });
 
       it('applies aria-pressed to a checked split button', () => {
-        const button: any = ReactTestUtils.renderIntoDocument<any>(
+        const button: any = ReactDOM.render(
           <DefaultButton
             toggle={true}
             checked={true}
@@ -324,7 +352,8 @@ describe('Button', () => {
             }}
           >
             Hello
-          </DefaultButton>
+          </DefaultButton>,
+          container
         );
         const renderedDOM: any = ReactDOM.findDOMNode(button as React.ReactInstance);
 
@@ -336,8 +365,9 @@ describe('Button', () => {
       let button: Element;
 
       beforeAll(() => {
-        const wrapper = ReactTestUtils.renderIntoDocument<any>(
-          <DefaultButton menuProps={{ items: [{ key: 'item', text: 'Item' }] }}>Hello</DefaultButton>
+        const wrapper = ReactDOM.render(
+          <DefaultButton menuProps={{ items: [{ key: 'item', text: 'Item' }] }}>Hello</DefaultButton>,
+          container
         ) as DefaultButton;
         button = ReactTestUtils.findRenderedDOMComponentWithTag(wrapper, 'button');
       });
@@ -351,7 +381,7 @@ describe('Button', () => {
       let button: Element;
 
       beforeAll(() => {
-        const wrapper = ReactTestUtils.renderIntoDocument<any>(<DefaultButton>Hello</DefaultButton>) as DefaultButton;
+        const wrapper = ReactDOM.render(<DefaultButton>Hello</DefaultButton>, container) as DefaultButton;
         button = ReactTestUtils.findRenderedDOMComponentWithTag(wrapper, 'button');
       });
 
@@ -364,8 +394,9 @@ describe('Button', () => {
       let button: Element;
 
       beforeAll(() => {
-        const wrapper = ReactTestUtils.renderIntoDocument<any>(
-          <DefaultButton menuIconProps={{ iconName: 'fontColor' }}>Hello</DefaultButton>
+        const wrapper = ReactDOM.render(
+          <DefaultButton menuIconProps={{ iconName: 'fontColor' }}>Hello</DefaultButton>,
+          container
         ) as DefaultButton;
         button = ReactTestUtils.findRenderedDOMComponentWithTag(wrapper, 'button');
       });
@@ -376,7 +407,7 @@ describe('Button', () => {
     });
 
     it('Providing onClick and menuProps does not render a SplitButton', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -395,7 +426,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       expect(renderedDOM.tagName).not.toEqual('DIV');
@@ -404,7 +436,7 @@ describe('Button', () => {
     it('Providing onKeyDown and menuProps still fires provided onKeyDown', () => {
       const keyDownSpy = jest.fn();
 
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -423,7 +455,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
 
       const menuButtonDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
@@ -436,7 +469,7 @@ describe('Button', () => {
     it('Providing onKeyDown, menuProps and setting splitButton to true fires provided onKeyDown on both buttons', () => {
       const keyDownSpy = jest.fn();
 
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -457,7 +490,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       const primaryButtonDOM: HTMLDivElement = renderedDOM.getElementsByTagName('div')[0] as HTMLDivElement;
@@ -468,7 +502,7 @@ describe('Button', () => {
     });
 
     it('Providing onClick, menuProps and setting splitButton to true renders a SplitButton', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -488,14 +522,15 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       expect(renderedDOM.tagName).toEqual('DIV');
     });
 
     it('Tapping menu button of SplitButton expands menu', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -515,7 +550,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       const menuButtonDOM: HTMLButtonElement = renderedDOM.getElementsByTagName('button')[1] as HTMLButtonElement;
@@ -524,7 +560,7 @@ describe('Button', () => {
     });
 
     it('Touch Start on primary button of SplitButton expands menu', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -544,7 +580,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const renderedDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
       const primaryButtonDOM: HTMLButtonElement = renderedDOM.getElementsByTagName('button')[0] as HTMLButtonElement;
@@ -558,7 +595,7 @@ describe('Button', () => {
     });
 
     it('If menu trigger is disabled, pressing down does not trigger menu', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -577,7 +614,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const menuButtonDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
 
@@ -588,7 +626,7 @@ describe('Button', () => {
     });
 
     it('If menu trigger is specified, default key is overridden', () => {
-      const button = ReactTestUtils.renderIntoDocument<any>(
+      const button = ReactDOM.render(
         <DefaultButton
           data-automation-id="test"
           text="Create account"
@@ -607,7 +645,8 @@ describe('Button', () => {
               }
             ]
           }}
-        />
+        />,
+        container
       );
       const menuButtonDOM = ReactDOM.findDOMNode(button as React.ReactInstance) as Element;
 
@@ -921,7 +960,9 @@ describe('Button', () => {
           </DefaultButton>
         );
 
-        const button = ReactTestUtils.renderIntoDocument<any>(element) as React.ReactInstance;
+        ReactDOM.render(element, container);
+
+        const button = ReactDOM.render(element, container) as React.ReactInstance;
         const renderedDOM = ReactDOM.findDOMNode(button) as HTMLElement;
 
         expect(renderedDOM).toBeDefined();

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Button renders ActionButton correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
             }
-        id="id__3"
+        id="id__0"
       >
         Button
       </div>
@@ -269,7 +269,7 @@ exports[`Button renders CommandBarButton correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
             }
-        id="id__10"
+        id="id__0"
       >
         Create account
       </div>
@@ -309,8 +309,8 @@ exports[`Button renders CommandBarButton correctly 1`] = `
 
 exports[`Button renders CompoundButton correctly 1`] = `
 <button
-  aria-describedby="id__14"
-  aria-labelledby="id__13"
+  aria-describedby="id__1"
+  aria-labelledby="id__0"
   className=
       ms-Button
       ms-Button--compound
@@ -435,7 +435,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
               margin-right: 0;
               margin-top: 0;
             }
-        id="id__13"
+        id="id__0"
       >
         Create account
       </div>
@@ -451,7 +451,7 @@ exports[`Button renders CompoundButton correctly 1`] = `
               font-weight: 400;
               line-height: 100%;
             }
-        id="id__14"
+        id="id__1"
       >
         You can create a new account here.
       </div>
@@ -822,7 +822,7 @@ exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
             }
-        id="id__6"
+        id="id__0"
       >
         Button
       </div>

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -35,7 +35,9 @@ const ANIMATIONS: { [key: number]: string | undefined } = {
   [RectangleEdge.right]: AnimationClassNames.slideRightIn10
 };
 
-const getClassNames = classNamesFunction<ICalloutContentStyleProps, ICalloutContentStyles>();
+const getClassNames = classNamesFunction<ICalloutContentStyleProps, ICalloutContentStyles>({
+  disableCaching: true
+});
 const BORDER_WIDTH = 1;
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 // Microsoft Edge will overwrite inline styles if there is an animation pertaining to that style.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -41,8 +41,12 @@ import { IContextualMenuItemStyleProps, IContextualMenuItemStyles } from './Cont
 
 import { getItemStyles } from './ContextualMenu.classNames';
 
-const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualMenuStyles>();
-const getContextualMenuItemClassNames = classNamesFunction<IContextualMenuItemStyleProps, IContextualMenuItemStyles>();
+const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualMenuStyles>({
+  disableCaching: true
+});
+const getContextualMenuItemClassNames = classNamesFunction<IContextualMenuItemStyleProps, IContextualMenuItemStyles>({
+  disableCaching: true
+});
 
 export interface IContextualMenuState {
   expandedMenuItemKey?: string;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -8,8 +8,12 @@ import { getStyles } from './DetailsRowCheck.styles';
 import { IDetailsRowCheckStyleProps, IDetailsRowCheckStyles } from './DetailsRowCheck.types';
 import { classNamesFunction } from '../../Utilities';
 
-const getCheckClassNames = classNamesFunction<ICheckStyleProps, ICheckStyles>();
-const getClassNames = classNamesFunction<IDetailsRowCheckStyleProps, IDetailsRowCheckStyles>();
+const getCheckClassNames = classNamesFunction<ICheckStyleProps, ICheckStyles>({
+  disableCaching: true
+});
+const getClassNames = classNamesFunction<IDetailsRowCheckStyleProps, IDetailsRowCheckStyles>({
+  disableCaching: true
+});
 
 const DetailsRowCheckBase = (props: IDetailsRowCheckProps) => {
   const {

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
@@ -20,11 +20,14 @@ export class FabricBase extends React.Component<
   }
 
   public render() {
+    const { className, ...rest } = this.props;
+
     const classNames = getClassNames(getStyles, {
-      ...(this.props as IFabricStyleProps),
-      ...this.state
+      theme: this.props.theme!,
+      className,
+      isFocusVisible: this.state.isFocusVisible
     });
-    const divProps = getNativeProps(this.props, divProperties);
+    const divProps = getNativeProps(rest, divProperties);
 
     return <div {...divProps} className={classNames.root} ref={this._rootElement} />;
   }

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -10,7 +10,9 @@ export interface IIconState {
   imageLoadError: boolean;
 }
 
-const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>();
+const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>({
+  disableCaching: true
+});
 
 export class IconBase extends React.Component<IIconProps, IIconState> {
   constructor(props: IIconProps) {

--- a/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
@@ -3,7 +3,10 @@ import { divProperties, getNativeProps } from '../../Utilities';
 import { classNamesFunction } from '../../Utilities';
 import { ILabelProps, ILabelStyleProps, ILabelStyles } from './Label.types';
 
-const getClassNames = classNamesFunction<ILabelStyleProps, ILabelStyles>();
+const getClassNames = classNamesFunction<ILabelStyleProps, ILabelStyles>({
+  disableCaching: true
+});
+
 export class LabelBase extends React.Component<ILabelProps, {}> {
   public render(): JSX.Element {
     const { as: RootType = 'label', children, className, disabled, styles, required, theme } = this.props;

--- a/packages/utilities/src/__snapshots__/styled.test.tsx.snap
+++ b/packages/utilities/src/__snapshots__/styled.test.tsx.snap
@@ -114,3 +114,28 @@ exports[`styled renders base styles (background red) 1`] = `
       }
 />
 `;
+
+exports[`styled respects styles arg 1`] = `
+<div>
+  <div
+    className=
+
+        {
+          background-color: red;
+        }
+  >
+    Panel1
+  </div>
+  <div
+    className=
+
+        {
+          background-color: green;
+        }
+  >
+    Panel2
+  </div>
+</div>
+`;
+
+exports[`styled respects styles type 1`] = `null`;

--- a/packages/utilities/src/classNamesFunction.test.ts
+++ b/packages/utilities/src/classNamesFunction.test.ts
@@ -1,0 +1,49 @@
+import { classNamesFunction } from './classNamesFunction';
+import { Stylesheet } from '@uifabric/merge-styles';
+
+describe('classNamesFunction', () => {
+  let lastRule: string;
+
+  beforeEach(() => {
+    Stylesheet.getInstance().setConfig({
+      onInsertRule: () => {
+        /*no-op*/
+      }
+    });
+  });
+
+  afterEach(() => {
+    Stylesheet.getInstance().setConfig({
+      onInsertRule: undefined
+    });
+  });
+
+  it('can cache rules', () => {
+    let styleFunctionCalled = false;
+    const getClassNames = classNamesFunction();
+    const getStyles = [
+      (props: { a: number }) => {
+        styleFunctionCalled = true;
+        return {
+          root: { width: props.a }
+        };
+      },
+      undefined,
+      undefined
+    ];
+
+    const classNames = getClassNames(getStyles, { a: 1, b: 'test' });
+    expect(styleFunctionCalled).toEqual(true);
+    styleFunctionCalled = false;
+
+    expect(getClassNames(getStyles, { a: 1, b: 'test' })).toEqual(classNames);
+    expect(styleFunctionCalled).toEqual(false);
+
+    expect(getClassNames(getStyles, { a: 2, b: 'test' })).not.toEqual(classNames);
+    expect(styleFunctionCalled).toEqual(true);
+
+    styleFunctionCalled = false;
+    getClassNames(getStyles, { a: 2, b: 'test' });
+    expect(styleFunctionCalled).toEqual(false);
+  });
+});

--- a/packages/utilities/src/classNamesFunction.test.ts
+++ b/packages/utilities/src/classNamesFunction.test.ts
@@ -1,5 +1,5 @@
 import { classNamesFunction } from './classNamesFunction';
-import { Stylesheet } from '@uifabric/merge-styles';
+import { Stylesheet, IStyle } from '@uifabric/merge-styles';
 
 describe('classNamesFunction', () => {
   let lastRule: string;
@@ -20,17 +20,13 @@ describe('classNamesFunction', () => {
 
   it('can cache rules', () => {
     let styleFunctionCalled = false;
-    const getClassNames = classNamesFunction();
-    const getStyles = [
-      (props: { a: number }) => {
-        styleFunctionCalled = true;
-        return {
-          root: { width: props.a }
-        };
-      },
-      undefined,
-      undefined
-    ];
+    const getClassNames = classNamesFunction<{ a: number; b: string }, { root: IStyle }>();
+    const getStyles = (props: { a: number; b: string }) => {
+      styleFunctionCalled = true;
+      return {
+        root: { width: props.a }
+      };
+    };
 
     const classNames = getClassNames(getStyles, { a: 1, b: 'test' });
     expect(styleFunctionCalled).toEqual(true);

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -58,8 +58,6 @@ export function classNamesFunction<TStyleProps extends {}, TStyleSet extends ISt
     if (disableCaching || !(current as any)[RetVal]) {
       if (styleFunctionOrObject === undefined) {
         (current as any)[RetVal] = {} as IProcessedStyleSet<TStyleSet>;
-      } else if (Array.isArray(styleFunctionOrObject)) {
-        (current as any)[RetVal] = mergeStyleSets(...(styleFunctionOrObject as any).map(_derive, styleProps));
       } else {
         (current as any)[RetVal] = mergeStyleSets(
           typeof styleFunctionOrObject === 'function' ? styleFunctionOrObject(styleProps) : styleFunctionOrObject
@@ -111,9 +109,9 @@ function _traverseEdge(current: Map<any, any>, value: any): Map<any, any> {
 }
 
 function _traverseMap(current: Map<any, any>, inputs: any[] | Object): Map<any, any> {
-  if (Array.isArray(inputs)) {
-    for (let i = 0; i < inputs.length; i++) {
-      current = _traverseEdge(current, inputs[i]);
+  if (typeof inputs === 'function' && (inputs as any).__cachedInputs__) {
+    for (const input of (inputs as any).__cachedInputs__) {
+      current = _traverseEdge(current, input);
     }
   } else if (typeof inputs === 'object') {
     for (const propName in inputs) {

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -1,7 +1,20 @@
-import { mergeStyleSets, IStyle, IStyleSet, IProcessedStyleSet } from '@uifabric/merge-styles';
+import { mergeStyleSets, IStyleSet, IProcessedStyleSet } from '@uifabric/merge-styles';
 import { IStyleFunctionOrObject } from '@uifabric/merge-styles';
 
-// TODO: deprecate disableCaching option if not used by classNamesFunction for optimization.
+const MAX_CACHE_COUNT = 50;
+
+// Note that because of the caching nature within the classNames memoization,
+// I've disabled this rule to simply be able to work with any types.
+// tslint:disable:no-any
+
+// This represents a prop we attach to each Map to indicate the cached return value
+// associated with the graph node.
+const RetVal = '__retval__';
+
+interface IRecursiveMemoNode extends Map<any, IRecursiveMemoNode> {
+  [RetVal]?: string;
+}
+
 export interface IClassNamesFunctionOptions {
   /**
    * Disables class caching for scenarios where styleProp parts mutate frequently.
@@ -12,29 +25,114 @@ export interface IClassNamesFunctionOptions {
 /**
  * Creates a getClassNames function which calls getStyles given the props, and injects them
  * into mergeStyleSets.
+ *
+ * Note that the props you pass in on every render should be in the same order and
+ * immutable (numbers, strings, and booleans). This will allow the results to be memoized. Violating
+ * these will cause extra recalcs to occur.
  */
 export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet<TStyleSet>>(
   options: IClassNamesFunctionOptions = {}
 ): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet> {
-  // TODO: memoize.
+  // We build a trie where each node is a Map. The map entry key represents an argument
+  // value, and the entry value is another node (Map). Each node has a `__retval__`
+  // property which is used to hold the cached response.
+
+  // To derive the response, we can simply ensure the arguments are added or already
+  // exist in the trie. At the last node, if there is a `__retval__` we return that. Otherwise
+  // we call the `getStyles` api to evaluate, cache on the property, and return that.
+  let map: IRecursiveMemoNode = new Map();
+  let resultCount = 0;
 
   const getClassNames = (
     styleFunctionOrObject: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined,
     styleProps: TStyleProps = {} as TStyleProps
   ): IProcessedStyleSet<TStyleSet> => {
-    // styleSet might be undefined if styleFunctionOrObject is undefined, but getStyles should never
-    // ordinarily be undefined (it would hardly make any sense).
-    // However, because we usually use `props.styles` as the argument to an invocation of this method, and
-    // `props.styles` itself is defined as optional, this avoids the need to use `!` at all invocation points.
-    if (styleFunctionOrObject === undefined) {
-      return {} as IProcessedStyleSet<TStyleSet>;
+    let current: Map<any, any> = map;
+    const disableCaching = options.disableCaching;
+
+    if (!options.disableCaching) {
+      current = _traverseMap(map, styleFunctionOrObject as any);
+      current = _traverseMap(current, styleProps);
     }
 
-    const styleSet =
-      styleFunctionOrObject && (typeof styleFunctionOrObject === 'function' ? styleFunctionOrObject(styleProps!) : styleFunctionOrObject);
+    if (disableCaching || !(current as any)[RetVal]) {
+      if (styleFunctionOrObject === undefined) {
+        (current as any)[RetVal] = {} as IProcessedStyleSet<TStyleSet>;
+      } else if (Array.isArray(styleFunctionOrObject)) {
+        (current as any)[RetVal] = mergeStyleSets(...(styleFunctionOrObject as any).map(_derive, styleProps));
+      } else {
+        (current as any)[RetVal] = mergeStyleSets(
+          typeof styleFunctionOrObject === 'function' ? styleFunctionOrObject(styleProps) : styleFunctionOrObject
+        );
+      }
 
-    return mergeStyleSets(styleSet as TStyleSet);
+      if (!disableCaching) {
+        resultCount++;
+      }
+    }
+
+    if (resultCount > MAX_CACHE_COUNT) {
+      map.clear();
+      resultCount = 0;
+
+      // Mutate the options passed in, that's all we can do.
+      options.disableCaching = true;
+
+      // Note: this code is great for debugging problems with styles being recaculated, but commenting it out
+      // to avoid confusing consumers.
+
+      // if (process.env.NODE_ENV !== 'production') {
+      //  console.log('Styles are being recalculated far too frequently. Something is mutating the class over and over.');
+      //  // tslint:disable-next-line:no-console
+      //  console.trace();
+      // }
+    }
+
+    // Note: the RetVal is an attached property on the Map; not a key in the Map. We use this attached property to
+    // cache the return value for this branch of the graph.
+    return (current as any)[RetVal];
   };
 
   return getClassNames;
+}
+
+function _derive(obj: any): any {
+  return typeof obj === 'function' ? obj(this) : obj;
+}
+
+function _traverseEdge(current: Map<any, any>, value: any): Map<any, any> {
+  value = _normalizeValue(value);
+
+  if (!current.has(value)) {
+    current.set(value, new Map<any, any>());
+  }
+
+  return current.get(value);
+}
+
+function _traverseMap(current: Map<any, any>, inputs: any[] | Object): Map<any, any> {
+  if (Array.isArray(inputs)) {
+    for (let i = 0; i < inputs.length; i++) {
+      current = _traverseEdge(current, inputs[i]);
+    }
+  } else if (typeof inputs === 'object') {
+    for (const propName in inputs) {
+      if (inputs.hasOwnProperty(propName)) {
+        current = _traverseEdge(current, (inputs as any)[propName]);
+      }
+    }
+  }
+
+  return current;
+}
+
+function _normalizeValue(value: any): string {
+  switch (value) {
+    case undefined:
+      return '__undefined__';
+    case null:
+      return '__null__';
+    default:
+      return value;
+  }
 }

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -65,7 +65,6 @@ export function styled<
     public static displayName = `Styled${Component.displayName || (Component as any).name}`;
 
     private _inCustomizerContext = false;
-    private _customizedStyles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
     private _styles: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
 
     public render(): JSX.Element {
@@ -97,9 +96,16 @@ export function styled<
     };
 
     private _updateStyles(customizedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>): void {
-      if (!this._styles || customizedStyles !== this._customizedStyles || !!this.props.styles) {
+      // tslint:disable-next-line:no-any
+      if (!this._styles || customizedStyles !== (this._styles as any).__cachedInputs__[1] || !!this.props.styles) {
+        // Cache the customized styles.
+        // this._customizedStyles = customizedStyles;
+
         // Using styled components as the Component arg will result in nested styling arrays.
         this._styles = (styleProps: TStyleProps) => _resolve(styleProps, baseStyles, customizedStyles, this.props.styles);
+
+        // The __cachedInputs__ array is attached to the function and consumed by the
+        // classNamesFunction as a list of keys to include for memoizing classnames.
 
         // tslint:disable-next-line:no-any
         (this._styles as any).__cachedInputs__ = [baseStyles, customizedStyles, this.props.styles];

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { flatten } from './array';
 import { concatStyleSets, IStyleSet, IStyleFunctionOrObject, IConcatenatedStyleSet } from '@uifabric/merge-styles';
 import { Customizations } from './customizations/Customizations';
 import { CustomizerContext, ICustomizerContext } from './customizations/CustomizerContext';
@@ -65,6 +66,7 @@ export function styled<
 
     private _inCustomizerContext = false;
     private _customizedStyles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
+    private _styles: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
 
     public render(): JSX.Element {
       return <CustomizerContext.Consumer>{this._renderContent}</CustomizerContext.Consumer>;
@@ -86,19 +88,23 @@ export function styled<
       this._inCustomizerContext = !!context.customizations.inCustomizerContext;
 
       const settings = Customizations.getSettings(fields, scope, context.customizations);
-      const { styles: customizedStyles, ...rest } = settings;
+      const { styles: customizedStyles, dir, ...rest } = settings;
       const additionalProps = getProps ? getProps(this.props) : undefined;
 
-      this._customizedStyles = customizedStyles;
+      this._updateStyles(customizedStyles);
 
-      return <Component {...rest} {...additionalProps} {...this.props} styles={this._resolveClassNames} />;
+      return <Component {...rest} {...additionalProps} {...this.props} styles={this._styles} />;
     };
 
-    private _resolveClassNames = (styleProps: TStyleProps): IConcatenatedStyleSet<TStyleSet> | undefined => {
-      return _resolve(styleProps, baseStyles, this._customizedStyles, this.props.styles);
-    };
+    private _updateStyles(customizedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>): void {
+      if (!this._styles || customizedStyles !== this._customizedStyles || !!this.props.styles) {
+        // Using styled components as the Component arg will result in nested styling arrays.
+        // Use flatten to ensure that the _styles array remains flat when styled components are wrapped.
+        this._styles = (styleProps: TStyleProps) => _resolve(styleProps, baseStyles, customizedStyles, this.props.styles);
+      }
+    }
 
-    private _onSettingsChanged = () => this.forceUpdate();
+    private _onSettingsChanged = (): void => this.forceUpdate();
   }
 
   // This preserves backwards compatibility.
@@ -109,7 +115,7 @@ export function styled<
 function _resolve<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
-): IConcatenatedStyleSet<TStyleSet> | undefined {
+): Partial<TStyleSet> {
   const result: Partial<TStyleSet>[] = [];
 
   for (const styles of allStyles) {
@@ -117,16 +123,17 @@ function _resolve<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
     }
   }
+
   if (result.length === 1) {
-    return result[0] as IConcatenatedStyleSet<TStyleSet>;
+    return result[0] as Partial<TStyleSet>;
   } else if (result.length) {
     // cliffkoh: I cannot figure out how to avoid the cast to any here.
     // It is something to do with the use of Omit in IStyleSet.
     // It might not be necessary once  Omit becomes part of lib.d.ts (when we remove our own Omit and rely on
     // the official version).
     // tslint:disable-next-line:no-any
-    return concatStyleSets(...(result as any)) as IConcatenatedStyleSet<TStyleSet>;
+    return concatStyleSets(...(result as any)) as any;
   }
 
-  return undefined;
+  return {};
 }

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -99,8 +99,10 @@ export function styled<
     private _updateStyles(customizedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>): void {
       if (!this._styles || customizedStyles !== this._customizedStyles || !!this.props.styles) {
         // Using styled components as the Component arg will result in nested styling arrays.
-        // Use flatten to ensure that the _styles array remains flat when styled components are wrapped.
         this._styles = (styleProps: TStyleProps) => _resolve(styleProps, baseStyles, customizedStyles, this.props.styles);
+
+        // tslint:disable-next-line:no-any
+        (this._styles as any).__cachedInputs__ = [baseStyles, customizedStyles, this.props.styles];
       }
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9285
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Reintroduce #8761 accounting for issues highlighted in #9237 and #9203. This change differs from #8761 primarily in that it preserves the same `_resolve` styles approach in `styled` as opposed to forwarding style arrays.

#### Focus areas to test

Add unit tests covering the issues reported in #9237.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9437)