### PR TITLE
Panel: remove window.innerHeight

### DIFF
--- a/common/changes/office-ui-fabric-react/panel-remove-windowheight_2019-07-02-01-32.json
+++ b/common/changes/office-ui-fabric-react/panel-remove-windowheight_2019-07-02-01-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: remove window.innerHeight from styles",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "kakje@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -12,8 +12,7 @@ import {
   elementContains,
   getId,
   getNativeProps,
-  getRTL,
-  getWindow
+  getRTL
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
@@ -143,9 +142,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
     const isOpen = this.isActive;
     const isAnimating = visibility === PanelVisibilityState.animatingClosed || visibility === PanelVisibilityState.animatingOpen;
-    const win = getWindow();
-    const windowHeight = typeof win !== 'undefined' ? win.innerHeight : '100%';
-    const maxWindowHeightStyles = { maxHeight: windowHeight };
 
     if (!isOpen && !isAnimating && !isHiddenOnDismiss) {
       return null;
@@ -159,6 +155,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       headerClassName,
       isAnimating,
       isFooterSticky,
+      isFooterAtBottom,
       isOnRightSide,
       isOpen,
       isHiddenOnDismiss,
@@ -192,20 +189,15 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
               isClickableOutsideFocusTrap={true}
               {...focusTrapZoneProps}
               className={_classNames.main}
-              style={{ ...customWidthStyles, ...maxWindowHeightStyles }}
+              style={customWidthStyles}
               elementToFocusOnDismiss={elementToFocusOnDismiss}
             >
               <div className={_classNames.commands} data-is-visible={true}>
                 {onRenderNavigation(this.props, this._onRenderNavigation)}
               </div>
-              <div className={_classNames.contentInner} style={maxWindowHeightStyles}>
+              <div className={_classNames.contentInner}>
                 {header}
-                <div
-                  ref={this._allowScrollOnPanel}
-                  className={_classNames.scrollableContent}
-                  style={{ [isFooterAtBottom ? 'height' : 'maxHeight']: windowHeight }}
-                  data-is-scrollable={true}
-                >
+                <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent} data-is-scrollable={true}>
                   {onRenderBody(this.props, this._onRenderBody)}
                 </div>
                 {onRenderFooter(this.props, this._onRenderFooter)}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -193,6 +193,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     headerClassName,
     isAnimating,
     isFooterSticky,
+    isFooterAtBottom,
     isOnRightSide,
     isOpen,
     isHiddenOnDismiss,
@@ -337,6 +338,9 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.scrollableContent,
       {
         overflowY: 'auto'
+      },
+      isFooterAtBottom && {
+        flexGrow: 1
       }
     ],
     content: [

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -148,11 +148,7 @@ exports[`Panel renders Panel correctly 1`] = `
           onBlur={[Function]}
           onFocus={[Function]}
           onFocusCapture={[Function]}
-          style={
-            Object {
-              "maxHeight": 768,
-            }
-          }
+          style={Object {}}
         >
           <div
             data-is-visible={true}
@@ -317,11 +313,6 @@ exports[`Panel renders Panel correctly 1`] = `
                   flex-grow: 1;
                   overflow-y: hidden;
                 }
-            style={
-              Object {
-                "maxHeight": 768,
-              }
-            }
           >
             <div
               className=
@@ -381,11 +372,6 @@ exports[`Panel renders Panel correctly 1`] = `
                     overflow-y: auto;
                   }
               data-is-scrollable={true}
-              style={
-                Object {
-                  "maxHeight": 768,
-                }
-              }
             >
               <div
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -233,11 +233,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
             onBlur={[Function]}
             onFocus={[Function]}
             onFocusCapture={[Function]}
-            style={
-              Object {
-                "maxHeight": 768,
-              }
-            }
+            style={Object {}}
           >
             <div
               data-is-visible={true}
@@ -402,11 +398,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                     flex-grow: 1;
                     overflow-y: hidden;
                   }
-              style={
-                Object {
-                  "maxHeight": 768,
-                }
-              }
             >
               <div
                 className=
@@ -466,11 +457,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                       overflow-y: auto;
                     }
                 data-is-scrollable={true}
-                style={
-                  Object {
-                    "maxHeight": 768,
-                  }
-                }
               >
                 <div
                   className=


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR removes the usage of `window.innerHeight` from Panel styles. Since PR #9612 updated Layer styles, `window.innerHeight` is no longer necessary to make Panel styles work on mobile browsers.

#### Focus areas to test

1. Mobile scrolling behavior should be unchanged.
2. Panel styles should not update on window resize.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9654)