### PR TITLE
Date-Time Calendar: fixing min/maxDate

### DIFF
--- a/common/changes/@uifabric/date-time/lorejoh12-dateTimeCalendarMinDateFix_2019-06-19-00-05.json
+++ b/common/changes/@uifabric/date-time/lorejoh12-dateTimeCalendarMinDateFix_2019-06-19-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "fixing min/max date being ignored",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com"
+}

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -221,7 +221,7 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
               today={this.props.today}
               highlightCurrentMonth={highlightCurrentMonth!}
               highlightSelectedMonth={highlightSelectedMonth!}
-              onHeaderSelect={this._onHeaderSelect}
+              onHeaderSelect={onHeaderSelect}
               navigationIcons={navigationIcons!}
               dateTimeFormatter={this.props.dateTimeFormatter!}
               minDate={minDate}

--- a/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
@@ -92,7 +92,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
         lineHeight: 40,
         fontSize: FontSizes.small,
         padding: 0,
-        margin: '0 12px 16px 0',
+        margin: '0 12px 0 0',
         color: palette.neutralPrimary,
         backgroundColor: 'transparent',
         border: 'none',

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Example.scss
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Example.scss
@@ -1,5 +1,5 @@
 .wrapper {
-  height: 340px;
+  height: 360px;
 }
 
 .button {

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -161,6 +161,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
           !day.isInMonth && classNames.dayOutsideNavigatedMonth
         )}
         ref={(element: HTMLTableCellElement) => this._setDayCellRef(element, day, isNavigatedDate)}
+        onClick={day.isInBounds ? day.onSelected : undefined}
         onMouseOver={this.onMouseOverDay(day)}
         onMouseDown={this.onMouseDownDay(day)}
         onMouseUp={this.onMouseUpDay(day)}
@@ -170,7 +171,6 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
           key={day.key + 'button'}
           className={css(classNames.dayButton, day.isToday && classNames.dayIsToday)}
           onKeyDown={this._onDayKeyDown(day.originalDate, weekIndex, dayIndex)}
-          onClick={day.isInBounds ? day.onSelected : undefined}
           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
           id={isNavigatedDate ? activeDescendantId : undefined}
           aria-selected={day.isInBounds ? day.isSelected : undefined}
@@ -378,14 +378,16 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
   }
 
   private _getIsRestrictedDate(date: Date): boolean {
-    const { restrictedDates } = this.props;
-    if (!restrictedDates) {
+    const { restrictedDates, minDate, maxDate } = this.props;
+    if (!restrictedDates && !minDate && !maxDate) {
       return false;
     }
-    const inRestrictedDates = !!find(restrictedDates, (rd: Date) => {
-      return compareDates(rd, date);
-    });
-    return inRestrictedDates && !this._getIsBeforeMinDate(date) && !this._getIsAfterMaxDate(date);
+    const inRestrictedDates =
+      restrictedDates &&
+      !!find(restrictedDates, (rd: Date) => {
+        return compareDates(rd, date);
+      });
+    return inRestrictedDates || this._getIsBeforeMinDate(date) || this._getIsAfterMaxDate(date);
   }
 
   private _getIsBeforeMinDate(date: Date): boolean {


### PR DESCRIPTION
…icted dates were specified

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

1. min/max date were being ignored in the date time calendar, which was reproable in the test page. Can confirm this is fixed by going down to the test example of restricted dates, and arrowing back to last month- before, all the days in the month were selectable. Now, only the days after the 18th (today) are selectable, which is expected.

2. was passing the wrong header select callback to the month picker, which meant the month-only picker scenario was broken, clicking a month switched you into the month and day picker with no way back.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9503)