### PR TITLE
a11y-tests: Run a11y tests on all component examples

### DIFF
--- a/apps/a11y-tests/src/getSarifReport.ts
+++ b/apps/a11y-tests/src/getSarifReport.ts
@@ -3,6 +3,8 @@ import { AxePuppeteer } from 'axe-puppeteer';
 import * as puppeteer from 'puppeteer';
 import { convertAxeToSarif, SarifLog } from 'axe-sarif-converter';
 import { Stylesheet, InjectionMode, resetIds } from 'office-ui-fabric-react';
+import * as path from 'path';
+import * as os from 'os';
 
 const disabledAxeRules = ['document-title', 'html-has-lang', 'landmark-one-main', 'page-has-heading-one', 'region', 'bypass'];
 
@@ -25,7 +27,9 @@ function renderTestHtml(element: React.ReactElement<any>): string {
 
 /* tslint:disable-next-line:no-any */
 export async function getSarifReport(element: React.ReactElement<any>): Promise<SarifLog> {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    userDataDir: path.resolve(os.tmpdir(), 'oufr-a11y-test-profile')
+  });
 
   const page = await browser.newPage();
   const testHtml = renderTestHtml(element);

--- a/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
+++ b/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
@@ -6,6 +6,8 @@ import { getSarifReport } from '../getSarifReport';
 import { SarifLog } from 'axe-sarif-converter/dist/sarif/sarif-log';
 import { Result } from 'axe-sarif-converter/dist/sarif/sarif-2.0.0';
 
