### PR TITLE
fixed master screener config to match vso settings rather than travis

### DIFF
--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -31,8 +31,7 @@ module.exports = {
   storybookConfigDir: '.storybook',
   apiKey: process.env.SCREENER_API_KEY,
   resolution: '1024x768',
-  baseBranch:
-    (process.env.TRAVIS_PULL_REQUEST !== 'false' && process.env.TRAVIS_BRANCH) || 'master',
+  baseBranch,
   failureExitCode: 0,
   alwaysAcceptBaseBranch: true,
   ...(process.env.BUILD_SOURCEBRANCH.indexOf('refs/pull') > -1


### PR DESCRIPTION
Screener config got overriden back to travis settings when 7.0 was merged into master. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9471)