### PR TITLE
Add condition for Edge browser to detect placeholder styles

### DIFF
--- a/common/changes/@uifabric/date-time/placeholder-edge_2019-06-18-01-08.json
+++ b/common/changes/@uifabric/date-time/placeholder-edge_2019-06-18-01-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "update snapshots",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "afhassan@microsoft.com"
+}

--- a/common/changes/@uifabric/experiments/placeholder-edge_2019-06-18-03-25.json
+++ b/common/changes/@uifabric/experiments/placeholder-edge_2019-06-18-03-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@uifabric/experiments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "afhassan@microsoft.com"
+}

--- a/common/changes/@uifabric/styling/placeholder-edge_2019-06-18-01-08.json
+++ b/common/changes/@uifabric/styling/placeholder-edge_2019-06-18-01-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add getPlaceholderStyles to return style object based on browser used",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "afhassan@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/placeholder-edge_2019-06-17-21-56.json
+++ b/common/changes/office-ui-fabric-react/placeholder-edge_2019-06-17-21-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TextField: Add condition for Edge browser to detect placeholder styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/placeholder-edge_2019-06-18-01-08.json
+++ b/common/changes/office-ui-fabric-react/placeholder-edge_2019-06-18-01-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "office-ui-fabric-react",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -145,6 +145,15 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -121,6 +121,12 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -147,12 +153,6 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="DatePicker0-label"
             onBlur={[Function]}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -127,33 +127,6 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -122,15 +122,30 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -121,6 +121,18 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1357,15 +1357,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -1388,12 +1379,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           }
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
@@ -1458,6 +1443,9 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1380,6 +1380,15 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -1443,6 +1452,15 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -395,6 +395,15 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
                     id="TextField0"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -535,6 +544,15 @@ exports[`ColorPicker renders correctly 1`] = `
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
                           color: #605e5c;
@@ -691,6 +709,15 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
                     id="TextField6"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -839,6 +866,15 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
                     id="TextField9"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -979,6 +1015,15 @@ exports[`ColorPicker renders correctly 1`] = `
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
                           color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -371,6 +371,12 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &:active, &:focus, &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -397,12 +403,6 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
-                        }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
-                        }
-                        &::-ms-clear {
-                          display: none;
                         }
                     id="TextField0"
                     onBlur={[Function]}
@@ -528,6 +528,12 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &:active, &:focus, &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -554,12 +560,6 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
-                        }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
-                        }
-                        &::-ms-clear {
-                          display: none;
                         }
                     id="TextField3"
                     onBlur={[Function]}
@@ -685,6 +685,12 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &:active, &:focus, &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -711,12 +717,6 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
-                        }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
-                        }
-                        &::-ms-clear {
-                          display: none;
                         }
                     id="TextField6"
                     onBlur={[Function]}
@@ -842,6 +842,12 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &:active, &:focus, &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -868,12 +874,6 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
-                        }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
-                        }
-                        &::-ms-clear {
-                          display: none;
                         }
                     id="TextField9"
                     onBlur={[Function]}
@@ -999,6 +999,12 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &:active, &:focus, &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -1025,12 +1031,6 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
-                        }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
-                        }
-                        &::-ms-clear {
-                          display: none;
                         }
                     id="TextField12"
                     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -377,33 +377,6 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
-                        &::placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &::-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
                     id="TextField0"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -533,33 +506,6 @@ exports[`ColorPicker renders correctly 1`] = `
                         }
                         &::-ms-clear {
                           display: none;
-                        }
-                        &::placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &::-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
                         }
                     id="TextField3"
                     onBlur={[Function]}
@@ -691,33 +637,6 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
-                        &::placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &::-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
                     id="TextField6"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -848,33 +767,6 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
-                        &::placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &::-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
                     id="TextField9"
                     onBlur={[Function]}
                     onChange={[Function]}
@@ -1004,33 +896,6 @@ exports[`ColorPicker renders correctly 1`] = `
                         }
                         &::-ms-clear {
                           display: none;
-                        }
-                        &::placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &::-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
                         }
                     id="TextField12"
                     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -371,6 +371,18 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &::placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
                         &:active, &:focus, &:hover {
                           outline: 0px;
                         }
@@ -500,6 +512,18 @@ exports[`ColorPicker renders correctly 1`] = `
                           padding-top: 0;
                           text-overflow: ellipsis;
                           width: 100%;
+                        }
+                        &::placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
                         }
                         &:active, &:focus, &:hover {
                           outline: 0px;
@@ -631,6 +655,18 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &::placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
                         &:active, &:focus, &:hover {
                           outline: 0px;
                         }
@@ -761,6 +797,18 @@ exports[`ColorPicker renders correctly 1`] = `
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &::placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
                         &:active, &:focus, &:hover {
                           outline: 0px;
                         }
@@ -890,6 +938,18 @@ exports[`ColorPicker renders correctly 1`] = `
                           padding-top: 0;
                           text-overflow: ellipsis;
                           width: 100%;
+                        }
+                        &::placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
                         }
                         &:active, &:focus, &:hover {
                           outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -372,15 +372,30 @@ exports[`ColorPicker renders correctly 1`] = `
                           width: 100%;
                         }
                         &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:active, &:focus, &:hover {
@@ -514,15 +529,30 @@ exports[`ColorPicker renders correctly 1`] = `
                           width: 100%;
                         }
                         &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:active, &:focus, &:hover {
@@ -656,15 +686,30 @@ exports[`ColorPicker renders correctly 1`] = `
                           width: 100%;
                         }
                         &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:active, &:focus, &:hover {
@@ -798,15 +843,30 @@ exports[`ColorPicker renders correctly 1`] = `
                           width: 100%;
                         }
                         &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:active, &:focus, &:hover {
@@ -940,15 +1000,30 @@ exports[`ColorPicker renders correctly 1`] = `
                           width: 100%;
                         }
                         &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -1,9 +1,18 @@
-import { FontSizes, FontWeights, IRawStyle, ITheme, concatStyleSets, getFocusStyle, HighContrastSelector } from '../../Styling';
+import {
+  FontSizes,
+  FontWeights,
+  IRawStyle,
+  ITheme,
+  concatStyleSets,
+  getFocusStyle,
+  HighContrastSelector,
+  IStyle,
+  getPlaceholderStyles
+} from '../../Styling';
 import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
 
 import { IButtonStyles } from '../../Button';
 import { memoizeFunction } from '../../Utilities';
-import { IStyle, getPlaceholderStyles } from '@uifabric/styling';
 
 const ComboBoxHeight = 32;
 const ComboBoxLineHeight = 30;
