### PR TITLE
Don't expand ComboBox flyout on touch when disabled.

### DIFF
--- a/common/changes/office-ui-fabric-react/phtucker-combobox_disabled_pointer_fix_2019-06-20-14-44.json
+++ b/common/changes/office-ui-fabric-react/phtucker-combobox_disabled_pointer_fix_2019-06-20-14-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Don't expand ComboBox flyout on touch when disabled.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "phtucker@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1915,9 +1915,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * Click handler for the autofill.
    */
   private _onAutofillClick = (): void => {
-    const { disabled } = this.props;
+    const { disabled, allowFreeform } = this.props;
 
-    if (this.props.allowFreeform && !disabled) {
+    if (allowFreeform && !disabled) {
       this.focus(this.state.isOpen || this._processingTouch);
     } else {
       this._onComboBoxClick();

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1915,7 +1915,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * Click handler for the autofill.
    */
   private _onAutofillClick = (): void => {
-    if (this.props.allowFreeform) {
+    const { disabled } = this.props;
+
+    if (this.props.allowFreeform && !disabled) {
       this.focus(this.state.isOpen || this._processingTouch);
     } else {
       this._onComboBoxClick();


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

ComboBox flyout was expanding on pointer events when disabled and AllowFreeform was set to true. This change checks whether or not the control is disabled before expanding the flyout on pointer events.

#### Focus areas to test

ComboBox


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9524)