### PR TITLE
Update implementation for raising a click event to support IE

### DIFF
--- a/common/changes/@uifabric/utilities/keypress-ie_2019-06-26-20-12.json
+++ b/common/changes/@uifabric/utilities/keypress-ie_2019-06-26-20-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Utilities: Update implementation for raising a click event to support IE",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "afhassan@microsoft.com"
+}

--- a/packages/utilities/src/dom/raiseClick.ts
+++ b/packages/utilities/src/dom/raiseClick.ts
@@ -1,7 +1,19 @@
 /** Raises a click event. */
 export function raiseClick(target: Element): void {
-  const event = new Event('MouseEvents');
-
+  const event = createNewEvent('MouseEvents');
   event.initEvent('click', true, true);
   target.dispatchEvent(event);
+}
+
+function createNewEvent(eventName: string): Event {
+  let event;
+  // Chrome, Opera, Firefox
+  if (typeof Event === 'function') {
+    event = new Event(eventName);
+  } else {
+    // IE
+    event = document.createEvent('Event');
+    event.initEvent(eventName, true, true);
+  }
+  return event;
 }

--- a/packages/utilities/src/dom/raiseClick.ts
+++ b/packages/utilities/src/dom/raiseClick.ts
@@ -7,8 +7,8 @@ export function raiseClick(target: Element): void {
 
 function createNewEvent(eventName: string): Event {
   let event;
-  // Chrome, Opera, Firefox
   if (typeof Event === 'function') {
+    // Chrome, Opera, Firefox
     event = new Event(eventName);
   } else {
     // IE


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9498
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
The `raiseClick` function in `@uifabric/utilities` which raises a click event does not work on `IE` since the `Event()` constructor is not compatible with `IE` as per the [compatibility matrix](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event). This `PR` changes the implementation, so as to work for `IE` along with other browsers we support. 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8922176/60210381-9436dc00-9811-11e9-96d3-c50a98ea1e1e.gif)


#### Focus areas to test
Verify that a keyboard input raises an event in `IE`
Have a `DetailsList` that sorts elements in a column and verify that the elements are sorted on both mouse click as well as keyboard event, similar to the scenario reported in the original bug. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9587)