### PR TITLE
[Cherry-pick] Filter disallowed props from Tile root element (#9650)

### DIFF
--- a/common/changes/@uifabric/experiments/tile-props_2019-07-01-23-47.json
+++ b/common/changes/@uifabric/experiments/tile-props_2019-07-01-23-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Filter out disallowed props from Tile root element",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ITileProps, TileSize } from './Tile.types';
 import { Check } from 'office-ui-fabric-react/lib/Check';
 import { SELECTION_CHANGE } from 'office-ui-fabric-react/lib/Selection';
-import { ISize, css, BaseComponent, getId } from '../../Utilities';
+import { ISize, css, BaseComponent, getId, getNativeProps, divProperties } from '../../Utilities';
 import * as TileStylesModule from './Tile.scss';
 import * as SignalStylesModule from '../signals/Signal.scss';
 import * as CheckStylesModule from 'office-ui-fabric-react/lib/components/Check/Check.scss';
@@ -204,7 +204,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     return (
       <div
         aria-selected={isSelected}
-        {...divProps}
+        {...getNativeProps(divProps, divProperties)}
         aria-labelledby={ariaLabel ? this._labelId : this._nameId}
         aria-describedby={descriptionAriaLabel ? this._descriptionId : this._activityId}
         className={css('ms-Tile', className, TileStyles.tile, {


### PR DESCRIPTION
Cherry-picking Tile fixes to 6.0 branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9664)