### PR TITLE
Enable conditional rendering of page sections depending on query present in the url to enable iframe rendering of examples on docs.microsoft OUFR portal

### DIFF
--- a/apps/fabric-website-resources/src/AppDefinition.tsx
+++ b/apps/fabric-website-resources/src/AppDefinition.tsx
@@ -234,13 +234,13 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/FloatingPeoplePickerPage').FloatingPeoplePickerPage,
           key: 'FloatingPeoplePicker',
           name: 'FloatingPeoplePicker',
-          url: '#examples/floatingpeoplepicker'
+          url: '#/examples/floatingpeoplepicker'
         },
         {
           component: require<any>('./components/pages/GroupedListPage').GroupedListPage,
           key: 'GroupedList',
           name: 'GroupedList',
-          url: '#examples/groupedlist'
+          url: '#/examples/groupedlist'
         },
         {
           component: require<any>('./components/pages/HoverCardPage').HoverCardPage,
@@ -384,13 +384,13 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/SelectedPeopleListPage').SelectedPeopleListPage,
           key: 'SelectedPeopleList',
           name: 'SelectedPeopleList',
-          url: '#examples/selectedpeoplelist'
+          url: '#/examples/selectedpeoplelist'
         },
         {
           component: require<any>('./components/pages/SeparatorPage').SeparatorPage,
           key: 'Separator',
           name: 'Separator',
-          url: '#examples/separator'
+          url: '#/examples/separator'
         },
         {
           component: require<any>('./components/pages/ShimmerPage').ShimmerPage,
@@ -467,7 +467,7 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/ExtendedPeoplePickerPage').ExtendedPeoplePickerPage,
           key: 'ExtendedPeoplePicker',
           name: 'ExtendedPeoplePicker',
-          url: '#examples/extendedpeoplepicker'
+          url: '#/examples/extendedpeoplepicker'
         }
       ]
     },
@@ -478,37 +478,37 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/FocusTrapZonePage').FocusTrapZonePage,
           key: 'FocusTrapZone',
           name: 'FocusTrapZone',
-          url: '#examples/focustrapzone'
+          url: '#/examples/focustrapzone'
         },
         {
           component: require<any>('./components/pages/FocusZonePage').FocusZonePage,
           key: 'FocusZone',
           name: 'FocusZone',
-          url: '#examples/focuszone'
+          url: '#/examples/focuszone'
         },
         {
           component: require<any>('./components/pages/MarqueeSelectionPage').MarqueeSelectionPage,
           key: 'MarqueeSelection',
           name: 'MarqueeSelection',
-          url: '#examples/marqueeselection'
+          url: '#/examples/marqueeselection'
         },
         {
           component: require<any>('./components/pages/SelectionPage').SelectionPage,
           key: 'Selection',
           name: 'Selection',
-          url: '#examples/selection'
+          url: '#/examples/selection'
         },
         {
           component: require<any>('./components/pages/ThemePage').ThemePage,
           key: 'Theme',
           name: 'Themes',
-          url: '#examples/themes'
+          url: '#/examples/themes'
         },
         {
           component: require<any>('./components/pages/ColorsPage').ColorsPage,
           key: 'Colors',
           name: 'Colors',
-          url: '#examples/themegenerator'
+          url: '#/examples/themegenerator'
         }
       ]
     },

--- a/apps/fabric-website-resources/src/AppDefinition.tsx
+++ b/apps/fabric-website-resources/src/AppDefinition.tsx
@@ -112,7 +112,7 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/ContextualMenuPage').ContextualMenuPage,
           key: 'ContextualMenu',
           name: 'ContextualMenu',
