### PR TITLE
Perf Test: Add missing copy step

### DIFF
--- a/apps/perf-test/tasks/perf-test.js
+++ b/apps/perf-test/tasks/perf-test.js
@@ -60,7 +60,7 @@ const urlForDeployPath = process.env.BUILD_SOURCEBRANCH
 const urlForDeploy = urlForDeployPath + '/index.html';
 
 const urlForMaster = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
-  ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test/index.html`
+  ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test/index.html`
   : 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/index.html';
 
 const logPath = path.join(__dirname, '../logfiles');

--- a/apps/perf-test/tasks/perf-test.js
+++ b/apps/perf-test/tasks/perf-test.js
@@ -59,7 +59,9 @@ const urlForDeployPath = process.env.BUILD_SOURCEBRANCH
 
 const urlForDeploy = urlForDeployPath + '/index.html';
 
-const urlForMaster = 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/index.html';
+const urlForMaster = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
+  ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test/index.html`
+  : 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/index.html';
 
 const logPath = path.join(__dirname, '../logfiles');
 const logFilePath = path.join(logPath, '/puppeteer.log');

--- a/apps/pr-deploy-site/config/pre-copy.json
+++ b/apps/pr-deploy-site/config/pre-copy.json
@@ -3,6 +3,7 @@
     "dist": ["./node_modules/@uifabric/*/dist/**", "index.html", "chiclet-test.html"],
     "dist/todo-app": ["./node_modules/todo-app/dist/**"],
     "dist/theming-designer": ["./node_modules/theming-designer/dist/**"],
-    "dist/test-bundles": ["./node_modules/test-bundles/dist/**"]
+    "dist/test-bundles": ["./node_modules/test-bundles/dist/**"],
+    "dist/perf-test": ["./node_modules/perf-test/dist/**"]
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

The [results](https://github.com/OfficeDev/office-ui-fabric-react/pull/9516#issuecomment-503795745) of #9516 exposed an issue where a missing copy step caused the PR to run against an old version of `perf-test`. We initially removed this copy step in #9550 because we thought it would cause an error on the second copy including test results, but didn't consider this would result in PRs using an old copy of `index.html`.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9571)