### PR TITLE
Reuse <style> nodes in IE11

### DIFF
--- a/common/changes/@uifabric/merge-styles/reuse-style-node-in-ie11_2019-06-27-22-57.json
+++ b/common/changes/@uifabric/merge-styles/reuse-style-node-in-ie11_2019-06-27-22-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/merge-styles",
+      "comment": "Re-use style nodes in IE11 to prevent unpredictable cascading",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/merge-styles",
+  "email": "miclo@microsoft.com"
+}

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -67,7 +67,7 @@ const STYLESHEET_SETTING = '__stylesheet__';
  * MSIE 11 doesn't cascade styles based on DOM ordering, but rather on the order that each style node
  * is created. As such, to maintain consistent priority, IE11 should reuse a single style node.
  */
-const REUSE_STYLE_NODE = /rv:11.0/.test(navigator.userAgent);
+const REUSE_STYLE_NODE = typeof navigator !== 'undefined' && /rv:11.0/.test(navigator.userAgent);
 
 // tslint:disable-next-line:no-any
 let _global: { [key: string]: any } = {};

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -63,6 +63,11 @@ export interface IStyleSheetConfig {
 }
 
 const STYLESHEET_SETTING = '__stylesheet__';
+/**
+ * MSIE 11 doesn't cascade styles based on DOM ordering, but rather on the order that each style node
+ * is created. As such, to maintain consistent priority, IE11 should reuse a single style node.
+ */
+const REUSE_STYLE_NODE = /rv:11.0/.test(navigator.userAgent);
 
 // tslint:disable-next-line:no-any
 let _global: { [key: string]: any } = {};
@@ -265,10 +270,12 @@ export class Stylesheet {
     if (!this._styleElement && typeof document !== 'undefined') {
       this._styleElement = this._createStyleElement();
 
-      // Reset the style element on the next frame.
-      window.requestAnimationFrame(() => {
-        this._styleElement = undefined;
-      });
+      if (!REUSE_STYLE_NODE) {
+        // Reset the style element on the next frame.
+        window.requestAnimationFrame(() => {
+          this._styleElement = undefined;
+        });
+      }
     }
     return this._styleElement;
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Most browsers, according to spec, determine cascading priority for rules with the same specificity based upon the DOM order of the style nodes in the `<head>`. When a new `<style> node is added, it inserts it in the appropriate place in `document.styleSheets`.

Internet Explorer 11 differs (because of course it does), instead determining the cascading order based upon when the `<style>` node was *created*. It merely appends any new stylesheets to the end of the `document.styleSheets` array, regardless of where in the DOM they are inserted.

This change preserves the intended cascading order of Fabric styles by re-using the single `<style>` node in IE11.

#### Focus areas to test

This will affect rendering performance in IE. We should ensure the regression is not too great.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9618)