### PR TITLE
a11y-tests: Run a11y-tests during local build

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "A11y Tests for Office UI Fabric React",
   "scripts": {
-    "build": "npx just-scripts build",
+    "build": "npx just-scripts build && npx just-scripts jest",
     "just": "npx just-scripts",
     "test": "npx just-scripts jest",
     "code-style": "npx just-scripts code-style",

--- a/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
+++ b/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
@@ -28,7 +28,7 @@ async function testComponent(component: { name: string; pageName: string; elem: 
 
     // Match the 'errors' section with snapshot
     expect(errors).toMatchSnapshot();
-  });
+  }, 20000);
 }
 
 function getControlAndPageName(exampleFilePath: string): [string, string] {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,10 +69,6 @@ steps:
       githubDescription: 'Click "Details" to go to the Deployed Site'
       githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
-  - script: |
-      npm run a11ytest
-    displayName: run a11y tests
-
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: './apps/a11y-tests/dist/reports'

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "checkchange": "node common/scripts/install-run-rush.js change -v",
     "update-api": "cd packages/office-ui-fabric-react && npm run update-api",
     "update-snapshots": "cd packages/office-ui-fabric-react && npm run update-snapshots",
+    "update-a11y": "cd apps/a11y-tests && npm run update-snapshots",
     "check-for-changed-files": "cd scripts && npx just-scripts check-for-modified-files",
     "prettier": "node scripts/prettier.js",
     "generate-version-files": "cd scripts && npx just-scripts generate-version-files",
     "codepen": "cd packages/office-ui-fabric-react && node ../../scripts/local-codepen.js",
     "precommit": "node scripts/node_modules/lint-staged/index.js",
-    "dom-test": "cd apps/dom-tests && npx just-scripts jest-dom-with-webpack",
-    "update-a11y": "cd apps/a11y-tests && npm run update-snapshots"
+    "dom-test": "cd apps/dom-tests && npx just-scripts jest-dom-with-webpack"
   },
   "license": "MIT",
   "lint-staged": {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Currently, a11y-test is only run during CI, causing some confusion with good local build but failed CI check. This PR fixes this by running a11y tests during local build and CI build.

(One possible downside of this change: any glitch in puppeteer will result in failures in 'build' step instead of 'a11y-tests'.)

#### Focus areas to test

- CI run should not be affected.
- Local builds should be able to prompt a11y-tests failures during build.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9616)