-          url: '#/examples/contextmenu'
+          url: '#/examples/contextualmenu'
         },
         {
           component: require<any>('./components/pages/DatePickerPage').DatePickerPage,
@@ -132,72 +132,71 @@ export const AppDefinition: IAppDefinition = {
               name: 'DetailsList - Basic',
               url: '#/examples/detailslist/basic'
             },
-
             {
               component: require<any>('./components/pages/DetailsList/DetailsListAdvancedPage').DetailsListAdvancedPage,
               key: 'DetailsList - Advanced',
               name: 'DetailsList - Advanced',
-              url: '#/examples/detailslist/advanced'
+              url: '#/examples/detailslist/variablerowheights'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListCompactPage').DetailsListCompactPage,
               key: 'DetailsList - Compact',
               name: 'DetailsList - Compact',
-              url: '#/examples/detailslist/Compact'
+              url: '#/examples/detailslist/compact'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListCustomColumnsPage').DetailsListCustomColumnsPage,
               key: 'DetailsList - CustomColumns',
               name: 'DetailsList - CustomColumns',
-              url: '#/examples/detailslist/CustomColumns'
+              url: '#/examples/detailslist/customitemcolumns'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListCustomGroupHeadersPage').DetailsListCustomGroupHeadersPage,
               key: 'DetailsList - CustomGroupHeaders',
               name: 'DetailsList - CustomGroupHeaders',
-              url: '#/examples/detailslist/CustomGroupHeaders'
+              url: '#/examples/detailslist/customgroupheaders'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListCustomRowsPage').DetailsListCustomRowsPage,
               key: 'DetailsList - CustomRows',
               name: 'DetailsList - CustomRows',
-              url: '#/examples/detailslist/CustomRows'
+              url: '#/examples/detailslist/customitemrows'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListCustomFooterPage').DetailsListCustomFooterPage,
               key: 'DetailsList - CustomFooter',
               name: 'DetailsList - CustomFooter',
-              url: '#/examples/detailslist/CustomFooter'
+              url: '#/examples/detailslist/customfooter'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListDragDropPage').DetailsListDragDropPage,
               key: 'DetailsList - DragDrop',
               name: 'DetailsList - DragDrop',
-              url: '#/examples/detailslist/DragDrop'
+              url: '#/examples/detailslist/draganddrop'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListLargeGroupedPage').DetailsListLargeGroupedPage,
               key: 'DetailsList - LargeGrouped',
               name: 'DetailsList - LargeGrouped',
-              url: '#/examples/detailslist/LargeGrouped'
+              url: '#/examples/detailslist/largegrouped'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListNavigatingFocusPage').DetailsListNavigatingFocusPage,
               key: 'DetailsList - NavigatingFocus',
               name: 'DetailsList - NavigatingFocus',
-              url: '#/examples/detailslist/NavigatingFocus'
+              url: '#/examples/detailslist/innernavigation'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListShimmerPage').DetailsListShimmerPage,
               key: 'DetailsList - Shimmer',
               name: 'DetailsList - Shimmer',
-              url: '#/examples/detailslist/Shimmer'
+              url: '#/examples/detailslist/shimmer'
             },
             {
               component: require<any>('./components/pages/DetailsList/DetailsListSimpleGroupedPage').DetailsListSimpleGroupedPage,
               key: 'DetailsList - SimpleGrouped',
               name: 'DetailsList - SimpleGrouped',
-              url: '#/examples/detailslist/SimpleGrouped'
+              url: '#/examples/detailslist/grouped'
             }
           ]
         },
@@ -211,7 +210,7 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/DividerPage').DividerPage,
           key: 'Divider',
           name: 'Divider',
-          url: '#/examples/Divider'
+          url: '#/examples/divider'
         },
         {
           component: require<any>('./components/pages/DocumentCardPage').DocumentCardPage,
@@ -331,7 +330,7 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/PeoplePickerPage').PeoplePickerPage,
           key: 'PeoplePicker',
           name: 'PeoplePicker',
-          url: '#/examples/PeoplePicker'
+          url: '#/examples/peoplepicker'
         },
         {
           component: require<any>('./components/pages/PersonaPage').PersonaPage,
@@ -457,7 +456,7 @@ export const AppDefinition: IAppDefinition = {
           component: require<any>('./components/pages/TooltipPage').TooltipPage,
           key: 'Tooltip',
           name: 'Tooltip',
-          url: '#/examples/Tooltip'
+          url: '#/examples/tooltip'
         }
       ]
     },

--- a/common/changes/@uifabric/example-app-base/vibraga-doc-smicrosoft_2019-06-12-07-35.json
+++ b/common/changes/@uifabric/example-app-base/vibraga-doc-smicrosoft_2019-06-12-07-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Adds conditional logic to the render of specific regions on the page to enable use of the examples on docs.microsoft portal for OUFR.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "vibraga@microsoft.com"
+}

