### PR TITLE
Revert "Tooltip: improve perf by preventing all render until after de…

### DIFF
--- a/apps/vr-tests/src/stories/Tooltip.stories.tsx
+++ b/apps/vr-tests/src/stories/Tooltip.stories.tsx
@@ -19,7 +19,7 @@ storiesOf('Tooltip', module)
     </Screener>
   ))
   .addStory('Default', () => (
-    <TooltipHost content="This is the tooltip" id="myID" delay={0} calloutProps={{ gapSpace: 0 }}>
+    <TooltipHost content="This is the tooltip" id="myID" calloutProps={{ gapSpace: 0 }}>
       Hover over me
     </TooltipHost>
   ));
@@ -42,10 +42,10 @@ storiesOf('Tooltip - Multiple', module)
   ))
   .addStory('Two Tooltips', () => (
     <div>
-      <TooltipHost delay={0} content="I am the outer tooltip">
+      <TooltipHost content="I am the outer tooltip">
         <div id="outerTooltip">I am the outer tooltip text</div>
         <div id="innerTooltip" style={{ padding: '20px' }}>
-          <TooltipHost delay={0} content="I am the inner tooltip">
+          <TooltipHost content="I am the inner tooltip">
             and I am the inner tooltip text
           </TooltipHost>
         </div>

--- a/common/changes/office-ui-fabric-react/revertTooltipPerf_2019-06-18-16-58.json
+++ b/common/changes/office-ui-fabric-react/revertTooltipPerf_2019-06-18-16-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: reverts commit 210fbabee ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentConformance.test.tsx
@@ -89,9 +89,6 @@ const requiredProps: { [key: string]: any } = {
   },
   Text: {
     children: 'TestText'
-  },
-  Tooltip: {
-    delay: 0
   }
 };
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, divProperties, getNativeProps, DelayedRender } from '../../Utilities';
+import { classNamesFunction, divProperties, getNativeProps } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { ITooltipProps, ITooltipStyleProps, ITooltipStyles, TooltipDelay } from './Tooltip.types';
 import { Callout } from '../../Callout';
@@ -42,19 +42,11 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className: className || (calloutProps && calloutProps.className),
+      delay: delay!,
       maxWidth: maxWidth!
     });
 
-    let renderDelay;
-    if (delay === TooltipDelay.zero) {
-      renderDelay = 0;
-    } else if (delay === TooltipDelay.medium) {
-      renderDelay = 300;
-    } else if (delay === TooltipDelay.long) {
-      renderDelay = 500;
-    }
-
-    const RenderedCallout = (
+    return (
       <Callout
         target={targetElement}
         directionalHint={directionalHint}
@@ -74,8 +66,6 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
         </div>
       </Callout>
     );
-
-    return delay === TooltipDelay.zero ? RenderedCallout : <DelayedRender delay={renderDelay}> {RenderedCallout} </DelayedRender>;
   }
 
   private _onRenderContent = (props: ITooltipProps): JSX.Element => {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -1,8 +1,8 @@
-import { ITooltipStyleProps, ITooltipStyles } from './Tooltip.types';
+import { ITooltipStyleProps, ITooltipStyles, TooltipDelay } from './Tooltip.types';
 import { AnimationClassNames } from '../../Styling';
 
 export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
-  const { className, maxWidth, theme } = props;
+  const { className, delay, maxWidth, theme } = props;
   const { palette, fonts } = theme;
 
   return {
@@ -13,7 +13,14 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
       {
         background: palette.white,
         padding: '8px',
+        animationDelay: '300ms',
         maxWidth: maxWidth
+      },
+      delay === TooltipDelay.zero && {
+        animationDelay: '0s'
+      },
+      delay === TooltipDelay.long && {
+        animationDelay: '500ms'
       },
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.test.tsx
@@ -28,7 +28,7 @@ describe('Tooltip', () => {
       return element;
     });
 
-    const component = renderer.create(<TooltipBase delay={0} />);
+    const component = renderer.create(<TooltipBase />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
 
@@ -69,7 +69,6 @@ describe('Tooltip', () => {
           return null;
         }}
         targetElement={targetElement}
-        delay={0}
       />
     );
 


### PR DESCRIPTION
…lay's done. (#9341)"

This reverts commit 210fbabee3045f1e8d06735c82e535816024b89a.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

DelayedRender was causing a run-time error in Tooltip.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9495)