### PR TITLE
Tooltip: fix closeDelay bug

### DIFF
--- a/common/changes/office-ui-fabric-react/tooltipCloseDelayBug_2019-06-19-23-10.json
+++ b/common/changes/office-ui-fabric-react/tooltipCloseDelayBug_2019-06-19-23-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "office-ui-fabric-react",
-      "comment": "TooltipHost: clear dismiss timer in _onTooltipMouseEnter before portals if condition to fix the closeDelay Tooltip bug.",
+      "comment": "TooltipHost: fix the closeDelay Tooltip bug where a user could not interact with the Tooltip because it would close.",
       "type": "patch"
     }
   ],

--- a/common/changes/office-ui-fabric-react/tooltipCloseDelayBug_2019-06-19-23-10.json
+++ b/common/changes/office-ui-fabric-react/tooltipCloseDelayBug_2019-06-19-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "TooltipHost: clear dismiss timer in _onTooltipMouseEnter before portals if condition to fix the closeDelay Tooltip bug.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -156,13 +156,14 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
       }
     }
 
+    this._clearDismissTimer();
+
     if (ev.target && portalContainsElement(ev.target as HTMLElement, this._getTargetElement())) {
       // Do not show tooltip when target is inside a portal relative to TooltipHost.
       return;
     }
 
     this._toggleTooltip(true);
-    this._clearDismissTimer();
   };
 
   // Hide Tooltip


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9464
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR moves the clear dismiss timer before the portals if condition check. 

Before these changes, the portals if condition check was short-circuiting the clear dismiss timer that the tooltips with a `closeDelay` prop are dependent on. Even when a user was interacting with a tooltip, the tooltip would close after the delay time specified by `closeDelay`. See below:

![TooltipClosing](https://user-images.githubusercontent.com/14134000/59807671-c4c8c400-92ad-11e9-8a9d-c1fa715e385a.gif)

With these changes, the dismiss timer is cleared if a user starts interacting with the tooltip and only restarts if a user hovers outside the tooltip or tooltiphost. See below:

![TooltipWithCloseDelayStaysOpen](https://user-images.githubusercontent.com/14134000/59807570-5dab0f80-92ad-11e9-8ded-af4a2c73f5e4.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9519)