### PR TITLE
Panel className performance and isFooterAtBottom prop

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-classnames-recalc_2019-06-26-00-10.json
+++ b/common/changes/office-ui-fabric-react/panel-classnames-recalc_2019-06-26-00-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: move windowHeight from classNames into inline styles to prevent unnecessary className recalculations, respect isFooterAtBottom prop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -12,7 +12,8 @@ import {
   elementContains,
   getId,
   getNativeProps,
-  getRTL
+  getRTL,
+  getWindow
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
@@ -142,6 +143,9 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
     const isOpen = this.isActive;
     const isAnimating = visibility === PanelVisibilityState.animatingClosed || visibility === PanelVisibilityState.animatingOpen;
+    const win = getWindow();
+    const windowHeight = typeof win !== 'undefined' ? win.innerHeight : '100%';
+    const maxWindowHeightStyles = { maxHeight: windowHeight };
 
     if (!isOpen && !isAnimating && !isHiddenOnDismiss) {
       return null;
@@ -154,7 +158,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       hasCloseButton,
       headerClassName,
       isAnimating,
-      isFooterAtBottom,
       isFooterSticky,
       isOnRightSide,
       isOpen,
@@ -189,15 +192,20 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
               isClickableOutsideFocusTrap={true}
               {...focusTrapZoneProps}
               className={_classNames.main}
-              style={customWidthStyles}
+              style={{ ...customWidthStyles, ...maxWindowHeightStyles }}
               elementToFocusOnDismiss={elementToFocusOnDismiss}
             >
               <div className={_classNames.commands} data-is-visible={true}>
                 {onRenderNavigation(this.props, this._onRenderNavigation)}
               </div>
-              <div className={_classNames.contentInner}>
+              <div className={_classNames.contentInner} style={maxWindowHeightStyles}>
                 {header}
-                <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent} data-is-scrollable={true}>
+                <div
+                  ref={this._allowScrollOnPanel}
+                  className={_classNames.scrollableContent}
+                  style={{ [isFooterAtBottom ? 'height' : 'maxHeight']: windowHeight }}
+                  data-is-scrollable={true}
+                >
                   {onRenderBody(this.props, this._onRenderBody)}
                 </div>
                 {onRenderFooter(this.props, this._onRenderFooter)}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
@@ -143,11 +143,6 @@ export const PanelPageProps: IDocPageProps = {
       title: 'Panel - Scrolling Content Sample',
       code: PanelScrollExampleCode,
       view: <PanelScrollExample />
-    },
-    {
-      title: 'Panel - Scrolling Content Sample',
-      code: PanelScrollExampleCode,
-      view: <PanelScrollExample />
     }
   ],
   overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Panel/docs/PanelOverview.md'),

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -13,7 +13,6 @@ import {
   IStyle
 } from '../../Styling';
 import { FontWeights } from '../../Styling';
-import { getWindow } from '../../Utilities';
 
 // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
 // import { IStyleFunctionOrObject } from '../../Utilities';
@@ -193,7 +192,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     hasCloseButton,
     headerClassName,
     isAnimating,
-    isFooterAtBottom,
     isFooterSticky,
     isOnRightSide,
     isOpen,
@@ -204,8 +202,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
   const { palette, effects } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const isCustomPanel = type === PanelType.custom || type === PanelType.customNear;
