### PR TITLE
Add `font-display: swap` when registering font face

### DIFF
--- a/common/changes/@uifabric/merge-styles/unindented-font-display-swap_2019-06-26-19-07.json
+++ b/common/changes/@uifabric/merge-styles/unindented-font-display-swap_2019-06-26-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Add `fontDisplay` to `IFontFace`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "unindented@gmail.com"
+}

--- a/common/changes/@uifabric/styling/unindented-font-display-swap_2019-06-26-19-07.json
+++ b/common/changes/@uifabric/styling/unindented-font-display-swap_2019-06-26-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/styling",
+      "comment": "Add `font-display: 'swap'` when registering font face'",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/styling",
+  "email": "unindented@gmail.com"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -50,6 +50,7 @@ export type ICSSRule = 'initial' | 'inherit' | 'unset';
 
 // @public
 export interface IFontFace extends IRawFontStyle {
+    fontDisplay?: 'auto' | 'block' | 'swap' | 'fallback' | 'optional';
     fontFeatureSettings?: string;
     src?: string;
     unicodeRange?: ICSSRule | string;

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -259,6 +259,12 @@ export interface IFontFace extends IRawFontStyle {
   unicodeRange?: ICSSRule | string;
 
   /**
+   * Determines how a font face is displayed based on whether and when it is downloaded
+   * and ready to use.
+   */
+  fontDisplay?: 'auto' | 'block' | 'swap' | 'fallback' | 'optional';
+
+  /**
    * Feature settings for the font.
    */
   fontFeatureSettings?: string;

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -19,7 +19,8 @@ function _registerFontFace(fontFamily: string, url: string, fontWeight?: IFontWe
     fontFamily,
     src: localFontSrc + `url('${url}.woff2') format('woff2'),` + `url('${url}.woff') format('woff')`,
     fontWeight,
-    fontStyle: 'normal'
+    fontStyle: 'normal',
+    fontDisplay: 'swap'
   });
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9214
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adds `font-display: swap` when registering font face, to avoid Flash of Invisible Text.

I could be convinced that `fallback` is better suited here. I just want fonts to not block rendering.

Can I Use table: https://caniuse.com/#feat=css-font-rendering-controls

More context here: https://developers.google.com/web/updates/2016/02/font-display

#### Focus areas to test

Old browsers will just ignore `font-display`, so there isn't much risk to this change really.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9584)