### PR TITLE
Remove charting package dependency from experiments

### DIFF
--- a/common/changes/@uifabric/experiments/remove-charting_2019-06-19-20-57.json
+++ b/common/changes/@uifabric/experiments/remove-charting_2019-06-19-20-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Removing charting from dependencies.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.7.13",
     "@uifabric/azure-themes": "^7.0.2",
-    "@uifabric/charting": "^0.131.3",
     "@uifabric/file-type-icons": "^7.0.3",
     "@uifabric/fluent-theme": "^7.0.2",
     "@uifabric/foundation": "^7.0.1",


### PR DESCRIPTION
There is no reason for the charting package dependency in experiments.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9512)