### PR TITLE
making all getting started links point to microsoft rather than kenotron

### DIFF
--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/web/GetStartedDevelopSimple.md
@@ -27,10 +27,10 @@ This scaffold uses the [Just](https://github.com/microsoft/just) build library. 
 
 UI Fabric also provides a starter using [Create React App](https://facebook.github.io/create-react-app/), a popular development stack maintained by the creators of React.
 
-Open a terminal, go to an appropriate folder, and clone the [starter repo](https://github.com/kenotron/create-react-app-uifabric):
+Open a terminal, go to an appropriate folder, and clone the [starter repo](https://github.com/microsoft/create-react-app-uifabric):
 
 ```shell
-git clone https://github.com/kenotron/create-react-app-uifabric.git my-app
+git clone https://github.com/microsoft/create-react-app-uifabric.git my-app
 cd my-app
 ```
 
@@ -57,4 +57,4 @@ cd gatsby-site
 gatsby develop
 ```
 
-This app be deployed to the cloud in one click—[learn more here](https://github.com/kenotron/gatsby-starter-uifabric#-deploy).
+This app be deployed to the cloud in one click—[learn more here](https://github.com/microsoft/gatsby-starter-uifabric#-deploy).

--- a/common/changes/@uifabric/fabric-website/better_2019-06-26-21-53.json
+++ b/common/changes/@uifabric/fabric-website/better_2019-06-26-21-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "making all getting started links point to microsoft rather than kenotron",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

After all the //BUILD activities, we have a some down time to register the starter kit repos under microsoft org in github rather than my personal ones. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9593)