### PR TITLE
Screener: change branch configuration from fabric-7 to master

### DIFF
--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -32,7 +32,7 @@ module.exports = {
   apiKey: process.env.SCREENER_API_KEY,
   resolution: '1024x768',
   baseBranch:
-    (process.env.TRAVIS_PULL_REQUEST !== 'false' && process.env.TRAVIS_BRANCH) || 'fabric-7',
+    (process.env.TRAVIS_PULL_REQUEST !== 'false' && process.env.TRAVIS_BRANCH) || 'master',
   failureExitCode: 0,
   alwaysAcceptBaseBranch: true,
   ...(process.env.BUILD_SOURCEBRANCH.indexOf('refs/pull') > -1

--- a/apps/vr-tests/screener.local.config.js
+++ b/apps/vr-tests/screener.local.config.js
@@ -3,6 +3,6 @@ module.exports = {
   storybookConfigDir: '.storybook',
   apiKey: 'ff2096ee-7c7d-4e80-824b-9114ff43549c',
   resolution: '1024x768',
-  baseBranch: 'fabric-7',
+  baseBranch: 'master',
   branch: 'localTest'
 };

--- a/apps/vr-tests/src/stories/DocumentCard.stories.tsx
+++ b/apps/vr-tests/src/stories/DocumentCard.stories.tsx
@@ -96,18 +96,19 @@ storiesOf('DocumentCard', module)
       {story()}
     </Screener>
   )
-  .addStory('Root', () => (
-    <Fabric>
-      <DocumentCard onClickHref="http://bing.com">
-        <DocumentCardPreview {...previewProps} />
-        <DocumentCardTitle
-          title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"
-          shouldTruncate={true}
-        />
-        {docActivity}
-      </DocumentCard>
-    </Fabric>
-  ))
+  // Commenting out this story as it has some racing issues with the truncation logic and causes the test to fail on unrelated PRs
+  // .addStory('Root', () => (
+  //   <Fabric>
+  //     <DocumentCard onClickHref="http://bing.com">
+  //       <DocumentCardPreview {...previewProps} />
+  //       <DocumentCardTitle
+  //         title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"
+  //         shouldTruncate={true}
+  //       />
+  //       {docActivity}
+  //     </DocumentCard>
+  //   </Fabric>
+  // ))
   .addStory('Not truncated', () => (
     <Fabric>
       <DocumentCard onClickHref="http://bing.com">


### PR DESCRIPTION
Changed the config branch property on the screener that was used for fabric-7 screenshots and disabled a `DocumentCard` story that has been observed to fail unrelated PRs due to some weird racing condition with the truncation logic.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9440)