### PR TITLE
makes perftest skip the prepend of polyfill in entry point

### DIFF
--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -22,15 +22,21 @@ function validateEnv() {
   }
 }
 
+function shouldPrepend(config) {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+  const excludedProjects = ['perf-test'];
+  const exportedAsBundle = config.output.libraryTarget === 'umd' || config.output.libraryTarget === 'var';
+  const hasReactAsDependency =
+    (packageJson.dependencies && Object.keys(packageJson.dependencies).includes('react')) ||
+    (packageJson.devDependencies && Object.keys(packageJson.devDependencies).includes('react'));
+  return !exportedAsBundle && hasReactAsDependency && !excludedProjects.includes(packageJson.name);
+}
+
 /**
  * Prepends the entry points with a react 16 compatible polyfill but only for sites that have react as a dependency
  */
-function prependEntryWithPolyfill(entry) {
-  const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
-  if (
-    (packageJson.dependencies && Object.keys(packageJson.dependencies).includes('react')) ||
-    (packageJson.devDependencies && Object.keys(packageJson.devDependencies).includes('react'))
-  ) {
+function createEntryWithPolyfill(config) {
+  if (shouldPrepend(config)) {
     validateEnv();
     const polyfill = 'react-app-polyfill/ie11';
     if (typeof entry === 'string') {
@@ -40,7 +46,7 @@ function prependEntryWithPolyfill(entry) {
     } else if (typeof entry === 'object') {
       const newEntry = { ...entry };
       Object.keys(entry).forEach(entryPoint => {
-        newEntry[entryPoint] = prependEntryWithPolyfill(entry[entryPoint]);
+        newEntry[entryPoint] = createEntryWithPolyfill(entry[entryPoint]);
       });
 
       return newEntry;
@@ -115,11 +121,7 @@ module.exports = {
     }
 
     for (let config of configs) {
-      // Skip prepending in case of UMD or VAR output.libraryTarget because those meant for distribution
-      // apps should provide their own polyfill
-      if (config.output && config.output.libraryTarget !== 'umd' && config.output.libraryTarget !== 'var') {
-        config.entry = prependEntryWithPolyfill(config.entry);
-      }
+      config.entry = createEntryWithPolyfill(config);
     }
 
     return configs;
@@ -203,7 +205,7 @@ module.exports = {
       customConfig
     );
 
-    config.entry = prependEntryWithPolyfill(config.entry);
+    config.entry = createEntryWithPolyfill(config);
 
     return config;
   }

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -36,8 +36,10 @@ function shouldPrepend(config) {
  * Prepends the entry points with a react 16 compatible polyfill but only for sites that have react as a dependency
  */
 function createEntryWithPolyfill(config) {
-  if (shouldPrepend(config)) {
+  const { entry } = config;
+  if (shouldPrepend(config) && entry) {
     validateEnv();
+
     const polyfill = 'react-app-polyfill/ie11';
     if (typeof entry === 'string') {
       return [polyfill, entry];


### PR DESCRIPTION
#### Description of changes

Because we know that the perf-test is run inside a Chromium environment, we don't need to keep the polyfill there. Gets rid of that noise in the data.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9629)