### PR TITLE
Fabric 7: Major bump foundation packages.

### DIFF
--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -14,7 +14,7 @@
     "@uifabric/experiments": "^7.0.3",
     "@uifabric/fabric-website-resources": "^7.0.2",
     "@uifabric/fabric-website": "^7.1.1",
-    "@uifabric/foundation-scenarios": "^7.0.0",
+    "@uifabric/foundation-scenarios": "^0.102.0",
     "perf-test": "^7.0.0",
     "test-bundles": "^7.0.0",
     "theming-designer": "^7.0.0",

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -14,7 +14,7 @@
     "@uifabric/experiments": "^7.0.3",
     "@uifabric/fabric-website-resources": "^7.0.2",
     "@uifabric/fabric-website": "^7.1.1",
-    "@uifabric/foundation-scenarios": "^0.102.0",
+    "@uifabric/foundation-scenarios": "^7.0.0",
     "perf-test": "^7.0.0",
     "test-bundles": "^7.0.0",
     "theming-designer": "^7.0.0",

--- a/common/changes/@uifabric/experiments/fix-foundation_2019-06-14-15-00.json
+++ b/common/changes/@uifabric/experiments/fix-foundation_2019-06-14-15-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Major bumping the foundation package.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/foundation/fix-foundation_2019-06-14-15-00.json
+++ b/common/changes/@uifabric/foundation/fix-foundation_2019-06-14-15-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/foundation",
+      "comment": "Major bumping the foundation package. (Though the tooling will report this as a patch.)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/foundation",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/@uifabric/react-cards/fix-foundation_2019-06-14-15-00.json
+++ b/common/changes/@uifabric/react-cards/fix-foundation_2019-06-14-15-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/react-cards",
+      "comment": "Major bumping the foundation package.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "dzearing@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/fix-foundation_2019-06-14-15-00.json
+++ b/common/changes/office-ui-fabric-react/fix-foundation_2019-06-14-15-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Major bumping the foundation package.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -57,7 +57,7 @@
     "@uifabric/charting": "^0.131.2",
     "@uifabric/file-type-icons": "^7.0.3",
     "@uifabric/fluent-theme": "^7.0.2",
-    "@uifabric/foundation": "^0.109.2",
+    "@uifabric/foundation": "^7.0.0",
     "@uifabric/icons": "^7.0.2",
     "@uifabric/merge-styles": "^7.0.2",
     "@uifabric/set-version": "^7.0.0",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/foundation",
-  "version": "0.109.2",
+  "version": "7.0.0",
   "description": "Foundation library for building Fabric components.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.7.13",
-    "@uifabric/foundation": "^0.109.2",
+    "@uifabric/foundation": "^7.0.0",
     "@uifabric/icons": "^7.0.2",
     "@uifabric/merge-styles": "^7.0.2",
     "@uifabric/set-version": "^7.0.0",

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -50,7 +50,7 @@
     "@uifabric/experiments": "^7.0.3",
     "@uifabric/file-type-icons": "^7.0.3",
     "@uifabric/fluent-theme": "^7.0.2",
-    "@uifabric/foundation": "^0.109.2",
+    "@uifabric/foundation": "^7.0.0",
     "@uifabric/set-version": "^7.0.0",
     "@uifabric/styling": "^7.0.2",
     "@uifabric/theme-samples": "^7.0.2",


### PR DESCRIPTION
Older Fabric 6 packages have a range dependency on @uifabric/foundation. This means they end up picking up newer pre-releases of foundation which depends on Fabric 7 utilities! :( :( :(

We need to keep the prerelease foundation in Fabric 6. We need to major bump it for Fabric 7. We need to never, never, never use range dependencies for pre-release packages, ever again.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9467)