### PR TITLE
Adds ISelectableDroppableTextProps to API References

### DIFF
--- a/common/changes/office-ui-fabric-react/addSelectableDroppableText_2019-06-19-17-41.json
+++ b/common/changes/office-ui-fabric-react/addSelectableDroppableText_2019-06-19-17-41.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "add inline tag to ISelectableDroppableTextProps",
+      "comment": "ISelectableDroppableTextProps: surface API reference in website documentation.",
       "type": "none"
     }
   ],

--- a/common/changes/office-ui-fabric-react/addSelectableDroppableText_2019-06-19-17-41.json
+++ b/common/changes/office-ui-fabric-react/addSelectableDroppableText_2019-06-19-17-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "add inline tag to ISelectableDroppableTextProps",
+      "type": "none"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -7,6 +7,7 @@ import { ISelectableOption } from '../../utilities/selectableOption/SelectableOp
 /**
  * TComponent - Component used for reference properties, such as componentRef
  * TListenerElement - Listener element associated with HTML event callbacks. Optional. If not provided, TComponent is assumed.
+ * {@docCategory ISelectableDroppableTextProps}
  */
 export interface ISelectableDroppableTextProps<TComponent, TListenerElement> extends React.HTMLAttributes<TListenerElement> {
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds an inline tag to `ISelectableDroppableTextProps` so that it shows up under "References" in the documentation. In the Dropdown documentation, you should now be able to navigate to `ISelectableDroppableTextProps`.

![image](https://user-images.githubusercontent.com/14134000/59788258-2bcf8400-9280-11e9-8d55-71e8a71ba2f3.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9509)