@@ -218,6 +227,8 @@ export const getStyles = memoizeFunction(
     const ComboBoxRootColorErrored = semanticColors.errorText;
     const ComboBoxOptionHeaderTextColor = semanticColors.menuHeader;
     const ComboBoxOptionDividerBorderColor = semanticColors.bodyDivider;
+
+    // placeholder style variables
     const placeholderStyles: IStyle = {
       color: semanticColors.inputPlaceholderText
     };
@@ -293,10 +304,7 @@ export const getStyles = memoizeFunction(
       rootHovered: {
         borderColor: ComboBoxRootBorderColorHovered,
         selectors: {
-          '.ms-ComboBox-Input': {
-            color: palette.neutralDark,
-            selectors: getPlaceholderStyles(hoverPlaceholderStyles)
-          },
+          '.ms-ComboBox-Input': [{ color: palette.neutralDark }, getPlaceholderStyles(hoverPlaceholderStyles)],
           [HighContrastSelector]: {
             color: 'HighlightText',
             borderColor: 'Highlight',
@@ -329,31 +337,28 @@ export const getStyles = memoizeFunction(
 
       rootDisallowFreeForm: {},
 
-      input: {
-        backgroundColor: ComboBoxRootBackground,
-        color: ComboBoxRootTextColor,
-        boxSizing: 'border-box',
-        width: '100%',
-        height: '28px',
-        borderStyle: 'none',
-        outline: 'none',
-        font: 'inherit',
-        textOverflow: 'ellipsis',
-        padding: '0',
-        selectors: {
-          '::-ms-clear': {
-            display: 'none'
-          },
-          ...getPlaceholderStyles(placeholderStyles)
-        }
-      },
-
-      inputDisabled: [
-        getDisabledStyles(theme),
+      input: [
+        getPlaceholderStyles(placeholderStyles),
         {
-          selectors: getPlaceholderStyles(disabledPlaceholderStyles)
+          backgroundColor: ComboBoxRootBackground,
+          color: ComboBoxRootTextColor,
+          boxSizing: 'border-box',
+          width: '100%',
+          height: '28px',
+          borderStyle: 'none',
+          outline: 'none',
+          font: 'inherit',
+          textOverflow: 'ellipsis',
+          padding: '0',
+          selectors: {
+            '::-ms-clear': {
+              display: 'none'
+            }
+          }
         }
       ],
+
+      inputDisabled: [getDisabledStyles(theme), getPlaceholderStyles(disabledPlaceholderStyles)],
       errorMessage: {
         color: ComboBoxRootColorErrored
       },

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -3,6 +3,7 @@ import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
 
 import { IButtonStyles } from '../../Button';
 import { memoizeFunction } from '../../Utilities';
+import { IStyle } from '@uifabric/styling';
 
 const ComboBoxHeight = 32;
 const ComboBoxLineHeight = 30;
@@ -217,6 +218,15 @@ export const getStyles = memoizeFunction(
     const ComboBoxRootColorErrored = semanticColors.errorText;
     const ComboBoxOptionHeaderTextColor = semanticColors.menuHeader;
     const ComboBoxOptionDividerBorderColor = semanticColors.bodyDivider;
+    const placeholderStyles: IStyle = {
+      color: semanticColors.inputPlaceholderText
+    };
+    const hoverPlaceholderStyles: IStyle = {
+      color: palette.neutralPrimary
+    };
+    const disabledPlaceholderStyles: IStyle = {
+      color: semanticColors.disabledText
+    };
 
     const ComboBoxRootHighContrastFocused = {
       color: 'HighlightText',
@@ -270,19 +280,6 @@ export const getStyles = memoizeFunction(
               display: 'inline-block',
               marginBottom: '8px'
             },
-            input: {
-              selectors: {
-                '::-ms-clear': {
-                  display: 'none'
-                },
-                '::placeholder': {
-                  color: semanticColors.inputPlaceholderText
-                },
-                ':-ms-input-placeholder': {
-                  color: semanticColors.inputPlaceholderText
-                }
-              }
-            },
             '&.is-open': {
               borderColor: ComboBoxRootBorderColorFocused,
               selectors: {
@@ -299,12 +296,9 @@ export const getStyles = memoizeFunction(
           '.ms-ComboBox-Input': {
             color: palette.neutralDark,
             selectors: {
-              '::placeholder': {
-                color: palette.neutralPrimary
-              },
-              ':-ms-input-placeholder': {
-                color: palette.neutralPrimary
-              }
+              '::placeholder': hoverPlaceholderStyles, // Chrome, Safari, Opera, Firefox
+              ':-ms-input-placeholder': hoverPlaceholderStyles, // IE 10+
+              '::-ms-input-placeholder': hoverPlaceholderStyles // Edge
             }
           },
           [HighContrastSelector]: {
@@ -349,19 +343,24 @@ export const getStyles = memoizeFunction(
         outline: 'none',
         font: 'inherit',
         textOverflow: 'ellipsis',
-        padding: '0'
+        padding: '0',
+        selectors: {
+          '::-ms-clear': {
+            display: 'none'
+          },
+          '::placeholder': placeholderStyles, // Chrome, Safari, Opera, Firefox
+          ':-ms-input-placeholder': placeholderStyles, // IE 10+
+          '::-ms-input-placeholder': placeholderStyles // Edge
+        }
       },
 
       inputDisabled: [
         getDisabledStyles(theme),
         {
           selectors: {
-            '::placeholder': {
-              color: semanticColors.disabledText
-            },
-            ':-ms-input-placeholder': {
-              color: semanticColors.disabledText
-            }
+            '::placeholder': disabledPlaceholderStyles, // Chrome, Safari, Opera, Firefox
+            ':-ms-input-placeholder': disabledPlaceholderStyles, // IE 10+
+            '::-ms-input-placeholder': disabledPlaceholderStyles // Edge
           }
         }
       ],

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -3,7 +3,7 @@ import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
 
 import { IButtonStyles } from '../../Button';
 import { memoizeFunction } from '../../Utilities';
-import { IStyle } from '@uifabric/styling';
+import { IStyle, getPlaceholderStyles } from '@uifabric/styling';
 
 const ComboBoxHeight = 32;
 const ComboBoxLineHeight = 30;
@@ -295,11 +295,7 @@ export const getStyles = memoizeFunction(
         selectors: {
           '.ms-ComboBox-Input': {
             color: palette.neutralDark,
-            selectors: {
-              '::placeholder': hoverPlaceholderStyles, // Chrome, Safari, Opera, Firefox
-              ':-ms-input-placeholder': hoverPlaceholderStyles, // IE 10+
-              '::-ms-input-placeholder': hoverPlaceholderStyles // Edge
-            }
+            selectors: getPlaceholderStyles(hoverPlaceholderStyles)
           },
           [HighContrastSelector]: {
             color: 'HighlightText',
@@ -348,20 +344,14 @@ export const getStyles = memoizeFunction(
           '::-ms-clear': {
             display: 'none'
           },
-          '::placeholder': placeholderStyles, // Chrome, Safari, Opera, Firefox
-          ':-ms-input-placeholder': placeholderStyles, // IE 10+
-          '::-ms-input-placeholder': placeholderStyles // Edge
+          ...getPlaceholderStyles(placeholderStyles)
         }
       },
 
       inputDisabled: [
         getDisabledStyles(theme),
         {
-          selectors: {
-            '::placeholder': disabledPlaceholderStyles, // Chrome, Safari, Opera, Firefox
-            ':-ms-input-placeholder': disabledPlaceholderStyles, // IE 10+
-            '::-ms-input-placeholder': disabledPlaceholderStyles // Edge
-          }
+          selectors: getPlaceholderStyles(disabledPlaceholderStyles)
         }
       ],
       errorMessage: {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -63,6 +63,15 @@ exports[`ComboBox Renders correctly 1`] = `
         &:hover .ms-ComboBox-Input {
           color: #201f1e;
         }
+        &:hover .ms-ComboBox-Input::placeholder {
+          color: #323130;
+        }
+        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          color: #323130;
+        }
+        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          color: #323130;
+        }
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
           background-color: Window;
@@ -126,6 +135,15 @@ exports[`ComboBox Renders correctly 1`] = `
             padding-top: 0;
             text-overflow: ellipsis;
             width: 100%;
+          }
+          &::placeholder {
+            color: #605e5c;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
           }
           &::-ms-clear {
             display: none;
@@ -350,6 +368,15 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         &:hover .ms-ComboBox-Input {
           color: #201f1e;
         }
+        &:hover .ms-ComboBox-Input::placeholder {
+          color: #323130;
+        }
+        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          color: #323130;
+        }
+        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+          color: #323130;
+        }
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
           background-color: Window;
@@ -415,6 +442,15 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             padding-top: 0;
             text-overflow: ellipsis;
             width: 100%;
+          }
+          &::placeholder {
+            color: #605e5c;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
           }
           &::-ms-clear {
             display: none;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -40,15 +40,6 @@ exports[`ComboBox Renders correctly 1`] = `
           display: inline-block;
           margin-bottom: 8px;
         }
-        & input::-ms-clear {
-          display: none;
-        }
-        & input::placeholder {
-          color: #605e5c;
-        }
-        & input:-ms-input-placeholder {
-          color: #605e5c;
-        }
         &.is-open {
           border-color: #0078d4;
         }
@@ -76,6 +67,9 @@ exports[`ComboBox Renders correctly 1`] = `
           color: #323130;
         }
         &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          color: #323130;
+        }
+        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
           color: #323130;
         }
         @media screen and (-ms-high-contrast: active){&:hover {
@@ -141,6 +135,18 @@ exports[`ComboBox Renders correctly 1`] = `
             padding-top: 0;
             text-overflow: ellipsis;
             width: 100%;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #605e5c;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
           }
       data-is-interactable={true}
       data-lpignore={true}
@@ -339,15 +345,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           display: inline-block;
           margin-bottom: 8px;
         }
-        & input::-ms-clear {
-          display: none;
-        }
-        & input::placeholder {
-          color: #605e5c;
-        }
-        & input:-ms-input-placeholder {
-          color: #605e5c;
-        }
         &.is-open {
           border-color: #0078d4;
         }
@@ -375,6 +372,9 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           color: #323130;
         }
         &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+          color: #323130;
+        }
+        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
           color: #323130;
         }
         @media screen and (-ms-high-contrast: active){&:hover {
@@ -442,6 +442,18 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             padding-top: 0;
             text-overflow: ellipsis;
             width: 100%;
+          }
+          &::-ms-clear {
+            display: none;
+          }
+          &::placeholder {
+            color: #605e5c;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
           }
       data-is-interactable={true}
       data-ktp-execute-target="ktp-a"

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -63,18 +63,6 @@ exports[`ComboBox Renders correctly 1`] = `
         &:hover .ms-ComboBox-Input {
           color: #201f1e;
         }
-        &:hover .ms-ComboBox-Input::-ms-clear {
-          display: none;
-        }
-        &:hover .ms-ComboBox-Input::placeholder {
-          color: #323130;
-        }
-        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-          color: #323130;
-        }
-        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-          color: #323130;
-        }
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
           background-color: Window;
@@ -141,15 +129,6 @@ exports[`ComboBox Renders correctly 1`] = `
           }
           &::-ms-clear {
             display: none;
-          }
-          &::placeholder {
-            color: #605e5c;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
           }
       data-is-interactable={true}
       data-lpignore={true}
@@ -371,18 +350,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         &:hover .ms-ComboBox-Input {
           color: #201f1e;
         }
-        &:hover .ms-ComboBox-Input::-ms-clear {
-          display: none;
-        }
-        &:hover .ms-ComboBox-Input::placeholder {
-          color: #323130;
-        }
-        &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-          color: #323130;
-        }
-        &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-          color: #323130;
-        }
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
           background-color: Window;
@@ -451,15 +418,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           }
           &::-ms-clear {
             display: none;
-          }
-          &::placeholder {
-            color: #605e5c;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
           }
       data-is-interactable={true}
       data-ktp-execute-target="ktp-a"

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -63,6 +63,9 @@ exports[`ComboBox Renders correctly 1`] = `
         &:hover .ms-ComboBox-Input {
           color: #201f1e;
         }
+        &:hover .ms-ComboBox-Input::-ms-clear {
+          display: none;
+        }
         &:hover .ms-ComboBox-Input::placeholder {
           color: #323130;
         }
@@ -367,6 +370,9 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         }
         &:hover .ms-ComboBox-Input {
           color: #201f1e;
+        }
+        &:hover .ms-ComboBox-Input::-ms-clear {
+          display: none;
         }
         &:hover .ms-ComboBox-Input::placeholder {
           color: #323130;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -145,6 +145,15 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -121,6 +121,12 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -147,12 +153,6 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="DatePicker0-label"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -127,33 +127,6 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="DatePicker0-label"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -122,15 +122,30 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -121,6 +121,18 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -1,5 +1,6 @@
 import { HighContrastSelector, AnimationVariables, normalize, IStyle } from '../../Styling';
 import { ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox.types';
+import { getPlaceholderStyles } from '@uifabric/styling';
 
 export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
   const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation } = props;
@@ -153,10 +154,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
           '::-ms-clear': {
             display: 'none'
           },
-          // '::placeholder': placeholderStyles && { opacity: 1 }, // Chrome, Safari, Opera, Firefox
-          '::placeholder': placeholderStyles, // Chrome, Safari, Opera, Firefox
-          ':-ms-input-placeholder': placeholderStyles, // IE 10+
-          '::-ms-input-placeholder': placeholderStyles // Edge
+          ...getPlaceholderStyles(placeholderStyles)
         }
       },
       disabled && {

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -5,6 +5,8 @@ import { getPlaceholderStyles } from '@uifabric/styling';
 export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
   const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation } = props;
   const { palette, fonts, semanticColors, effects } = theme;
+
+  // placeholder style constants
   const placeholderStyles: IStyle = {
     color: semanticColors.inputPlaceholderText,
     opacity: 1
@@ -133,6 +135,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
     field: [
       'ms-SearchBox-field',
       normalize,
+      getPlaceholderStyles(placeholderStyles),
       {
         backgroundColor: 'transparent',
         border: 'none',
@@ -153,8 +156,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         selectors: {
           '::-ms-clear': {
             display: 'none'
-          },
-          ...getPlaceholderStyles(placeholderStyles)
+          }
         }
       },
       disabled && {

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -1,9 +1,13 @@
-import { HighContrastSelector, AnimationVariables, normalize } from '../../Styling';
+import { HighContrastSelector, AnimationVariables, normalize, IStyle } from '../../Styling';
 import { ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox.types';
 
 export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
   const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation } = props;
   const { palette, fonts, semanticColors, effects } = theme;
+  const placeholderStyles: IStyle = {
+    color: semanticColors.inputPlaceholderText,
+    opacity: 1
+  };
 
   return {
     root: [
@@ -149,13 +153,10 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
           '::-ms-clear': {
             display: 'none'
           },
-          '::placeholder': {
-            color: semanticColors.inputPlaceholderText,
-            opacity: 1
-          },
-          ':-ms-input-placeholder': {
-            color: semanticColors.inputPlaceholderText
-          }
+          // '::placeholder': placeholderStyles && { opacity: 1 }, // Chrome, Safari, Opera, Firefox
+          '::placeholder': placeholderStyles, // Chrome, Safari, Opera, Firefox
+          ':-ms-input-placeholder': placeholderStyles, // IE 10+
+          '::-ms-input-placeholder': placeholderStyles // Edge
         }
       },
       disabled && {

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -112,18 +112,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         &::-ms-clear {
           display: none;
         }
-        &::placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &:-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &::-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
     id="SearchBox0"
     onChange={[Function]}
     onInput={[Function]}
@@ -242,18 +230,6 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         }
         &::-ms-clear {
           display: none;
-        }
-        &::placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &:-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &::-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
         }
     id="SearchBox5"
     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -118,6 +118,11 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         }
         &:-ms-input-placeholder {
           color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
         }
     id="SearchBox0"
     onChange={[Function]}
@@ -244,6 +249,11 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         }
         &:-ms-input-placeholder {
           color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
         }
     id="SearchBox5"
     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -109,6 +109,18 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           padding-top: 0px;
           text-overflow: ellipsis;
         }
+        &::placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &:-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
         &::-ms-clear {
           display: none;
         }
@@ -227,6 +239,18 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
           padding-right: 0px;
           padding-top: 0px;
           text-overflow: ellipsis;
+        }
+        &::placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &:-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
         }
         &::-ms-clear {
           display: none;

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -143,6 +143,15 @@ exports[`MaskedTextField renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -120,15 +120,30 @@ exports[`MaskedTextField renders correctly 1`] = `
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -125,33 +125,6 @@ exports[`MaskedTextField renders correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -119,6 +119,12 @@ exports[`MaskedTextField renders correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -145,12 +151,6 @@ exports[`MaskedTextField renders correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -119,6 +119,18 @@ exports[`MaskedTextField renders correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
             &:active, &:focus, &:hover {
               outline: 0px;
             }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -281,7 +281,6 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       theme.fonts.medium,
       classNames.field,
       normalize,
-      getPlaceholderStyles(placeholderStyles),
       {
         fontSize: FontSizes.medium,
         borderRadius: 0,
@@ -301,6 +300,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           }
         }
       },
+      getPlaceholderStyles(placeholderStyles),
       multiline &&
         !resizable && [
           classNames.unresizable,

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -282,7 +282,6 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       normalize,
       getPlaceholderStyles(placeholderStyles),
       {
-        fontSize: FontSizes.medium,
         borderRadius: 0,
         border: 'none',
         background: 'none',

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -94,6 +94,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
 
   // placeholder style constants
   const placeholderStyles: IStyle = [
+    theme.fonts.medium,
     {
       color: semanticColors.inputPlaceholderText,
       opacity: 1
@@ -282,6 +283,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       normalize,
       getPlaceholderStyles(placeholderStyles),
       {
+        fontSize: FontSizes.medium,
         borderRadius: 0,
         border: 'none',
         background: 'none',

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -2,6 +2,7 @@ import { AnimationClassNames, FontSizes, getGlobalClassNames, HighContrastSelect
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
+import { getPlaceholderStyles } from '@uifabric/styling';
 
 const globalClassNames = {
   root: 'ms-TextField',
@@ -289,9 +290,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           '::-ms-clear': {
             display: 'none'
           },
-          '::placeholder': placeholderStyles, // Chrome, Safari, Opera, Firefox
-          ':-ms-input-placeholder': placeholderStyles, // IE 10+
-          '::-ms-input-placeholder': placeholderStyles // Edge
+          ...getPlaceholderStyles(placeholderStyles)
         }
       },
       multiline &&

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -84,6 +84,18 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     flexShrink: 0
   };
 
+  const placeholderStyles: IStyle = [
+    theme.fonts.medium,
+    {
+      color: semanticColors.inputPlaceholderText,
+      opacity: 1
+    }
+  ];
+
+  const disabledPlaceholderStyles: IStyle = {
+    color: semanticColors.disabledText
+  };
+
   return {
     root: [
       classNames.root,
@@ -277,20 +289,9 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           '::-ms-clear': {
             display: 'none'
           },
-          '::placeholder': [
-            theme.fonts.medium,
-            {
-              color: semanticColors.inputPlaceholderText,
-              opacity: 1
-            }
-          ],
-          ':-ms-input-placeholder': [
-            theme.fonts.medium,
-            {
-              color: semanticColors.inputPlaceholderText,
-              opacity: 1
-            }
-          ]
+          '::placeholder': placeholderStyles, // Chrome, Safari, Opera, Firefox
+          ':-ms-input-placeholder': placeholderStyles, // IE 10+
+          '::-ms-input-placeholder': placeholderStyles // Edge
         }
       },
       multiline &&
@@ -325,12 +326,9 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         borderColor: 'transparent',
         color: semanticColors.disabledText,
         selectors: {
-          '::placeholder': {
-            color: semanticColors.disabledText
-          },
-          ':-ms-input-placeholder': {
-            color: semanticColors.disabledText
-          }
+          '::placeholder': disabledPlaceholderStyles, // Chrome, Safari, Opera, Firefox
+          ':-ms-input-placeholder': disabledPlaceholderStyles, // IE 10+
+          '::-ms-input-placeholder': disabledPlaceholderStyles // Edge
         }
       },
       underlined && {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -1,8 +1,15 @@
-import { AnimationClassNames, FontSizes, getGlobalClassNames, HighContrastSelector, IStyle, normalize } from '../../Styling';
+import {
+  AnimationClassNames,
+  FontSizes,
+  getGlobalClassNames,
+  HighContrastSelector,
+  IStyle,
+  normalize,
+  getPlaceholderStyles
+} from '../../Styling';
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { getPlaceholderStyles } from '@uifabric/styling';
 
 const globalClassNames = {
   root: 'ms-TextField',
@@ -85,8 +92,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     flexShrink: 0
   };
 
+  // placeholder style constants
   const placeholderStyles: IStyle = [
-    theme.fonts.medium,
     {
       color: semanticColors.inputPlaceholderText,
       opacity: 1
@@ -273,6 +280,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       theme.fonts.medium,
       classNames.field,
       normalize,
+      getPlaceholderStyles(placeholderStyles),
       {
         fontSize: FontSizes.medium,
         borderRadius: 0,
@@ -289,8 +297,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           '&:active, &:focus, &:hover': { outline: 0 },
           '::-ms-clear': {
             display: 'none'
-          },
-          ...getPlaceholderStyles(placeholderStyles)
+          }
         }
       },
       multiline &&
@@ -320,16 +327,14 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         hasIcon && {
           paddingRight: 40
         },
-      disabled && {
-        backgroundColor: 'transparent',
-        borderColor: 'transparent',
-        color: semanticColors.disabledText,
-        selectors: {
-          '::placeholder': disabledPlaceholderStyles, // Chrome, Safari, Opera, Firefox
-          ':-ms-input-placeholder': disabledPlaceholderStyles, // IE 10+
-          '::-ms-input-placeholder': disabledPlaceholderStyles // Edge
-        }
-      },
+      disabled && [
+        {
+          backgroundColor: 'transparent',
+          borderColor: 'transparent',
+          color: semanticColors.disabledText
+        },
+        getPlaceholderStyles(disabledPlaceholderStyles)
+      ],
       underlined && {
         textAlign: 'left'
       },

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -145,6 +145,15 @@ exports[`TextField snapshots renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}
@@ -343,6 +352,15 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               color: #605e5c;
@@ -591,6 +609,15 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               font-weight: 400;
               opacity: 1;
             }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}
@@ -786,6 +813,15 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}
@@ -940,6 +976,15 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               color: #605e5c;
@@ -1147,6 +1192,15 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -121,6 +121,12 @@ exports[`TextField snapshots renders correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -147,12 +153,6 @@ exports[`TextField snapshots renders correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -336,6 +336,12 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -362,12 +368,6 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -585,6 +585,12 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -611,12 +617,6 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -789,6 +789,12 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -815,12 +821,6 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -960,6 +960,12 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -986,12 +992,6 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -1176,6 +1176,12 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               text-overflow: ellipsis;
               width: 100%;
             }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -1202,12 +1208,6 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
-            }
-            &:active, &:focus, &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
             }
         id="TextField0"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -127,33 +127,6 @@ exports[`TextField snapshots renders correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}
@@ -341,33 +314,6 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -591,33 +537,6 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}
@@ -795,33 +714,6 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
         id="TextField0"
         onBlur={[Function]}
         onChange={[Function]}
@@ -965,33 +857,6 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -1181,33 +1046,6 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
             }
         id="TextField0"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -121,6 +121,18 @@ exports[`TextField snapshots renders correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
             &:active, &:focus, &:hover {
               outline: 0px;
             }
@@ -308,6 +320,18 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               text-align: left;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
             }
             &:active, &:focus, &:hover {
               outline: 0px;
@@ -531,6 +555,18 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               text-overflow: ellipsis;
               width: 100%;
             }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
             &:active, &:focus, &:hover {
               outline: 0px;
             }
@@ -708,6 +744,18 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
             &:active, &:focus, &:hover {
               outline: 0px;
             }
@@ -851,6 +899,18 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               resize: none;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
             }
             &:active, &:focus, &:hover {
               outline: 0px;
@@ -1040,6 +1100,18 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               text-align: left;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
             }
             &:active, &:focus, &:hover {
               outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -122,15 +122,30 @@ exports[`TextField snapshots renders correctly 1`] = `
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {
@@ -322,15 +337,30 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {
@@ -556,15 +586,30 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {
@@ -745,15 +790,30 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {
@@ -901,15 +961,30 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {
@@ -1102,15 +1177,30 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               width: 100%;
             }
             &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
               color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
               opacity: 1;
             }
             &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -402,6 +402,15 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            opacity: 1;
+                          }
                       id="TextField0"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -542,6 +551,15 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
                             color: #605e5c;
@@ -698,6 +716,15 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            opacity: 1;
+                          }
                       id="TextField6"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -846,6 +873,15 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            opacity: 1;
+                          }
                       id="TextField9"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -986,6 +1022,15 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
                             color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -378,6 +378,12 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -404,12 +410,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
-                          }
-                          &:active, &:focus, &:hover {
-                            outline: 0px;
-                          }
-                          &::-ms-clear {
-                            display: none;
                           }
                       id="TextField0"
                       onBlur={[Function]}
@@ -535,6 +535,12 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -561,12 +567,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
-                          }
-                          &:active, &:focus, &:hover {
-                            outline: 0px;
-                          }
-                          &::-ms-clear {
-                            display: none;
                           }
                       id="TextField3"
                       onBlur={[Function]}
@@ -692,6 +692,12 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -718,12 +724,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
-                          }
-                          &:active, &:focus, &:hover {
-                            outline: 0px;
-                          }
-                          &::-ms-clear {
-                            display: none;
                           }
                       id="TextField6"
                       onBlur={[Function]}
@@ -849,6 +849,12 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -875,12 +881,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
-                          }
-                          &:active, &:focus, &:hover {
-                            outline: 0px;
-                          }
-                          &::-ms-clear {
-                            display: none;
                           }
                       id="TextField9"
                       onBlur={[Function]}
@@ -1006,6 +1006,12 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &:active, &:focus, &:hover {
+                            outline: 0px;
+                          }
+                          &::-ms-clear {
+                            display: none;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -1032,12 +1038,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
-                          }
-                          &:active, &:focus, &:hover {
-                            outline: 0px;
-                          }
-                          &::-ms-clear {
-                            display: none;
                           }
                       id="TextField12"
                       onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -384,33 +384,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
-                          &::placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &:-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &::-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
                       id="TextField0"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -540,33 +513,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           }
                           &::-ms-clear {
                             display: none;
-                          }
-                          &::placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &:-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &::-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
                           }
                       id="TextField3"
                       onBlur={[Function]}
@@ -698,33 +644,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
-                          &::placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &:-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &::-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
                       id="TextField6"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -855,33 +774,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
-                          &::placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &:-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &::-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
                       id="TextField9"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -1011,33 +903,6 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           }
                           &::-ms-clear {
                             display: none;
-                          }
-                          &::placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &:-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
-                          }
-                          &::-ms-input-placeholder {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #605e5c;
-                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                            font-size: 14px;
-                            font-weight: 400;
-                            opacity: 1;
                           }
                       id="TextField12"
                       onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -379,15 +379,30 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             width: 100%;
                           }
                           &::placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:active, &:focus, &:hover {
@@ -521,15 +536,30 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             width: 100%;
                           }
                           &::placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:active, &:focus, &:hover {
@@ -663,15 +693,30 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             width: 100%;
                           }
                           &::placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:active, &:focus, &:hover {
@@ -805,15 +850,30 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             width: 100%;
                           }
                           &::placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:active, &:focus, &:hover {
@@ -947,15 +1007,30 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             width: 100%;
                           }
                           &::placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &::-ms-input-placeholder {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
                             color: #605e5c;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
                             opacity: 1;
                           }
                           &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -378,6 +378,18 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
                           &:active, &:focus, &:hover {
                             outline: 0px;
                           }
@@ -507,6 +519,18 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             padding-top: 0;
                             text-overflow: ellipsis;
                             width: 100%;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
                           }
                           &:active, &:focus, &:hover {
                             outline: 0px;
@@ -638,6 +662,18 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
                           &:active, &:focus, &:hover {
                             outline: 0px;
                           }
@@ -768,6 +804,18 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             text-overflow: ellipsis;
                             width: 100%;
                           }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
                           &:active, &:focus, &:hover {
                             outline: 0px;
                           }
@@ -897,6 +945,18 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             padding-top: 0;
                             text-overflow: ellipsis;
                             width: 100%;
+                          }
+                          &::placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &:-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
+                          }
+                          &::-ms-input-placeholder {
+                            color: #605e5c;
+                            opacity: 1;
                           }
                           &:active, &:focus, &:hover {
                             outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -122,6 +122,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             &:hover .ms-ComboBox-Input {
               color: #201f1e;
             }
+            &:hover .ms-ComboBox-Input::placeholder {
+              color: #323130;
+            }
+            &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+              color: #323130;
+            }
+            &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+              color: #323130;
+            }
             @media screen and (-ms-high-contrast: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Window;
@@ -186,6 +195,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 padding-top: 0;
                 text-overflow: ellipsis;
                 width: 100%;
+              }
+              &::placeholder {
+                color: #605e5c;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
               }
               &::-ms-clear {
                 display: none;
@@ -568,6 +586,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -632,6 +659,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;
@@ -882,6 +918,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -946,6 +991,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;
@@ -1197,6 +1251,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -1261,6 +1324,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;
@@ -3388,6 +3460,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+            }
             &::-ms-clear {
               display: none;
             }
