### PR TITLE
Theme Designer: color picker text fields need to be editable.

### DIFF
--- a/apps/theming-designer/src/components/ThemeDesignerColorPicker.tsx
+++ b/apps/theming-designer/src/components/ThemeDesignerColorPicker.tsx
@@ -69,7 +69,12 @@ export class ThemeDesignerColorPicker extends React.Component<IThemeDesignerColo
               style={{ backgroundColor: this.props.color.str }}
               onClick={this._updateColorPickerVisible}
             />
-            <TextField id="textfield" className={textBoxClassName} value={this.props.color.str} onChange={this._onTextFieldValueChange} />
+            <TextField
+              id="textfield"
+              className={textBoxClassName}
+              defaultValue={this.props.color.str}
+              onChange={this._onTextFieldValueChange}
+            />
           </Stack>
         </Stack>
         {this.state.isColorPickerVisible && (

--- a/apps/theming-designer/src/components/ThemeDesignerColorPicker.tsx
+++ b/apps/theming-designer/src/components/ThemeDesignerColorPicker.tsx
@@ -40,6 +40,7 @@ export interface IThemeDesignerColorPickerProps {
 
 export interface IThemeDesignerColorPickerState {
   isColorPickerVisible: boolean;
+  editingColorStr?: string;
 }
 
 export class ThemeDesignerColorPicker extends React.Component<IThemeDesignerColorPickerProps, IThemeDesignerColorPickerState> {
@@ -57,6 +58,7 @@ export class ThemeDesignerColorPicker extends React.Component<IThemeDesignerColo
   }
 
   public render() {
+    const { editingColorStr = this.props.color.str } = this.state;
     return (
       <div>
         <Stack horizontal horizontalAlign={'space-between'} gap={20}>
@@ -69,12 +71,7 @@ export class ThemeDesignerColorPicker extends React.Component<IThemeDesignerColo
               style={{ backgroundColor: this.props.color.str }}
               onClick={this._updateColorPickerVisible}
             />
-            <TextField
-              id="textfield"
-              className={textBoxClassName}
-              defaultValue={this.props.color.str}
-              onChange={this._onTextFieldValueChange}
-            />
+            <TextField id="textfield" className={textBoxClassName} value={editingColorStr} onChange={this._onTextFieldValueChange} />
           </Stack>
         </Stack>
         {this.state.isColorPickerVisible && (
@@ -93,8 +90,12 @@ export class ThemeDesignerColorPicker extends React.Component<IThemeDesignerColo
   }
 
   private _onTextFieldValueChange(ev: any, newValue: string | undefined) {
-    if (newValue) {
-      this.props.onColorChange(getColorFromString(newValue!));
+    const newColor = getColorFromString(newValue!);
+    if (newColor) {
+      this.props.onColorChange(newColor);
+      this.setState({ editingColorStr: undefined });
+    } else {
+      this.setState({ editingColorStr: newValue });
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

In the update from Fabric 6.0 to 7.0, the textfields used in the theme designer's color pickers became uneditable due to changes in the textfield component itself. Added maintaining of state for the color string value while the textfield's being edited so that it goes back to being editable & the keystrokes are not ignored.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9577)