### PR TITLE
Fixing file that caused tslint issue in pre-commit hook validation

### DIFF
--- a/common/changes/@uifabric/migration/tslintErrors_2019-06-13-22-56.json
+++ b/common/changes/@uifabric/migration/tslintErrors_2019-06-13-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/migration",
+      "comment": "Fixing file that caused tslint issue in pre-commit hook validation.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/migration",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/migration/fixtures/7.0.0/searchbox.tsx
+++ b/packages/migration/fixtures/7.0.0/searchbox.tsx
@@ -1,12 +1,16 @@
 import { SearchBox } from 'office-ui-fabric-react';
 
-class SearchBoxFullSizeExample extends React.Component<any, any> {
+class SearchBoxFullSizeExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     return (
       <div className="ms-SearchBoxExample">
-        <SearchBox onChange={() => console.log('onChange called')} />
-        <SearchBox onChange={() => console.log('onChange called')}>Has children...</SearchBox>
+        <SearchBox onChange={this._onChange} />
+        <SearchBox onChange={this._onChange}>Has children...</SearchBox>
       </div>
     );
   }
+
+  private _onChange = () => {
+    console.log('onChange called');
+  };
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

It appears that, on commits where a lot of files have been changed (for example branch merges that had conflicts), the pre-commit hooks are complaining about tslint issues on the use of `any` and `lambdas` on `searchbox.tsx` in the `@uifabric/migration` package. This PR fixes that issue so no one else encounters it.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9459)