### PR TITLE
Fix export to codepen for fabric 7

### DIFF
--- a/common/changes/@uifabric/example-app-base/codepen7_2019-06-13-18-50.json
+++ b/common/changes/@uifabric/example-app-base/codepen7_2019-06-13-18-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/example-app-base",
+      "comment": "Fix export to codepen in fabric 7",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/example-app-base/src/components/CodepenComponent/CodepenComponent.tsx
+++ b/packages/example-app-base/src/components/CodepenComponent/CodepenComponent.tsx
@@ -15,10 +15,10 @@ const CodepenComponentBase: React.StatelessComponent<ICodepenProps> = props => {
 
   // boilerplate for codepen API
   const htmlContent =
-    '<script src="//unpkg.com/office-ui-fabric-react@beta/dist/office-ui-fabric-react.js"></script>\n<div id="content"></div>';
+    '<script src="//unpkg.com/office-ui-fabric-react@7/dist/office-ui-fabric-react.js"></script>\n<div id="content"></div>';
 
   const headContent =
-    '<script type="text/javascript" src="https://unpkg.com/react@16/umd/react.development.js"></script>\n<script type="text/javascript" src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>';
+    '<script type="text/javascript" src="https://unpkg.com/react@16.8.6/umd/react.development.js"></script>\n<script type="text/javascript" src="https://unpkg.com/react-dom@16.8.6/umd/react-dom.development.js"></script>';
 
   const valueData = {
     title: 'Fabric Example Pen',


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Export to codepen for fabric 7 should load `office-ui-fabric-react@7`. I also changed the React version to be the same specific one we use in our UI (16.8.6).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9450)