@@ -3675,6 +3756,15 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #a19f9d;
+            }
+            &:-ms-input-placeholder {
+              color: #a19f9d;
+            }
+            &::-ms-input-placeholder {
+              color: #a19f9d;
             }
             &::-ms-clear {
               display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -122,18 +122,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             &:hover .ms-ComboBox-Input {
               color: #201f1e;
             }
-            &:hover .ms-ComboBox-Input::-ms-clear {
-              display: none;
-            }
-            &:hover .ms-ComboBox-Input::placeholder {
-              color: #323130;
-            }
-            &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-              color: #323130;
-            }
-            &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-              color: #323130;
-            }
             @media screen and (-ms-high-contrast: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Window;
@@ -201,15 +189,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               }
               &::-ms-clear {
                 display: none;
-              }
-              &::placeholder {
-                color: #605e5c;
-              }
-              &:-ms-input-placeholder {
-                color: #605e5c;
-              }
-              &::-ms-input-placeholder {
-                color: #605e5c;
               }
           data-is-interactable={true}
           data-lpignore={true}
@@ -589,18 +568,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -668,15 +635,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -924,18 +882,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -1003,15 +949,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -1260,18 +1197,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -1339,15 +1264,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -3475,15 +3391,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-            }
         data-is-interactable={true}
         data-lpignore={true}
         id="ComboBox19-input"
