### PR TITLE
Perf Test: Fix on 6.0

### DIFF
--- a/scripts/tasks/perf-test.js
+++ b/scripts/tasks/perf-test.js
@@ -9,7 +9,7 @@ const sampleSize = 50;
 const urlFromDeployJob = process.env.BUILD_SOURCEBRANCH
   ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test/`
   : 'http://localhost:4322';
-const urlForMaster = 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/';
+const urlForMaster = 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/6.0/perf-test/';
 
 const outputPath = path.join(__dirname, '../../apps/perf-test/dist');
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

#9550 changed the baseline tests for master. This ended up breaking 6.0 builds because the 6.0 branch hadn't been switched over to use 6.0 deploy links for its baseline tests. This PR fixes this problem.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9566)