### PR TITLE
GroupedList: Fix "Show All" not rendering all items in a section

### DIFF
--- a/common/changes/office-ui-fabric-react/keco-fix-groupshowall_2019-06-27-19-58.json
+++ b/common/changes/office-ui-fabric-react/keco-fix-groupshowall_2019-06-27-19-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "GroupedList: Fix \"Show All\" not rendering all items in a group",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -6,6 +6,8 @@ import { DetailsRow } from '../DetailsList/DetailsRow';
 import { IGroup } from './GroupedList.types';
 import { IColumn } from '../DetailsList/DetailsList.types';
 import { List } from '../List/List';
+import { GroupShowAll } from './GroupShowAll';
+import { Link } from 'office-ui-fabric-react/lib/Link';
 
 describe('GroupedList', () => {
   it("sets inner List page key to IGroup's key attribute for uniqueness", () => {
@@ -197,6 +199,60 @@ describe('GroupedList', () => {
 
     const listRows = wrapper.find(DetailsRow);
     expect(listRows.length).toBe(0);
+
+    wrapper.unmount();
+  });
+
+  it('renders the specified count of rows if "Show All" is to be displayed and all rows once "Show All" is clicked', () => {
+    const _selection = new Selection();
+    const _items: Array<{ key: string }> = [{ key: '1' }, { key: '2' }, { key: '3' }];
+    const _groups: Array<IGroup> = [
+      {
+        count: 1,
+        hasMoreData: true,
+        isCollapsed: false,
+        key: 'group0',
+        name: 'group 0',
+        startIndex: 0,
+        level: 0
+      }
+    ];
+
+    function _onRenderCell(nestingDepth: number, item: any, itemIndex: number): JSX.Element {
+      return (
+        <DetailsRow
+          columns={Object.keys(item)
+            .slice(0, 2)
+            .map(
+              (value): IColumn => {
+                return {
+                  key: value,
+                  name: value,
+                  fieldName: value,
+                  minWidth: 300
+                };
+              }
+            )}
+          groupNestingDepth={nestingDepth}
+          item={item}
+          itemIndex={itemIndex}
+          selection={_selection}
+          selectionMode={SelectionMode.multiple}
+        />
+      );
+    }
+
+    const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
+
+    let listRows = wrapper.find(DetailsRow);
+    expect(listRows.length).toBe(1);
+
+    const groupShowAllElement = wrapper.find(GroupShowAll);
+
+    groupShowAllElement.simulate('click');
+
+    listRows = wrapper.find(DetailsRow);
+    expect(listRows.length).toBe(1);
 
     wrapper.unmount();
   });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -7,6 +7,7 @@ import { IGroup } from './GroupedList.types';
 import { IColumn } from '../DetailsList/DetailsList.types';
 import { List } from '../List/List';
 import { GroupShowAll } from './GroupShowAll';
+import { Link } from '../Link/Link';
 
 describe('GroupedList', () => {
   it("sets inner List page key to IGroup's key attribute for uniqueness", () => {
@@ -248,10 +249,10 @@ describe('GroupedList', () => {
 
     const groupShowAllElement = wrapper.find(GroupShowAll);
 
-    groupShowAllElement.simulate('click');
+    groupShowAllElement.find(Link).simulate('click');
 
     listRows = wrapper.find(DetailsRow);
-    expect(listRows).toHaveLength(1);
+    expect(listRows).toHaveLength(3);
 
     wrapper.unmount();
   });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -7,7 +7,6 @@ import { IGroup } from './GroupedList.types';
 import { IColumn } from '../DetailsList/DetailsList.types';
 import { List } from '../List/List';
 import { GroupShowAll } from './GroupShowAll';
-import { Link } from 'office-ui-fabric-react/lib/Link';
 
 describe('GroupedList', () => {
   it("sets inner List page key to IGroup's key attribute for uniqueness", () => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -101,7 +101,7 @@ describe('GroupedList', () => {
     const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
 
     const listRows = wrapper.find(DetailsRow);
-    expect(listRows.length).toBe(3);
+    expect(listRows).toHaveLength(3);
 
     wrapper.unmount();
   });
@@ -149,7 +149,7 @@ describe('GroupedList', () => {
     const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
 
     const listRows = wrapper.find(DetailsRow);
-    expect(listRows.length).toBe(1);
+    expect(listRows).toHaveLength(1);
 
     wrapper.unmount();
   });
@@ -197,7 +197,7 @@ describe('GroupedList', () => {
     const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
 
     const listRows = wrapper.find(DetailsRow);
-    expect(listRows.length).toBe(0);
+    expect(listRows).toHaveLength(0);
 
     wrapper.unmount();
   });
@@ -244,14 +244,14 @@ describe('GroupedList', () => {
     const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
 
     let listRows = wrapper.find(DetailsRow);
-    expect(listRows.length).toBe(1);
+    expect(listRows).toHaveLength(1);
 
     const groupShowAllElement = wrapper.find(GroupShowAll);
 
     groupShowAllElement.simulate('click');
 
     listRows = wrapper.find(DetailsRow);
-    expect(listRows.length).toBe(1);
+    expect(listRows).toHaveLength(1);
 
     wrapper.unmount();
   });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -56,4 +56,148 @@ describe('GroupedList', () => {
 
     wrapper.unmount();
   });
+
+  it("renders the number of rows specified by a group's count when startIndex is zero", () => {
+    const _selection = new Selection();
+    const _items: Array<{ key: string }> = [{ key: '1' }, { key: '2' }, { key: '3' }];
+    const _groups: Array<IGroup> = [
+      {
+        count: 3,
+        hasMoreData: true,
+        isCollapsed: false,
+        key: 'group0',
+        name: 'group 0',
+        startIndex: 0,
+        level: 0,
+        children: []
+      }
+    ];
+
+    function _onRenderCell(nestingDepth: number, item: any, itemIndex: number): JSX.Element {
+      return (
+        <DetailsRow
+          columns={Object.keys(item)
+            .slice(0, 2)
+            .map(
+              (value): IColumn => {
+                return {
+                  key: value,
+                  name: value,
+                  fieldName: value,
+                  minWidth: 300
+                };
+              }
+            )}
+          groupNestingDepth={nestingDepth}
+          item={item}
+          itemIndex={itemIndex}
+          selection={_selection}
+          selectionMode={SelectionMode.multiple}
+        />
+      );
+    }
+
+    const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
+
+    const listRows = wrapper.find(DetailsRow);
+    expect(listRows.length).toBe(3);
+
+    wrapper.unmount();
+  });
+
+  it("renders the number of rows specified by a group's count when startIndex is not zero", () => {
+    const _selection = new Selection();
+    const _items: Array<{ key: string }> = [{ key: '1' }, { key: '2' }, { key: '3' }];
+    const _groups: Array<IGroup> = [
+      {
+        count: 3,
+        hasMoreData: true,
+        isCollapsed: false,
+        key: 'group0',
+        name: 'group 0',
+        startIndex: 2,
+        level: 0,
+        children: []
+      }
+    ];
+
+    function _onRenderCell(nestingDepth: number, item: any, itemIndex: number): JSX.Element {
+      return (
+        <DetailsRow
+          columns={Object.keys(item)
+            .slice(0, 2)
+            .map(
+              (value): IColumn => {
+                return {
+                  key: value,
+                  name: value,
+                  fieldName: value,
+                  minWidth: 300
+                };
+              }
+            )}
+          groupNestingDepth={nestingDepth}
+          item={item}
+          itemIndex={itemIndex}
+          selection={_selection}
+          selectionMode={SelectionMode.multiple}
+        />
+      );
+    }
+
+    const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
+
+    const listRows = wrapper.find(DetailsRow);
+    expect(listRows.length).toBe(1);
+
+    wrapper.unmount();
+  });
+
+  it('renders no rows if group is collapsed', () => {
+    const _selection = new Selection();
+    const _items: Array<{ key: string }> = [{ key: '1' }, { key: '2' }, { key: '3' }];
+    const _groups: Array<IGroup> = [
+      {
+        count: 3,
+        hasMoreData: true,
+        isCollapsed: true,
+        key: 'group0',
+        name: 'group 0',
+        startIndex: 0,
+        level: 0,
+        children: []
+      }
+    ];
+
+    function _onRenderCell(nestingDepth: number, item: any, itemIndex: number): JSX.Element {
+      return (
+        <DetailsRow
+          columns={Object.keys(item)
+            .slice(0, 2)
+            .map(
+              (value): IColumn => {
+                return {
+                  key: value,
+                  name: value,
+                  fieldName: value,
+                  minWidth: 300
+                };
+              }
+            )}
+          groupNestingDepth={nestingDepth}
+          item={item}
+          itemIndex={itemIndex}
+          selection={_selection}
+          selectionMode={SelectionMode.multiple}
+        />
+      );
+    }
+
+    const wrapper = mount(<GroupedList items={_items} groups={_groups} onRenderCell={_onRenderCell} selection={_selection} />);
+
+    const listRows = wrapper.find(DetailsRow);
+    expect(listRows.length).toBe(0);
+
+    wrapper.unmount();
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -298,7 +298,7 @@ export class GroupedListSection extends BaseComponent<IGroupedListSectionProps, 
 
   private _onRenderGroup(renderCount: number): JSX.Element {
     const { group, items, onRenderCell, listProps, groupNestingDepth, onShouldVirtualize } = this.props;
-    const count = group ? group.count : items.length;
+    const count = group && !group.isShowingAll ? group.count : items.length;
     const startIndex = group ? group.startIndex : 0;
 
     return (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9561
- [x] Include a change request file using `$ npm run change`

#### Description of changes

`GroupedList` has the capability per section to render a "Show All" call to action that when pressed toggles a boolean on the `IGroup` instance. Currently when this happens, the "Show All" UI is dismissed, but the rendered rows remain the same. Instead, ALL of the rows should render.

Unfortunately it is not easy to track down the feature add and assumed regression via git history. However, this change fixes the issue.

**Note:** I will cherry-pick this fix into `6.0`.

Thanks @dliu120 for the initial bug report.

#### Focus areas to test

Compare the following screen-capture:

![groupedlist_showall](https://user-images.githubusercontent.com/706967/60297862-0543c580-98de-11e9-9574-b87c1ddbdc9b.gif)

with current behavior at: https://codepen.io/anon/pen/gNmKWJ?editors=0010

---

I will attempt to follow-up with unit test coverage. I tried initially, but there is something wrong with `GroupedList` in unit tests that requires debugging.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9610)