### PR TITLE
Panel: Overflowing header text should word break and word wrap by default

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-panel-headerText-word-wrap_2019-06-26-20-35.json
+++ b/common/changes/office-ui-fabric-react/keco-panel-headerText-word-wrap_2019-06-26-20-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Overflowing header text should word break and wrap by default",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -325,7 +325,11 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         fontSize: 20, // TODO: after the type ramp gets reevaluated this needs to be changed
         fontWeight: FontWeights.semibold,
         lineHeight: '27px',
-        margin: 0
+        margin: 0,
+        overflowWrap: 'break-word',
+        wordWrap: 'break-word',
+        wordBreak: 'break-word',
+        hyphens: 'auto'
       },
       headerClassName
     ],

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -358,11 +358,15 @@ exports[`Panel renders Panel correctly 1`] = `
                       font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 20px;
                       font-weight: 600;
+                      hyphens: auto;
                       line-height: 27px;
                       margin-bottom: 0px;
                       margin-left: 0px;
                       margin-right: 0px;
                       margin-top: 0px;
+                      overflow-wrap: break-word;
+                      word-break: break-word;
+                      word-wrap: break-word;
                     }
                 id="Panel0-headerText"
                 role="heading"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -443,11 +443,15 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 20px;
                         font-weight: 600;
+                        hyphens: auto;
                         line-height: 27px;
                         margin-bottom: 0px;
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
+                        overflow-wrap: break-word;
+                        word-break: break-word;
+                        word-wrap: break-word;
                       }
                   id="Panel3-headerText"
                   role="heading"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9576
- [x] Include a change request file using `$ npm run change`

#### Description of changes

As per offline conversation with design:

This change-set modifies the `Panel` so that _by default_ overflowing header text word wraps and breaks. This is done to make the text more readable and useful, otherwise it overflows outside the visible region.

This change is for `7.x` and forward to avoid visually regressing partners. `6.x` consumers can override the style manually to achieve the desired effect.

cc: @Vitalius1 for awareness when back in case it impacts MDL theming.

#### Focus areas to test

CI should pass


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9589)