### PR TITLE
Remove Unused SCSS File from Rating Example

### DIFF
--- a/common/changes/office-ui-fabric-react/RatingRemoveSCSS_2019-06-27-23-30.json
+++ b/common/changes/office-ui-fabric-react/RatingRemoveSCSS_2019-06-27-23-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed used Rating SCSS file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pandasa123@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.scss
@@ -1,3 +1,0 @@
-.dummy {
-  background: blue;
-}

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { Rating, RatingSize } from 'office-ui-fabric-react/lib/Rating';
 import { getTheme, createTheme, ITheme } from 'office-ui-fabric-react/lib/Styling';
 
-import './Rating.Basic.Example.scss';
-
 export class RatingBasicExample extends React.Component<
   {},
   {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

- `Rating.Basic.Example.scss` wasn't used at all so I removed it

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9621)