@@ -3771,15 +3678,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #a19f9d;
-            }
-            &:-ms-input-placeholder {
-              color: #a19f9d;
-            }
-            &::-ms-input-placeholder {
-              color: #a19f9d;
             }
             @media screen and (-ms-high-contrast: active){& {
               border-color: GrayText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -122,6 +122,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             &:hover .ms-ComboBox-Input {
               color: #201f1e;
             }
+            &:hover .ms-ComboBox-Input::-ms-clear {
+              display: none;
+            }
             &:hover .ms-ComboBox-Input::placeholder {
               color: #323130;
             }
@@ -586,6 +589,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
+          }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;
           }
@@ -917,6 +923,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
           }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;
@@ -1250,6 +1259,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
           }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -99,15 +99,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               display: inline-block;
               margin-bottom: 8px;
             }
-            & input::-ms-clear {
-              display: none;
-            }
-            & input::placeholder {
-              color: #605e5c;
-            }
-            & input:-ms-input-placeholder {
-              color: #605e5c;
-            }
             &.is-open {
               border-color: #0078d4;
             }
@@ -135,6 +126,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               color: #323130;
             }
             &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+              color: #323130;
+            }
+            &:hover .ms-ComboBox-Input::-ms-input-placeholder {
               color: #323130;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
@@ -201,6 +195,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 padding-top: 0;
                 text-overflow: ellipsis;
                 width: 100%;
+              }
+              &::-ms-clear {
+                display: none;
+              }
+              &::placeholder {
+                color: #605e5c;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
               }
           data-is-interactable={true}
           data-lpignore={true}
