### PR TITLE
Facepile - Adding OnRenderPersona and OnRenderPersonaCoin as optional Props

### DIFF
--- a/common/changes/office-ui-fabric-react/makathur-facepile_onrenders_2019-06-18-07-56.json
+++ b/common/changes/office-ui-fabric-react/makathur-facepile_onrenders_2019-06-18-07-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Facepile: Introducing OnRenderPersona and OnRenderPersonaCoin to override default implementation of Persona and PersonaCoin. ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "makathur@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4453,6 +4453,8 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
     componentRef?: IRefObject<IFacepile>;
     getPersonaProps?: (persona: IFacepilePersona) => IPersonaSharedProps;
     maxDisplayablePersonas?: number;
+    onRenderPersona?: IRenderFunction<IFacepilePersona>;
+    onRenderPersonaCoin?: IRenderFunction<IFacepilePersona>;
     overflowButtonProps?: IButtonProps;
     overflowButtonType?: OverflowButtonType;
     overflowPersonas?: IFacepilePersona[];

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -84,8 +84,11 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
   }
 
   private _onRenderVisiblePersonas(personas: IFacepilePersona[], singlePersona: boolean): JSX.Element[] {
+    const { onRenderPersona = this._getPersonaControl, onRenderPersonaCoin = this._getPersonaCoinControl } = this.props;
     return personas.map((persona: IFacepilePersona, index: number) => {
-      const personaControl: JSX.Element = singlePersona ? this._getPersonaControl(persona) : this._getPersonaCoinControl(persona);
+      const personaControl: JSX.Element | null = singlePersona
+        ? onRenderPersona(persona, this._getPersonaControl)
+        : onRenderPersonaCoin(persona, this._getPersonaCoinControl);
       return (
         <li role="option" key={`${singlePersona ? 'persona' : 'personaCoin'}-${index}`} className={this._classNames.member}>
           {persona.onClick
@@ -96,7 +99,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     });
   }
 
-  private _getPersonaControl(persona: IFacepilePersona): JSX.Element {
+  private _getPersonaControl = (persona: IFacepilePersona): JSX.Element | null => {
     const { getPersonaProps, personaSize } = this.props;
     const personaStyles: Partial<IPersonaStyles> = {
       details: {
@@ -116,9 +119,9 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
         styles={personaStyles}
       />
     );
-  }
+  };
 
-  private _getPersonaCoinControl(persona: IFacepilePersona): JSX.Element {
+  private _getPersonaCoinControl = (persona: IFacepilePersona): JSX.Element | null => {
     const { getPersonaProps, personaSize } = this.props;
     return (
       <PersonaCoin
@@ -131,9 +134,9 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
         {...(getPersonaProps ? getPersonaProps(persona) : null)}
       />
     );
-  }
+  };
 
-  private _getElementWithOnClickEvent(personaControl: JSX.Element, persona: IFacepilePersona, index: number): JSX.Element {
+  private _getElementWithOnClickEvent(personaControl: JSX.Element | null, persona: IFacepilePersona, index: number): JSX.Element {
     const { keytipProps } = persona;
     return (
       <FacepileButton
@@ -147,7 +150,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     );
   }
 
-  private _getElementWithoutOnClickEvent(personaControl: JSX.Element, persona: IFacepilePersona, index: number): JSX.Element {
+  private _getElementWithoutOnClickEvent(personaControl: JSX.Element | null, persona: IFacepilePersona, index: number): JSX.Element {
     return (
       <div {...getNativeProps(persona, buttonProperties)} {...this._getElementProps(persona, index)}>
         {personaControl}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { FacepileBase } from './Facepile.base';
 import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IButtonProps } from '../../Button';
 import { IPersonaSharedProps, PersonaInitialsColor, PersonaSize } from '../../Persona';
 import { IKeytipProps } from '../../Keytip';
@@ -73,6 +73,12 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
 
   /** Type of overflow icon to use */
   overflowButtonType?: OverflowButtonType;
+
+  /** Optional custom renderer for the persona, gets called when there is one persona in personas array*/
+  onRenderPersona?: IRenderFunction<IFacepilePersona>;
+
+  /** Optional custom renderer for the persona coins, gets called when there are multiple persona in personas array*/
+  onRenderPersonaCoin?: IRenderFunction<IFacepilePersona>;
 
   /** Method to access properties on the underlying Persona control */
   getPersonaProps?: (persona: IFacepilePersona) => IPersonaSharedProps;


### PR DESCRIPTION
Porting changes from 7.0 version to 6.0 version
Changes Description - Facepile - Adding OnRenderPersona and OnRenderPersonaCoin as optional props
Original commit Id - 21cca397dcbfbf89b762f23dd7b9e61123f98423


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9506)