### PR TITLE
create-component: add @docCategory tag to mustache templates

### DIFF
--- a/scripts/templates/create-component/EmptyComponent.mustache
+++ b/scripts/templates/create-component/EmptyComponent.mustache
@@ -4,6 +4,9 @@ import { use{{componentName}}State } from './{{componentName}}.state';
 import { I{{componentName}}Props } from './{{componentName}}.types';
 import { createComponent } from '../../Foundation';
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export const {{componentName}}: React.StatelessComponent<I{{componentName}}Props> = createComponent({
   displayName: '{{componentName}}',
   view: {{componentName}}View,

--- a/scripts/templates/create-component/EmptyComponentStateless.mustache
+++ b/scripts/templates/create-component/EmptyComponentStateless.mustache
@@ -3,6 +3,9 @@ import { {{componentName}}Styles, {{componentName}}Tokens } from './{{componentN
 import { I{{componentName}}Props } from './{{componentName}}.types';
 import { createComponent } from '../../Foundation';
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export const {{componentName}}: React.StatelessComponent<I{{componentName}}Props> = createComponent({
   displayName: '{{componentName}}',
   view: {{componentName}}View,

--- a/scripts/templates/create-component/EmptyState.mustache
+++ b/scripts/templates/create-component/EmptyState.mustache
@@ -2,6 +2,9 @@ import { useCallback, useState } from 'react';
 import { I{{componentName}}Component, I{{componentName}}Props, I{{componentName}}ViewProps } from './{{componentName}}.types';
 import { useControlledState } from '../../Foundation';
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export const use{{componentName}}State: I{{componentName}}Component['state'] = (
   props: Readonly<I{{componentName}}Props>
 ): I{{componentName}}ViewProps => {

--- a/scripts/templates/create-component/EmptyStyles.mustache
+++ b/scripts/templates/create-component/EmptyStyles.mustache
@@ -18,11 +18,17 @@ const warningTokens: I{{componentName}}Component['tokens'] = {
   textColor: 'red'
 };
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export const {{componentName}}Tokens: I{{componentName}}Component['tokens'] = (props, theme): I{{componentName}}TokenReturnType => [
   baseTokens,
   props.warning && warningTokens
 ];
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export const {{componentName}}Styles: I{{componentName}}Component['styles'] = (props, theme, tokens): I{{componentName}}StylesReturnType => {
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 

--- a/scripts/templates/create-component/EmptyTypes.mustache
+++ b/scripts/templates/create-component/EmptyTypes.mustache
@@ -1,18 +1,35 @@
 import { ITextSlot } from 'office-ui-fabric-react/lib/Text';
 import { IComponent, IComponentStyles, IHTMLSlot, IStyleableComponentProps } from '../../Foundation';
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}Component =
   IComponent<I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles, I{{componentName}}ViewProps>;
 
-// These types are redundant with I{{componentName}}Component but are needed until TS function return widening issue is resolved:
+// The following two types are redundant with I{{componentName}}Component but are needed until TS function return widening issue is resolved:
 // https://github.com/Microsoft/TypeScript/issues/241
 // For now, these helper types can be used to provide return type safety for tokens and styles functions.
+
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}TokenReturnType = ReturnType<Extract<I{{componentName}}Component['tokens'], Function>>;
+
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}StylesReturnType = ReturnType<Extract<I{{componentName}}Component['styles'], Function>>;
 
-// Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
+/*
+* Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}} { }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}Slots {
   // All props for your component are to be defined here.
   /**
@@ -27,8 +44,11 @@ export interface I{{componentName}}Slots {
   text?: ITextSlot;
 }
 
-// Extending IStyleableComponentProps will automatically add styleable props for you, such as styles, tokens and theme.
-// If you don't want these props to be included in your component, just remove this extension.
+/**
+* Extending IStyleableComponentProps will automatically add styleable props for you, such as styles, tokens and theme.
+* If you don't want these props to be included in your component, just remove this extension.
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}Props extends
   I{{componentName}}Slots,
   IStyleableComponentProps<I{{componentName}}ViewProps, I{{componentName}}Tokens, I{{componentName}}Styles> {
@@ -43,6 +63,9 @@ export interface I{{componentName}}Props extends
   warning?: boolean;
 }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}ViewProps extends I{{componentName}}Props {
   // You can define view only props here.
   /**
@@ -53,10 +76,16 @@ export interface I{{componentName}}ViewProps extends I{{componentName}}Props {
   onClick?: (ev?: React.MouseEvent<HTMLElement>) => void;
 }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}Tokens {
   // Define tokens for your component here. Tokens are styling 'knobs' that your component will automatically
   // apply to styling sections in the styles file.
   textColor?: string;
 }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}Styles = IComponentStyles<I{{componentName}}Slots>;

--- a/scripts/templates/create-component/EmptyTypesStateless.mustache
+++ b/scripts/templates/create-component/EmptyTypesStateless.mustache
@@ -1,17 +1,34 @@
 import { ITextSlot } from 'office-ui-fabric-react/lib/Text';
 import { IComponent, IComponentStyles, IHTMLSlot, IStyleableComponentProps } from '../../Foundation';
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}Component = IComponent<I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles>;
 
-// These types are redundant with I{{componentName}}Component but are needed until TS function return widening issue is resolved:
+// The following two types are redundant with I{{componentName}}Component but are needed until TS function return widening issue is resolved:
 // https://github.com/Microsoft/TypeScript/issues/241
 // For now, these helper types can be used to provide return type safety for tokens and styles functions.
+
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}TokenReturnType = ReturnType<Extract<I{{componentName}}Component['tokens'], Function>>;
+
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}StylesReturnType = ReturnType<Extract<I{{componentName}}Component['styles'], Function>>;
 
-// Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
+/*
+* Optional interface to use for componentRef. This should be limited in scope with the most common scenario being for focusing elements.
+* @{docCategory {{componentName}}}
+*/
 export interface I{{componentName}} { }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}Slots {
   // All props for your component are to be defined here.
   /**
@@ -26,8 +43,11 @@ export interface I{{componentName}}Slots {
   text?: ITextSlot;
 }
 
-// Extending IStyleableComponentProps will automatically add styleable props for you, such as styles and theme.
-// If you don't want these props to be included in your component, just remove this extension.
+/**
+* Extending IStyleableComponentProps will automatically add styleable props for you, such as styles and theme.
+* If you don't want these props to be included in your component, just remove this extension.
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}Props extends
   I{{componentName}}Slots,
   IStyleableComponentProps<I{{componentName}}Props, I{{componentName}}Tokens, I{{componentName}}Styles> {
@@ -40,10 +60,16 @@ export interface I{{componentName}}Props extends
   warning?: boolean;
 }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export interface I{{componentName}}Tokens {
   // Define tokens for your component here. Tokens are styling 'knobs' that your component will automatically
   // apply to styling sections in the styles file.
   textColor?: string;
 }
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export type I{{componentName}}Styles = IComponentStyles<I{{componentName}}Slots>;

--- a/scripts/templates/create-component/EmptyView.mustache
+++ b/scripts/templates/create-component/EmptyView.mustache
@@ -4,6 +4,9 @@ import { withSlots, getSlots } from '../../Foundation';
 
 import { I{{componentName}}Component, I{{componentName}}Props, I{{componentName}}Slots } from './{{componentName}}.types';
 
+/**
+* {@docCategory {{componentName}}}
+*/
 export const {{componentName}}View: I{{componentName}}Component['view'] = props => {
 
   const Slots = getSlots<I{{componentName}}Props, I{{componentName}}Slots>(props, {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds the `@docCategory` inline tag to mustache templates. These tags ensure that when a component is promoted to the `office-ui-fabric-react` package, it will be documented on the Fabric site.

#### Focus areas to test

The updated TSDoc comments should show up in the new component files when running `npm run create-component -- --name <component-name>`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9558)