@@ -557,15 +563,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -593,6 +590,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -659,6 +659,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -883,15 +895,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -919,6 +922,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -985,6 +991,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -1210,15 +1228,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -1246,6 +1255,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -1312,6 +1324,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -3382,15 +3406,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -3444,6 +3459,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -3681,15 +3708,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -3739,15 +3757,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-overflow: ellipsis;
               width: 100%;
             }
-            @media screen and (-ms-high-contrast: active){& {
-              border-color: GrayText;
-              color: GrayText;
+            &::-ms-clear {
+              display: none;
             }
             &::placeholder {
               color: #a19f9d;
             }
             &:-ms-input-placeholder {
               color: #a19f9d;
+            }
+            &::-ms-input-placeholder {
+              color: #a19f9d;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: GrayText;
+              color: GrayText;
             }
         data-is-interactable={false}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -96,15 +96,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -132,6 +123,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -198,6 +192,18 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -422,15 +428,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -458,6 +455,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -524,6 +524,18 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -119,6 +119,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
+          }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;
           }
@@ -450,6 +453,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           }
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
           }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -119,18 +119,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -198,15 +186,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -454,18 +433,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -533,15 +500,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -119,6 +119,15 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -183,6 +192,15 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;
@@ -433,6 +451,15 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -497,6 +524,15 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -123,6 +123,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
+          }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;
           }
@@ -454,6 +457,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           }
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
           }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -123,6 +123,15 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -187,6 +196,15 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;
@@ -437,6 +455,15 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -501,6 +528,15 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -123,18 +123,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -202,15 +190,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -458,18 +437,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -537,15 +504,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -100,15 +100,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -136,6 +127,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -202,6 +196,18 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}
@@ -426,15 +432,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -462,6 +459,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -528,6 +528,18 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -120,6 +120,15 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -184,6 +193,15 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -120,6 +120,9 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
+          }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -97,15 +97,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -133,6 +124,9 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -199,6 +193,18 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -120,18 +120,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -199,15 +187,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -92,15 +92,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             display: inline-block;
             margin-bottom: 8px;
           }
-          & input::-ms-clear {
-            display: none;
-          }
-          & input::placeholder {
-            color: #605e5c;
-          }
-          & input:-ms-input-placeholder {
-            color: #605e5c;
-          }
           &.is-open {
             border-color: #0078d4;
           }
@@ -128,6 +119,9 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             color: #323130;
           }
           &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
             color: #323130;
           }
           @media screen and (-ms-high-contrast: active){&:hover {
@@ -194,6 +188,18 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -115,6 +115,9 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::-ms-clear {
+            display: none;
+          }
           &:hover .ms-ComboBox-Input::placeholder {
             color: #323130;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -115,18 +115,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
-          &:hover .ms-ComboBox-Input::-ms-clear {
-            display: none;
-          }
-          &:hover .ms-ComboBox-Input::placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
-            color: #323130;
-          }
-          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
-            color: #323130;
-          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -194,15 +182,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             }
             &::-ms-clear {
               display: none;
-            }
-            &::placeholder {
-              color: #605e5c;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
             }
         data-is-interactable={true}
         data-lpignore={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -115,6 +115,15 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           &:hover .ms-ComboBox-Input {
             color: #201f1e;
           }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #323130;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #323130;
+          }
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -179,6 +188,15 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
               padding-top: 0;
               text-overflow: ellipsis;
               width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
             }
             &::-ms-clear {
               display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -148,6 +148,15 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -125,15 +125,30 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -124,6 +124,12 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -150,12 +156,6 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -130,33 +130,6 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -124,6 +124,18 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -149,6 +149,15 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -125,6 +125,18 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -125,6 +125,12 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -151,12 +157,6 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -131,33 +131,6 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -126,15 +126,30 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -154,6 +154,15 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -130,6 +130,18 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -131,15 +131,30 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -130,6 +130,12 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -156,12 +162,6 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -136,33 +136,6 @@ Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -150,6 +150,15 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               disabled={true}
               id="DatePicker0-label"
               onBlur={[Function]}
@@ -367,6 +376,15 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #a19f9d;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -132,33 +132,6 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #a19f9d;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #a19f9d;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #a19f9d;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               disabled={true}
               id="DatePicker0-label"
               onBlur={[Function]}
@@ -365,33 +338,6 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   }
                   &::-ms-clear {
                     display: none;
-                  }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #a19f9d;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #a19f9d;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #a19f9d;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
                   }
               disabled={true}
               id="DatePicker5-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -126,6 +126,12 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -152,12 +158,6 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               disabled={true}
               id="DatePicker0-label"
@@ -360,6 +360,12 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -386,12 +392,6 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               disabled={true}
               id="DatePicker5-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -126,6 +126,18 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #a19f9d;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #a19f9d;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #a19f9d;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }
@@ -332,6 +344,18 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     padding-top: 0;
                     text-overflow: ellipsis;
                     width: 100%;
+                  }
+                  &::placeholder {
+                    color: #a19f9d;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #a19f9d;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #a19f9d;
+                    opacity: 1;
                   }
                   &:active, &:focus, &:hover {
                     outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -127,15 +127,30 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {
@@ -346,15 +361,30 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #a19f9d;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -182,6 +182,15 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -159,15 +159,30 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -164,33 +164,6 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -158,6 +158,12 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -184,12 +190,6 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -158,6 +158,18 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -182,6 +182,15 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -158,6 +158,18 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -159,15 +159,30 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -164,33 +164,6 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -158,6 +158,12 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -184,12 +190,6 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -188,6 +188,15 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}
@@ -382,6 +391,15 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -164,6 +164,12 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -190,12 +196,6 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}
@@ -375,6 +375,12 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -401,12 +407,6 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker5-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -165,15 +165,30 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {
@@ -361,15 +376,30 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -170,33 +170,6 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}
@@ -380,33 +353,6 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   }
                   &::-ms-clear {
                     display: none;
-                  }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
                   }
               id="DatePicker5-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -164,6 +164,18 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }
