### PR TITLE
Remove SCSS from DatePicker examples

### DIFF
--- a/common/changes/office-ui-fabric-react/DatePickerRemoveSCSS_2019-06-28-04-34.json
+++ b/common/changes/office-ui-fabric-react/DatePickerRemoveSCSS_2019-06-28-04-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed SCSS from DatePicker Example and updated DatePicker snapshots",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pandasa123@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -20,7 +20,7 @@ const DayPickerStrings: IDatePickerStrings = {
   closeButtonAriaLabel: 'Close date picker'
 };
 
-export interface IDatePickerExampleState {
+export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;
 }
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -20,9 +20,28 @@ const DayPickerStrings: IDatePickerStrings = {
   closeButtonAriaLabel: 'Close date picker'
 };
 
-export interface IDatePickerBasicExampleState {
+export interface IDatePickerExampleState {
   firstDayOfWeek?: DayOfWeek;
 }
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
 
 export class DatePickerBasicExample extends React.Component<{}, IDatePickerBasicExampleState> {
   public constructor(props: {}) {
@@ -37,7 +56,7 @@ export class DatePickerBasicExample extends React.Component<{}, IDatePickerBasic
     const { firstDayOfWeek } = this.state;
 
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <DatePicker firstDayOfWeek={firstDayOfWeek} strings={DayPickerStrings} placeholder="Select a date..." ariaLabel="Select a date" />
         <Dropdown
           label="Select the first day of the week"

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react/lib/DatePicker';
 import { addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const today: Date = new Date(Date.now());
 const minDate: Date = addMonths(today, -1);
@@ -37,6 +37,29 @@ export interface IDatePickerRequiredExampleState {
   firstDayOfWeek?: DayOfWeek;
 }
 
+export interface IDatePickerExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
+
 export class DatePickerBoundedExample extends React.Component<{}, IDatePickerRequiredExampleState> {
   constructor(props: {}) {
     super(props);
@@ -50,7 +73,7 @@ export class DatePickerBoundedExample extends React.Component<{}, IDatePickerReq
     const { firstDayOfWeek } = this.state;
 
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <p>{description}</p>
         <DatePicker
           isRequired={false}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react/lib/DatePicker';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -23,6 +23,29 @@ export interface IDatePickerDisabledExampleState {
   firstDayOfWeek?: DayOfWeek;
 }
 
+export interface IDatePickerExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
+
 export class DatePickerDisabledExample extends React.Component<{}, IDatePickerDisabledExampleState> {
   public constructor(props: {}) {
     super(props);
@@ -36,7 +59,7 @@ export class DatePickerDisabledExample extends React.Component<{}, IDatePickerDi
     const { firstDayOfWeek } = this.state;
 
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <DatePicker
           firstDayOfWeek={firstDayOfWeek}
           strings={DayPickerStrings}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Examples.scss
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Examples.scss
@@ -1,9 +1,0 @@
-:global {
-  .docs-DatePickerExample {
-    .ms-DatePicker,
-    .ms-Dropdown {
-      margin: 0 0 15px 0;
-      max-width: 300px;
-    }
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react/lib/DatePicker';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -28,6 +28,29 @@ export interface IDatePickerFormatExampleState {
   firstDayOfWeek?: DayOfWeek;
   value?: Date | null;
 }
+
+export interface IDatePickerExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
 
 export class DatePickerFormatExample extends React.Component<{}, IDatePickerFormatExampleState> {
   public constructor(props: {}) {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -66,7 +66,7 @@ export class DatePickerFormatExample extends React.Component<{}, IDatePickerForm
     const { firstDayOfWeek, value } = this.state;
     const desc = 'This field is required. One of the support input formats is year dash month dash day.';
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <p>
           Applications can customize how dates are formatted and parsed. Formatted dates can be ambiguous, so the control will avoid parsing
           the formatted strings of dates selected using the UI when text input is allowed. In this example, we are formatting and parsing

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react/lib/DatePicker';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -29,6 +29,29 @@ export interface IDatePickerInputExampleState {
   value?: Date | null;
 }
 
+export interface IDatePickerExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
+
 export class DatePickerInputExample extends React.Component<{}, IDatePickerInputExampleState> {
   constructor(props: {}) {
     super(props);
@@ -43,7 +66,7 @@ export class DatePickerInputExample extends React.Component<{}, IDatePickerInput
     const { firstDayOfWeek, value } = this.state;
     const desc = 'This field is required. One of the support input formats is year dash month dash day.';
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <p>
           Text input allowed by default when use keyboard navigation. Mouse click the TextField will popup DatePicker, click the TextField
           again will dismiss the DatePicker and allow text input.

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react/lib/DatePicker';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -27,6 +27,29 @@ export interface IDatePickerRequiredExampleState {
   firstDayOfWeek?: DayOfWeek;
 }
 
+export interface IDatePickerExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
+
 export class DatePickerRequiredExample extends React.Component<{}, IDatePickerRequiredExampleState> {
   constructor(props: {}) {
     super(props);
@@ -40,7 +63,7 @@ export class DatePickerRequiredExample extends React.Component<{}, IDatePickerRe
     const { firstDayOfWeek } = this.state;
 
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <p>Validation will happen when Date Picker loses focus.</p>
         <DatePicker
           label="Date required (with label)"

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -60,7 +60,7 @@ export class DatePickerWeekNumbersExample extends React.Component<{}, IDatePicke
     const { firstDayOfWeek } = this.state;
 
     return (
-      <div className="docs-DatePickerExample">
+      <div className={classNames.datePickerExample}>
         <DatePicker
           firstDayOfWeek={firstDayOfWeek}
           strings={DayPickerStrings}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from 'office-ui-fabric-react/lib/DatePicker';
-import './DatePicker.Examples.scss';
+import { mergeStyleSets } from '@uifabric/styling';
 
 const DayPickerStrings: IDatePickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -23,6 +23,29 @@ const DayPickerStrings: IDatePickerStrings = {
 export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;
 }
+
+export interface IDatePickerExampleState {
+  firstDayOfWeek?: DayOfWeek;
+}
+
+interface IDatePickerExampleObject {
+  datePickerExample: string;
+}
+
+const classNames: IDatePickerExampleObject = mergeStyleSets({
+  datePickerExample: {
+    selectors: {
+      '&.ms-DatePicker': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      },
+      '&.ms-Dropdown': {
+        margin: '0 0 15px 0',
+        maxWidth: 300
+      }
+    }
+  }
+});
 
 export class DatePickerWeekNumbersExample extends React.Component<{}, IDatePickerBasicExampleState> {
   constructor(props: {}) {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.Bounded.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <p>
     When date boundaries are set (via minDate and maxDate props) the DatePicker will not allow

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <p>
     Applications can customize how dates are formatted and parsed. Formatted dates can be ambiguous, so the control will avoid parsing the formatted strings of dates selected using the UI when text input is allowed. In this example, we are formatting and parsing dates as dd/MM/yy.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <p>
     Text input allowed by default when use keyboard navigation. Mouse click the TextField will popup DatePicker, click the TextField again will dismiss the DatePicker and allow text input.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <p>
     Validation will happen when Date Picker loses focus.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -2,7 +2,22 @@
 
 exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly 1`] = `
 <div
-  className="docs-DatePickerExample"
+  className=
+
+      &.ms-DatePicker {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
+      &.ms-Dropdown {
+        margin-bottom: 15px;
+        margin-left: 0;
+        margin-right: 0;
+        margin-top: 0;
+        max-width: 300px;
+      }
 >
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-519:hover + .headerDividerBar-520 {
+      & .headerDivider-520:hover + .headerDividerBar-521 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #6075 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

- Remove SCSS from DatePicker examples
- Updated DatePicker snapshots

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9628)