### PR TITLE
Card: Importing from office-ui-fabric-react directly instead of from office-ui-fabric-react/lib/...

### DIFF
--- a/common/changes/@uifabric/react-cards/cardImports_2019-07-02-00-22.json
+++ b/common/changes/@uifabric/react-cards/cardImports_2019-07-02-00-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/react-cards",
+      "comment": "Card: Importing from office-ui-fabric-react directly instead of from office-ui-fabric-react/lib/...",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/react-cards",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { withSlots, getSlots } from '@uifabric/foundation';
 import { getNativeProps, htmlElementProperties, warn } from '@uifabric/utilities';
-import { Stack, IStackComponent } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, IStackComponent } from 'office-ui-fabric-react';
 
 import { ICardComponent, ICardProps, ICardSlots, ICardTokens } from './Card.types';
 import { CardItem } from './CardItem/CardItem';

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
@@ -1,6 +1,6 @@
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
 import { IBaseProps } from '@uifabric/utilities';
-import { IStackItemProps, IStackItemSlots, IStackItemTokens } from 'office-ui-fabric-react/lib/Stack';
+import { IStackItemProps, IStackItemSlots, IStackItemTokens } from 'office-ui-fabric-react';
 
 /**
  * {@docCategory CardItem}

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
@@ -1,6 +1,6 @@
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
 import { IBaseProps } from '@uifabric/utilities';
-import { IStackProps, IStackSlots, IStackTokens } from 'office-ui-fabric-react/lib/Stack';
+import { IStackProps, IStackSlots, IStackTokens } from 'office-ui-fabric-react';
 
 /**
  * {@docCategory CardSection}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

A partner recently complained that they were having jest issues when importing `Card` from `@uifabric/react-cards`. After digging out a little bit I think this is happening because `Card` is importing from `office-ui-fabric-react/lib/...` instead of from `office-ui-fabric-react` directly. This PR changes these imports so that they now import directly from `office-ui-fabric-react`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9652)