### PR TITLE
Perf tests: Fix break by making them more robust

### DIFF
--- a/apps/perf-test/src/App.tsx
+++ b/apps/perf-test/src/App.tsx
@@ -26,6 +26,7 @@ export const App = () => {
             className="scenario"
             options={Scenarios}
             selectedKey={scenario.key}
+            data-automationid="scenario"
             onChange={(ev, option) => {
               setItemsVisible(false);
               if (option) {

--- a/scripts/tasks/perf-test.js
+++ b/scripts/tasks/perf-test.js
@@ -76,8 +76,11 @@ async function runAvailableScenarios(page, componentCount, iterations, sampleSiz
   const perfNumbers = {};
 
   // Iterate through scenarios available
-  const scenarioDropdown = await page.$('.scenario');
-  let scenarioName = (await page.$eval('.scenario', dropdown => dropdown.textContent)).replace(/[^a-zA-Z\s]/g, '');
+  await page.evaluate(() => {
+    debugger;
+  });
+  const scenarioDropdown = await page.$('div[data-automationid="scenario"]');
+  let scenarioName = (await page.$eval('div[data-automationid="scenario"]', dropdown => dropdown.textContent)).replace(/[^a-zA-Z\s]/g, '');
   while (!perfNumbers[scenarioName]) {
     // get numbers
     perfNumbers[scenarioName] = await runScenarioNTimes(page, sampleSize);
@@ -85,7 +88,7 @@ async function runAvailableScenarios(page, componentCount, iterations, sampleSiz
     // go to next scenario
     await scenarioDropdown.focus();
     await page.keyboard.press('ArrowDown');
-    scenarioName = (await page.$eval('.scenario', dropdown => dropdown.textContent)).replace(/[^a-zA-Z\s]/g, '');
+    scenarioName = (await page.$eval('div[data-automationid="scenario"]', dropdown => dropdown.textContent)).replace(/[^a-zA-Z\s]/g, '');
   }
 
   return perfNumbers;

--- a/scripts/tasks/perf-test.js
+++ b/scripts/tasks/perf-test.js
@@ -75,10 +75,6 @@ async function runAvailableScenarios(page, componentCount, iterations, sampleSiz
 
   const perfNumbers = {};
 
-  // Iterate through scenarios available
-  await page.evaluate(() => {
-    debugger;
-  });
   const scenarioDropdown = await page.$('div[data-automationid="scenario"]');
   let scenarioName = (await page.$eval('div[data-automationid="scenario"]', dropdown => dropdown.textContent)).replace(/[^a-zA-Z\s]/g, '');
   while (!perfNumbers[scenarioName]) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Originally perf tests selected the dropdown by class name, the placement of the classname changed in 7.0 so I've changed the tests to use a queryselector targeting a data-automationid instead.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9502)