-  const win = getWindow();
-  const windowHeight = typeof win !== 'undefined' ? win.innerHeight : '100%';
 
   return {
     root: [
@@ -252,7 +248,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         overflowX: 'hidden',
         overflowY: 'auto',
         WebkitOverflowScrolling: 'touch',
-        maxHeight: windowHeight,
         bottom: 0,
         top: 0,
         // (left, right, width) - Properties to be overridden depending on the type of the Panel and the screen breakpoint.
@@ -282,9 +277,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       isCustomPanel && {
         maxWidth: '100vw'
       },
-      isFooterAtBottom && {
-        height: windowHeight
-      },
       isOpen && isAnimating && !isOnRightSide && AnimationClassNames.slideRightIn40,
       isOpen && isAnimating && isOnRightSide && AnimationClassNames.slideLeftIn40,
       !isOpen && isAnimating && !isOnRightSide && AnimationClassNames.slideLeftOut40,
@@ -308,11 +300,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         display: 'flex',
         flexDirection: 'column',
         flexGrow: 1,
-        maxHeight: windowHeight,
         overflowY: 'hidden'
-      },
-      isFooterAtBottom && {
-        height: windowHeight
       }
     ],
     header: [
@@ -344,8 +332,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     scrollableContent: [
       classNames.scrollableContent,
       {
-        overflowY: 'auto',
-        height: windowHeight
+        overflowY: 'auto'
       }
     ],
     content: [

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -130,7 +130,6 @@ exports[`Panel renders Panel correctly 1`] = `
                 display: flex;
                 flex-direction: column;
                 left: auto;
-                max-height: 768px;
                 overflow-x: hidden;
                 overflow-y: auto;
                 pointer-events: auto;
@@ -149,7 +148,11 @@ exports[`Panel renders Panel correctly 1`] = `
           onBlur={[Function]}
           onFocus={[Function]}
           onFocusCapture={[Function]}
-          style={Object {}}
+          style={
+            Object {
+              "maxHeight": 768,
+            }
+          }
         >
           <div
             data-is-visible={true}
@@ -312,9 +315,13 @@ exports[`Panel renders Panel correctly 1`] = `
                   display: flex;
                   flex-direction: column;
                   flex-grow: 1;
-                  max-height: 768px;
                   overflow-y: hidden;
                 }
+            style={
+              Object {
+                "maxHeight": 768,
+              }
+            }
           >
             <div
               className=
@@ -367,10 +374,14 @@ exports[`Panel renders Panel correctly 1`] = `
               className=
                   ms-Panel-scrollableContent
                   {
-                    height: 768px;
                     overflow-y: auto;
                   }
               data-is-scrollable={true}
+              style={
+                Object {
+                  "maxHeight": 768,
+                }
+              }
             >
               <div
                 className=

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Scroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Scroll.Example.tsx
@@ -19,7 +19,6 @@ export class PanelScrollExample extends React.Component<{}, IPanelScrollExampleS
           isOpen={this.state.showPanel}
           type={PanelType.smallFixedFar}
           onDismiss={this._hidePanel}
-          isFooterAtBottom={true}
           headerText="Panel with scrolling content"
           closeButtonAriaLabel="Close"
           onRenderFooterContent={this._onRenderFooterContent}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -215,7 +215,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                   display: flex;
                   flex-direction: column;
                   left: auto;
-                  max-height: 768px;
                   overflow-x: hidden;
                   overflow-y: auto;
                   pointer-events: auto;
@@ -234,7 +233,11 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
             onBlur={[Function]}
             onFocus={[Function]}
             onFocusCapture={[Function]}
-            style={Object {}}
+            style={
+              Object {
+                "maxHeight": 768,
+              }
+            }
           >
             <div
               data-is-visible={true}
@@ -397,9 +400,13 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                     display: flex;
                     flex-direction: column;
                     flex-grow: 1;
-                    max-height: 768px;
                     overflow-y: hidden;
                   }
+              style={
+                Object {
+                  "maxHeight": 768,
+                }
+              }
             >
               <div
                 className=
@@ -452,10 +459,14 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                 className=
                     ms-Panel-scrollableContent
                     {
-                      height: 768px;
                       overflow-y: auto;
                     }
                 data-is-scrollable={true}
+                style={
+                  Object {
+                    "maxHeight": 768,
+                  }
+                }
               >
                 <div
                   className=


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This pull request makes two modifications to the Panel component:

##### Class names recalculation
Previously, the Panel `getStyles` function recalculated `window.innerHeight`, causing the classNames to be regenerated on window resize. This change moves the `window.innerHeight` usages into inline styles in `Panel.render`.

Before (classNames recalculated on window resize):
![panel-classnames-recalc-before-ffmpeg-2](https://user-images.githubusercontent.com/6687333/60142398-7ebca600-976e-11e9-849b-bf1257fcf384.gif)

After (inline styles recalculated on window resize, classNames remain unchanged):
![panel-classnames-recalc-after-ffmpeg-2](https://user-images.githubusercontent.com/6687333/60142452-ba577000-976e-11e9-82d3-73222cfe5fb3.gif)

##### isFooterAtBottom prop
Previously, the footer was always rendered at the bottom of the Panel regardless of the value of the `isFooterAtBottom` prop. The `getStyles` function used the value of the `isFooterAtBottom` prop to set the height of the main and contentInner divs, but this had no effect on the placement of the footer. This change uses the `isFooterAtBottom` prop to set the height of the scrollableContent div (which does affect the placement of the footer). If `isFooterAtBottom` is true, the scrollableContent div has a height of `windowHeight`. Otherwise, the scrollableContent div has a maxHeight of `windowHeight`. (The main and contentInner divs now only have `maxHeight: windowHeight`, not `height: windowHeight`.)

Before - isFooterAtBottom is false, footer is rendered at bottom:
![panel-isfooteratbottom-false-before](https://user-images.githubusercontent.com/6687333/60142370-5e8ce700-976e-11e9-9a5a-88032b3f38ae.PNG)

After - isFooterAtBottom is false, footer is not rendered at bottom:
![panel-isfooteratbottom-false-after](https://user-images.githubusercontent.com/6687333/60142380-68164f00-976e-11e9-9e34-e0d77e000266.PNG)

Before - isFooterAtBottom is true, footer is rendered at bottom:
![panel-isfooteratbottom-true-before](https://user-images.githubusercontent.com/6687333/60142388-6fd5f380-976e-11e9-860d-c21ddb9ae1e4.PNG)

After - isFooterAtBottom is true, footer is rendered at bottom:
![panel-isfooteratbottom-true-after](https://user-images.githubusercontent.com/6687333/60142396-77959800-976e-11e9-903b-af7f5edf8aaf.PNG)

Finally, this PR removes a duplicate instance of the PanelScrollExample in the Panel docs.

#### Focus areas to test

1. Perf - the Panel classNames should not recompute on window resize.
2. Mobile:
a. Footers should be visible on mobile browsers.
b. Scrolling should be possible within Panels on mobile browsers, without scrolling the body behind a Panel (i.e. these two mobile behaviors should be unchanged).
3. isFooterAtBottom prop should be respected:
a. When isFooterAtBottom is true, the footer should be rendered at the bottom of the Panel (scrollableContent should have a height of maxHeight).
b. When isFooterAtBottom is false, the footer should be rendered directly below the content of the Panel (scrollableContent should have a maxHeight of windowHeight.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9580)