### PR TITLE
Add placeholder as a TextArea property

### DIFF
--- a/common/changes/@uifabric/utilities/rcasto-fix-placeholder-multiline-textfield_2019-06-27-02-07.json
+++ b/common/changes/@uifabric/utilities/rcasto-fix-placeholder-multiline-textfield_2019-06-27-02-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/utilities",
+      "comment": "Add placeholder as TextArea property",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/utilities",
+  "email": "rcasto92@gmail.com"
+}

--- a/common/changes/office-ui-fabric-react/rcasto-fix-placeholder-multiline-textfield_2019-06-27-02-07.json
+++ b/common/changes/office-ui-fabric-react/rcasto-fix-placeholder-multiline-textfield_2019-06-27-02-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add placeholder as TextArea property, allows placeholder in multiline TextField",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "rcasto92@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -76,6 +76,12 @@ describe('TextField snapshots', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders multiline with placeholder correctly', () => {
+    const component = renderer.create(<TextField label="Label" multiline={true} placeholder="test placeholder" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('renders multiline correctly with props affecting styling', () => {
     const component = renderer.create(
       <TextField label="Label" errorMessage="test message" underlined={true} prefix="test prefix" suffix="test suffix" />

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1005,6 +1005,176 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
 </div>
 `;
 
+exports[`TextField snapshots renders multiline with placeholder correctly 1`] = `
+<div
+  className=
+      ms-TextField
+      ms-TextField--multiline
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        box-shadow: none;
+        box-sizing: border-box;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+>
+  <div
+    className=
+        ms-TextField-wrapper
+
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="TextField0"
+      id="TextFieldLabel2"
+    >
+      Label
+    </label>
+    <div
+      className=
+          ms-TextField-fieldGroup
+          {
+            align-items: stretch;
+            background: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #8a8886;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: text;
+            display: flex;
+            flex-direction: row;
+            height: auto;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            min-height: 60px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+    >
+      <textarea
+        aria-invalid={false}
+        className=
+            ms-TextField-field
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              background: none;
+              border-radius: 0px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              flex-grow: 1;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              line-height: 17px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-height: inherit;
+              min-width: 0px;
+              outline: 0px;
+              overflow: auto;
+              padding-bottom: 6px;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 6px;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &:active, &:focus, &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+        id="TextField0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        placeholder="test placeholder"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TextField snapshots should resepect user component and subcomponent styling 1`] = `
 <div
   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -938,6 +938,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             onChange={[Function]}
             onFocus={[Function]}
             onInput={[Function]}
+            placeholder="No borders here, folks."
             value=""
           />
         </div>

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -222,7 +222,7 @@ export const inputProperties = buttonProperties.concat([
   'min', // input, meter
   'multiple', // input, select
   'pattern', // input
-  'placeholder', // input
+  'placeholder', // input, textarea
   'readOnly', // input, textarea
   'required', // input, select, textarea
   'src', // audio, embed, iframe, img, input, script, source, track, video
@@ -243,6 +243,7 @@ export const textAreaProperties = buttonProperties.concat([
   'dirname', // input, textarea
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
   'maxLength', // input, textarea
+  'placeholder', // input, textarea
   'readOnly', // input, textarea
   'required', // input, select, textarea
   'rows', // textarea


### PR DESCRIPTION
#### Pull request checklist
- [X] Addresses an existing issue: Fixes #9588 
- [X] Include a change request file using `$ npm run change`

#### Description of changes
- Adds placeholder as a [TextArea property](https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement)
- Add test to ensure multiline TextField has placeholder attribute

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9600)