### PR TITLE
Bring back breakpoint for small screen sizes

### DIFF
--- a/common/changes/office-ui-fabric-react/mobile-size-dropdown_2019-06-21-01-44.json
+++ b/common/changes/office-ui-fabric-react/mobile-size-dropdown_2019-06-21-01-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Dropdown:Bring back breakpoint for small screen sizes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -352,8 +352,6 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       panel: {
         root: [panelClassName],
         main: {
-          // Force drop shadow even under medium breakpoint
-          boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)',
           selectors: {
             // In case of extra small screen sizes
             [MinimumScreenSelector]: {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -9,7 +9,9 @@ import {
   IStyle,
   getGlobalClassNames,
   normalize,
-  HighContrastSelectorWhite
+  HighContrastSelectorWhite,
+  getScreenSelector,
+  ScreenWidthMinMedium
 } from '../../Styling';
 
 const GlobalClassNames = {
@@ -62,6 +64,8 @@ const highContrastBorderState: IRawStyle = {
     }
   }
 };
+
+const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMinMedium);
 
 export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = props => {
   const {
@@ -347,7 +351,18 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       label: { root: { display: 'inline-block' } },
       panel: {
         root: [panelClassName],
-        content: { padding: 0 }
+        main: {
+          // Force drop shadow even under medium breakpoint
+          boxShadow: '-30px 0px 30px -30px rgba(0,0,0,0.2)',
+          selectors: {
+            // In case of extra small screen sizes
+            [MinimumScreenSelector]: {
+              // panelWidth xs
+              width: 272
+            }
+          }
+        },
+        contentInner: { padding: '0 0 20px' }
       }
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9508
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
For screen sizes less than 480 px, the Panel's width is `100%`, which gives no empty area to tap. This `PR` adds an extra breakpoint to support these screens in case of `Dropdown` usage.

This is bringing back the change that was introduced in https://github.com/OfficeDev/office-ui-fabric-react/pull/8937 but lost during the migration to `Fabric 7`

#### Focus areas to test
Have a dropdown and open on screens of size <480 px


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9538)