### PR TITLE
ThemeDesigner: Update a11y checker to match new design of just 2 pairs

### DIFF
--- a/apps/theming-designer/src/components/AccessibilityChecker.tsx
+++ b/apps/theming-designer/src/components/AccessibilityChecker.tsx
@@ -15,13 +15,14 @@ export interface IAccessibilityCheckerProps {
 export interface IContrastRatioPair {
   contrastRatioValue: string;
   contrastRatioPair: string;
+  colorPair: string;
 }
 
 export const AccessibilityChecker: React.StatelessComponent<IAccessibilityCheckerProps> = (props: IAccessibilityCheckerProps) => {
   let nonAccessiblePairs: IContrastRatioPair[] = [];
   let accessiblePairs: IContrastRatioPair[] = [];
 
-  const calculateContrastRatio = (foreground: FabricSlots, background: FabricSlots) => {
+  const calculateContrastRatio = (foreground: FabricSlots, background: FabricSlots, colorPairString: string) => {
     if (props.themeRules) {
       const bgc: IColor = props.themeRules[FabricSlots[background]].color!;
       const fgc: IColor = props.themeRules[FabricSlots[foreground]].color!;
@@ -32,29 +33,24 @@ export const AccessibilityChecker: React.StatelessComponent<IAccessibilityChecke
       const currContrastRatioPair = FabricSlots[foreground] + ' on ' + FabricSlots[background];
 
       if (currContrastRatio < 4.5) {
-        nonAccessiblePairs.push({ contrastRatioValue: contrastRatioString, contrastRatioPair: currContrastRatioPair });
+        nonAccessiblePairs.push({
+          contrastRatioValue: contrastRatioString,
+          contrastRatioPair: currContrastRatioPair,
+          colorPair: colorPairString
+        });
       } else {
-        accessiblePairs.push({ contrastRatioValue: contrastRatioString, contrastRatioPair: currContrastRatioPair });
+        accessiblePairs.push({
+          contrastRatioValue: contrastRatioString,
+          contrastRatioPair: currContrastRatioPair,
+          colorPair: colorPairString
+        });
       }
     }
   };
 
   const loadAllContrastRatioPairsList = () => {
-    calculateContrastRatio(FabricSlots.neutralPrimary, FabricSlots.white); // default
-    // primary color also needs to be accessible, this is also strong variant default
-    calculateContrastRatio(FabricSlots.white, FabricSlots.themePrimary);
-    calculateContrastRatio(FabricSlots.neutralPrimary, FabricSlots.neutralLighter); // neutral variant default
-    calculateContrastRatio(FabricSlots.themeDarkAlt, FabricSlots.neutralLighter);
-    // these are the text and primary colors on top of the soft variant, whose bg depends on invertedness of original theme
-    if (!isDark(props.themeRules![BaseSlots[BaseSlots.backgroundColor]].color!)) {
-      // is not inverted
-      calculateContrastRatio(FabricSlots.neutralPrimary, FabricSlots.themeLighterAlt);
-      calculateContrastRatio(FabricSlots.themeDarkAlt, FabricSlots.themeLighterAlt);
-    } else {
-      // is inverted
-      calculateContrastRatio(FabricSlots.neutralPrimary, FabricSlots.themeLight);
-      calculateContrastRatio(FabricSlots.themeDarkAlt, FabricSlots.themeLight);
-    }
+    calculateContrastRatio(FabricSlots.themePrimary, FabricSlots.white, 'Primary color on Background color');
+    calculateContrastRatio(FabricSlots.neutralPrimary, FabricSlots.white, 'Text color on Background color');
   };
 
   loadAllContrastRatioPairsList();

--- a/apps/theming-designer/src/components/AccessibilityDetailsList.tsx
+++ b/apps/theming-designer/src/components/AccessibilityDetailsList.tsx
@@ -22,6 +22,7 @@ interface IAccessibilityDetailsList {
   key: string;
   contrastRatio: String;
   slotPair: String;
+  colorPair: String;
 }
 
 export const AccessibilityDetailsList: React.StatelessComponent<IAccessibilityDetailsListProps> = (
@@ -84,7 +85,8 @@ export const AccessibilityDetailsList: React.StatelessComponent<IAccessibilityDe
     items.push({
       key: i.toString(),
       contrastRatio: allContrastRatioPairs[i].contrastRatioValue,
-      slotPair: allContrastRatioPairs[i].contrastRatioPair
+      slotPair: allContrastRatioPairs[i].contrastRatioPair,
+      colorPair: allContrastRatioPairs[i].colorPair
     });
   }
 
@@ -100,6 +102,7 @@ export const AccessibilityDetailsList: React.StatelessComponent<IAccessibilityDe
 
   columns = [
     { key: 'contrastRatio', name: 'Contrast ratio: AA', fieldName: 'contrastRatio', minWidth: 100, maxWidth: 200, isResizable: true },
+    { key: 'colorPair', name: 'Color pair', fieldName: 'colorPair', minWidth: 100, maxWidth: 200 },
     { key: 'slotPair', name: 'Slot pair', fieldName: 'slotPair', minWidth: 100, maxWidth: 200 }
   ];
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

It's pretty arbitrary to compare all the FabricSlots with each other & doesn't provide much value. Instead, just comparing primary on background and text on background helps the user focus on what's useful.
New:
![image](https://user-images.githubusercontent.com/4161791/59807067-7ca8a200-92ab-11e9-9c3a-31dd5dfde882.png)
Current:
![image](https://user-images.githubusercontent.com/4161791/59807108-9518bc80-92ab-11e9-8646-fc9188899b60.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9514)