### PR TITLE
Card: Making elevation themable by using the effects from theme instead of directly referencing Depths

### DIFF
--- a/common/changes/@uifabric/react-cards/cardElevation_2019-06-14-21-56.json
+++ b/common/changes/@uifabric/react-cards/cardElevation_2019-06-14-21-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/react-cards",
+      "comment": "Card: Making elevation themable by using the effects from theme instead of directly referencing Depths.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/common/changes/@uifabric/react-cards/cardElevation_2019-06-14-21-56.json
+++ b/common/changes/@uifabric/react-cards/cardElevation_2019-06-14-21-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@uifabric/react-cards",
-      "comment": "Card: Making elevation themable by using the effects from theme instead of directly referencing Depths.",
+      "comment": "Card: Making elevation themable by using the effects from theme instead of directly referencing Depths and removing @uifabric/fluent-theme from package.json.",
       "type": "patch"
     }
   ],

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -49,7 +49,6 @@
     "@uifabric/azure-themes": "^7.0.2",
     "@uifabric/experiments": "^7.1.0",
     "@uifabric/file-type-icons": "^7.0.3",
-    "@uifabric/fluent-theme": "^7.0.2",
     "@uifabric/foundation": "^7.0.1",
     "@uifabric/set-version": "^7.0.0",
     "@uifabric/styling": "^7.0.2",

--- a/packages/react-cards/src/components/Card/Card.styles.ts
+++ b/packages/react-cards/src/components/Card/Card.styles.ts
@@ -1,21 +1,24 @@
 import { getGlobalClassNames, HighContrastSelector } from '@uifabric/styling';
-import { Depths } from '@uifabric/fluent-theme';
 import { ICardComponent, ICardStylesReturnType, ICardTokenReturnType } from './Card.types';
 
 const GlobalClassNames = {
   root: 'ms-Card'
 };
 
-const baseTokens: ICardComponent['tokens'] = {
-  boxShadow: Depths.depth4,
-  childrenGap: 12,
-  childrenMargin: 0,
-  cursor: 'default',
-  height: 'inherit',
-  highContrastBoxShadow: '0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight',
-  minHeight: '348px',
-  minWidth: '212px',
-  maxWidth: '286px'
+const baseTokens: ICardComponent['tokens'] = (props, theme) => {
+  const { effects } = theme;
+
+  return {
+    boxShadow: effects.elevation4,
+    childrenGap: 12,
+    childrenMargin: 0,
+    cursor: 'default',
+    height: 'inherit',
+    highContrastBoxShadow: '0 1.6px 3.6px 0 Highlight, 0 0.3px 0.9px 0 Highlight',
+    minHeight: '348px',
+    minWidth: '212px',
+    maxWidth: '286px'
+  };
 };
 
 const compactTokens: ICardComponent['tokens'] = {
@@ -24,10 +27,14 @@ const compactTokens: ICardComponent['tokens'] = {
   maxWidth: '500px'
 };
 
-const clickableTokens: ICardComponent['tokens'] = {
-  boxShadowHovered: Depths.depth8,
-  cursor: 'pointer',
-  highContrastBoxShadowHovered: '0 3.2px 7.2px 0 Highlight, 0 0.6px 1.8px 0 Highlight'
+const clickableTokens: ICardComponent['tokens'] = (props, theme) => {
+  const { effects } = theme;
+
+  return {
+    boxShadowHovered: effects.elevation8,
+    cursor: 'pointer',
+    highContrastBoxShadowHovered: '0 3.2px 7.2px 0 Highlight, 0 0.6px 1.8px 0 Highlight'
+  };
 };
 
 export const CardTokens: ICardComponent['tokens'] = (props, theme): ICardTokenReturnType => [

--- a/packages/react-cards/src/demo/customizations.ts
+++ b/packages/react-cards/src/demo/customizations.ts
@@ -1,11 +1,9 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
-import { FluentCustomizations } from '@uifabric/fluent-theme';
 import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
 import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Default', customizations: DefaultCustomizations },
-  { title: 'Fluent', customizations: FluentCustomizations },
   { title: 'Word', customizations: WordCustomizations },
   { title: 'Teams', customizations: TeamsCustomizations },
   { title: 'Azure', customizations: AzureCustomizationsLight },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9169
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`Card's` elevation/box-shadow wasn't themable because it was directly referencing `Depths`. This PR changes that so that `Card` uses the `effect` provided via the `theme` instead.

This PR also removes `@uifabric/fluent-theme` from `package.json` and `customizations.ts` as we're not using it anymore for `Depths` and, given that `Card` is _Fluent by Default_, we shouldn't need a Fluent customization in the demos, hence why we don't need the package dependency anymore.

#### Focus areas to test

Because the correct `effects` have been chosen there shouldn't be any differences and this PR should comply with all of `Card's` snapshot and visual regression tests.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9472)