@@ -347,6 +359,18 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     padding-top: 0;
                     text-overflow: ellipsis;
                     width: 100%;
+                  }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
                   }
                   &:active, &:focus, &:hover {
                     outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -149,6 +149,15 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -126,15 +126,30 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -125,6 +125,12 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -151,12 +157,6 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -125,6 +125,18 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -131,33 +131,6 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="DatePicker0-label"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -176,6 +176,15 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -152,6 +152,12 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -178,12 +184,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -152,6 +152,18 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -158,33 +158,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -153,15 +153,30 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -176,6 +176,15 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -158,33 +158,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -152,6 +152,12 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -178,12 +184,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -152,6 +152,18 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -153,15 +153,30 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -519,6 +519,15 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField2"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -496,15 +496,30 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -501,33 +501,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField2"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -495,6 +495,18 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -495,6 +495,12 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -521,12 +527,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField2"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -331,6 +331,15 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField1"
             onBlur={[Function]}
             onChange={[Function]}
@@ -477,6 +486,15 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -307,6 +307,18 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -442,6 +454,18 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -313,33 +313,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField1"
             onBlur={[Function]}
             onChange={[Function]}
@@ -475,33 +448,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField4"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -308,15 +308,30 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -456,15 +471,30 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -307,6 +307,12 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -333,12 +339,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField1"
             onBlur={[Function]}
@@ -470,6 +470,12 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -496,12 +502,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField4"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -127,6 +127,11 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
             }
             &:-ms-input-placeholder {
               color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
             }
         id="SearchBox0"
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -121,18 +121,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
         id="SearchBox0"
         onChange={[Function]}
         onInput={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -118,6 +118,18 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
               padding-top: 0px;
               text-overflow: ellipsis;
             }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
             &::-ms-clear {
               display: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -356,6 +356,15 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField1"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -332,6 +332,18 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -338,33 +338,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField1"
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -333,15 +333,30 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -332,6 +332,12 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -358,12 +364,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField1"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -538,6 +538,15 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="TextField4"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -520,33 +520,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="TextField4"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -514,6 +514,18 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -515,15 +515,30 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -514,6 +514,12 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -540,12 +546,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="TextField4"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -538,6 +538,15 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="TextField4"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -514,6 +514,12 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -540,12 +546,6 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="TextField4"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -520,33 +520,6 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="TextField4"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -514,6 +514,18 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -515,15 +515,30 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -400,6 +400,15 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="TextField7"
               onBlur={[Function]}
               onChange={[Function]}
@@ -1011,6 +1020,15 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -377,15 +377,30 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {
@@ -990,15 +1005,30 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -382,33 +382,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="TextField7"
               onBlur={[Function]}
               onChange={[Function]}
@@ -1009,33 +982,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               }
               &::-ms-clear {
                 display: none;
-              }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
               }
           id="TextField23"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -376,6 +376,18 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }
@@ -976,6 +988,18 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 padding-top: 0;
                 text-overflow: ellipsis;
                 width: 100%;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
               }
               &:active, &:focus, &:hover {
                 outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -376,6 +376,12 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -402,12 +408,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="TextField7"
               onBlur={[Function]}
@@ -1004,6 +1004,12 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -1030,12 +1036,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField23"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -400,6 +400,15 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="TextField7"
               onBlur={[Function]}
               onChange={[Function]}
@@ -1182,6 +1191,15 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
                     color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -377,15 +377,30 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {
@@ -1161,15 +1176,30 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -376,6 +376,12 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -402,12 +408,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="TextField7"
               onBlur={[Function]}
@@ -1175,6 +1175,12 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1201,12 +1207,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="TextField26"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -376,6 +376,18 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }
@@ -1147,6 +1159,18 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     padding-top: 0;
                     text-overflow: ellipsis;
                     width: 100%;
+                  }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
                   }
                   &:active, &:focus, &:hover {
                     outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -382,33 +382,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="TextField7"
               onBlur={[Function]}
               onChange={[Function]}
@@ -1180,33 +1153,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   }
                   &::-ms-clear {
                     display: none;
-                  }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
                   }
               id="TextField26"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -231,6 +231,15 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="anInput0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -207,6 +207,12 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -233,12 +239,6 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="anInput0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -208,15 +208,30 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -207,6 +207,18 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -213,33 +213,6 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="anInput0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -146,6 +146,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             }
             &:-ms-input-placeholder {
               color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
             }
         id="SearchBox1"
         onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -140,18 +140,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             &::-ms-clear {
               display: none;
             }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
         id="SearchBox1"
         onChange={[Function]}
         onInput={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -137,6 +137,18 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               padding-top: 0px;
               text-overflow: ellipsis;
             }
+            &::placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+              opacity: 1;
+            }
             &::-ms-clear {
               display: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -116,18 +116,6 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
           &::-ms-clear {
             display: none;
           }
-          &::placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
       id="SearchBox0"
       onChange={[Function]}
       onInput={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -122,6 +122,11 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
           }
           &:-ms-input-placeholder {
             color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
       id="SearchBox0"
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -113,6 +113,18 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
             padding-top: 0px;
             text-overflow: ellipsis;
           }
+          &::placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
           &::-ms-clear {
             display: none;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -120,18 +120,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           &::-ms-clear {
             display: none;
           }
-          &::placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
       disabled={true}
       id="SearchBox0"
       onChange={[Function]}
@@ -258,18 +246,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
           &::-ms-clear {
             display: none;
-          }
-          &::placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
           }
       disabled={true}
       id="SearchBox1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -117,6 +117,18 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
             padding-top: 0px;
             text-overflow: ellipsis;
           }
+          &::placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
           &::-ms-clear {
             display: none;
           }
@@ -243,6 +255,18 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
             padding-right: 0px;
             padding-top: 0px;
             text-overflow: ellipsis;
+          }
+          &::placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
           &::-ms-clear {
             display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -126,6 +126,11 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
           &:-ms-input-placeholder {
             color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
       disabled={true}
       id="SearchBox0"
@@ -260,6 +265,11 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
           &:-ms-input-placeholder {
             color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
       disabled={true}
       id="SearchBox1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -113,6 +113,18 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             padding-top: 0px;
             text-overflow: ellipsis;
           }
+          &::placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
           &::-ms-clear {
             display: none;
           }
@@ -230,6 +242,18 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             padding-right: 0px;
             padding-top: 0px;
             text-overflow: ellipsis;
+          }
+          &::placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &:-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
           &::-ms-clear {
             display: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -122,6 +122,11 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           }
           &:-ms-input-placeholder {
             color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
       id="SearchBox0"
       onChange={[Function]}
@@ -247,6 +252,11 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           }
           &:-ms-input-placeholder {
             color: #605e5c;
+            opacity: 1;
+          }
+          &::-ms-input-placeholder {
+            color: #605e5c;
+            opacity: 1;
           }
       id="SearchBox1"
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -116,18 +116,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           &::-ms-clear {
             display: none;
           }
-          &::placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
       id="SearchBox0"
       onChange={[Function]}
       onInput={[Function]}
@@ -245,18 +233,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           }
           &::-ms-clear {
             display: none;
-          }
-          &::placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &:-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
-          }
-          &::-ms-input-placeholder {
-            color: #605e5c;
-            opacity: 1;
           }
       id="SearchBox1"
       onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -111,6 +111,18 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
           padding-top: 0px;
           text-overflow: ellipsis;
         }
+        &::placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &:-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
         &::-ms-clear {
           display: none;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -114,18 +114,6 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
         &::-ms-clear {
           display: none;
         }
-        &::placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &:-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &::-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
     id="SearchBox0"
     onChange={[Function]}
     onInput={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -120,6 +120,11 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
         }
         &:-ms-input-placeholder {
           color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
         }
     id="SearchBox0"
     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -112,6 +112,18 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
           padding-top: 0px;
           text-overflow: ellipsis;
         }
+        &::placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &:-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
+        }
         &::-ms-clear {
           display: none;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -115,18 +115,6 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
         &::-ms-clear {
           display: none;
         }
-        &::placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &:-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
-        &::-ms-input-placeholder {
-          color: #605e5c;
-          opacity: 1;
-        }
     id="SearchBox0"
     onChange={[Function]}
     onInput={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -121,6 +121,11 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
         }
         &:-ms-input-placeholder {
           color: #605e5c;
+          opacity: 1;
+        }
+        &::-ms-input-placeholder {
+          color: #605e5c;
+          opacity: 1;
         }
     id="SearchBox0"
     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3707,6 +3707,15 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     font-weight: 400;
                     opacity: 1;
                   }
