### PR TITLE
fix calendar display for small screen

### DIFF
--- a/common/changes/@uifabric/date-time/calendar-remove-verticalline_2019-06-22-01-15.json
+++ b/common/changes/@uifabric/date-time/calendar-remove-verticalline_2019-06-22-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/date-time",
+      "comment": "Calendar: fix calendar display for small screen",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/date-time",
+  "email": "afhassan@microsoft.com"
+}

--- a/common/changes/office-ui-fabric-react/calendar-remove-verticalline_2019-06-22-01-15.json
+++ b/common/changes/office-ui-fabric-react/calendar-remove-verticalline_2019-06-22-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Calendar: fix calendar display for small screen",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/date-time/src/components/Calendar/Calendar.styles.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.styles.ts
@@ -1,5 +1,7 @@
 import { ICalendarStyleProps, ICalendarStyles } from './Calendar.types';
-import { normalize, FontSizes, getFocusStyle } from '@uifabric/styling';
+import { normalize, FontSizes, getFocusStyle, getScreenSelector, ScreenWidthMinMedium } from '@uifabric/styling';
+
+const MinimumScreenSelector = getScreenSelector(0, ScreenWidthMinMedium);
 
 export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
   const { className, theme, isDayPickerVisible, isMonthPickerVisible, showWeekNumbers } = props;
@@ -25,12 +27,22 @@ export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
     divider: {
       top: 0,
       borderRight: '1px solid',
-      borderColor: palette.neutralLight
+      borderColor: palette.neutralLight,
+      selectors: {
+        [MinimumScreenSelector]: {
+          display: 'none'
+        }
+      }
     },
     monthPickerWrapper: [
       {
         display: 'flex',
-        flexDirection: 'column'
+        flexDirection: 'column',
+        selectors: {
+          [MinimumScreenSelector]: {
+            display: 'none'
+          }
+        }
       }
     ],
     goTodayButton: [

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -729,6 +729,12 @@ $Calendar-dayPicker-margin: 10px;
   .yearComponents {
     margin-top: 2px;
   }
+  .divider {
+    display: none;
+  }
+  .goTodayInlineMonth {
+    top: initial;
+  }
 }
 
 .goToday {

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -733,7 +733,7 @@ $Calendar-dayPicker-margin: 10px;
     display: none;
   }
   .goTodayInlineMonth {
-    top: initial;
+    top: auto;
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9544
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
1. Fixes the `divider` (vertical line) showing up on small screens by doing `display: none;`
2. Fixes the `Go to Today` string not showing up correctly by doing `display: none;`

In `OUFR` package
<img width="201" alt="oufr-before" src="https://user-images.githubusercontent.com/8922176/59957519-f4aecd80-944d-11e9-8e5a-a9e7d9ea3031.PNG">
<img width="203" alt="oufr-after" src="https://user-images.githubusercontent.com/8922176/59957520-f6789100-944d-11e9-88f5-3ff1b70460ca.PNG">

In `date-time` package
<img width="198" alt="date-time-before" src="https://user-images.githubusercontent.com/8922176/59957530-17d97d00-944e-11e9-883f-dd5f57cc4ec3.PNG">
<img width="198" alt="date-time-after" src="https://user-images.githubusercontent.com/8922176/59957534-1c059a80-944e-11e9-8c74-6b1a50d1ba63.PNG">


#### Focus areas to test
Verify that on small screens, the vertical line is not displayed, and the `Go to Today` string is not overlapping with the calendar


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9554)