### PR TITLE
BaseFloatingItem: fix tests + remove redundant state 

### DIFF
--- a/common/changes/office-ui-fabric-react/u-mahuangh-basepicker-state-and-tests_2019-06-18-21-04.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-basepicker-state-and-tests_2019-06-18-21-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Fix tests for BasePicker + remove redundant state",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "mhuan13@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/u-mahuangh-basepicker-state-and-tests_2019-06-18-21-04.json
+++ b/common/changes/office-ui-fabric-react/u-mahuangh-basepicker-state-and-tests_2019-06-18-21-04.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Fix tests for BasePicker + remove redundant state",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -197,7 +197,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentDidUpdate(): void;
+    componentDidUpdate(prevProps: P, prevState: IBaseFloatingPickerState): void;
     // (undocumented)
     componentWillReceiveProps(newProps: IBaseFloatingPickerProps<T>): void;
     // (undocumented)
@@ -1575,8 +1575,6 @@ export interface IBaseExtendedPickerProps<T> {
 export interface IBaseExtendedPickerState<T> {
     // (undocumented)
     queryString: string | null;
-    // (undocumented)
-    selectedItems: T[] | null;
     // (undocumented)
     suggestionItems: T[] | null;
 }

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.test.tsx
@@ -1,8 +1,7 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
-/* tslint:enable:no-unused-variable */
+import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 
 import { IBaseExtendedPickerProps } from './BaseExtendedPicker.types';
@@ -44,11 +43,11 @@ const BaseSelectedItemsListWithType = BaseSelectedItemsList as new (props: IBase
 >;
 
 const basicSuggestionRenderer = (props: ISimple) => {
-  return <div> {props.name} </div>;
+  return <div key={props.key}> {props.name} </div>;
 };
 
 const basicItemRenderer = (props: ISelectedItemProps<ISimple>) => {
-  return <div> {props.name} </div>;
+  return <div key={props.key}> {props.name} </div>;
 };
 
 const basicRenderFloatingPicker = (props: IBaseFloatingPickerProps<ISimple>) => {
@@ -56,7 +55,7 @@ const basicRenderFloatingPicker = (props: IBaseFloatingPickerProps<ISimple>) => 
 };
 
 const basicRenderSelectedItemsList = (props: IBaseSelectedItemsListProps<ISimple>) => {
-  return <BaseSelectedItemsListWithType />;
+  return <BaseSelectedItemsListWithType {...props} />;
 };
 
 const floatingPickerProps = {
@@ -82,8 +81,26 @@ describe('Pickers', () => {
       ISimple,
       IBaseExtendedPickerProps<ISimple>
     >;
+    // Our functional tests need to run against actual DOM for callouts to work,
+    // since callout mount a new react root with ReactDOM.
+    //
+    // see https://github.com/facebook/react/pull/12895
+    let hostNode: HTMLDivElement | null = null;
+    const create = (elem: React.ReactElement) => {
+      hostNode = document.createElement('div');
+      document.body.appendChild(hostNode);
+      ReactDOM.render(elem, hostNode);
+    };
 
-    it('renders BaseExtendedPicker correctly', () => {
+    afterEach(() => {
+      if (hostNode) {
+        ReactDOM.unmountComponentAtNode(hostNode);
+        document.body.removeChild(hostNode);
+        hostNode = null;
+      }
+    });
+
+    it('renders BaseExtendedPicker correctly with no items', () => {
       const component = renderer.create(
         <BaseExtendedPickerWithType
           floatingPickerProps={floatingPickerProps}
@@ -96,51 +113,85 @@ describe('Pickers', () => {
       expect(tree).toMatchSnapshot();
     });
 
-    it('force resolves to the first suggestion', () => {
-      const root = document.createElement('div');
-      document.body.appendChild(root);
-
-      const picker: TypedBaseExtendedPicker = (ReactDOM.render(
+    it('renders BaseExtendedPicker correctly with selected and suggested items', () => {
+      const component = renderer.create(
         <BaseExtendedPickerWithType
           floatingPickerProps={floatingPickerProps}
           selectedItemsListProps={selectedItemsListProps}
           onRenderSelectedItems={basicRenderSelectedItemsList}
           onRenderFloatingPicker={basicRenderFloatingPicker}
-        />,
-        root
-      ) as unknown) as TypedBaseExtendedPicker;
+          suggestionItems={[
+            {
+              name: 'yellow',
+              key: 'yellow'
+            }
+          ]}
+          selectedItems={[
+            {
+              name: 'red',
+              key: 'red'
+            },
+            {
+              name: 'green',
+              key: 'green'
+            }
+          ]}
+        />
+      );
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('force resolves to the first suggestion', () => {
+      const pickerRef: React.RefObject<TypedBaseExtendedPicker> = React.createRef();
+      create(
+        <BaseExtendedPickerWithType
+          ref={pickerRef}
+          defaultSelectedItems={[]}
+          floatingPickerProps={floatingPickerProps}
+          selectedItemsListProps={selectedItemsListProps}
+          onRenderSelectedItems={basicRenderSelectedItemsList}
+          onRenderFloatingPicker={basicRenderFloatingPicker}
+        />
+      );
+
+      expect(pickerRef.current).not.toBeFalsy();
+      const picker = pickerRef.current!;
 
       if (picker.inputElement) {
         picker.inputElement.value = 'bl';
+        ReactTestUtils.Simulate.input(picker.inputElement);
       }
 
+      expect(picker.state.queryString).toBe('bl');
       expect(picker.floatingPicker.current && picker.floatingPicker.current.suggestions.length).toBe(2);
-      expect(picker.floatingPicker.current && picker.floatingPicker.current.suggestions[0].name).toBe('black');
+      expect(picker.floatingPicker.current && picker.floatingPicker.current.suggestions[0].item.name).toBe('black');
 
       // Force resolve to the first suggestions
       picker.floatingPicker.current && picker.floatingPicker.current.forceResolveSuggestion();
       expect(picker.items.length).toBe(1);
       expect(picker.items[0].name).toBe('black');
-
-      ReactDOM.unmountComponentAtNode(root);
     });
 
     it('Can hide and show picker', () => {
-      const root = document.createElement('div');
-      document.body.appendChild(root);
-
-      const picker: TypedBaseExtendedPicker = (ReactDOM.render(
+      const pickerRef: React.RefObject<TypedBaseExtendedPicker> = React.createRef();
+      create(
         <BaseExtendedPickerWithType
+          ref={pickerRef}
+          defaultSelectedItems={[]}
           floatingPickerProps={floatingPickerProps}
           selectedItemsListProps={selectedItemsListProps}
           onRenderSelectedItems={basicRenderSelectedItemsList}
           onRenderFloatingPicker={basicRenderFloatingPicker}
-        />,
-        root
-      ) as unknown) as TypedBaseExtendedPicker;
+        />
+      );
+
+      expect(pickerRef.current).not.toBeFalsy();
+      const picker = pickerRef.current!;
 
       if (picker.inputElement) {
         picker.inputElement.value = 'bl';
+        ReactTestUtils.Simulate.input(picker.inputElement);
       }
 
       expect(picker.floatingPicker.current && picker.floatingPicker.current.isSuggestionsShown).toBeTruthy();
@@ -148,34 +199,58 @@ describe('Pickers', () => {
       expect(picker.floatingPicker.current && picker.floatingPicker.current.isSuggestionsShown).toBeFalsy();
       picker.floatingPicker.current && picker.floatingPicker.current.showPicker();
       expect(picker.floatingPicker.current && picker.floatingPicker.current.isSuggestionsShown).toBeTruthy();
-
-      ReactDOM.unmountComponentAtNode(root);
     });
 
     it('Completes the suggestion', () => {
-      const root = document.createElement('div');
-      document.body.appendChild(root);
-
-      const picker: TypedBaseExtendedPicker = (ReactDOM.render(
+      const pickerRef: React.RefObject<TypedBaseExtendedPicker> = React.createRef();
+      create(
         <BaseExtendedPickerWithType
+          ref={pickerRef}
+          defaultSelectedItems={[]}
           floatingPickerProps={floatingPickerProps}
           selectedItemsListProps={selectedItemsListProps}
           onRenderSelectedItems={basicRenderSelectedItemsList}
           onRenderFloatingPicker={basicRenderFloatingPicker}
-        />,
-        root
-      ) as unknown) as TypedBaseExtendedPicker;
+        />
+      );
 
+      expect(pickerRef.current).not.toBeFalsy();
+      const picker = pickerRef.current!;
+
+      // setup
       if (picker.inputElement) {
         picker.inputElement.value = 'bl';
+        ReactTestUtils.Simulate.input(picker.inputElement);
         ReactTestUtils.Simulate.keyDown(picker.inputElement, { which: KeyCodes.down });
       }
 
-      picker.floatingPicker.current && picker.floatingPicker.current.completeSuggestion();
-      expect(picker.selectedItemsList.current && picker.selectedItemsList.current.items.length).toBe(1);
-      expect(picker.selectedItemsList.current && picker.selectedItemsList.current.items[0].name).toBe('blue');
+      // precondition check
+      expect(picker.floatingPicker.current).toBeTruthy();
+      expect(picker.floatingPicker.current!.suggestions).toEqual([
+        jasmine.objectContaining({
+          item: jasmine.objectContaining({
+            name: 'black',
+            key: 'black'
+          })
+        }),
+        jasmine.objectContaining({
+          item: jasmine.objectContaining({
+            name: 'blue',
+            key: 'blue'
+          })
+        })
+      ]);
 
-      ReactDOM.unmountComponentAtNode(root);
+      // act
+      picker.floatingPicker.current && picker.floatingPicker.current.completeSuggestion();
+
+      // assert
+      expect(picker.items).toEqual([
+        jasmine.objectContaining({
+          name: 'black',
+          key: 'black'
+        })
+      ]);
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -13,7 +13,6 @@ const styles: any = stylesImport;
 
 export interface IBaseExtendedPickerState<T> {
   queryString: string | null;
-  selectedItems: T[] | null;
   suggestionItems: T[] | null;
 }
 
@@ -35,12 +34,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
 
     this.state = {
       queryString: '',
-      suggestionItems: this.props.suggestionItems ? (this.props.suggestionItems as T[]) : null,
-      selectedItems: this.props.defaultSelectedItems
-        ? (this.props.defaultSelectedItems as T[])
-        : this.props.selectedItems
-        ? (this.props.selectedItems as T[])
-        : null
+      suggestionItems: this.props.suggestionItems ? (this.props.suggestionItems as T[]) : null
     };
 
     this.floatingPickerProps = this.props.floatingPickerProps;
@@ -49,14 +43,11 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
 
   // tslint:disable-next-line:no-any
   public get items(): any {
-    return this.state.selectedItems
-      ? this.state.selectedItems
-      : this.selectedItemsList.current
-      ? this.selectedItemsList.current.items
-      : null;
+    return this.selectedItemsList.current ? this.selectedItemsList.current.items : null;
   }
 
   public componentDidMount(): void {
+    super.componentDidMount();
     this.forceUpdate();
   }
 
@@ -67,10 +58,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
 
     if (newProps.selectedItemsListProps) {
       this.selectedItemsListProps = newProps.selectedItemsListProps;
-    }
-
-    if (newProps.selectedItems) {
-      this.setState({ selectedItems: newProps.selectedItems });
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pickers BasePicker renders BaseExtendedPicker correctly with no items 1`] = `
+<div
+  className="ms-BasePicker ms-BaseExtendedPicker"
+  onCopy={[Function]}
+  onKeyDown={[Function]}
+>
+  <div
+    className=
+        ms-FocusZone
+        &:focus {
+          outline: none;
+        }
+    data-focuszone-id="FocusZone0"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+    role="presentation"
+  >
+    <div
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
+      onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="presentation"
+    >
+      <div
+        className="ms-BasePicker-text"
+        role="list"
+      >
+        <input
+          aria-expanded={false}
+          aria-haspopup="true"
+          aria-owns="suggestion-list"
+          autoCapitalize="off"
+          autoComplete="off"
+          className="ms-BasePicker-input"
+          data-lpignore={true}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          role="combobox"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="ms-BasePicker ms-BaseFloatingPicker"
+  />
+</div>
+`;
+
+exports[`Pickers BasePicker renders BaseExtendedPicker correctly with selected and suggested items 1`] = `
+<div
+  className="ms-BasePicker ms-BaseExtendedPicker"
+  onCopy={[Function]}
+  onKeyDown={[Function]}
+>
+  <div
+    className=
+        ms-FocusZone
+        &:focus {
+          outline: none;
+        }
+    data-focuszone-id="FocusZone1"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+    role="presentation"
+  >
+    <div
+      className="ms-SelectionZone"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onFocusCapture={[Function]}
+      onKeyDown={[Function]}
+      onKeyDownCapture={[Function]}
+      onMouseDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="presentation"
+    >
+      <div
+        className="ms-BasePicker-text"
+        role="list"
+      >
+        <div>
+           
+           
+        </div>
+        <div>
+           
+           
+        </div>
+        <input
+          aria-expanded={false}
+          aria-haspopup="true"
+          aria-owns="suggestion-list"
+          autoCapitalize="off"
+          autoComplete="off"
+          className="ms-BasePicker-input"
+          data-lpignore={true}
+          onChange={[Function]}
+          onClick={[Function]}
+          onCompositionEnd={[Function]}
+          onCompositionStart={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          onPaste={[Function]}
+          role="combobox"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="ms-BasePicker ms-BaseFloatingPicker"
+  />
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -105,13 +105,15 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   };
 
   public componentDidMount(): void {
+    super.componentDidMount();
     this._bindToInputElement();
     this.isComponentMounted = true;
 
     this._onResolveSuggestions = this._async.debounce(this._onResolveSuggestions, this.props.resolveDelay);
   }
 
-  public componentDidUpdate(): void {
+  public componentDidUpdate(prevProps: P, prevState: IBaseFloatingPickerState): void {
+    super.componentDidUpdate(prevProps, prevState);
     this._bindToInputElement();
   }
 

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -147,10 +147,11 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
   }
 
   public componentDidMount(): void {
+    super.componentDidMount();
     this.selection.setItems(this.state.items);
   }
 
-  public componentWillReceiveProps(newProps: P): void {
+  public componentWillReceiveProps(newProps: P, nextContent: any): void {
     const newItems = newProps.selectedItems;
 
     if (newItems) {

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -151,7 +151,7 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     this.selection.setItems(this.state.items);
   }
 
-  public componentWillReceiveProps(newProps: P, nextContent: any): void {
+  public componentWillReceiveProps(newProps: P): void {
     const newItems = newProps.selectedItems;
 
     if (newItems) {


### PR DESCRIPTION
#### Pull request checklist

- ~~ [ ] Addresses an existing issue: Fixes #0000 ~~
- [x] Include a change request file using `$ npm run change`

#### Description of changes

While working on a feature change for pickers to support OWA, I noticed that:

- the tests for BasePicker have not been running, ever (It was named `BaseExtendedPicker.test*s*.tsx`)
- Component refs have not been being set properly in basePicker. None of the components call super.componentDidMount/etc to manage the values of `componentRef`. In part because of this, all the tests that were written were failing.
- selectedItems state in basePicker is unused in the uncontrolled mode. Instead BasePicker always uses the selectedItems state in the child selectedItemsList, (I talked to & confirmed this with the origianl author, @amyngu)

This is part 1/2 -- I figured it'd make reviewing easier if the fixes & the new work were in separate changes

#### Focus areas to test

BaseExtendedPicker

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9500)