### PR TITLE
Fabric 6: Removing charting from experiments

### DIFF
--- a/common/changes/@uifabric/experiments/remove-charting-6_2019-06-19-20-59.json
+++ b/common/changes/@uifabric/experiments/remove-charting-6_2019-06-19-20-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Removing charting from deps.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com"
+}

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.7.13",
     "@uifabric/azure-themes": "^6.0.3",
-    "@uifabric/charting": "^0.30.4",
     "@uifabric/file-type-icons": "^6.5.2",
     "@uifabric/fluent-theme": "^0.16.12",
     "@uifabric/foundation": "^0.8.1",


### PR DESCRIPTION
There is no reason for the charting dependency in experiments.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9513)