### PR TITLE
Button: Adding focus tests for Button, MenuButton and SplitButton.

### DIFF
--- a/common/changes/@uifabric/experiments/buttonFocusTest_2019-06-17-23-47.json
+++ b/common/changes/@uifabric/experiments/buttonFocusTest_2019-06-17-23-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Button: Adding focus tests for Button, MenuButton and SplitButton.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/experiments/src/components/Button/Button.test.tsx
+++ b/packages/experiments/src/components/Button/Button.test.tsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 
 import { CommandBar, Icon, Text } from 'office-ui-fabric-react';
 import { Button } from './Button';
+import { IButton } from './Button.types';
 
 describe('Button', () => {
   it('renders a default Button with content correctly', () => {
@@ -102,24 +103,28 @@ describe('Button', () => {
   });
 
   it('focuses correctly when focus is triggered via IButton interface', () => {
+    const button1 = React.createRef<IButton>();
+    const button2 = React.createRef<IButton>();
+    const button3 = React.createRef<IButton>();
+
     const wrapper = mount(
       <div>
-        <Button content="Button 1" />
-        <Button content="Button 2" />
-        <Button content="Button 3" />
+        <Button content="Button 1" componentRef={button1} />
+        <Button content="Button 2" componentRef={button2} />
+        <Button content="Button 3" componentRef={button3} />
       </div>
     );
 
     const buttons = wrapper.getDOMNode().querySelectorAll('button.ms-Button') as NodeListOf<HTMLButtonElement>;
     expect(buttons.length).toEqual(3);
 
-    buttons[0].focus();
-    expect(document.activeElement!.textContent).toEqual('Button 1');
+    button1.current!.focus();
+    expect(document.activeElement!).toBe(buttons[0]);
 
-    buttons[1].focus();
-    expect(document.activeElement!.textContent).toEqual('Button 2');
+    button2.current!.focus();
+    expect(document.activeElement!).toBe(buttons[1]);
 
-    buttons[2].focus();
-    expect(document.activeElement!.textContent).toEqual('Button 3');
+    button3.current!.focus();
+    expect(document.activeElement!).toBe(buttons[2]);
   });
 });

--- a/packages/experiments/src/components/Button/Button.test.tsx
+++ b/packages/experiments/src/components/Button/Button.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 import { CommandBar, Icon, Text } from 'office-ui-fabric-react';
 import { Button } from './Button';
@@ -98,5 +99,27 @@ describe('Button', () => {
     const component = renderer.create(<Button primary checked circular icon="Volume3" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot;
+  });
+
+  it('focuses correctly when focus is triggered via IButton interface', () => {
+    const wrapper = mount(
+      <div>
+        <Button content="Button 1" />
+        <Button content="Button 2" />
+        <Button content="Button 3" />
+      </div>
+    );
+
+    const buttons = wrapper.getDOMNode().querySelectorAll('button.ms-Button') as NodeListOf<HTMLButtonElement>;
+    expect(buttons.length).toEqual(3);
+
+    buttons[0].focus();
+    expect(document.activeElement!.textContent).toEqual('Button 1');
+
+    buttons[1].focus();
+    expect(document.activeElement!.textContent).toEqual('Button 2');
+
+    buttons[2].focus();
+    expect(document.activeElement!.textContent).toEqual('Button 3');
   });
 });

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.styles.ts
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.styles.ts
@@ -1,5 +1,5 @@
-import { IMenuButtonComponent, IMenuButtonStylesReturnType, IMenuButtonTokenReturnType } from './MenuButton.types';
 import { getGlobalClassNames, HighContrastSelector } from '../../../Styling';
+import { IMenuButtonComponent, IMenuButtonStylesReturnType, IMenuButtonTokenReturnType } from './MenuButton.types';
 
 const baseTokens: IMenuButtonComponent['tokens'] = (props, theme): IMenuButtonTokenReturnType => {
   return {
@@ -60,15 +60,14 @@ export const MenuButtonTokens: IMenuButtonComponent['tokens'] = (props, theme): 
   props.primary && props.expanded && primaryExpandedTokens
 ];
 
+const GlobalClassNames = {
+  msMenuButton: 'ms-MenuButton'
+};
+
 export const MenuButtonStyles: IMenuButtonComponent['styles'] = (props, theme, tokens): IMenuButtonStylesReturnType => {
   const { className } = props;
 
-  const globalClassNames = getGlobalClassNames(
-    {
-      msMenuButton: 'ms-MenuButton'
-    },
-    theme
-  );
+  const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
     root: {

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.test.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 import { Stack, Text } from 'office-ui-fabric-react';
 import { MenuButton } from './MenuButton';
@@ -48,5 +49,27 @@ describe('MenuButton', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot;
+  });
+
+  it('focuses correctly when focus is triggered via IMenuButton interface', () => {
+    const wrapper = mount(
+      <div>
+        <MenuButton content="Menu Button 1" />
+        <MenuButton content="Menu Button 2" />
+        <MenuButton content="Menu Button 3" />
+      </div>
+    );
+
+    const buttons = wrapper.getDOMNode().querySelectorAll('button.ms-MenuButton') as NodeListOf<HTMLButtonElement>;
+    expect(buttons.length).toEqual(3);
+
+    buttons[0].focus();
+    expect(document.activeElement!.children[0].children[0].textContent).toEqual('Menu Button 1');
+
+    buttons[1].focus();
+    expect(document.activeElement!.children[0].children[0].textContent).toEqual('Menu Button 2');
+
+    buttons[2].focus();
+    expect(document.activeElement!.children[0].children[0].textContent).toEqual('Menu Button 3');
   });
 });

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.test.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.test.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 
 import { Stack, Text } from 'office-ui-fabric-react';
 import { MenuButton } from './MenuButton';
-import { IMenuButtonProps } from './MenuButton.types';
+import { IMenuButton, IMenuButtonProps } from './MenuButton.types';
 
 const menuProps: IMenuButtonProps['menu'] = {
   items: [
@@ -52,24 +52,28 @@ describe('MenuButton', () => {
   });
 
   it('focuses correctly when focus is triggered via IMenuButton interface', () => {
+    const button1 = React.createRef<IMenuButton>();
+    const button2 = React.createRef<IMenuButton>();
+    const button3 = React.createRef<IMenuButton>();
+
     const wrapper = mount(
       <div>
-        <MenuButton content="Menu Button 1" />
-        <MenuButton content="Menu Button 2" />
-        <MenuButton content="Menu Button 3" />
+        <MenuButton content="Button 1" componentRef={button1} />
+        <MenuButton content="Button 2" componentRef={button2} />
+        <MenuButton content="Button 3" componentRef={button3} />
       </div>
     );
 
     const buttons = wrapper.getDOMNode().querySelectorAll('button.ms-MenuButton') as NodeListOf<HTMLButtonElement>;
     expect(buttons.length).toEqual(3);
 
-    buttons[0].focus();
-    expect(document.activeElement!.children[0].children[0].textContent).toEqual('Menu Button 1');
+    button1.current!.focus();
+    expect(document.activeElement!).toBe(buttons[0]);
 
-    buttons[1].focus();
-    expect(document.activeElement!.children[0].children[0].textContent).toEqual('Menu Button 2');
+    button2.current!.focus();
+    expect(document.activeElement!).toBe(buttons[1]);
 
-    buttons[2].focus();
-    expect(document.activeElement!.children[0].children[0].textContent).toEqual('Menu Button 3');
+    button3.current!.focus();
+    expect(document.activeElement!).toBe(buttons[2]);
   });
 });

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -1,4 +1,4 @@
-import { HighContrastSelector } from '../../../Styling';
+import { getGlobalClassNames, HighContrastSelector } from '../../../Styling';
 import { ISplitButtonComponent, ISplitButtonStylesReturnType, ISplitButtonTokenReturnType } from './SplitButton.types';
 
 const baseTokens: ISplitButtonComponent['tokens'] = (props, theme): ISplitButtonTokenReturnType => {
@@ -58,28 +58,37 @@ export const SplitButtonTokens: ISplitButtonComponent['tokens'] = (props, theme)
   props.disabled && disabledTokens
 ];
 
+const GlobalClassNames = {
+  msSplitButton: 'ms-SplitButton'
+};
+
 export const SplitButtonStyles: ISplitButtonComponent['styles'] = (props, theme, tokens): ISplitButtonStylesReturnType => {
   const { semanticColors } = theme;
 
-  return {
-    root: {
-      borderRadius: tokens.borderRadius,
-      boxSizing: 'border-box',
-      display: 'inline-flex',
-      zIndex: 1,
+  const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
-      selectors: {
-        [HighContrastSelector]: {
-          borderColor: 'transparent'
-        },
-        ':hover': {
-          borderColor: props.primaryActionDisabled ? 'transparent' : tokens.borderColorHovered
-        },
-        ':active': {
-          borderColor: props.primaryActionDisabled ? 'transparent' : tokens.borderColorPressed
+  return {
+    root: [
+      globalClassNames.msSplitButton,
+      {
+        borderRadius: tokens.borderRadius,
+        boxSizing: 'border-box',
+        display: 'inline-flex',
+        zIndex: 1,
+
+        selectors: {
+          [HighContrastSelector]: {
+            borderColor: 'transparent'
+          },
+          ':hover': {
+            borderColor: props.primaryActionDisabled ? 'transparent' : tokens.borderColorHovered
+          },
+          ':active': {
+            borderColor: props.primaryActionDisabled ? 'transparent' : tokens.borderColorPressed
+          }
         }
       }
-    },
+    ],
     button: {
       borderBottomLeftRadius: tokens.borderRadius,
       borderBottomRightRadius: '0px',

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.test.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
 
 import { SplitButton } from './SplitButton';
 import { ISplitButtonProps } from './SplitButton.types';
@@ -56,5 +57,27 @@ describe('SplitButton', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot;
+  });
+
+  it('focuses correctly when focus is triggered via ISplitButton interface', () => {
+    const wrapper = mount(
+      <div>
+        <SplitButton content="Split Button 1" />
+        <SplitButton content="Split Button 2" />
+        <SplitButton content="Split Button 3" />
+      </div>
+    );
+
+    const buttons = wrapper.getDOMNode().querySelectorAll('span.ms-SplitButton > button.ms-Button') as NodeListOf<HTMLButtonElement>;
+    expect(buttons.length).toEqual(3);
+
+    buttons[0].focus();
+    expect(document.activeElement!.textContent).toEqual('Split Button 1');
+
+    buttons[1].focus();
+    expect(document.activeElement!.textContent).toEqual('Split Button 2');
+
+    buttons[2].focus();
+    expect(document.activeElement!.textContent).toEqual('Split Button 3');
   });
 });

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.test.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.test.tsx
@@ -3,7 +3,7 @@ import * as renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 
 import { SplitButton } from './SplitButton';
-import { ISplitButtonProps } from './SplitButton.types';
+import { ISplitButton, ISplitButtonProps } from './SplitButton.types';
 
 const menuProps: ISplitButtonProps['menu'] = {
   items: [
@@ -60,24 +60,28 @@ describe('SplitButton', () => {
   });
 
   it('focuses correctly when focus is triggered via ISplitButton interface', () => {
+    const button1 = React.createRef<ISplitButton>();
+    const button2 = React.createRef<ISplitButton>();
+    const button3 = React.createRef<ISplitButton>();
+
     const wrapper = mount(
       <div>
-        <SplitButton content="Split Button 1" />
-        <SplitButton content="Split Button 2" />
-        <SplitButton content="Split Button 3" />
+        <SplitButton content="Button 1" componentRef={button1} />
+        <SplitButton content="Button 2" componentRef={button2} />
+        <SplitButton content="Button 3" componentRef={button3} />
       </div>
     );
 
     const buttons = wrapper.getDOMNode().querySelectorAll('span.ms-SplitButton > button.ms-Button') as NodeListOf<HTMLButtonElement>;
     expect(buttons.length).toEqual(3);
 
-    buttons[0].focus();
-    expect(document.activeElement!.textContent).toEqual('Split Button 1');
+    button1.current!.focus();
+    expect(document.activeElement!).toBe(buttons[0]);
 
-    buttons[1].focus();
-    expect(document.activeElement!.textContent).toEqual('Split Button 2');
+    button2.current!.focus();
+    expect(document.activeElement!).toBe(buttons[1]);
 
-    buttons[2].focus();
-    expect(document.activeElement!.textContent).toEqual('Split Button 3');
+    button3.current!.focus();
+    expect(document.activeElement!).toBe(buttons[2]);
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds tests to guard against regressions in the use of the `focus` method in the public interface of the `Button`, `MenuButton` and `SplitButton` components.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9490)