### PR TITLE
BasePicker click to open suggestions even when focus is already on input box

### DIFF
--- a/common/changes/office-ui-fabric-react/user-v-joslam-basepicker-click-open-suggestions_2019-06-21-16-21.json
+++ b/common/changes/office-ui-fabric-react/user-v-joslam-basepicker-click-open-suggestions_2019-06-21-16-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "BasePicker would only reveal suggestions on type or click, shifting focus. Now shows for click, not shifting focus as well.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "v-joslam@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -311,6 +311,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     protected onBlur: (ev: React.FocusEvent<HTMLElement | Autofill>) => void;
     // (undocumented)
     protected onChange(items?: T[]): void;
+    protected onClick: (ev: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
     // (undocumented)
     protected onEmptyInputFocus(): void;
     // (undocumented)
@@ -1654,7 +1655,9 @@ export interface IBasePickerProps<T> extends React.Props<any> {
     onBlur?: React.FocusEventHandler<HTMLInputElement | BaseAutoFill>;
     onChange?: (items?: T[]) => void;
     onDismiss?: (ev?: any, selectedItem?: T) => void;
+    // @deprecated
     onEmptyInputFocus?: (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
+    onEmptyResolveSuggestions?: (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
     onFocus?: React.FocusEventHandler<HTMLInputElement | BaseAutoFill>;
     onGetMoreResults?: (filter: string, selectedItems?: T[]) => T[] | PromiseLike<T[]>;
     onInputChange?: (input: string) => string;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -554,6 +554,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected onClick = (ev: React.MouseEvent<HTMLInputElement>): void => {
     const input = this.input.current ? this.input.current.value : '';
 
+    if (this.props.inputProps !== undefined && this.props.inputProps.onClick !== undefined) {
+      this.props.inputProps.onClick(ev);
+    }
+
     // Only primary (left) clicks show suggestions.
     if (ev.button === 0 && !this.state.suggestionsVisible) {
       const emptyResolveSuggestions = this.props.onEmptyResolveSuggestions

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -77,6 +77,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected _ariaMap: IPickerAriaIds;
   private _styledSuggestions = getStyledSuggestions(this.SuggestionOfProperType);
   private _id: string;
+  private _requestSuggestionsOnClick = false;
 
   constructor(basePickerProps: P) {
     super(basePickerProps);
@@ -185,6 +186,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     } else {
       selectItemFunction();
     }
+
+    this._requestSuggestionsOnClick = false;
     this.setState({ suggestionsVisible: false });
   };
 
@@ -257,9 +260,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
               {this.canAddItems() && (
                 <Autofill
                   spellCheck={false}
-                  {...inputProps as any}
+                  {...(inputProps as any)}
                   className={classNames.input}
                   componentRef={this.input}
+                  onClick={this.onClick}
                   onFocus={this.onInputFocus}
                   onBlur={this.onInputBlur}
                   onInputValueChange={this.onInputChange}
@@ -385,8 +389,11 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   }
 
   protected onEmptyInputFocus() {
-    const onEmptyInputFocus = this.props.onEmptyInputFocus as (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
-    const suggestions: T[] | PromiseLike<T[]> = onEmptyInputFocus(this.state.items);
+    const emptyResolveSuggestions = this.props.onEmptyResolveSuggestions
+      ? this.props.onEmptyResolveSuggestions
+      : this.props.onEmptyInputFocus;
+
+    const suggestions = emptyResolveSuggestions!(this.state.items);
     this.updateSuggestionsList(suggestions);
   }
 
@@ -412,13 +419,11 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
       if (updatedValue !== undefined) {
         this.setState({
-          suggestionsVisible: this.input.current
-            ? this.input.current.value !== '' && this.input.current.inputElement === document.activeElement
-            : false
+          suggestionsVisible: this.getShowSuggestions()
         });
       } else {
         this.setState({
-          suggestionsVisible: this.input.current ? this.input.current.inputElement === document.activeElement : false
+          suggestionsVisible: this.input.current! && this.input.current!.inputElement === document.activeElement
         });
       }
 
@@ -446,12 +451,25 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     this.setState(
       {
         suggestedDisplayValue: itemValue,
-        suggestionsVisible: this.input.current
-          ? this.input.current.value !== '' && this.input.current.inputElement === document.activeElement
-          : false
+        suggestionsVisible: this.getShowSuggestions()
       },
       () => this.setState({ suggestionsLoading: false })
     );
+  }
+
+  /**
+   * Suggestions are normally shown after the user updates text and the text
+   * is non-empty, but also when the user clicks on the input element.
+   * @returns True if suggestions should be shown.
+   */
+  protected getShowSuggestions(): boolean {
+    const areSuggestionsVisible =
+      this.input.current !== undefined &&
+      this.input.current !== null &&
+      this.input.current.inputElement === document.activeElement &&
+      (this.input.current.value !== '' || this._requestSuggestionsOnClick);
+
+    return areSuggestionsVisible;
   }
 
   protected onChange(items?: T[]) {
@@ -470,6 +488,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
   protected onSuggestionClick = (ev: React.MouseEvent<HTMLElement>, item: any, index: number): void => {
     this.addItemByIndex(index);
+    this._requestSuggestionsOnClick = false;
     this.setState({ suggestionsVisible: false });
   };
 
@@ -487,14 +506,20 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     if (!this.state.isFocused) {
       this.setState({ isFocused: true });
       this.selection.setAllSelected(false);
-      if (this.input.current && this.input.current.value === '' && this.props.onEmptyInputFocus) {
+
+      if (
+        this.input.current &&
+        this.input.current.value === '' &&
+        (this.props.onEmptyResolveSuggestions || this.props.onEmptyInputFocus) &&
+        !this._requestSuggestionsOnClick
+      ) {
         this.onEmptyInputFocus();
         this.setState({
           isMostRecentlyUsedVisible: true,
           moreSuggestionsAvailable: false,
           suggestionsVisible: true
         });
-      } else if (this.input.current && this.input.current.value) {
+      } else if (this.input.current && this.input.current.value && !this._requestSuggestionsOnClick) {
         this.setState({
           isMostRecentlyUsedVisible: false,
           suggestionsVisible: true
@@ -537,11 +562,36 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     }
   };
 
+  /**
+   * Reveals suggestions any time the user clicks on the input element
+   * without shifting focus.
+   */
+  protected onClick = (ev: React.MouseEvent<HTMLInputElement>): void => {
+    const input = this.input.current ? this.input.current.value : '';
+
+    // Only primary (left) clicks show suggestions.
+    if (ev.button === 0 && !this.state.suggestionsVisible) {
+      const emptyResolveSuggestions = this.props.onEmptyResolveSuggestions
+        ? this.props.onEmptyResolveSuggestions
+        : this.props.onEmptyInputFocus;
+
+      if (input === '' && emptyResolveSuggestions) {
+        this.setState({ suggestionsVisible: true });
+        const suggestions = emptyResolveSuggestions!(this.state.items);
+        this.updateSuggestionsList(suggestions);
+      } else {
+        this._requestSuggestionsOnClick = true;
+        this._onResolveSuggestions(input);
+      }
+    }
+  };
+
   protected onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
     const keyCode = ev.which;
     switch (keyCode) {
       case KeyCodes.escape:
         if (this.state.suggestionsVisible) {
+          this._requestSuggestionsOnClick = false;
           this.setState({ suggestionsVisible: false });
           ev.preventDefault();
           ev.stopPropagation();
@@ -903,11 +953,12 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
           {this.getSuggestionsAlert(classNames.screenReaderText)}
           <div className={classNames.text}>
             <Autofill
-              {...inputProps as any}
+              {...(inputProps as any)}
               className={classNames.input}
               componentRef={this.input}
               onFocus={this.onInputFocus}
               onBlur={this.onInputBlur}
+              onClick={this.onClick}
               onInputValueChange={this.onInputChange}
               suggestedDisplayValue={suggestedDisplayValue}
               aria-activedescendant={this.getActiveDescendant()}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -419,7 +419,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
       if (updatedValue !== undefined) {
         this.setState({
-          suggestionsVisible: this.getShowSuggestions()
+          suggestionsVisible: this._getShowSuggestions()
         });
       } else {
         this.setState({
@@ -451,25 +451,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     this.setState(
       {
         suggestedDisplayValue: itemValue,
-        suggestionsVisible: this.getShowSuggestions()
+        suggestionsVisible: this._getShowSuggestions()
       },
       () => this.setState({ suggestionsLoading: false })
     );
-  }
-
-  /**
-   * Suggestions are normally shown after the user updates text and the text
-   * is non-empty, but also when the user clicks on the input element.
-   * @returns True if suggestions should be shown.
-   */
-  protected getShowSuggestions(): boolean {
-    const areSuggestionsVisible =
-      this.input.current !== undefined &&
-      this.input.current !== null &&
-      this.input.current.inputElement === document.activeElement &&
-      (this.input.current.value !== '' || this._requestSuggestionsOnClick);
-
-    return areSuggestionsVisible;
   }
 
   protected onChange(items?: T[]) {
@@ -847,6 +832,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
       );
     }
   }
+
   /**
    * Takes in the current updated value and either resolves it with the new suggestions
    * or if updated value is undefined then it clears out currently suggested items
@@ -882,6 +868,21 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   private _onSelectedItemsUpdated(items?: T[], focusIndex?: number): void {
     this.resetFocus(focusIndex);
     this.onChange(items);
+  }
+
+  /**
+   * Suggestions are normally shown after the user updates text and the text
+   * is non-empty, but also when the user clicks on the input element.
+   * @returns True if suggestions should be shown.
+   */
+  private _getShowSuggestions(): boolean {
+    const areSuggestionsVisible =
+      this.input.current !== undefined &&
+      this.input.current !== null &&
+      this.input.current.inputElement === document.activeElement &&
+      (this.input.current.value !== '' || this._requestSuggestionsOnClick);
+
+    return areSuggestionsVisible;
   }
 
   private _onResolveSuggestions(updatedValue: string): void {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -60,9 +60,19 @@ export interface IBasePickerProps<T> extends React.Props<any> {
   resolveDelay?: number;
 
   /**
-   * A callback for what should happen when a user clicks the input.
+   * A callback for what should happen when a user clicks within the input area.
+   * @deprecated Please use onEmptyResolveSuggestions instead, as the suggestions aren't about
+   * setting focus as they are about resolving suggestions when there is no input.
    */
   onEmptyInputFocus?: (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
+
+  /**
+   * A callback for what should happen when suggestions are shown without
+   * input provided.
+   * Returns the already selected items so the resolver can filter them out.
+   * If used in conjunction with resolveDelay this will ony kick off after the delay throttle.
+   */
+  onEmptyResolveSuggestions?: (selectedItems?: T[]) => T[] | PromiseLike<T[]>;
 
   /**
    * Initial items that have already been selected and should appear in the people picker.


### PR DESCRIPTION
Fixes #9373

The People Picker previously had these scenarios handled:
- User begins typing, suggestions appear
- User clicks, changing focus to the input textbox, suggestions appear

This scenario is addressed in this PR:
- User clicks on the input textbox when it already has focus, suggestions appear

**[Before and after video](https://1drv.ms/v/s!Am1nwb99OTm3b3swhurVvuXbWA8?e=nxaXyC)**

Now users will not be frustrated by having to resort to keyboard or click in and out of the picker to select additional people (which they might not have discovered or fully understood).

This updates the API to deprecate onEmptyInputFocus and use onEmptyResolveSuggestions instead. Both function at the moment, but the name should definitely be changed to reflect it's not about focus. See the issue this resolves for more.

Test areas: BasePicker, PeoplePicker

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9547)