### PR TITLE
Add handling for onMenuClick to ContextualMenu items

### DIFF
--- a/common/changes/office-ui-fabric-react/context-menu-click_2019-06-27-18-15.json
+++ b/common/changes/office-ui-fabric-react/context-menu-click_2019-06-27-18-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Add handling for onMenuClick to ContextualMenu items",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -40,6 +40,7 @@ import { IProcessedStyleSet, mergeStyleSets } from '../../Styling';
 import { IContextualMenuItemStyleProps, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 
 import { getItemStyles } from './ContextualMenu.classNames';
+import { IButtonProps } from '../Button';
 
 const getClassNames = classNamesFunction<IContextualMenuStyleProps, IContextualMenuStyles>({
   disableCaching: true
@@ -1029,6 +1030,10 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
       this._executeItemClick(item, ev);
     } else {
       if (item.key !== this.state.expandedMenuItemKey) {
+        if (item.onMenuClick) {
+          item.onMenuClick(ev, item as IButtonProps);
+        }
+
         // This has a collapsed sub menu. Expand it.
         this.setState({
           // When Edge + Narrator are used together (regardless of if the button is in a form or not), pressing

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -4,7 +4,7 @@ import { IFocusZoneProps } from '../../FocusZone';
 import { IIconProps } from '../Icon/Icon.types';
 import { ICalloutProps, ICalloutContentStyleProps, Target } from '../../Callout';
 import { ITheme, IStyle } from '../../Styling';
-import { IButtonStyles } from '../../Button';
+import { IButtonStyles, IButtonProps } from '../../Button';
 import { IRefObject, IBaseProps, IRectangle, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IWithResponsiveModeState } from '../../utilities/decorators/withResponsiveMode';
 import { IContextualMenuClassNames, IMenuItemClassNames } from './ContextualMenu.classNames';
@@ -358,6 +358,11 @@ export interface IContextualMenuItem {
    * Returning true will dismiss the menu even if ev.preventDefault() was called.
    */
   onClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
+
+  /**
+   * Callback invoked when the sub-menu is opened.
+   */
+  onMenuClick?: IButtonProps['onMenuClick'];
 
   /**
    * An optional URL to navigate to upon selection


### PR DESCRIPTION
Although `CommandBarButton` has handling for an `onMenuClick` passed to command bar items, `ContextualMenu` does not currently honor the callback if passed to an `IContextualMenuItem`.
This change formally adds the `onMenuClick` prop to `IContextualMenuItem` and then handles it, if provided, in `ContextualMenu`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9606)