### PR TITLE
Add Fabric 7 to homepage dropdown in Fabric 5 website

### DIFF
--- a/apps/fabric-website/src/pages/HomePage/HomePage.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { css, getId } from 'office-ui-fabric-react/lib/Utilities';
-import { Dropdown, IDropdownOption, DropdownMenuItemType } from 'office-ui-fabric-react/lib/Dropdown';
+import { css } from 'office-ui-fabric-react/lib/Utilities';
 import * as stylesImport from './HomePage.module.scss';
 import { getParameterByName, updateUrlParameter } from '../../utilities/location';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { IContextualMenuItem, IContextualMenuStyles } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 
 const styles: any = stylesImport;
@@ -12,10 +11,13 @@ const styles: any = stylesImport;
 const corePackageData = require('../../../node_modules/office-ui-fabric-core/package.json');
 const reactPackageData = require('../../../node_modules/office-ui-fabric-react/package.json');
 
-const versionLinkId = getId('versionLink');
-
 // Update as new Fabric versions are released
 const fabricVersionOptions: IContextualMenuItem[] = [
+  {
+    key: 'C',
+    name: 'Fabric 7',
+    data: '7'
+  },
   {
     key: 'A',
     name: 'Fabric 6',
@@ -24,7 +26,8 @@ const fabricVersionOptions: IContextualMenuItem[] = [
   {
     key: 'B',
     name: 'Fabric 5',
-    data: '5'
+    data: '5',
+    checked: true
   }
 ];
 

--- a/common/changes/@uifabric/fabric-website/2019-06-13-21-51.json
+++ b/common/changes/@uifabric/fabric-website/2019-06-13-21-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Add Fabric 7 to website dropdown",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Add Fabric 7 to homepage dropdown on Fabric 5 website.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9455)