### PR TITLE
Slider: fire onChanged after delay following keydown or keyup

### DIFF
--- a/common/changes/office-ui-fabric-react/sliderOnChanged_2019-06-20-18-36.json
+++ b/common/changes/office-ui-fabric-react/sliderOnChanged_2019-06-20-18-36.json
@@ -3,7 +3,7 @@
     {
       "packageName": "office-ui-fabric-react",
       "comment": "Slider: onChanged is fired after a delay following keydown events.",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "office-ui-fabric-react",

--- a/common/changes/office-ui-fabric-react/sliderOnChanged_2019-06-20-18-36.json
+++ b/common/changes/office-ui-fabric-react/sliderOnChanged_2019-06-20-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Slider: onChanged is fired after a delay following keydown events.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8022,6 +8022,9 @@ export type OnChangeCallback = (evt?: React.FormEvent<HTMLElement | HTMLInputEle
 export type OnFocusCallback = (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
 
 // @public (undocumented)
+export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
+
+// @public (undocumented)
 export enum OpenCardMode {
     hotKey = 1,
     hover = 0

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6760,7 +6760,7 @@ export interface ISliderProps extends React.ClassAttributes<SliderBase> {
     max?: number;
     min?: number;
     onChange?: (value: number) => void;
-    onChanged?: (event: MouseEvent | TouchEvent, value: number) => void;
+    onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number) => void;
     originFromZero?: boolean;
     showValue?: boolean;
     step?: number;

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -10,7 +10,7 @@ export interface ISliderState {
 }
 
 const getClassNames = classNamesFunction<ISliderStyleProps, ISliderStyles>();
-const ONKEYDOWN_TIMEOUT_DURATION = 1000;
+export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
 
 export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implements ISlider {
   public static defaultProps: ISliderProps = {

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -10,6 +10,8 @@ export interface ISliderState {
 }
 
 const getClassNames = classNamesFunction<ISliderStyleProps, ISliderStyles>();
+const ONKEYDOWN_TIMEOUT_DURATION = 1000;
+
 export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implements ISlider {
   public static defaultProps: ISliderProps = {
     step: 1,
@@ -25,6 +27,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
   private _sliderLine = React.createRef<HTMLDivElement>();
   private _thumb = React.createRef<HTMLSpanElement>();
   private _id: string;
+  private _onKeyDownTimer = -1;
 
   constructor(props: ISliderProps) {
     super(props);
@@ -295,10 +298,18 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
       case getRTLSafeKeyCode(KeyCodes.left):
       case KeyCodes.down:
         diff = -(step as number);
+
+        this._clearOnKeyDownTimer();
+        this._setOnKeyDownTimer(event);
+
         break;
       case getRTLSafeKeyCode(KeyCodes.right):
       case KeyCodes.up:
         diff = step;
+
+        this._clearOnKeyDownTimer();
+        this._setOnKeyDownTimer(event);
+
         break;
 
       case KeyCodes.home:
@@ -319,5 +330,17 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 
     event.preventDefault();
     event.stopPropagation();
+  };
+
+  private _clearOnKeyDownTimer = (): void => {
+    this._async.clearTimeout(this._onKeyDownTimer);
+  };
+
+  private _setOnKeyDownTimer = (event: KeyboardEvent): void => {
+    this._onKeyDownTimer = this._async.setTimeout(() => {
+      if (this.props.onChanged) {
+        this.props.onChanged(event, this.state.value as number);
+      }
+    }, ONKEYDOWN_TIMEOUT_DURATION);
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
+import * as ReactTestUtils from 'react-dom/test-utils';
+
 import { mount } from 'enzyme';
 import { Slider } from './Slider';
 import { ISlider } from './Slider.types';
+import { ONKEYDOWN_TIMEOUT_DURATION } from './Slider.base';
+import { KeyCodes } from '../../Utilities';
 
 describe('Slider', () => {
   it('renders correctly', () => {
@@ -100,5 +105,30 @@ describe('Slider', () => {
     const component = mount(<Slider value={value} min={0} max={100} showValue={true} valueFormat={valueFormat} />);
 
     expect(component.find('label.ms-Label.ms-Slider-value').text()).toEqual(valueFormat(value));
+  });
+
+  it('calls onChanged after keyboard event', () => {
+    jest.useFakeTimers();
+    const onChanged = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    ReactDOM.render(<Slider label="slider" defaultValue={12} min={0} max={100} onChanged={onChanged} />, container);
+    const sliderSlideBox = container.querySelector('.ms-Slider-slideBox') as HTMLElement;
+
+    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
+
+    expect(sliderSlideBox.getAttribute('aria-valuenow')).toEqual('9');
+
+    setTimeout(() => {
+      expect(onChanged).toHaveBeenCalledTimes(1);
+    }, ONKEYDOWN_TIMEOUT_DURATION);
+
+    jest.runOnlyPendingTimers();
+
+    ReactDOM.unmountComponentAtNode(container);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -120,8 +120,13 @@ describe('Slider', () => {
     ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
     ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
     ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.up });
+    ReactTestUtils.Simulate.keyDown(sliderSlideBox, { which: KeyCodes.down });
 
     expect(sliderSlideBox.getAttribute('aria-valuenow')).toEqual('9');
+
+    // onChanged should only be called after a delay
+    expect(onChanged).toHaveBeenCalledTimes(0);
 
     setTimeout(() => {
       expect(onChanged).toHaveBeenCalledTimes(1);

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
@@ -81,7 +81,7 @@ export interface ISliderProps extends React.ClassAttributes<SliderBase> {
   /**
    * Callback on mouse up or touch end
    */
-  onChanged?: (event: MouseEvent | TouchEvent, value: number) => void;
+  onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number) => void;
 
   /**
    * A description of the Slider for the benefit of screen readers.


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9426
- [X] Include a change request file using `$ npm run change`

#### Description of changes

With these changes, `onChanged` will now be fired following a key down or key up event and some delay. Right now, this delay is set to 1000 milliseconds. In other words, `onChanged` will be fired after a user is done changing the value on a Slider using their keyboard.

Currently, `onChanged` is only being fired on mouse or touch events, but the ask seemed valid if a developer only want to send API request to process the new value when the user is done changing the value. 

#### Focus areas to test

I added a test case to ensure that `onChanged` is fired only after the 1000 millisecond delay.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9530)