--- a/common/changes/@uifabric/fabric-website-resources/vibraga-doc-smicrosoft_2019-06-12-07-35.json
+++ b/common/changes/@uifabric/fabric-website-resources/vibraga-doc-smicrosoft_2019-06-12-07-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website-resources",
+      "comment": "AppDefinition: fixes urls to align to the ones on the website.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "vibraga@microsoft.com"
+}

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -16,6 +16,7 @@ import { Text } from 'office-ui-fabric-react/lib/Text';
 import { ILinkToken } from 'office-ui-fabric-react/lib/common/DocPage.types';
 import { IApiInterfaceProperty, IApiEnumProperty, IMethod } from './ApiReferencesTableSet.types';
 import { Markdown } from '../Markdown/index';
+import { getCurrentUrl } from '../../utilities/getCurrentUrl';
 
 export interface IApiReferencesTableProps {
   title?: string;
@@ -126,8 +127,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
       };
     }
 
-    const doc = getDocument();
-    this._baseUrl = doc ? document.location.href : '';
+    this._baseUrl = getCurrentUrl();
 
     this._defaultColumns = [
       {

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IRenderFunction, getDocument } from 'office-ui-fabric-react/lib/Utilities';
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import {
   DetailsList,
   DetailsRow,

--- a/packages/example-app-base/src/components/App/App.styles.ts
+++ b/packages/example-app-base/src/components/App/App.styles.ts
@@ -18,7 +18,7 @@ const headerHeight = 50;
 const navWidth = 300;
 
 export const getStyles: IStyleFunction<IAppStyleProps, IAppStyles> = props => {
-  const { responsiveMode, theme = getTheme() } = props;
+  const { responsiveMode, theme = getTheme(), showOnlyExamples } = props;
   const isLargeDown = responsiveMode <= ResponsiveMode.large;
   return {
     root: [
@@ -67,9 +67,9 @@ export const getStyles: IStyleFunction<IAppStyleProps, IAppStyles> = props => {
     content: [
       {
         position: 'absolute',
-        left: isLargeDown ? 0 : navWidth,
+        left: isLargeDown || showOnlyExamples ? 0 : navWidth,
         right: 0,
-        top: headerHeight,
+        top: !showOnlyExamples ? headerHeight : 0,
         bottom: 0,
         padding: isLargeDown ? 5 : undefined,
         overflowX: 'auto',

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -26,7 +26,9 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
     const { customizations } = appDefinition;
     const { isMenuVisible } = this.state;
 
-    const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme }));
+    const showOnlyExamples = location.hash.indexOf('docsExample=true') > -1;
+
+    const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme, showOnlyExamples }));
 
     const isLargeDown = responsiveMode <= ResponsiveMode.large;
 
@@ -41,18 +43,20 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
 
     const app = (
       <Fabric className={classNames.root}>
-        <div className={classNames.headerContainer}>
-          <Header
-            isLargeDown={isLargeDown}
-            title={appDefinition.appTitle}
-            sideLinks={appDefinition.headerLinks}
-            isMenuVisible={isMenuVisible}
-            onIsMenuVisibleChanged={this._onIsMenuVisibleChanged}
-            styles={classNames.subComponentStyles.header}
-          />
-        </div>
+        {!showOnlyExamples && (
+          <div className={classNames.headerContainer}>
+            <Header
+              isLargeDown={isLargeDown}
+              title={appDefinition.appTitle}
+              sideLinks={appDefinition.headerLinks}
+              isMenuVisible={isMenuVisible}
+              onIsMenuVisibleChanged={this._onIsMenuVisibleChanged}
+              styles={classNames.subComponentStyles.header}
+            />
+          </div>
+        )}
 
-        {!isLargeDown && <div className={classNames.leftNavContainer}>{nav}</div>}
+        {!isLargeDown && !showOnlyExamples && <div className={classNames.leftNavContainer}>{nav}</div>}
 
         <div className={classNames.content} data-is-scrollable="true">
           {this.props.children}

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -9,6 +9,7 @@ import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
 import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { ResponsiveMode, withResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
+import { showOnlyExamples } from '../../utilities/showOnlyExamples';
 
 export interface IAppState {
   isMenuVisible: boolean;
@@ -34,9 +35,9 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
     const { customizations } = appDefinition;
     const { isMenuVisible } = this.state;
 
-    const showOnlyExamples = this._baseUrl.indexOf('docsExample=true') > -1;
+    const onlyExamples = showOnlyExamples(this._baseUrl);
 
-    const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme, showOnlyExamples }));
+    const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme, showOnlyExamples: onlyExamples }));
 
     const isLargeDown = responsiveMode <= ResponsiveMode.large;
 
