### PR TITLE
Hovercard fix

### DIFF
--- a/common/changes/office-ui-fabric-react/hovercard-fix_2019-06-18-21-46.json
+++ b/common/changes/office-ui-fabric-react/hovercard-fix_2019-06-18-21-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Moved setSate in _setHeightOffsetEveryFrame so it does not run more than necessary and added and if to check if there is a given position and final height, then stop running _updateAsyncPosition",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "esteban.230@hotmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -105,10 +105,9 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
       if (!this._hasListeners) {
         this._addListeners();
       }
-      if (this.state.positions && this.props.finalHeight) {
-        return;
+      if (!this.state.positions || !this.props.finalHeight) {
+        this._updateAsyncPosition();
       }
-      this._updateAsyncPosition();
     } else {
       if (this._hasListeners) {
         this._removeListeners();

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -105,6 +105,9 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
       if (!this._hasListeners) {
         this._addListeners();
       }
+      if (this.state.positions && this.props.finalHeight) {
+        return;
+      }
       this._updateAsyncPosition();
     } else {
       if (this._hasListeners) {
@@ -509,11 +512,10 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
         const cardCurrHeight: number = calloutMainElem.offsetHeight;
         const scrollDiff: number = cardScrollHeight - cardCurrHeight;
 
-        this.setState({
-          heightOffset: this.state.heightOffset! + scrollDiff
-        });
-
         if (calloutMainElem.offsetHeight < this.props.finalHeight!) {
+          this.setState({
+            heightOffset: this.state.heightOffset! + scrollDiff
+          });
           this._setHeightOffsetEveryFrame();
         } else {
           this._async.cancelAnimationFrame(this._setHeightOffsetTimer);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9132
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There are two changes, one was that a setState was being executed more than it needs to so I moved it to the inside of the if statement. The second issue is what fixes the jump, I added an if statement to check if the card has a final height and a position since once you have both there is no need to keep updating the position.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9501)