### PR TITLE
DetailsList: Add aria-hidden to checkbox header label

### DIFF
--- a/common/changes/office-ui-fabric-react/detailsListCheckboxLabel_2019-06-18-21-00.json
+++ b/common/changes/office-ui-fabric-react/detailsListCheckboxLabel_2019-06-18-21-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "DetailsList: add aria-hidden to checkbox labels",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -257,11 +257,11 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
               </div>,
               !this.props.onRenderColumnHeaderTooltip ? (
                 ariaLabelForSelectAllCheckbox && !isCheckboxHidden ? (
-                  <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel}>
+                  <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel} aria-hidden={true}>
                     {ariaLabelForSelectAllCheckbox}
                   </label>
                 ) : ariaLabelForSelectionColumn && isCheckboxHidden ? (
-                  <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel}>
+                  <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel} aria-hidden={true}>
                     {ariaLabelForSelectionColumn}
                   </label>
                 ) : null

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -374,6 +374,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                 </span>
               </div>
               <label
+                aria-hidden={true}
                 className=
 
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -320,6 +320,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
               </span>
             </div>
             <label
+              aria-hidden={true}
               className=
 
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1075,6 +1075,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               </span>
             </div>
             <label
+              aria-hidden={true}
               className=
 
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -506,6 +506,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 </span>
               </div>
               <label
+                aria-hidden={true}
                 className=
 
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -507,6 +507,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 </span>
               </div>
               <label
+                aria-hidden={true}
                 className=
 
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -311,6 +311,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             </span>
           </div>
           <label
+            aria-hidden={true}
             className=
 
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -312,6 +312,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             </span>
           </div>
           <label
+            aria-hidden={true}
             className=
 
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -311,6 +311,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             </span>
           </div>
           <label
+            aria-hidden={true}
             className=
 
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -815,6 +815,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 </span>
               </div>
               <label
+                aria-hidden={true}
                 className=
 
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -705,6 +705,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               </span>
             </div>
             <label
+              aria-hidden={true}
               className=
 
                   {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -311,6 +311,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             </span>
           </div>
           <label
+            aria-hidden={true}
             className=
 
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -311,6 +311,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             </span>
           </div>
           <label
+            aria-hidden={true}
             className=
 
                 {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9465
- [X] Include a change request file using `$ npm run change`

#### Description of changes

These changes add `aria-hidden=true` to the checkbox header label. This fixes an issue where when navigating through DetailsList on Edge in Narrator's Scan Mode, there is an extra unnecessary stop between the checkbox header and the second column header.

**What Narrator was reading out before (without `aria-hidden`):**

Table, has 501 rows, 5 columns,, File Type, button,, Column Header, Row 1 of 501 Column 1 of 5
Scan
Column operations for File type, Press to sort on File type, 
File Type 
Column operations for File type, Press to sort on File type
column header, Ascending, read-only, Column Header, Row 1 of 501 Column 2 of 5
button, Name

**What Narrator reads out with these changes (with `aria-hidden`):**

Table, has 501 rows, 5 columns,, File Type, button,, Column Header, Row 1 of 501 Column 1 of 5
Scan
Column operations for File type, Press to sort on File type, 
File Type
column header, Ascending, read-only, Column Header, Row 1 of 501 Column 2 of 5
button, Name

Note the extraneous "Column Operations for File type, Press to sort on File Type" without `aria-hidden`.

#### Focus areas to test

Open the DetailsList example in Edge and turn on Narrator. Turn on Scan Mode. Tab to the DetailsList header and navigate using the arrow keys. Check that everything is read out as normal and that the extra label stop between the checkbox header and the next column header is gone.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9504)