@@ -51,7 +52,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
 
     const app = (
       <Fabric className={classNames.root}>
-        {!showOnlyExamples && (
+        {!onlyExamples && (
           <div className={classNames.headerContainer}>
             <Header
               isLargeDown={isLargeDown}
@@ -64,7 +65,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
           </div>
         )}
 
-        {!isLargeDown && !showOnlyExamples && <div className={classNames.leftNavContainer}>{nav}</div>}
+        {!isLargeDown && !onlyExamples && <div className={classNames.leftNavContainer}>{nav}</div>}
 
         <div className={classNames.content} data-is-scrollable="true">
           {this.props.children}

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppCustomizationsContext } from '../../utilities/customizations';
-import { classNamesFunction, css, styled } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, css, styled, getDocument } from 'office-ui-fabric-react/lib/Utilities';
 import { ExampleStatus, IAppProps, IAppStyleProps, IAppStyles } from './App.types';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { getStyles } from './App.styles';
@@ -26,7 +26,9 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
     const { customizations } = appDefinition;
     const { isMenuVisible } = this.state;
 
-    const showOnlyExamples = location.hash.indexOf('docsExample=true') > -1;
+    const doc = getDocument();
+    const baseUrl = doc ? doc.location.href : '';
+    const showOnlyExamples = baseUrl.indexOf('docsExample=true') > -1;
 
     const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme, showOnlyExamples }));
 

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -9,6 +9,7 @@ import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
 import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { ResponsiveMode, withResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
+import { ShowOnlyExamplesContext } from '../../utilities/showOnlyExamples';
 
 export interface IAppState {
   isMenuVisible: boolean;
@@ -20,15 +21,21 @@ const getClassNames = classNamesFunction<IAppStyleProps, IAppStyles>();
 export class AppBase extends React.Component<IAppProps, IAppState> {
   public state: IAppState = { isMenuVisible: false };
   private _classNames: IProcessedStyleSet<IAppStyles>;
+  private _baseUrl: string;
+
+  constructor(props: IAppProps) {
+    super(props);
+
+    const doc = getDocument();
+    this._baseUrl = doc ? document.location.href : '';
+  }
 
   public render(): JSX.Element {
     const { appDefinition, styles, responsiveMode = ResponsiveMode.xLarge, theme } = this.props;
     const { customizations } = appDefinition;
     const { isMenuVisible } = this.state;
 
-    const doc = getDocument();
-    const baseUrl = doc ? doc.location.href : '';
-    const showOnlyExamples = baseUrl.indexOf('docsExample=true') > -1;
+    const showOnlyExamples = this._baseUrl.indexOf('docsExample=true') > -1;
 
     const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme, showOnlyExamples }));
 
@@ -61,7 +68,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
         {!isLargeDown && !showOnlyExamples && <div className={classNames.leftNavContainer}>{nav}</div>}
 
         <div className={classNames.content} data-is-scrollable="true">
-          {this.props.children}
+          <ShowOnlyExamplesContext.Provider value={{ showOnlyExamples }}>{this.props.children}</ShowOnlyExamplesContext.Provider>
         </div>
 
         {isLargeDown && (

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppCustomizationsContext } from '../../utilities/customizations';
-import { classNamesFunction, css, styled, getDocument } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, css, styled } from 'office-ui-fabric-react/lib/Utilities';
 import { ExampleStatus, IAppProps, IAppStyleProps, IAppStyles } from './App.types';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { getStyles } from './App.styles';
@@ -21,13 +21,12 @@ const getClassNames = classNamesFunction<IAppStyleProps, IAppStyles>();
 export class AppBase extends React.Component<IAppProps, IAppState> {
   public state: IAppState = { isMenuVisible: false };
   private _classNames: IProcessedStyleSet<IAppStyles>;
-  private _baseUrl: string;
+  private _showOnlyExamples: boolean;
 
   constructor(props: IAppProps) {
     super(props);
 
-    const doc = getDocument();
-    this._baseUrl = doc ? document.location.href : '';
+    this._showOnlyExamples = showOnlyExamples();
   }
 
   public render(): JSX.Element {
@@ -35,7 +34,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
     const { customizations } = appDefinition;
     const { isMenuVisible } = this.state;
 
-    const onlyExamples = showOnlyExamples(this._baseUrl);
+    const onlyExamples = this._showOnlyExamples;
 
     const classNames = (this._classNames = getClassNames(styles, { responsiveMode, theme, showOnlyExamples: onlyExamples }));
 

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -9,7 +9,6 @@ import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
 import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { ResponsiveMode, withResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
-import { ShowOnlyExamplesContext } from '../../utilities/showOnlyExamples';
 
 export interface IAppState {
   isMenuVisible: boolean;
@@ -68,7 +67,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
         {!isLargeDown && !showOnlyExamples && <div className={classNames.leftNavContainer}>{nav}</div>}
 
         <div className={classNames.content} data-is-scrollable="true">
-          <ShowOnlyExamplesContext.Provider value={{ showOnlyExamples }}>{this.props.children}</ShowOnlyExamplesContext.Provider>
+          {this.props.children}
         </div>
 
         {isLargeDown && (

--- a/packages/example-app-base/src/components/App/App.types.ts
+++ b/packages/example-app-base/src/components/App/App.types.ts
@@ -44,7 +44,11 @@ export interface IAppProps extends IWithResponsiveModeState {
   styles?: IStyleFunctionOrObject<IAppStyleProps, IAppStyles>;
 }
 
-export type IAppStyleProps = Required<Pick<IAppProps, 'responsiveMode'>> & Pick<IAppProps, 'theme'>;
+export type IAppStyleProps = Required<Pick<IAppProps, 'responsiveMode'>> &
+  Pick<IAppProps, 'theme'> & {
+    /** Whether the page needs to show only the examples card */
+    showOnlyExamples?: boolean;
+  };
 
 export interface IAppStyles {
   root: IStyle;

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -7,6 +7,7 @@ import { MessageBar } from 'office-ui-fabric-react/lib/MessageBar';
 import { EditSection } from '../EditSection/index';
 import { IComponentPageProps, IComponentPageStyleProps, IComponentPageStyles, IComponentPageSection } from './ComponentPage.types';
 import { getStyles } from './ComponentPage.styles';
+import { ShowOnlyExamplesContext } from '../../utilities/showOnlyExamples';
 
 const getClassNames = classNamesFunction<IComponentPageStyleProps, IComponentPageStyles>();
 
@@ -36,6 +37,8 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
     areBadgesVisible: false
   };
 
+  public static contextType = ShowOnlyExamplesContext;
+
   private _baseUrl: string;
   private _styles: IProcessedStyleSet<IComponentPageStyles>;
 
@@ -49,7 +52,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
   public render() {
     const { componentName, className, otherSections, styles, theme } = this.props;
 
-    const showOnlyExamples = this._baseUrl && this._baseUrl.indexOf('docsExample=true') > -1;
+    const { showOnlyExamples } = this.context;
 
     const classNames = (this._styles = getClassNames(styles, { theme }));
 

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -49,7 +49,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
   public render() {
     const { componentName, className, otherSections, styles, theme } = this.props;
 
-    const showOnlyExamples = location.hash.indexOf('docsExample=true') > -1;
+    const showOnlyExamples = this._baseUrl && this._baseUrl.indexOf('docsExample=true') > -1;
 
     const classNames = (this._styles = getClassNames(styles, { theme }));
 

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -7,7 +7,6 @@ import { MessageBar } from 'office-ui-fabric-react/lib/MessageBar';
 import { EditSection } from '../EditSection/index';
 import { IComponentPageProps, IComponentPageStyleProps, IComponentPageStyles, IComponentPageSection } from './ComponentPage.types';
 import { getStyles } from './ComponentPage.styles';
-import { ShowOnlyExamplesContext } from '../../utilities/showOnlyExamples';
 
 const getClassNames = classNamesFunction<IComponentPageStyleProps, IComponentPageStyles>();
 
@@ -37,8 +36,6 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
     areBadgesVisible: false
   };
 
-  public static contextType = ShowOnlyExamplesContext;
-
   private _baseUrl: string;
   private _styles: IProcessedStyleSet<IComponentPageStyles>;
 
@@ -52,7 +49,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
   public render() {
     const { componentName, className, otherSections, styles, theme } = this.props;
 
-    const { showOnlyExamples } = this.context;
+    const showOnlyExamples = this._baseUrl.indexOf('docsExample=true') > -1;
 
     const classNames = (this._styles = getClassNames(styles, { theme }));
 

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -7,6 +7,7 @@ import { MessageBar } from 'office-ui-fabric-react/lib/MessageBar';
 import { EditSection } from '../EditSection/index';
 import { IComponentPageProps, IComponentPageStyleProps, IComponentPageStyles, IComponentPageSection } from './ComponentPage.types';
 import { getStyles } from './ComponentPage.styles';
+import { showOnlyExamples } from '../../utilities/showOnlyExamples';
 
 const getClassNames = classNamesFunction<IComponentPageStyleProps, IComponentPageStyles>();
 
@@ -49,11 +50,11 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
   public render() {
     const { componentName, className, otherSections, styles, theme } = this.props;
 
-    const showOnlyExamples = this._baseUrl.indexOf('docsExample=true') > -1;
+    const onlyExamples = showOnlyExamples(this._baseUrl);
 
     const classNames = (this._styles = getClassNames(styles, { theme }));
 
-    return showOnlyExamples ? (
+    return onlyExamples ? (
       this._getVariants()
     ) : (
       <div className={css(classNames.root, className)}>

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -49,19 +49,21 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
   public render() {
     const { componentName, className, otherSections, styles, theme } = this.props;
 
+    const showOnlyExamples = location.hash.indexOf('docsExample=true') > -1;
+
     const classNames = (this._styles = getClassNames(styles, { theme }));
 
     return (
       <div className={css(classNames.root, className)}>
         <div className={componentName}>
-          {this._getPageHeader()}
+          {!showOnlyExamples && this._getPageHeader()}
           <div className={classNames.body}>
-            {this._getOverview()}
-            {this._getBestPractices()}
+            {!showOnlyExamples && this._getOverview()}
+            {!showOnlyExamples && this._getBestPractices()}
             {this._getVariants()}
-            {this._getPropertiesTable()}
-            {this._getFeedback()}
-            {otherSections && otherSections.map(section => this._getSection(section))}
+            {!showOnlyExamples && this._getPropertiesTable()}
+            {!showOnlyExamples && this._getFeedback()}
+            {!showOnlyExamples && otherSections && otherSections.map(section => this._getSection(section))}
           </div>
         </div>
       </div>

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { css, getDocument, classNamesFunction, styled } from 'office-ui-fabric-react/lib/Utilities';
+import { css, classNamesFunction, styled } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { Stack, IStackProps } from 'office-ui-fabric-react/lib/Stack';
@@ -8,6 +8,7 @@ import { EditSection } from '../EditSection/index';
 import { IComponentPageProps, IComponentPageStyleProps, IComponentPageStyles, IComponentPageSection } from './ComponentPage.types';
 import { getStyles } from './ComponentPage.styles';
 import { showOnlyExamples } from '../../utilities/showOnlyExamples';
+import { getCurrentUrl } from '../../utilities/getCurrentUrl';
 
 const getClassNames = classNamesFunction<IComponentPageStyleProps, IComponentPageStyles>();
 
@@ -38,19 +39,20 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
   };
 
   private _baseUrl: string;
+  private _showOnlyExamples: boolean;
   private _styles: IProcessedStyleSet<IComponentPageStyles>;
 
   constructor(props: IComponentPageProps) {
     super(props);
 
-    const doc = getDocument();
-    this._baseUrl = doc ? document.location.href : '';
+    this._baseUrl = getCurrentUrl();
+    this._showOnlyExamples = showOnlyExamples();
   }
 
   public render() {
     const { componentName, className, otherSections, styles, theme } = this.props;
 
-    const onlyExamples = showOnlyExamples(this._baseUrl);
+    const onlyExamples = this._showOnlyExamples;
 
     const classNames = (this._styles = getClassNames(styles, { theme }));
 

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -53,17 +53,19 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
 
     const classNames = (this._styles = getClassNames(styles, { theme }));
 
-    return (
+    return showOnlyExamples ? (
+      this._getVariants()
+    ) : (
       <div className={css(classNames.root, className)}>
         <div className={componentName}>
-          {!showOnlyExamples && this._getPageHeader()}
+          {this._getPageHeader()}
           <div className={classNames.body}>
-            {!showOnlyExamples && this._getOverview()}
-            {!showOnlyExamples && this._getBestPractices()}
+            {this._getOverview()}
+            {this._getBestPractices()}
             {this._getVariants()}
-            {!showOnlyExamples && this._getPropertiesTable()}
-            {!showOnlyExamples && this._getFeedback()}
-            {!showOnlyExamples && otherSections && otherSections.map(section => this._getSection(section))}
+            {this._getPropertiesTable()}
+            {this._getFeedback()}
+            {otherSections && otherSections.map(section => this._getSection(section))}
           </div>
         </div>
       </div>

--- a/packages/example-app-base/src/utilities/getCurrentUrl.ts
+++ b/packages/example-app-base/src/utilities/getCurrentUrl.ts
@@ -5,7 +5,6 @@ import { getDocument } from 'office-ui-fabric-react/lib/Utilities';
  */
 export function getCurrentUrl(): string {
   const doc = getDocument();
-  console.log('doc: ', doc);
   const url = doc ? document.location.href : '';
 
   return url;

--- a/packages/example-app-base/src/utilities/getCurrentUrl.ts
+++ b/packages/example-app-base/src/utilities/getCurrentUrl.ts
@@ -1,7 +1,7 @@
 import { getDocument } from 'office-ui-fabric-react/lib/Utilities';
 
 /**
- * Get the current url of the loaded page.
+ * Get the current url of the loaded page. Returns empty string if server-side rendering (`document` is undefined).
  */
 export function getCurrentUrl(): string {
   const doc = getDocument();

--- a/packages/example-app-base/src/utilities/getCurrentUrl.ts
+++ b/packages/example-app-base/src/utilities/getCurrentUrl.ts
@@ -1,0 +1,12 @@
+import { getDocument } from 'office-ui-fabric-react/lib/Utilities';
+
+/**
+ * Get the current url of the loaded page.
+ */
+export function getCurrentUrl(): string {
+  const doc = getDocument();
+  console.log('doc: ', doc);
+  const url = doc ? document.location.href : '';
+
+  return url;
+}

--- a/packages/example-app-base/src/utilities/showOnlyExamples.ts
+++ b/packages/example-app-base/src/utilities/showOnlyExamples.ts
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-export interface IShowOnlyExamplesContext {
-  showOnlyExamples: boolean;
-}
-
-export const ShowOnlyExamplesContext = React.createContext<IShowOnlyExamplesContext>({
-  showOnlyExamples: false
-});

--- a/packages/example-app-base/src/utilities/showOnlyExamples.ts
+++ b/packages/example-app-base/src/utilities/showOnlyExamples.ts
@@ -1,7 +1,10 @@
+import { getCurrentUrl } from './getCurrentUrl';
+
 /**
  * Helper function that returns a boolean whether a `docsExample=true` string is contained within an url.
- * @param url url to check.
  */
-export function showOnlyExamples(url: string): boolean {
+export function showOnlyExamples(): boolean {
+  const url = getCurrentUrl();
+
   return url.indexOf('docsExample=true') > -1;
 }

--- a/packages/example-app-base/src/utilities/showOnlyExamples.ts
+++ b/packages/example-app-base/src/utilities/showOnlyExamples.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface IShowOnlyExamplesContext {
+  showOnlyExamples: boolean;
+}
+
+export const ShowOnlyExamplesContext = React.createContext<IShowOnlyExamplesContext>({
+  showOnlyExamples: false
+});

--- a/packages/example-app-base/src/utilities/showOnlyExamples.ts
+++ b/packages/example-app-base/src/utilities/showOnlyExamples.ts
@@ -1,0 +1,7 @@
+/**
+ * Helper function that returns a boolean whether a `docsExample=true` string is contained within an url.
+ * @param url url to check.
+ */
+export function showOnlyExamples(url: string): boolean {
+  return url.indexOf('docsExample=true') > -1;
+}


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ npm run change`

#### Description of changes
Enable conditional rendering of page sections depending on query present in the url to enable iframe rendering of examples on docs.microsoft OUFR portal: example [here](https://review.docs.microsoft.com/en-us/javascript/docs/examples/button?view=office-ui-fabric-react-latest&branch=testPackageSetup)

Adjusted some of the `AppDefinition` urls to align better with the live fabric website and facilitate the auto generation of iframes for the docs portal.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9438)