### PR TITLE
ColorPicker: fluent update

### DIFF
--- a/common/changes/@uifabric/fluent-theme/v-mare-ColorPicker-fluent-update_2019-06-24-23-47.json
+++ b/common/changes/@uifabric/fluent-theme/v-mare-ColorPicker-fluent-update_2019-06-24-23-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "ColorPicker: Updates ColorPicker component to match fluent toolkit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-mare@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/ColorPicker.styles.ts
@@ -45,7 +45,8 @@ export const ColorRectangleStyles = (props: IColorRectangleStyleProps): Partial<
   return {
     root: {
       border: `1px solid ${palette.neutralLighter}`,
-      borderRadius: effects.roundedCorner2
+      borderRadius: effects.roundedCorner2,
+      marginBottom: 8
     },
     thumb: {
       borderColor: palette.neutralTertiary,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #7044
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update ColorPicker component per most current web fluent toolkit. Only some bottom margin on the color rectangle was needed.

#### Before
![Screen Shot 2019-06-24 at 2 28 40 PM](https://user-images.githubusercontent.com/13246181/60059305-e2789d80-96a0-11e9-8b8c-10bbf0af35e5.png)

#### After
![Screen Shot 2019-06-24 at 4 52 35 PM](https://user-images.githubusercontent.com/13246181/60059267-a5aca680-96a0-11e9-8bf3-b0555cd284cd.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9564)