### PR TITLE
Tooltip: fluent update

### DIFF
--- a/common/changes/@uifabric/fluent-theme/v-mare-Tooltip-fluent-update_2019-06-25-18-12.json
+++ b/common/changes/@uifabric/fluent-theme/v-mare-Tooltip-fluent-update_2019-06-25-18-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fluent-theme",
+      "comment": "Tooltip: Updates box shadow to match toolkit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-mare@microsoft.com"
+}

--- a/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/Callout.styles.ts
@@ -8,7 +8,12 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<
     root: {
       borderRadius: effects.roundedCorner2,
       borderWidth: 0,
-      boxShadow: effects.elevation16
+      boxShadow: effects.elevation16,
+      selectors: {
+        '&.ms-Tooltip': {
+          boxShadow: effects.elevation8
+        }
+      }
     },
     beakCurtain: {
       borderRadius: effects.roundedCorner2


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #7157 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Changing Tooltip box shadow to elevation8 from elevation16 to match web fluent toolkit.

#### Before
![Screen Shot 2019-06-25 at 11 09 15 AM](https://user-images.githubusercontent.com/13246181/60122576-5d41c700-973a-11e9-8a90-6f4ce2c16ba6.png)


#### After
![Screen Shot 2019-06-25 at 11 09 56 AM](https://user-images.githubusercontent.com/13246181/60122844-efe26600-973a-11e9-866b-e0c2877d6556.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9572)