### PR TITLE
Charting: Fix React styling dependency range.

### DIFF
--- a/common/changes/@uifabric/charting/fix-styling-deps_2019-06-19-20-18.json
+++ b/common/changes/@uifabric/charting/fix-styling-deps_2019-06-19-20-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/charting",
+      "comment": "Fixing peer deps.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/charting",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -70,7 +70,7 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "react": "16.8.6",
-    "react-dom": "16.8.6"
+    "react": ">=16.8.0 <17.0.0",
+    "react-dom": ">=16.8.0 <17.0.0"
   }
 }


### PR DESCRIPTION
Peer dependency for charting package is totally wrong.

Converting to range.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9511)