### PR TITLE
Downgrade rush because it is causing commandline args not to appear in npm run scripts

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -15,7 +15,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.9.0",
+  "rushVersion": "5.6.0",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process


### PR DESCRIPTION
Ever since we upgraded rush to 5.9.0, the `--production` (or indeed any flags from rush commands) are not passed down to the `npm run scripts`. So this makes us not build any minified or AMD builds. I'm downgrading to what we had before to keep building AMD bundles 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9445)