### PR TITLE
Fix 404 with universal header "Skip to main content" tab stop

### DIFF
--- a/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
+++ b/apps/fabric-website/src/SiteDefinition/SiteDefinition.tsx
@@ -55,7 +55,8 @@ export const SiteDefinition: ISiteDefinition<Platforms> = {
     { from: '#/styles/typography', to: '#/styles/web/typography' },
     { from: '#/styles/utilities', to: '#/styles/web' },
     { from: '#/controls/web/fluent-theme', to: '#/styles/web/fluent-theme' },
-    { from: '#/examples', to: '#/controls/web' }
+    { from: '#/examples', to: '#/controls/web' },
+    { from: '#mainContent', to: '#/get-started' } // Universal header accessibility tab stop
   ],
   messageBars: [
     {

--- a/common/changes/@uifabric/fabric-website/keco-main-content-redirect_2019-06-25-16-00.json
+++ b/common/changes/@uifabric/fabric-website/keco-main-content-redirect_2019-06-25-16-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Fix 404 by adding redirect for universal header jump to main content",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9563
- [x] Include a change request file using `$ npm run change`

#### Description of changes

The universal header on the Fabric documentation site has a tab stop for jumping to main content as per [accessibility specs](https://www.w3.org/TR/WCAG20-TECHS/G1.html). The anchor points to `#mainContent` which is not currently handled by our site and therefore results in a 404.

See https://developer.microsoft.com/en-us/fabric#mainContent

The solution here is to add a redirect to our "Getting started" route for `#mainContent`.

The header's DOM:

![image](https://user-images.githubusercontent.com/706967/60114214-3aa6b280-9728-11e9-96e0-0849a82b9f95.png)

This might need to be cherry-picked for previous releases of the website cc: @ecraig12345.

#### Focus areas to test

I replicated the scenario to the best of my ability locally since we lack the header in local dev.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9570)