+                  &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    opacity: 1;
+                  }
               id="TextField15"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3683,6 +3683,18 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &::placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &:-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
+                  &::-ms-input-placeholder {
+                    color: #605e5c;
+                    opacity: 1;
+                  }
                   &:active, &:focus, &:hover {
                     outline: 0px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3684,15 +3684,30 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 100%;
                   }
                   &::placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &::-ms-input-placeholder {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     color: #605e5c;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
                     opacity: 1;
                   }
                   &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3689,33 +3689,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   &::-ms-clear {
                     display: none;
                   }
-                  &::placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &:-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
-                  &::-ms-input-placeholder {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    color: #605e5c;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 14px;
-                    font-weight: 400;
-                    opacity: 1;
-                  }
               id="TextField15"
               onBlur={[Function]}
               onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3683,6 +3683,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     text-overflow: ellipsis;
                     width: 100%;
                   }
+                  &:active, &:focus, &:hover {
+                    outline: 0px;
+                  }
+                  &::-ms-clear {
+                    display: none;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -3709,12 +3715,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
-                  }
-                  &:active, &:focus, &:hover {
-                    outline: 0px;
-                  }
-                  &::-ms-clear {
-                    display: none;
                   }
               id="TextField15"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -2422,6 +2422,15 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           font-weight: 400;
                           opacity: 1;
                         }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
                     id="TextField11"
                     onBlur={[Function]}
                     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -2399,15 +2399,30 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           width: 100%;
                         }
                         &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
                           opacity: 1;
                         }
                         &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -2398,6 +2398,18 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &::placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          color: #605e5c;
+                          opacity: 1;
+                        }
                         &:active, &:focus, &:hover {
                           outline: 0px;
                         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -2398,6 +2398,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           text-overflow: ellipsis;
                           width: 100%;
                         }
+                        &:active, &:focus, &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -2424,12 +2430,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
-                        }
-                        &:active, &:focus, &:hover {
-                          outline: 0px;
-                        }
-                        &::-ms-clear {
-                          display: none;
                         }
                     id="TextField11"
                     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -2404,33 +2404,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         &::-ms-clear {
                           display: none;
                         }
-                        &::placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &:-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
-                        &::-ms-input-placeholder {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          color: #605e5c;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          opacity: 1;
-                        }
                     id="TextField11"
                     onBlur={[Function]}
                     onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -185,6 +185,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -342,6 +351,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             disabled={true}
             id="TextField3"
             onBlur={[Function]}
@@ -488,6 +506,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;
@@ -656,6 +683,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField9"
             onBlur={[Function]}
             onChange={[Function]}
@@ -783,6 +819,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;
@@ -942,6 +987,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;
@@ -1132,6 +1186,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField18"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1281,6 +1344,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;
@@ -1467,6 +1539,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField24"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1617,6 +1698,15 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #a19f9d;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -161,6 +161,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -300,6 +312,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -435,6 +459,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -578,6 +614,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -694,6 +742,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -835,6 +895,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -1000,6 +1072,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -1138,6 +1222,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -1299,6 +1395,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -1438,6 +1546,18 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -161,6 +161,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -187,12 +193,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -327,6 +327,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -353,12 +359,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             disabled={true}
             id="TextField3"
@@ -490,6 +490,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -516,12 +522,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -659,6 +659,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -685,12 +691,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -803,6 +803,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -829,12 +835,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField12"
             onBlur={[Function]}
@@ -971,6 +971,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -997,12 +1003,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField15"
             onBlur={[Function]}
@@ -1162,6 +1162,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1188,12 +1194,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField18"
             onBlur={[Function]}
@@ -1328,6 +1328,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1354,12 +1360,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField21"
             onBlur={[Function]}
@@ -1515,6 +1515,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1541,12 +1547,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField24"
             onBlur={[Function]}
@@ -1682,6 +1682,12 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1708,12 +1714,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             disabled={true}
             id="TextField27"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -162,15 +162,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -313,15 +328,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -461,15 +491,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -615,15 +660,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -744,15 +804,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -897,15 +972,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -1073,15 +1163,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -1224,15 +1329,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -1396,15 +1516,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -1548,15 +1683,30 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -167,33 +167,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -333,33 +306,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             disabled={true}
             id="TextField3"
             onBlur={[Function]}
@@ -495,33 +441,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -665,33 +584,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField9"
             onBlur={[Function]}
             onChange={[Function]}
@@ -808,33 +700,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField12"
             onBlur={[Function]}
@@ -976,33 +841,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField15"
             onBlur={[Function]}
@@ -1168,33 +1006,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField18"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1333,33 +1144,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField21"
             onBlur={[Function]}
@@ -1521,33 +1305,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField24"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1687,33 +1444,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             disabled={true}
             id="TextField27"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -203,6 +203,15 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -364,6 +373,15 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
@@ -550,6 +568,15 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField6"
             onBlur={[Function]}
             onChange={[Function]}
@@ -728,6 +755,15 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField9"
             onBlur={[Function]}
             onChange={[Function]}
@@ -880,6 +916,15 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -185,33 +185,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -362,33 +335,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             disabled={true}
             id="TextField3"
@@ -550,33 +496,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField6"
             onBlur={[Function]}
             onChange={[Function]}
@@ -737,33 +656,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField9"
             onBlur={[Function]}
             onChange={[Function]}
@@ -905,33 +797,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField12"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -179,6 +179,12 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -205,12 +211,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -357,6 +357,12 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -383,12 +389,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             disabled={true}
             id="TextField3"
@@ -544,6 +544,12 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -570,12 +576,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -731,6 +731,12 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -757,12 +763,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -900,6 +900,12 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -926,12 +932,6 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField12"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -180,15 +180,30 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -343,15 +358,30 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -515,15 +545,30 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -687,15 +732,30 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -841,15 +901,30 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -179,6 +179,18 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -329,6 +341,18 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-align: left;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -490,6 +514,18 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -650,6 +686,18 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -791,6 +839,18 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   padding-top: 6px;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -165,6 +165,15 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}
@@ -311,6 +320,15 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -141,6 +141,18 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }
@@ -276,6 +288,18 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 padding-top: 0;
                 text-overflow: ellipsis;
                 width: 100%;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
               }
               &:active, &:focus, &:hover {
                 outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -142,15 +142,30 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {
@@ -290,15 +305,30 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -141,6 +141,12 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -167,12 +173,6 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField0"
           onBlur={[Function]}
@@ -304,6 +304,12 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -330,12 +336,6 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField3"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -147,33 +147,6 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}
@@ -309,33 +282,6 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               }
               &::-ms-clear {
                 display: none;
-              }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
               }
           id="TextField3"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -286,6 +286,15 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField2"
           onBlur={[Function]}
           onChange={[Function]}
@@ -447,6 +456,15 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -262,6 +262,12 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -288,12 +294,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField2"
           onBlur={[Function]}
@@ -440,6 +440,12 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -466,12 +472,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField8"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -263,15 +263,30 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {
@@ -426,15 +441,30 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -262,6 +262,18 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }
@@ -412,6 +424,18 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 padding-top: 0;
                 text-overflow: ellipsis;
                 width: 100%;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
               }
               &:active, &:focus, &:hover {
                 outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -268,33 +268,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField2"
           onBlur={[Function]}
           onChange={[Function]}
@@ -445,33 +418,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               }
               &::-ms-clear {
                 display: none;
-              }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
               }
           id="TextField8"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -168,6 +168,15 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -144,6 +144,12 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -170,12 +176,6 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -150,33 +150,6 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -144,6 +144,18 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -145,15 +145,30 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -190,6 +190,15 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -352,6 +361,15 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             disabled={true}
             id="TextField3"
             onBlur={[Function]}
@@ -505,6 +523,15 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;
@@ -692,6 +719,15 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField9"
             onBlur={[Function]}
             onChange={[Function]}
@@ -836,6 +872,15 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -166,6 +166,18 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -310,6 +322,18 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -452,6 +476,18 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   resize: none;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -614,6 +650,18 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -747,6 +795,18 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -172,33 +172,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -343,33 +316,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             disabled={true}
             id="TextField3"
             onBlur={[Function]}
@@ -512,33 +458,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -701,33 +620,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField9"
             onBlur={[Function]}
             onChange={[Function]}
@@ -861,33 +753,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField12"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -167,15 +167,30 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -323,15 +338,30 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -478,15 +508,30 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -651,15 +696,30 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -797,15 +857,30 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -166,6 +166,12 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -192,12 +198,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -337,6 +337,12 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -363,12 +369,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             disabled={true}
             id="TextField3"
@@ -507,6 +507,12 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -533,12 +539,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -695,6 +695,12 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -721,12 +727,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -856,6 +856,12 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -882,12 +888,6 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField12"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -213,6 +213,15 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -398,6 +407,15 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-weight: 400;
                   opacity: 1;
                 }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
             disabled={true}
             id="TextField3"
             onBlur={[Function]}
