### PR TITLE
Updates to tileslist, list and marquee selection

### DIFF
--- a/common/changes/@uifabric/experiments/wiolsen-pr-changes_2019-06-18-22-39.json
+++ b/common/changes/@uifabric/experiments/wiolsen-pr-changes_2019-06-18-22-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Updates to tileslist, list and marquee selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "wiolsen@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/wiolsen-pr-changes_2019-06-18-22-39.json
+++ b/common/changes/office-ui-fabric-react/wiolsen-pr-changes_2019-06-18-22-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Updates to tileslist, list and marquee selection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "wiolsen@microsoft.com"
+}

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -382,7 +382,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
 
     const endIndex = Math.min(
       cells.length,
-      this.props.cellsPerPage && this.props.cellsPerPage > 0 ? startIndex! + this.props.cellsPerPage : startIndex! + CELLS_PER_PAGE
+      this.props.cellsPerPage && this.props.cellsPerPage > 0 ? startIndex + this.props.cellsPerPage : startIndex + CELLS_PER_PAGE
     );
 
     let rowWidth = 0;

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -108,13 +108,13 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
   public render(): JSX.Element {
     const { cells } = this.state;
 
-    const { className, onActiveElementChanged, items, cellsPerPage, role, focusZoneComponentRef, ...divProps } = this.props;
+    const { className, onActiveElementChanged, items, cellsPerPage, ref, role, focusZoneComponentRef, ...divProps } = this.props;
 
     return (
       <FocusZone
         role={role}
         {...divProps}
-        ref={focusZoneComponentRef as ((element: FocusZone | null) => void)}
+        ref={ref as ((element: FocusZone | null) => void)}
         componentRef={focusZoneComponentRef}
         className={css('ms-TilesList', className)}
         direction={FocusZoneDirection.bidirectional}
@@ -134,7 +134,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
   }
 
   public scrollToIndex(index: number, mode: ScrollToMode = ScrollToMode.auto): void {
-    if (this.listRef && this.listRef.current) {
+    if (this.listRef.current) {
       this.listRef.current.scrollToIndex(
         index,
         (itemIndex: number) => {

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IRefObject, IBaseProps, ISize } from 'office-ui-fabric-react/lib/Utilities';
 import { TilesList } from './TilesList';
 import { IFocusZone } from 'office-ui-fabric-react/lib/FocusZone';
+import { IListProps } from 'office-ui-fabric-react/lib/List';
 
 export interface ITilesGridItem<TItem> {
   /**
@@ -123,4 +124,13 @@ export interface ITilesListProps<TItem> extends IBaseProps, React.Props<TilesLis
    * Callback for when the active element within the list's FocusZone changes.
    */
   onActiveElementChanged?: (element: HTMLElement) => void;
+  /**
+   * calback to return the height of a single item in pixels
+   */
+  getItemHeight?: (index: number) => number;
+
+  /**
+   * props to pass through to the underlying List
+   */
+  listProps?: Partial<IListProps>;
 }

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -125,11 +125,6 @@ export interface ITilesListProps<TItem> extends IBaseProps, React.Props<TilesLis
    */
   onActiveElementChanged?: (element: HTMLElement) => void;
   /**
-   * calback to return the height of a single item in pixels
-   */
-  getItemHeight?: (index: number) => number;
-
-  /**
    * props to pass through to the underlying List
    */
   listProps?: Partial<IListProps>;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -493,7 +493,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalloutState" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export class Callout extends React.Component<ICalloutProps, ICalloutState> {
     // (undocumented)
@@ -656,7 +656,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     static defaultProps: IComboBoxProps;
     dismissMenu: () => void;
     // Warning: (ae-unresolved-inheritdoc-base) The @inheritDoc tag needs a TSDoc declaration reference; signature matching is not supported yet
-    // 
+    //
     // (undocumented)
     focus: (shouldOpenOnFocus?: boolean | undefined, useFocusAsync?: boolean | undefined) => void;
     // (undocumented)
@@ -2839,7 +2839,7 @@ export interface IContextualMenuItem {
     data?: any;
     disabled?: boolean;
     // Warning: (ae-forgotten-export) The symbol "IMenuItemClassNames" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @deprecated
     getItemClassNames?: (theme: ITheme, disabled: boolean, expanded: boolean, checked: boolean, isAnchorLink: boolean, knownIcon: boolean, itemClassName?: string, dividerClassName?: string, iconClassName?: string, subMenuClassName?: string, primaryDisabled?: boolean) => IMenuItemClassNames;
     getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
@@ -2939,7 +2939,7 @@ export interface IContextualMenuListProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -2959,7 +2959,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // Warning: (ae-forgotten-export) The symbol "IContextualMenuClassNames" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // @deprecated
     getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
     hidden?: boolean;
@@ -3709,7 +3709,7 @@ export interface IDialogFooterStyles {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IAccessiblePopupProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiveModeState, IAccessiblePopupProps {
     // @deprecated
@@ -3812,7 +3812,7 @@ export interface IDocumentCardActions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActionsBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardActionsProps extends React.ClassAttributes<DocumentCardActionsBase> {
     actions: IButtonProps[];
@@ -3855,7 +3855,7 @@ export interface IDocumentCardActivityPerson {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActivityBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardActivityProps extends React.ClassAttributes<DocumentCardActivityBase> {
     activity: string;
@@ -3894,7 +3894,7 @@ export interface IDocumentCardDetails {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardDetailsBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardDetailsProps extends React.Props<DocumentCardDetailsBase> {
     className?: string;
@@ -3953,7 +3953,7 @@ export interface IDocumentCardLocation {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLocationBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardLocationProps extends React.ClassAttributes<DocumentCardLocationBase> {
     ariaLabel?: string;
@@ -3983,7 +3983,7 @@ export interface IDocumentCardLogo {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLogoBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardLogoProps extends React.ClassAttributes<DocumentCardLogoBase> {
     className?: string;
@@ -4083,7 +4083,7 @@ export interface IDocumentCardStatus {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardStatusBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardStatusProps extends React.Props<DocumentCardStatusBase> {
     className?: string;
@@ -4125,7 +4125,7 @@ export interface IDocumentCardTitle {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardTitleBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IDocumentCardTitleProps extends React.ClassAttributes<DocumentCardTitleBase> {
     className?: string;
@@ -4327,7 +4327,7 @@ export interface IExpandingCard {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExpandingCardStyles, IExpandingCardStyleProps> {
     compactCardHeight?: number;
@@ -4346,7 +4346,7 @@ export interface IExpandingCardState {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyleProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
     compactCardHeight?: number;
@@ -4356,7 +4356,7 @@ export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyles" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IExpandingCardStyles extends IBaseCardStyles {
     compactCard?: IStyle;
@@ -5207,6 +5207,7 @@ export interface ILinkStyles {
 export interface IList {
     forceUpdate: () => void;
     getStartItemIndexInView: () => number;
+    getTotalListHeight?: () => number;
     scrollToIndex: (index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode) => void;
 }
 
@@ -5216,7 +5217,7 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
     componentRef?: IRefObject<IList>;
     getItemCountForPage?: (itemIndex?: number, visibleRect?: IRectangle) => number;
     getKey?: (item: T, index?: number) => string;
-    getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle) => number;
+    getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle, itemCount?: number) => number;
     getPageSpecification?: (itemIndex?: number, visibleRect?: IRectangle) => IPageSpecification;
     getPageStyle?: (page: IPage<T>) => any;
     items?: T[];
@@ -5633,6 +5634,8 @@ export interface IPage<T = any> {
     // (undocumented)
     isSpacer?: boolean;
     // (undocumented)
+    isVisible?: boolean;
+    // (undocumented)
     itemCount: number;
     // (undocumented)
     items: T[] | undefined;
@@ -5673,7 +5676,7 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     className?: string;
@@ -6827,7 +6830,7 @@ export interface ISpinButtonProps {
     keytipProps?: IKeytipProps;
     label?: string;
     // Warning: (ae-forgotten-export) The symbol "Position" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     labelPosition?: Position;
     max?: number;
@@ -7442,14 +7445,14 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldSnapshot" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export interface ITextFieldSnapshot {
     selection?: [number | null, number | null];
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldState" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
@@ -7723,7 +7726,7 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IKeytipDataProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class KeytipData extends React.Component<IKeytipDataProps & IRenderComponent<{}>, {}> {
     // (undocumented)
@@ -7751,7 +7754,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
     // (undocumented)
     getCurrentSequence(): string;
     // Warning: (ae-forgotten-export) The symbol "KeytipTree" needs to be exported by the entry point index.d.ts
-    // 
+    //
     // (undocumented)
     getKeytipTree(): KeytipTree;
     processInput(key: string, ev?: React.KeyboardEvent<HTMLElement>): void;
@@ -7793,7 +7796,7 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     }
 
 // Warning: (ae-forgotten-export) The symbol "ILayerHostProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export class LayerHost extends React.Component<ILayerHostProps> {
     // (undocumented)
@@ -7835,6 +7838,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
     forceUpdate(): void;
     // (undocumented)
     getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number;
+    getTotalListHeight(): number;
     // (undocumented)
     refs: {
         [key: string]: React.ReactInstance;
@@ -9165,7 +9169,7 @@ export const TextField: React.StatelessComponent<ITextFieldProps>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldState" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldSnapshot" which is marked as @internal
-// 
+//
 // @public (undocumented)
 export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldState, ITextFieldSnapshot> implements ITextField {
     constructor(props: ITextFieldProps);
@@ -9322,7 +9326,7 @@ export * from "@uifabric/styling";
 export * from "@uifabric/utilities";
 
 // Warnings were encountered during analysis:
-// 
+//
 // lib/components/ColorPicker/ColorPicker.base.d.ts:8:9 - (ae-forgotten-export) The symbol "IRGBHex" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -856,7 +856,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
 
       const { itemCount = this._getItemCountForPage(itemIndex, visibleRect) } = pageData;
 
-      const { height = this._getPageHeight(itemIndex, itemCount, visibleRect) } = pageData;
+      const { height = this._getPageHeight(itemIndex, visibleRect, itemCount) } = pageData;
 
       return {
         itemCount: itemCount,
@@ -869,7 +869,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
 
       return {
         itemCount: itemCount,
-        height: this._getPageHeight(itemIndex, itemCount, visibleRect)
+        height: this._getPageHeight(itemIndex, visibleRect, itemCount)
       };
     }
   }
@@ -878,9 +878,9 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
    * Get the pixel height of a give page. Will use the props getPageHeight first, and if not provided, fallback to
    * cached height, or estimated page height, or default page height.
    */
-  private _getPageHeight(itemIndex: number, itemsPerPage: number, visibleRect: IRectangle): number {
+  private _getPageHeight(itemIndex: number, visibleRect: IRectangle, itemsPerPage: number): number {
     if (this.props.getPageHeight) {
-      return this.props.getPageHeight(itemIndex, itemsPerPage, visibleRect);
+      return this.props.getPageHeight(itemIndex, visibleRect, itemsPerPage);
     } else {
       const cachedHeight = this._cachedPageHeights[itemIndex];
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -168,7 +168,6 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
     this._estimatedPageHeight = 0;
     this._focusedIndex = -1;
     this._pageCache = {};
-    this.refs = {};
   }
 
   /**
@@ -307,10 +306,6 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
       this._events.on(this._scrollElement, 'scroll', this._onScroll);
       this._events.on(this._scrollElement, 'scroll', this._onAsyncScroll);
     }
-  }
-
-  public componentWillUnmount(): void {
-    this._events.dispose();
   }
 
   public componentWillReceiveProps(newProps: IListProps<T>): void {

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -567,7 +567,6 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
    * This function is debounced.
    */
   private _onScrollingDone(): void {
-    this._onAsyncIdle(); // Guarantees the creation of lookahead images when scrolling is done
     this.setState({ isScrolling: false });
   }
 
@@ -606,7 +605,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
           // Enqueue an idle bump.
           this._onAsyncIdle();
         }
-      } else if (!this.props.disableLookAhead) {
+      } else {
         // Enqueue an idle bump
         this._onAsyncIdle();
       }

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -128,7 +128,6 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
   private _scrollHeight: number;
   private _scrollTop: number;
   private _pageCache: IPageCache<T>;
-  private _scrollTopOffset: number | undefined;
 
   constructor(props: IListProps<T>) {
     super(props);
@@ -954,22 +953,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
         scrollHeight !== this._scrollHeight ||
         Math.abs(this._scrollTop - scrollTop) > this._estimatedPageHeight / 3)
     ) {
-      // Will only call getBoundingClientRect when refresh or first load; otherwise, will use scrollTop to calculate new values
-      if (!scrollHeight || !this._surfaceRect || scrollHeight !== this._scrollHeight || forceUpdate) {
-        const newSurfaceRect = _measureSurfaceRect(this._surface.current);
-        surfaceRect = this._surfaceRect = newSurfaceRect;
-        this._scrollTopOffset = newSurfaceRect.top + scrollTop;
-      } else {
-        const surfaceRectTop = -1 * scrollTop + this._scrollTopOffset!;
-        surfaceRect = this._surfaceRect = {
-          width: this._surfaceRect.width,
-          height: this._surfaceRect.height,
-          top: surfaceRectTop,
-          bottom: this._surfaceRect.height + surfaceRectTop,
-          left: this._surfaceRect.left,
-          right: this._surfaceRect.right
-        };
-      }
+      surfaceRect = this._surfaceRect = _measureSurfaceRect(this._surface.current);
       this._scrollTop = scrollTop;
     }
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -365,11 +365,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
    * Get the current height the list and it's pages.
    */
   public getTotalListHeight(): number {
-    let height = 0;
-    for (const curPage of this.state.pages!) {
-      height += curPage.height;
-    }
-    return height;
+    return this._surfaceRect!.height;
   }
 
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -955,7 +955,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
         Math.abs(this._scrollTop - scrollTop) > this._estimatedPageHeight / 3)
     ) {
       // Will only call getBoundingClientRect when refresh or first load; otherwise, will use scrollTop to calculate new values
-      if (!this._surfaceRect || scrollHeight !== this._scrollHeight || forceUpdate) {
+      if (!scrollHeight || !this._surfaceRect || scrollHeight !== this._scrollHeight || forceUpdate) {
         const newSurfaceRect = _measureSurfaceRect(this._surface.current);
         surfaceRect = this._surfaceRect = newSurfaceRect;
         this._scrollTopOffset = newSurfaceRect.top + scrollTop;

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -127,7 +127,7 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * in pixels, which has been seen to cause browser performance issues.
    * In general, use `getPageSpecification` instead.
    */
-  getPageHeight?: (itemIndex?: number, itemCount?: number, visibleRect?: IRectangle) => number;
+  getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle, itemCount?: number) => number;
 
   /**
    * Method called by the list to derive the page style object. For spacer pages, the list will derive

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -161,13 +161,6 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
   usePageCache?: boolean;
 
   /**
-   * Boolean to disable the onAsyncIdle call. Recommended to use when doing jumping through the list.
-   * As the user is moving through the list very quickly, creating lookaheads is heavy and unneccessary.
-   * @defaultvalue false
-   */
-  disableLookAhead?: boolean;
-
-  /**
    * Optional callback to determine whether the list should be rendered in full, or virtualized.
    * Virtualization will add and remove pages of items as the user scrolls them into the visible range.
    * This benefits larger list scenarios by reducing the DOM on the screen, but can negatively affect performance for smaller lists.

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -39,6 +39,11 @@ export interface IList {
   forceUpdate: () => void;
 
   /**
+   * Get the current height the list and it's pages.
+   */
+  getTotalListHeight?: () => number;
+
+  /**
    * Scroll to the given index. By default will bring the page the specified item is on into the view. If a callback
    * to measure the height of an individual item is specified, will only scroll to bring the specific item into view.
    *
@@ -122,7 +127,7 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * in pixels, which has been seen to cause browser performance issues.
    * In general, use `getPageSpecification` instead.
    */
-  getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle) => number;
+  getPageHeight?: (itemIndex?: number, itemCount?: number, visibleRect?: IRectangle) => number;
 
   /**
    * Method called by the list to derive the page style object. For spacer pages, the list will derive
@@ -154,6 +159,13 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * @defaultvalue false
    */
   usePageCache?: boolean;
+
+  /**
+   * Boolean to disable the onAsyncIdle call. Recommended to use when doing jumping through the list.
+   * As the user is moving through the list very quickly, creating lookaheads is heavy and unneccessary.
+   * @defaultvalue false
+   */
+  disableLookAhead?: boolean;
 
   /**
    * Optional callback to determine whether the list should be rendered in full, or virtualized.
@@ -189,6 +201,7 @@ export interface IPage<T = any> {
   height: number;
   data?: any;
   isSpacer?: boolean;
+  isVisible?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -75,10 +75,6 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
     if (this._autoScroll) {
       this._autoScroll.dispose();
     }
-    if (this._evaluateSelection) {
-      delete this._evaluateSelection;
-    }
-    this._events.dispose();
   }
 
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -241,15 +241,21 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
           rectHeight = this._dragOrigin.y;
         }
 
-        if (rectTop + rectHeight > rootRect.height) {
-          rectHeight = rootRect.height - rectTop;
+        // constrain rect height to root rect width, if root rect height is valid.
+        if (rootRect.width > 0) {
+          if (rectTop + rectHeight > rootRect.height) {
+            rectHeight = rootRect.height - rectTop;
+          }
         }
 
-        // since we don't have a width pass down to the element, we use the _scrollableSurface width
-        // to constraint the marquee rect to not falls out the right boundary
-        const viewportWidth = rootRect.width > 0 ? rootRect.width : this._scrollableSurface!.clientWidth;
-        if (rectLeft + rectWidth > viewportWidth) {
-          rectWidth = viewportWidth - rectLeft;
+        // constrain rect width to root rect width, if root rect width is valid.
+        if (rootRect.width > 0) {
+          // since we don't have a width pass down to the element, we use the _scrollableSurface width
+          // to constraint the marquee rect to not falls out the right boundary
+          const viewportWidth = rootRect.width > 0 ? rootRect.width : this._scrollableSurface!.clientWidth;
+          if (rectLeft + rectWidth > viewportWidth) {
+            rectWidth = viewportWidth - rectLeft;
+          }
         }
 
         const dragRect = {
@@ -402,7 +408,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
 
     // check if needs to update selection, only when current _allSelectedIndices
     // is different than previousSelectedIndices
-    let needToUpdate = false;
+    let needToUpdate = true;
     for (const index in this._allSelectedIndices!) {
       if (this._allSelectedIndices![index] !== previousSelectedIndices![index]) {
         needToUpdate = true;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -241,7 +241,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
           rectHeight = this._dragOrigin.y;
         }
 
-        // constrain rect height to root rect width, if root rect height is valid.
+        // constrain rect height to root rect height, if root rect height is valid.
         if (rootRect.width > 0) {
           if (rectTop + rectHeight > rootRect.height) {
             rectHeight = rootRect.height - rectTop;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -363,7 +363,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
     }
 
     // set previousSelectedIndices to be all of the selected indices from last time
-    const previousSelectedIndices = this._allSelectedIndices;
+    const previousSelectedIndices = this._allSelectedIndices || {};
     this._allSelectedIndices = {};
 
     // set all indices that are supposed to be selected in _allSelectedIndices

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -225,26 +225,26 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
           y: this._lastMouseEvent!.clientY - rootRect.top
         };
 
-        let rectLeft = Math.min(this._dragOrigin.x, constrainedPoint.x);
-        let rectTop = Math.min(this._dragOrigin.y, constrainedPoint.y);
+        let left = Math.min(this._dragOrigin.x, constrainedPoint.x);
+        let top = Math.min(this._dragOrigin.y, constrainedPoint.y);
 
-        let rectWidth = Math.abs(constrainedPoint.x - this._dragOrigin.x);
-        let rectHeight = Math.abs(constrainedPoint.y - this._dragOrigin.y);
+        let width = Math.abs(constrainedPoint.x - this._dragOrigin.x);
+        let height = Math.abs(constrainedPoint.y - this._dragOrigin.y);
 
-        if (rectLeft < 0) {
-          rectLeft = 0;
-          rectWidth = this._dragOrigin.x;
+        if (left < 0) {
+          left = 0;
+          width = this._dragOrigin.x;
         }
 
-        if (rectTop < 0) {
-          rectTop = 0;
-          rectHeight = this._dragOrigin.y;
+        if (top < 0) {
+          top = 0;
+          height = this._dragOrigin.y;
         }
 
         // constrain rect height to root rect height, if root rect height is valid.
         if (rootRect.width > 0) {
-          if (rectTop + rectHeight > rootRect.height) {
-            rectHeight = rootRect.height - rectTop;
+          if (top + height > rootRect.height) {
+            height = rootRect.height - top;
           }
         }
 
@@ -253,17 +253,12 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
           // since we don't have a width pass down to the element, we use the _scrollableSurface width
           // to constraint the marquee rect to not falls out the right boundary
           const viewportWidth = rootRect.width > 0 ? rootRect.width : this._scrollableSurface!.clientWidth;
-          if (rectLeft + rectWidth > viewportWidth) {
-            rectWidth = viewportWidth - rectLeft;
+          if (left + width > viewportWidth) {
+            width = viewportWidth - left;
           }
         }
 
-        const dragRect = {
-          left: rectLeft,
-          top: rectTop,
-          width: rectWidth,
-          height: rectHeight
-        };
+        const dragRect = { left, top, width, height };
 
         this._evaluateSelection(dragRect, rootRect);
 
@@ -391,7 +386,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
     const previousSelectedIndices = this._allSelectedIndices;
     this._allSelectedIndices = {};
 
-    // set all indices that is supposed to be selected in _allSelectedIndices
+    // set all indices that are supposed to be selected in _allSelectedIndices
     for (const index in this._selectedIndicies!) {
       if (this._selectedIndicies!.hasOwnProperty(index)) {
         this._allSelectedIndices![index] = true;
@@ -406,7 +401,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
 
     // check if needs to update selection, only when current _allSelectedIndices
     // is different than previousSelectedIndices
-    let needToUpdate = true;
+    let needToUpdate = false;
     for (const index in this._allSelectedIndices!) {
       if (this._allSelectedIndices![index] !== previousSelectedIndices![index]) {
         needToUpdate = true;

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -350,10 +350,6 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
       this._itemRectCache = {};
     }
 
-    // Stop change events, clear selection to re-populate.
-    selection.setChangeEvents(false);
-    selection.setAllSelected(false);
-
     for (let i = 0; i < allElements.length; i++) {
       const element = allElements[i];
       const index = element.getAttribute('data-selection-index') as string;
@@ -402,8 +398,10 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
       }
     }
 
-    for (const index of this._preservedIndicies!) {
-      this._allSelectedIndices![index] = true;
+    if (this._preservedIndicies) {
+      for (const index of this._preservedIndicies!) {
+        this._allSelectedIndices![index] = true;
+      }
     }
 
     // check if needs to update selection, only when current _allSelectedIndices
@@ -437,7 +435,5 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
 
       selection.setChangeEvents(true);
     }
-
-    selection.setChangeEvents(true);
   }
 }

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.test.tsx
@@ -19,4 +19,48 @@ describe('MarqueeSelection', () => {
     // Run snapshot test.
     expect(component.getDOMNode()).toMatchSnapshot();
   });
+
+  it('updates the selection when an item is selected', () => {
+    // stub selection implementation to measure number of calls to setIndexSelected.
+    class SelectionStub extends Selection {
+      public numSetIndexSelectedCalls = 0;
+      public setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean): void {
+        this.numSetIndexSelectedCalls++;
+      }
+    }
+
+    const selection = new SelectionStub();
+    // It is necessary to use `mount` here so that mouse events can be properly simulated.
+    const component = mount(
+      <MarqueeSelection selection={selection}>
+        <div className={'itemToSelect'} data-selection-index="0">
+          0
+        </div>
+      </MarqueeSelection>
+    );
+
+    const element = component.getDOMNode();
+    const itemToSelect = element.querySelector('.itemToSelect') as HTMLElement;
+    itemToSelect.getBoundingClientRect = () => {
+      return {
+        top: 10,
+        left: 10,
+        bottom: 90,
+        right: 90,
+        width: 80,
+        height: 80
+      };
+    };
+
+    // Simulate clicking and dragging to select the div.
+    const top = window.document.body;
+    const dragStart = new MouseEvent('mousedown', { button: 0, buttons: 1, clientX: 0, clientY: 0 });
+    top.dispatchEvent(dragStart);
+    const dragEnd = new MouseEvent('mousedown', { button: 0, buttons: 1, clientX: 100, clientY: 100 });
+    top.dispatchEvent(dragEnd);
+
+    component.update();
+
+    expect(selection.numSetIndexSelectedCalls).toEqual(1);
+  });
 });


### PR DESCRIPTION
#### Pull request checklist
#### Description of changes
- List.tsx - Limit number of calls to getBoundingClientRect in to improve perf
- List.tsx - Pass ItemsPerPage to get page height function in 
- List.tsx - add getTotalListHeight() method
- List.Types.ts - add 'isVisible' parameter to IPage so that list owner can know which pages are visible to the user
- MarqueeSelection.tsx - limit selection change updates to only call when the selection actually updates for perf improvement
- MarqeeSelection.tsx - constrain the dragRect to be within the viewport
- TilesList.tsx - Implementing proper support for cellPerPage prop override
- TilesList.tsx - added scrollToIndex method
- TilesList.tsx - added ListProps props so that owner can pass props through to the underlying list






#### Focus areas to test


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9439)