+const ReactDOM = require('react-dom');
+
 // Keep only errors to reduce snapshot size
 function dehydrateSarifReport(report: SarifLog): Result[] {
   return report.runs[0]!.results!.filter(item => item.level === 'error');
@@ -31,28 +33,67 @@ function getControlAndPageName(exampleFilePath: string): [string, string] {
   return [match[1], match[2]];
 }
 
-// List of controls we expose to a11y tests
-const enabledControls: string[] = ['Button', 'TextField'];
-const files: string[] = [];
+const excludedExampleFiles: string[] = ['Keytips.Basic.Example', 'List.Basic.Example', 'Picker.CustomResult.Example'];
 
-enabledControls.forEach((control: string) => {
+/* tslint:disable-next-line:no-any */
+declare const global: any;
+
+describe('a11y test', () => {
+  const constantDate = new Date(Date.UTC(2017, 0, 6, 4, 41, 20));
+
+  beforeAll(() => {
+    // Mock createPortal to capture its component hierarchy in snapshot output.
+    ReactDOM.createPortal = jest.fn(element => {
+      return element;
+    });
+
+    // Ensure test output is consistent across machine locale and time zone config.
+    const mockToLocaleString = () => {
+      return constantDate.toUTCString();
+    };
+
+    global.Date.prototype.toLocaleString = mockToLocaleString;
+    global.Date.prototype.toLocaleTimeString = mockToLocaleString;
+    global.Date.prototype.toLocaleDateString = mockToLocaleString;
+
+    // Prevent random and time elements from failing repeated tests.
+    global.Date = class {
+      public static now() {
+        return constantDate;
+      }
+
+      constructor() {
+        return constantDate;
+      }
+    };
+
+    jest.spyOn(Math, 'random').mockImplementation(() => {
+      return 0;
+    });
+  });
+
+  const files: string[] = [];
   const exampleFiles: string[] = glob.sync(
-    path.resolve(process.cwd(), `node_modules/office-ui-fabric-react/lib-commonjs/components/${control}/examples/*Example*.js`)
+    path.resolve(process.cwd(), `node_modules/office-ui-fabric-react/lib-commonjs/components/**/examples/*Example*.js`)
   );
   files.push(...exampleFiles);
-});
 
-files.forEach((componentFile: string) => {
-  const componentModule = require(componentFile);
-  const [controlName, pageName] = getControlAndPageName(componentFile);
-  Object.keys(componentModule)
-    .filter(key => typeof componentModule[key] === 'function')
-    .forEach(key => {
-      const ComponentUnderTest: React.ComponentClass = componentModule[key];
-      testComponent({
-        name: controlName,
-        pageName: pageName,
-        elem: <ComponentUnderTest />
-      });
+  files
+    .filter((componentFile: string) => {
+      return !excludedExampleFiles.some(excludedFile => componentFile.indexOf('/' + excludedFile) !== -1);
+    })
+    .forEach((componentFile: string) => {
+      const componentModule = require(componentFile);
+      const [controlName, pageName] = getControlAndPageName(componentFile);
+      Object.keys(componentModule)
+        .filter(key => typeof componentModule[key] === 'function')
+        .forEach(key => {
+          const ComponentUnderTest: React.ComponentClass = componentModule[key];
+          testComponent({
+            name: controlName,
+            pageName: pageName,
+            elem: <ComponentUnderTest />
+          });
+        });
     });
 });

--- a/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
+++ b/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
@@ -17,14 +17,17 @@ function dehydrateSarifReport(report: SarifLog): Result[] {
 async function testComponent(component: { name: string; pageName: string; elem: React.ReactElement<any> }) {
   it(`checks accessibility of ${component.name} (${component.pageName})`, async () => {
     const sarifReport: SarifLog = await getSarifReport(component.elem);
+    const errors = dehydrateSarifReport(sarifReport);
 
-    // Save the report into `dist/reports` folder
-    fs.writeFileSync(path.resolve(__dirname, `../../dist/reports/${component.pageName}.sarif`), JSON.stringify(sarifReport), {
-      encoding: 'utf8'
-    });
+    // Save the report into `dist/reports` folder (only when there're errors)
+    if (errors.length > 0) {
+      fs.writeFileSync(path.resolve(__dirname, `../../dist/reports/${component.pageName}.sarif`), JSON.stringify(sarifReport), {
+        encoding: 'utf8'
+      });
+    }
 
     // Match the 'errors' section with snapshot
-    expect(dehydrateSarifReport(sarifReport)).toMatchSnapshot();
+    expect(errors).toMatchSnapshot();
   });
 }
 

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -1,12 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`checks accessibility of Button (Button.Action.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Basic.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.Anchor.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Compact.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.Command.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Persona.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.CommandBar.Example) 1`] = `
+exports[`a11y test checks accessibility of Announced (Announced.BulkOperations.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Announced (Announced.LazyLoading.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Announced (Announced.QuickActions.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Announced (Announced.SearchResults.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Static.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.Action.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.Anchor.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.Command.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.CommandBar.Example) 1`] = `
 Array [
   Object {
     "level": "error",
@@ -53,11 +71,11 @@ Array [
 ]
 `;
 
-exports[`checks accessibility of Button (Button.Compound.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Compound.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.ContextualMenu.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.ContextualMenu.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.CustomSplit.Example) 1`] = `
+exports[`a11y test checks accessibility of Button (Button.CustomSplit.Example) 1`] = `
 Array [
   Object {
     "level": "error",
@@ -226,15 +244,15 @@ Fix any of the following:
 ]
 `;
 
-exports[`checks accessibility of Button (Button.Default.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Default.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.Icon.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Icon.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.Primary.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Primary.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.ScreenReader.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.ScreenReader.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of Button (Button.Split.Example) 1`] = `
+exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `
 Array [
   Object {
     "level": "error",
@@ -505,7 +523,7 @@ Array [
 ]
 `;
 
-exports[`checks accessibility of Button (Button.Split.Example) 2`] = `
+exports[`a11y test checks accessibility of Button (Button.Split.Example) 2`] = `
 Array [
   Object {
     "level": "error",
@@ -674,9 +692,11 @@ Fix any of the following:
 ]
 `;
 
-exports[`checks accessibility of Button (Button.Toggle.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Toggle.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of TextField (TextField.Basic.Example) 1`] = `
+exports[`a11y test checks accessibility of Calendar (Calendar.Button.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Calendar (Calendar.Inline.Example) 1`] = `
 Array [
   Object {
     "level": "error",
@@ -685,7 +705,7973 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField12\\" required=\\"\\" value=\\"\\" class=\\"ms-TextField-field field-6\\" aria-invalid=\\"false\\">",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"June 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jan</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"June\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(1)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"June\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(1)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"February 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Feb</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(2)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(2)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"November 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Mar</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"November\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(3)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"November\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(3)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"September 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Apr</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"September\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(4)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"September\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(4)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"August 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">May</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(5)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(5)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"August 2019\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" type=\\"button\\">Jun</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(6)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(6)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"September 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jul</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"September\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(7)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"September\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(7)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"November 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Aug</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"November\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(8)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"November\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(8)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"February 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Sep</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(9)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(9)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"June 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Oct</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"June\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(10)",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"June\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(10)",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"November 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Nov</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-label=\\"November\\\\ 2020\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-label=\\"November\\\\ 2020\\"]",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2021\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Dec</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-label=\\"May\\\\ 2021\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-label=\\"May\\\\ 2021\\"]",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<table class=\\"ms-DatePicker-table\\" aria-readonly=\\"true\\" aria-multiselectable=\\"false\\" aria-labelledby=\\"DatePickerDay-monthAndYear2\\" aria-activedescendant=\\"DatePickerDay-active0\\" role=\\"grid\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "table",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-activedescendant=\\"DatePickerDay-active0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-activedescendant=\\"DatePickerDay-active0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "table",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Callout (Callout.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Callout (Callout.Cover.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Callout (Callout.Directional.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Callout (Callout.FocusTrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Callout (Callout.Nested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Checkbox (Checkbox.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Checkbox (Checkbox.Other.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Custom.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Icon.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Image.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Label.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Coachmark (Coachmark.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Coachmark/PositioningContainer (PositioningContainer.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ColorPicker (ColorPicker.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<label id=\\"ComboBox23-label\\" for=\\"ComboBox23-input\\" class=\\"ms-Label root-30\\">Disabled ComboBox</label>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#ComboBox23-label",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#ComboBox23-label",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Controlled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.CustomStyled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Toggles.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Virtualized.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of CommandBar (CommandBar.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of CommandBar (CommandBar.ButtonAs.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of CommandBar (CommandBar.CommandBarButtonAs.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of CommandBar (CommandBar.CommandBarButtonAs.Example) 2`] = `Array []`;
+
+exports[`a11y test checks accessibility of CommandBar (CommandBar.SplitDisabled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Checkmarks.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.CustomMenuItem.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.CustomMenuList.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Customization.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.CustomizationWithNoWrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Directional.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Header.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Icon.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Icon.SecondaryText.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Persisted.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.ScrollBar.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Section.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Submenu.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.Bounded.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.Disabled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.Format.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.Input.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.Required.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DatePicker (DatePicker.WeekNumbers.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.Advanced.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.Compact.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomColumns.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<span id=\\"header0-thumbnail\\" aria-labelledby=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellTitle cellTitle-38\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"false\\"><span id=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellName cellName-39\\"></span></span>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#header0-thumbnail",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#header0-thumbnail",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomFooter.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomGroupHeaders.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomRows.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.Documents.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.DragDrop.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.Grouped.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.Grouped.Large.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DetailsList (DetailsList.NavigatingFocus.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dialog (Dialog.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Dialog (Dialog.Blocking.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Dialog (Dialog.LargeHeader.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Dialog (Dialog.Modeless.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__1\\" aria-describedby=\\"id__2\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__1\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__2\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__1\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__4\\" aria-describedby=\\"id__5\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__4\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__5\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__4\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" placeholder=\\"Focus Me While Open\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "input[type=\\"text\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "input[type=\\"text\\"]",
+      "ruleId": "label",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Dialog (Dialog.TopOffsetFixed.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Divider (VerticalDivider.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Divider (VerticalDivider.Custom.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DocumentCard (DocumentCard.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DocumentCard (DocumentCard.Compact.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DocumentCard (DocumentCard.Complete.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DocumentCard (DocumentCard.Conversation.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of DocumentCard (DocumentCard.Image.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dropdown (Dropdown.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dropdown (Dropdown.Controlled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dropdown (Dropdown.ControlledMulti.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dropdown (Dropdown.Custom.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dropdown (Dropdown.Error.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Dropdown (Dropdown.Required.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ExtendedPicker (ExtendedPeoplePicker.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-BasePicker-text",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA child role not present: listitem",
+      "text": "Fix any of the following: Required ARIA child role not present: listitem.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-BasePicker-text",
+      "ruleId": "aria-required-children",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-children",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-owns=\\"suggestion-list\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "input",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "input",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of ExtendedPicker (ExtendedPeoplePicker.Controlled.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-BasePicker-text",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA child role not present: listitem",
+      "text": "Fix any of the following: Required ARIA child role not present: listitem.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-BasePicker-text",
+      "ruleId": "aria-required-children",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-children",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-owns=\\"suggestion-list\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "input",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "input",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Facepile (Facepile.AddFace.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Facepile (Facepile.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Facepile (Facepile.Overflow.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FloatingPicker/PeoplePicker (FloatingPeoplePicker.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Click.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.FocusOnCustomElement.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.DialogInPanel.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.FocusZone.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Nested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Disabled.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#TextField7",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#TextField7",
+      "ruleId": "label",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField23\\" value=\\"Tabbable Element 2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#TextField23",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#TextField23",
+      "ruleId": "label",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.List.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"0\\" data-item-index=\\"0\\" aria-rowindex=\\"1\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\30 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\30 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"1\\" data-item-index=\\"1\\" aria-rowindex=\\"2\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone5\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\31 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\31 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"2\\" data-item-index=\\"2\\" aria-rowindex=\\"3\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone9\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\32 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\32 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"3\\" data-item-index=\\"3\\" aria-rowindex=\\"4\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone13\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\33 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\33 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"4\\" data-item-index=\\"4\\" aria-rowindex=\\"5\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone17\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\34 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\34 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"5\\" data-item-index=\\"5\\" aria-rowindex=\\"6\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone21\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\35 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\35 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"6\\" data-item-index=\\"6\\" aria-rowindex=\\"7\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone25\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\36 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\36 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"7\\" data-item-index=\\"7\\" aria-rowindex=\\"8\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone29\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\37 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\37 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"8\\" data-item-index=\\"8\\" aria-rowindex=\\"9\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone33\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\38 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\38 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"9\\" data-item-index=\\"9\\" aria-rowindex=\\"10\\" data-is-draggable=\\"false\\" draggable=\\"false\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone37\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\39 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\39 \\"]",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Photos.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element does not have an alt attribute
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element has no title attribute or the title attribute is empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
+      "ruleId": "image-alt",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "image-alt",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"1\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"2\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"3\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"4\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"5\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"6\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"7\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"8\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"9\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"10\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"11\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"12\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"13\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"14\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"15\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"16\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"17\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"18\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"19\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"20\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"]",
+      "ruleId": "listitem",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "listitem",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Tabbable.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#TextField7",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#TextField7",
+      "ruleId": "label",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField26\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#TextField26",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#TextField26",
+      "ruleId": "label",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of GroupedList (GroupedList.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of GroupedList (GroupedList.Custom.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of HoverCard (HoverCard.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of HoverCard (HoverCard.InstantDismiss.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of HoverCard (HoverCard.PlainCard.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of HoverCard (HoverCard.Target.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Icon (Icon.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Icon (Icon.Color.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Icon (Icon.ImageSheet.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Icon (Icon.Svg.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.Center.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.CenterContain.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.CenterCover.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.Contain.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.Cover.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.Default.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.MaximizeFrame.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Image (Image.None.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Keytip (Keytips.Button.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-1-a\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-1-a\\" data-ktp-execute-target=\\"ktp-1-a\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-2-a\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-2-a\\" data-ktp-execute-target=\\"ktp-2-a\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div aria-describedby=\\"ktp-layer-id ktp-2-b\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-2-b\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-18\\" tabindex=\\"0\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".css-18",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".css-18",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-29\\" aria-describedby=\\"ktp-layer-id ktp-0-0\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-0\\" data-ktp-execute-target=\\"ktp-0-0\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".root-29",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".root-29",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-0-1\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-1\\" data-ktp-execute-target=\\"ktp-0-1\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" data-ktp-execute-target=\\"ktp-2-b\\" tabindex=\\"-1\\" class=\\"ms-Button root-22\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".root-22",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".root-22",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Keytip (Keytips.CommandBar.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Keytip (Keytips.Overflow.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" name=\\"Link 1\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-q\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-q\\" data-ktp-execute-target=\\"ktp-q\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 1\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 1\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" name=\\"Link 2\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-w\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-w\\" data-ktp-execute-target=\\"ktp-w\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 2\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 2\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" name=\\"Link 3\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-e\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-e\\" data-ktp-execute-target=\\"ktp-e\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 3\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 3\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".root-11",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".root-11",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".root-11",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".root-11",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Label (Label.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<label class=\\"ms-Label root-1\\">I'm a disabled Label</label>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".root-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".root-1",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Layer (Layer.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Layer (Layer.Customized.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Layer (Layer.Hosted.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Layer (Layer.NestedLayers.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Link (Link.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of List (List.Ghosting.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of List (List.Grid.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of List (List.Scrolling.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField14\\" value=\\"0\\" class=\\"ms-TextField-field field-32\\" aria-invalid=\\"false\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#TextField14",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Form element does not have an implicit (wrapped) &lt;label>
+- Form element does not have an explicit &lt;label>
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#TextField14",
+      "ruleId": "label",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "label",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of MarqueeSelection (MarqueeSelection.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<ul>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "ul",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- List element has direct children that are not allowed inside &lt;li> elements",
+      "text": "Fix all of the following: List element has direct children that are not allowed inside <li> elements.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "ul",
+      "ruleId": "list",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "list",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of MessageBar (MessageBar.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of MessageBar (MessageBar.Styled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Modal (Modal.Modeless.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Nav (Nav.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-Nav-linkText linkText-1\\">Documents</div>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "text": "Fix any of the following: Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
+      "ruleId": "color-contrast",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "color-contrast",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Nav (Nav.CustomGroupHeaders.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Nav (Nav.FabricDemoApp.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Nav (Nav.Nested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-Button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-Button",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Custom.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-20\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".root-20",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".root-20",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Vertical.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Add\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Upload\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Share\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-haspopup=\\"true\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-haspopup=\\"true\\"]",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Overlay (Overlay.Dark.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Overlay (Overlay.Light.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Controlled.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Custom.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.CustomLeft.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.ExtraLarge.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.HandleDismissTarget.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.HiddenOnDismiss.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Large.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.LargeFixed.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.LightDismiss.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.LightDismissCustom.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Medium.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.NonModal.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.PreventDefault.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Scroll.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.SmallFluid.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.SmallLeft.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.SmallRight.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Persona (Persona.Alternate.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Persona (Persona.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Persona (Persona.Colors.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Persona (Persona.CustomCoinRender.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Persona (Persona.CustomRender.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Persona (Persona.Initials.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Persona (Persona.UnknownPersona.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Fabric.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"Pivot0-Tab2\\" class=\\"ms-Button ms-Button--action ms-Button--command ms-Pivot-link link-17\\" role=\\"tab\\" aria-selected=\\"false\\" data-content=\\" xx\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Pivot0-Tab2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Pivot0-Tab2",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Large.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.OnChange.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Override.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Remove.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Separate.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div aria-labelledby=\\"ShapeColorPivot_rectangleRed\\" role=\\"tabitem\\" style=\\"float:left;width:100px;height:200px;background:red\\"></div>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Role must be one of the valid ARIA roles",
+      "text": "Fix all of the following: Role must be one of the valid ARIA roles.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
+      "ruleId": "aria-roles",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-roles",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.SeparateNoSelectedKey.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-15\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-16\\"><i data-icon-name=\\"Settings\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-21\\" style=\\"color:blue\\"></i></div></button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-Button--icon",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Element is in tab order and does not have accessible text
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty
+- Element has no value attribute or the value attribute is empty
+- Element does not have inner text that is visible to screen readers
+- aria-label attribute does not exist or is empty
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+- Element's default semantics were not overridden with role=\\"presentation\\"
+- Element's default semantics were not overridden with role=\\"none\\"
+- Element has no title attribute or the title attribute is empty",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-Button--icon",
+      "ruleId": "button-name",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "button-name",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.Tabs.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.TabsLarge.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ProgressIndicator (ProgressIndicator.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ProgressIndicator (ProgressIndicator.Indeterminate.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Rating (Rating.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-0\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-1\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-2\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-3\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-4\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-0\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating3-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating3-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-1\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating3-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating3-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-2\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating3-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating3-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-3\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating3-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating3-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-4\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating3-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating3-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-0\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-1\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-2\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-3\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-4\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-5\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-5",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-5",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-6\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-6",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-6",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-7\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-7",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-7",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-8\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-8",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-8",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-9\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating6-star-9",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating6-star-9",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-0\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating9-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating9-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating9-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating9-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-2\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating9-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating9-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating9-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating9-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating9-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating9-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating12-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating12-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating12-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating12-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-2\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating12-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating12-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating12-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating12-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating12-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating12-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating15-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating15-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating15-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating15-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-2\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating15-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating15-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating15-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating15-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating15-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating15-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-0\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating18-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating18-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-1\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating18-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating18-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-2\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating18-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating18-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-3\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating18-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating18-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-4\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating18-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating18-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Rating (Rating.ButtonControlled.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-2\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#Rating0-star-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#Rating0-star-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.FlexBox.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.OverflowSet.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.VerticalOverflowSet.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.Default.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.DetailsList.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SearchBox (SearchBox.CustomIcon.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Disabled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SearchBox (SearchBox.FullSize.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Small.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Underlined.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SelectedItemsList (SelectedPeopleList.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-PickerPersona-container\\" data-is-focusable=\\"true\\" data-is-sub-focuszone=\\"true\\" data-selection-index=\\"0\\" role=\\"listitem\\" aria-labelledby=\\"selectedItemPersona-id__3\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parent role not present: list",
+      "text": "Fix any of the following: Required ARIA parent role not present: list.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of SelectedItemsList (SelectedPeopleList.Controlled.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-PickerPersona-container\\" data-is-focusable=\\"true\\" data-is-sub-focuszone=\\"true\\" data-selection-index=\\"0\\" role=\\"listitem\\" aria-labelledby=\\"selectedItemPersona-id__3\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA parent role not present: list",
+      "text": "Fix any of the following: Required ARIA parent role not present: list.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
+      "ruleId": "aria-required-parent",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-parent",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Separator (Separator.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Separator (Separator.Icon.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Separator (Separator.Theming.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Shimmer (Shimmer.Application.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Shimmer (Shimmer.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Shimmer (Shimmer.CustomElements.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Shimmer (Shimmer.LoadData.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Shimmer (Shimmer.Styling.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Slider (Slider.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Slider (Slider.Vertical.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.BasicDisabled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.BasicWithEndPosition.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.BasicWithIcon.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.BasicWithIconDisabled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.CustomStyled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SpinButton (SpinButton.Stateful.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" value=\\"7 cm\\" id=\\"input1\\" class=\\"ms-spinButton-input css-5\\" autocomplete=\\"off\\" role=\\"spinbutton\\" aria-labelledby=\\"Label0\\" aria-valuetext=\\"7 cm\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-disabled=\\"false\\" data-lpignore=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#input1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- Required ARIA attribute not present: aria-valuenow",
+      "text": "Fix any of the following: Required ARIA attribute not present: aria-valuenow.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#input1",
+      "ruleId": "aria-required-attr",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-required-attr",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Spinner (Spinner.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Spinner (Spinner.Labeled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Configure.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Grow.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.HorizontalAlign.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Reversed.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Shrink.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Spacing.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.VerticalAlign.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.Wrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.WrapAdvanced.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Horizontal.WrapNested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Configure.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Grow.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.HorizontalAlign.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Reversed.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Shrink.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Spacing.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.VerticalAlign.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.Wrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.WrapAdvanced.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Stack (Stack.Vertical.WrapNested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of SwatchColorPicker (SwatchColorPicker.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker0-a-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker0-a-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker0-b-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker0-b-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker0-c-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker0-c-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker0-d-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker0-d-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-9\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker0-e-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker0-e-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker18-a-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker18-a-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker18-b-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker18-b-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker18-c-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker18-c-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker18-d-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker18-d-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-14\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker18-e-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker18-e-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker36-a-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker36-a-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker36-b-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker36-b-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker36-c-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker36-c-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker36-d-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker36-d-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-18\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker36-e-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker36-e-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"red\\" aria-label=\\"red\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-a-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-a-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-b-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-b-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orangeYellow\\" aria-label=\\"orangeYellow\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-c-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-c-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"yellowGreen\\" aria-label=\\"yellowGreen\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-d-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-d-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"green\\" aria-label=\\"green\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-e-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-e-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-f-5\\" data-index=\\"5\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-f-5",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-f-5",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-g-6\\" data-index=\\"6\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyanBlue\\" aria-label=\\"cyanBlue\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-g-6",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-g-6",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-h-7\\" data-index=\\"7\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-h-7",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-h-7",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-i-8\\" data-index=\\"8\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magentaPink\\" aria-label=\\"magentaPink\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-i-8",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-i-8",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-j-9\\" data-index=\\"9\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"black\\" aria-label=\\"black\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-j-9",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-j-9",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-k-10\\" data-index=\\"10\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray\\" aria-label=\\"gray\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-k-10",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-k-10",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-l-11\\" data-index=\\"11\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray20\\" aria-label=\\"gray20\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker54-l-11",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker54-l-11",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-a-0\\" data-index=\\"0\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" disabled=\\"\\" aria-label=\\"orange\\" aria-disabled=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker93-a-0",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker93-a-0",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-b-1\\" data-index=\\"1\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" disabled=\\"\\" aria-label=\\"cyan\\" aria-disabled=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker93-b-1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker93-b-1",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-c-2\\" data-index=\\"2\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" disabled=\\"\\" aria-label=\\"blueMagenta\\" aria-disabled=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker93-c-2",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker93-c-2",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-d-3\\" data-index=\\"3\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" disabled=\\"\\" aria-label=\\"magenta\\" aria-disabled=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker93-d-3",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker93-d-3",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-e-4\\" data-index=\\"4\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-24\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" disabled=\\"\\" aria-label=\\"white\\" aria-disabled=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#swatchColorPicker93-e-4",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#swatchColorPicker93-e-4",
+      "ruleId": "aria-allowed-role",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-allowed-role",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Condensed.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Illustration.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.SmallHeadline.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.WideIllustration.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Text (Text.Block.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Text (Text.Ramp.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Text (Text.Wrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField12\\" required=\\"\\" value=\\"\\" class=\\"ms-TextField-field field-5\\" aria-invalid=\\"false\\">",
             },
           },
         ],
@@ -720,11 +8706,11 @@ Array [
 ]
 `;
 
-exports[`checks accessibility of TextField (TextField.Borderless.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.Borderless.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of TextField (TextField.Controlled.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.Controlled.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `
+exports[`a11y test checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `
 Array [
   Object {
     "level": "error",
@@ -838,13 +8824,13 @@ Array [
 ]
 `;
 
-exports[`checks accessibility of TextField (TextField.ErrorMessage.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.ErrorMessage.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of TextField (TextField.Masked.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.Masked.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of TextField (TextField.Multiline.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.Multiline.Example) 1`] = `Array []`;
 
-exports[`checks accessibility of TextField (TextField.PrefixAndSuffix.Example) 1`] = `
+exports[`a11y test checks accessibility of TextField (TextField.PrefixAndSuffix.Example) 1`] = `
 Array [
   Object {
     "level": "error",
@@ -884,4 +8870,287 @@ Array [
 ]
 `;
 
-exports[`checks accessibility of TextField (TextField.Styled.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.Styled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Toggle (Toggle.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Absolute.Position.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"targetButton1\\" aria-labelledby=\\"tooltipHost0\\" style=\\"position:absolute;top:50px;left:200px\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "#targetButton1",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "#targetButton1",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Custom.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Display.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost10\\">Hover Over Me</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost10\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost10\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost21\\">Hover Over Me</button>",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost21\\"]",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost21\\"]",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Interactive.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.NoScroll.Example) 1`] = `
+Array [
+  Object {
+    "level": "error",
+    "locations": Array [
+      Object {
+        "annotations": Array [
+          Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"text-tooltip0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        ],
+        "fullyQualifiedLogicalName": "button",
+        "physicalLocation": Object {
+          "fileLocation": Object {
+            "uri": "about:blank",
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "richText": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\"",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
+    },
+    "partialFingerprints": Object {
+      "fullyQualifiedLogicalName": "button",
+      "ruleId": "aria-valid-attr-value",
+    },
+    "properties": Object {
+      "tags": Array [
+        "Accessibility",
+      ],
+    },
+    "ruleId": "aria-valid-attr-value",
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Overflow.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers (TagPicker.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Types.Example) 1`] = `Array []`;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This PR expands the scope of a11y tests from previous Button & TextField to all component examples (heavily borrowed mocks and routines from https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx).

Also resolves an issue where parallel jest execution can cause `fixWinEPERM` errors due to https://github.com/GoogleChrome/puppeteer/issues/298

#### Focus areas to test

As always, the stability of a11y snapshots has to be monitored after check in.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9479)