@@ -567,6 +585,15 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;
@@ -775,6 +802,15 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
                   color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -189,6 +189,12 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -215,12 +221,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -383,6 +383,12 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -409,12 +415,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             disabled={true}
             id="TextField3"
@@ -569,6 +569,12 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -595,12 +601,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -786,6 +786,12 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &:active, &:focus, &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -812,12 +818,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
-                }
-                &:active, &:focus, &:hover {
-                  outline: 0px;
-                }
-                &::-ms-clear {
-                  display: none;
                 }
             id="TextField9"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -190,15 +190,30 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -369,15 +384,30 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #a19f9d;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -540,15 +570,30 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {
@@ -742,15 +787,30 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   width: 100%;
                 }
                 &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
                   color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
                   opacity: 1;
                 }
                 &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -189,6 +189,18 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -356,6 +368,18 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   text-overflow: ellipsis;
                   width: 100%;
                 }
+                &::placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #a19f9d;
+                  opacity: 1;
+                }
                 &:active, &:focus, &:hover {
                   outline: 0px;
                 }
@@ -514,6 +538,18 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;
@@ -704,6 +740,18 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-top: 0;
                   text-overflow: ellipsis;
                   width: 100%;
+                }
+                &::placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &:-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
+                }
+                &::-ms-input-placeholder {
+                  color: #605e5c;
+                  opacity: 1;
                 }
                 &:active, &:focus, &:hover {
                   outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -195,33 +195,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             id="TextField0"
             onBlur={[Function]}
             onChange={[Function]}
@@ -389,33 +362,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 &::-ms-clear {
                   display: none;
                 }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #a19f9d;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
             disabled={true}
             id="TextField3"
             onBlur={[Function]}
@@ -574,33 +520,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -791,33 +710,6 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 }
                 &::-ms-clear {
                   display: none;
-                }
-                &::placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &:-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
-                }
-                &::-ms-input-placeholder {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  opacity: 1;
                 }
             id="TextField9"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -190,6 +190,15 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-weight: 400;
                 opacity: 1;
               }
+              &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}
@@ -343,6 +352,15 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 color: #605e5c;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -167,15 +167,30 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {
@@ -322,15 +337,30 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 width: 100%;
               }
               &::placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &::-ms-input-placeholder {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 color: #605e5c;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
                 opacity: 1;
               }
               &:active, &:focus, &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -172,33 +172,6 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               &::-ms-clear {
                 display: none;
               }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
           id="TextField0"
           onBlur={[Function]}
           onChange={[Function]}
@@ -341,33 +314,6 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               }
               &::-ms-clear {
                 display: none;
-              }
-              &::placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &:-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
-              }
-              &::-ms-input-placeholder {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                color: #605e5c;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                opacity: 1;
               }
           id="TextField3"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -166,6 +166,18 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
               &:active, &:focus, &:hover {
                 outline: 0px;
               }
@@ -308,6 +320,18 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 padding-top: 0;
                 text-overflow: ellipsis;
                 width: 100%;
+              }
+              &::placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &:-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
+              }
+              &::-ms-input-placeholder {
+                color: #605e5c;
+                opacity: 1;
               }
               &:active, &:focus, &:hover {
                 outline: 0px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -166,6 +166,12 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -192,12 +198,6 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField0"
           onBlur={[Function]}
@@ -336,6 +336,12 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 text-overflow: ellipsis;
                 width: 100%;
               }
+              &:active, &:focus, &:hover {
+                outline: 0px;
+              }
+              &::-ms-clear {
+                display: none;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -362,12 +368,6 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
-              }
-              &:active, &:focus, &:hover {
-                outline: 0px;
-              }
-              &::-ms-clear {
-                display: none;
               }
           id="TextField3"
           onBlur={[Function]}

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -134,9 +134,7 @@ export function getIcon(name?: string): IIconRecord | undefined;
 export function getIconClassName(name: string): string;
 
 // @public
-export function getPlaceholderStyles(styles: IStyle): {
-    [key: string]: IStyle;
-};
+export function getPlaceholderStyles(styles: IStyle): IStyle;
 
 // @public (undocumented)
 export function getScreenSelector(min: number, max: number): string;

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -133,6 +133,11 @@ export function getIcon(name?: string): IIconRecord | undefined;
 // @public
 export function getIconClassName(name: string): string;
 
+// @public
+export function getPlaceholderStyles(styles: IStyle): {
+    [key: string]: IStyle;
+};
+
 // @public (undocumented)
 export function getScreenSelector(min: number, max: number): string;
 

--- a/packages/styling/src/styles/getPlaceholderStyles.ts
+++ b/packages/styling/src/styles/getPlaceholderStyles.ts
@@ -1,0 +1,22 @@
+import { IStyle } from '@uifabric/merge-styles';
+
+/**
+ * Generates a style for placeholder for each of the browsers supported by office-ui-fabric-react.
+ * @param styles - The style to use.
+ * @returns The style object with the placeholder directive as key and the style passed in as value,
+ * for each browser depending on the placeholder directive it uses.
+ */
+export function getPlaceholderStyles(
+  styles: IStyle
+): {
+  [key: string]: IStyle;
+} {
+  return {
+    '::-ms-clear': {
+      display: 'none'
+    },
+    '::placeholder': styles, // Chrome, Safari, Opera, Firefox
+    ':-ms-input-placeholder': styles, // IE 10+
+    '::-ms-input-placeholder': styles // Edge
+  };
+}

--- a/packages/styling/src/styles/getPlaceholderStyles.ts
+++ b/packages/styling/src/styles/getPlaceholderStyles.ts
@@ -1,10 +1,9 @@
 import { IStyle } from '@uifabric/merge-styles';
 
 /**
- * Generates a style for placeholder for each of the browsers supported by office-ui-fabric-react.
+ * Generates placeholder style for each of the browsers supported by office-ui-fabric-react.
  * @param styles - The style to use.
- * @returns The style object with the placeholder directive as key and the style passed in as value,
- * for each browser depending on the placeholder directive it uses.
+ * @returns The placeholder style object for each browser depending on the placeholder directive it uses.
  */
 export function getPlaceholderStyles(styles: IStyle): IStyle {
   return {

--- a/packages/styling/src/styles/getPlaceholderStyles.ts
+++ b/packages/styling/src/styles/getPlaceholderStyles.ts
@@ -6,14 +6,12 @@ import { IStyle } from '@uifabric/merge-styles';
  * @returns The style object with the placeholder directive as key and the style passed in as value,
  * for each browser depending on the placeholder directive it uses.
  */
-export function getPlaceholderStyles(
-  styles: IStyle
-): {
-  [key: string]: IStyle;
-} {
+export function getPlaceholderStyles(styles: IStyle): IStyle {
   return {
-    '::placeholder': styles, // Chrome, Safari, Opera, Firefox
-    ':-ms-input-placeholder': styles, // IE 10+
-    '::-ms-input-placeholder': styles // Edge
+    selectors: {
+      '::placeholder': styles, // Chrome, Safari, Opera, Firefox
+      ':-ms-input-placeholder': styles, // IE 10+
+      '::-ms-input-placeholder': styles // Edge
+    }
   };
 }

--- a/packages/styling/src/styles/getPlaceholderStyles.ts
+++ b/packages/styling/src/styles/getPlaceholderStyles.ts
@@ -12,9 +12,6 @@ export function getPlaceholderStyles(
   [key: string]: IStyle;
 } {
   return {
-    '::-ms-clear': {
-      display: 'none'
-    },
     '::placeholder': styles, // Chrome, Safari, Opera, Firefox
     ':-ms-input-placeholder': styles, // IE 10+
     '::-ms-input-placeholder': styles // Edge

--- a/packages/styling/src/styles/index.ts
+++ b/packages/styling/src/styles/index.ts
@@ -11,4 +11,5 @@ export { ThemeSettingName, getTheme, loadTheme, createTheme, registerOnThemeChan
 export * from './CommonStyles';
 export * from './GeneralStyles';
 export * from './getFadedOverflowStyle';
+export * from './getPlaceholderStyles';
 export * from './zIndexes';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9478
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

1. Edge browser needs `::-ms-input-placeholder` for [placeholder](https://caniuse.com/#feat=css-placeholder). Hoisting the styles to a variable and re-using it depending on the placeholder CSS pseudo-element used by the specific browser.

2. Fixes are done across the other components where similar bug could reproduce - `ComboBox` and `SearchBox`, in addition to `TextField`

3. While fixing this bug, also noticed that, if you have a disabled `ComboBox`, the `placeholder` styles never worked, due to specificity. Moved from root->selectors->input->selectors->placeholder to input->selectors->placeholder fixes this and styles take effect. 

#### Focus areas to test
For `TextField`, `ComboBox` and `SearchBox`, `placeholder` now shows expected styles in Edge browser; placeholder continues to show styles in `Chrome`, `Firefox`, `Opera` and `IE` 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9488)