### PR TITLE
Contextual menu fluent update

### DIFF
--- a/common/changes/@uifabric/fluent-theme/v-mare-ContextualMenu-fluent-update_2019-06-22-00-48.json
+++ b/common/changes/@uifabric/fluent-theme/v-mare-ContextualMenu-fluent-update_2019-06-22-00-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Updated ContextualMenu styles to match fluent toolkit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-mare@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ContextualMenu.styles.ts
@@ -81,7 +81,17 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
           splitPrimary: [
             {
               height: CONTEXTUAL_MENU_ITEM_HEIGHT,
-              lineHeight: CONTEXTUAL_MENU_ITEM_HEIGHT
+              lineHeight: CONTEXTUAL_MENU_ITEM_HEIGHT,
+              selectors: {
+                ':hover': {
+                  backgroundColor: palette.neutralLighter,
+                  selectors: {
+                    '~$splitMenu': {
+                      backgroundColor: palette.white
+                    }
+                  }
+                }
+              }
             },
             !(disabled || primaryDisabled) &&
               !checked && {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #6749
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Updated splitPrimary button hover state to only highlight the splitButton and not entire list item.

#### Before
![Screen Shot 2019-06-24 at 1 59 49 PM](https://user-images.githubusercontent.com/13246181/60051703-67a38880-9688-11e9-81e6-0cf13ca326fc.png)

#### After
![Screen Shot 2019-06-24 at 1 55 47 PM](https://user-images.githubusercontent.com/13246181/60051542-15626780-9688-11e9-833f-d59aaf4ccfc3.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9553)