### PR TITLE
a11y-tests: Update axe-sarif-converter for SARIF v2.1.0

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -14,7 +14,7 @@
     "@uifabric/fabric-website-resources": "^7.2.0",
     "axe-core": "^3.2.2",
     "axe-puppeteer": "^1.0.0",
-    "axe-sarif-converter": "^1.0.0",
+    "axe-sarif-converter": "^2.0.1",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.1",
     "office-ui-fabric-react": "^7.7.2",
@@ -31,6 +31,7 @@
     "@types/puppeteer": "1.12.3",
     "@types/react": "16.8.11",
     "@types/react-dom": "16.8.4",
+    "@types/sarif": "^2.1.1",
     "@uifabric/build": "^7.0.0",
     "@uifabric/icons": "^7.1.0",
     "@uifabric/tslint-rules": "^7.0.2"

--- a/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
+++ b/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as glob from 'glob';
 import { getSarifReport } from '../getSarifReport';
-import { SarifLog } from 'axe-sarif-converter/dist/sarif/sarif-log';
-import { Result } from 'axe-sarif-converter/dist/sarif/sarif-2.0.0';
+import { SarifLog } from 'axe-sarif-converter';
+import { Result } from 'sarif';
 
 const ReactDOM = require('react-dom');
 

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -27,46 +27,43 @@ exports[`a11y test checks accessibility of Button (Button.Command.Example) 1`] =
 exports[`a11y test checks accessibility of Button (Button.CommandBar.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-16",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".root-16",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-16",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -78,168 +75,156 @@ exports[`a11y test checks accessibility of Button (Button.ContextualMenu.Example
 exports[`a11y test checks accessibility of Button (Button.CustomSplit.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".css-10",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-10",
-      "ruleId": "aria-allowed-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".css-10",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-10",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-Button--icon",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" class=\\"ms-Button ms-Button--icon root-1\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-Button--icon",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-Button--icon",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-16",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".root-16",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-16",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -255,270 +240,249 @@ exports[`a11y test checks accessibility of Button (Button.ScreenReader.Example) 
 exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div:nth-child(1) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(1) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(1) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-      "ruleId": "aria-allowed-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-      "ruleId": "aria-allowed-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-      "ruleId": "aria-allowed-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".css-34",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"true\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-34\\" tabindex=\\"0\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".css-34",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-34",
-      "ruleId": "aria-allowed-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-25\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-25\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-36",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button is-disabled root-36\\" aria-disabled=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".root-36",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-36",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -526,168 +490,156 @@ Array [
 exports[`a11y test checks accessibility of Button (Button.Split.Example) 2`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".css-10",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription",
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-10",
-      "ruleId": "aria-allowed-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".css-10",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-10",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-Button--icon",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" class=\\"ms-Button ms-Button--icon root-1\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-Button--icon",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-Button--icon",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-16",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".root-16",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-16",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -699,459 +651,420 @@ exports[`a11y test checks accessibility of Calendar (Calendar.Button.Example) 1`
 exports[`a11y test checks accessibility of Calendar (Calendar.Inline.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"July\\\\ 2016\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"July 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jan</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"July\\\\ 2016\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"July\\\\ 2016\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"August\\\\ 2016\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"August 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Feb</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"August\\\\ 2016\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"August\\\\ 2016\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"September\\\\ 2016\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"September 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Mar</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"September\\\\ 2016\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"September\\\\ 2016\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"October\\\\ 2016\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"October 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Apr</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"October\\\\ 2016\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"October\\\\ 2016\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"November\\\\ 2016\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"November 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">May</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"November\\\\ 2016\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"November\\\\ 2016\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"December\\\\ 2016\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"December 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jun</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"December\\\\ 2016\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"December\\\\ 2016\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"January\\\\ 2017\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"January 2017\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" type=\\"button\\">Jul</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"January\\\\ 2017\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"January\\\\ 2017\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"February\\\\ 2017\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"February 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Aug</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"February\\\\ 2017\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"February\\\\ 2017\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"March\\\\ 2017\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"March 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Sep</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"March\\\\ 2017\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"March\\\\ 2017\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"April\\\\ 2017\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"April 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Oct</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"April\\\\ 2017\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"April\\\\ 2017\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"May\\\\ 2017\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Nov</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"May\\\\ 2017\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"May\\\\ 2017\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-label=\\"June\\\\ 2017\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"June 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Dec</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-label=\\"June\\\\ 2017\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-label=\\"June\\\\ 2017\\"]",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "table",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<table class=\\"ms-DatePicker-table\\" aria-readonly=\\"true\\" aria-multiselectable=\\"false\\" aria-labelledby=\\"DatePickerDay-monthAndYear2\\" aria-activedescendant=\\"DatePickerDay-active0\\" role=\\"grid\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "table",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-activedescendant=\\"DatePickerDay-active0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-activedescendant=\\"DatePickerDay-active0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-activedescendant=\\"DatePickerDay-active0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "table",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1189,39 +1102,36 @@ exports[`a11y test checks accessibility of ColorPicker (ColorPicker.Basic.Exampl
 exports[`a11y test checks accessibility of ComboBox (ComboBox.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#ComboBox23-label",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<label id=\\"ComboBox23-label\\" for=\\"ComboBox23-input\\" class=\\"ms-Label root-30\\">Disabled ComboBox</label>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#ComboBox23-label",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1",
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
       "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#ComboBox23-label",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "color-contrast",
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -1297,46 +1207,43 @@ exports[`a11y test checks accessibility of DetailsList (DetailsList.Compact.Exam
 exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomColumns.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#header0-thumbnail",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<span id=\\"header0-thumbnail\\" aria-labelledby=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellTitle cellTitle-38\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"false\\"><span id=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellName cellName-39\\"></span></span>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#header0-thumbnail",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#header0-thumbnail",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -1360,39 +1267,36 @@ exports[`a11y test checks accessibility of DetailsList (DetailsList.NavigatingFo
 exports[`a11y test checks accessibility of Dialog (Dialog.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__4\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1400,39 +1304,36 @@ Array [
 exports[`a11y test checks accessibility of Dialog (Dialog.Blocking.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1440,39 +1341,36 @@ Array [
 exports[`a11y test checks accessibility of Dialog (Dialog.LargeHeader.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1480,113 +1378,104 @@ Array [
 exports[`a11y test checks accessibility of Dialog (Dialog.Modeless.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"id__1\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__1\\" aria-describedby=\\"id__2\\" data-is-focusable=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__1\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__2\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__1\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"id__4\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__4\\" aria-describedby=\\"id__5\\" data-is-focusable=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__4\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__5\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"id__4\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "input[type=\\"text\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" placeholder=\\"Focus Me While Open\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "input[type=\\"text\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "input[type=\\"text\\"]",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -1594,39 +1483,36 @@ Array [
 exports[`a11y test checks accessibility of Dialog (Dialog.TopOffsetFixed.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1660,74 +1546,68 @@ exports[`a11y test checks accessibility of Dropdown (Dropdown.Required.Example) 
 exports[`a11y test checks accessibility of ExtendedPicker (ExtendedPeoplePicker.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-BasePicker-text",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-BasePicker-text",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA child role not present: listitem",
+      "markdown": "Fix any of the following:
+- Required ARIA child role not present: listitem.",
       "text": "Fix any of the following: Required ARIA child role not present: listitem.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-BasePicker-text",
-      "ruleId": "aria-required-children",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-children",
+    "ruleIndex": 8,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "input",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-owns=\\"suggestion-list\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "input",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "input",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1735,74 +1615,68 @@ Array [
 exports[`a11y test checks accessibility of ExtendedPicker (ExtendedPeoplePicker.Controlled.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-BasePicker-text",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-BasePicker-text",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA child role not present: listitem",
+      "markdown": "Fix any of the following:
+- Required ARIA child role not present: listitem.",
       "text": "Fix any of the following: Required ARIA child role not present: listitem.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-BasePicker-text",
-      "ruleId": "aria-required-children",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-children",
+    "ruleIndex": 8,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "input",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-owns=\\"suggestion-list\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "input",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "input",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1824,39 +1698,36 @@ exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Focu
 exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.DialogInPanel.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -1868,82 +1739,76 @@ exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Nested.E
 exports[`a11y test checks accessibility of FocusZone (FocusZone.Disabled.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField7",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#TextField7",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField7",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField23",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField23\\" value=\\"Tabbable Element 2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#TextField23",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField23",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -1951,354 +1816,324 @@ Array [
 exports[`a11y test checks accessibility of FocusZone (FocusZone.List.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\30 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"0\\" data-item-index=\\"0\\" aria-rowindex=\\"1\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone1\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\30 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\30 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\31 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"1\\" data-item-index=\\"1\\" aria-rowindex=\\"2\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone5\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\31 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\31 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\32 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"2\\" data-item-index=\\"2\\" aria-rowindex=\\"3\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone9\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\32 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\32 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\33 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"3\\" data-item-index=\\"3\\" aria-rowindex=\\"4\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone13\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\33 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\33 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\34 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"4\\" data-item-index=\\"4\\" aria-rowindex=\\"5\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone17\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\34 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\34 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\35 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"5\\" data-item-index=\\"5\\" aria-rowindex=\\"6\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone21\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\35 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\35 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\36 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"6\\" data-item-index=\\"6\\" aria-rowindex=\\"7\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone25\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\36 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\36 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\37 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"7\\" data-item-index=\\"7\\" aria-rowindex=\\"8\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone29\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\37 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\37 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\38 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"8\\" data-item-index=\\"8\\" aria-rowindex=\\"9\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone33\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\38 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\38 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\39 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"9\\" data-item-index=\\"9\\" aria-rowindex=\\"10\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone37\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\39 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table",
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
       "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[data-selection-index=\\"\\\\39 \\"]",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
 ]
 `;
@@ -2306,1504 +2141,1384 @@ Array [
 exports[`a11y test checks accessibility of FocusZone (FocusZone.Photos.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element does not have an alt attribute
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element has no title attribute or the title attribute is empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"",
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
       "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
-      "ruleId": "image-alt",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "image-alt",
+    "ruleIndex": 31,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"1\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"2\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\33 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"3\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\33 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\34 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"4\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\34 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\35 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"5\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\35 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\36 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"6\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\36 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\37 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"7\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\37 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\38 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"8\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\38 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\39 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"9\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\39 \\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 0\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"10\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 0\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 1\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"11\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 1\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 2\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"12\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 2\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 3\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"13\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 3\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 4\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"14\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 4\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 5\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"15\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 5\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 6\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"16\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 6\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 7\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"17\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 7\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 8\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"18\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 8\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 9\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"19\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\31 9\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 0\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<li class=\\"photoCell-83\\" aria-posinset=\\"20\\" aria-setsize=\\"20\\" aria-label=\\"Photo\\" data-is-focusable=\\"true\\"><div class=\\"ms-Image root-0\\" style=\\"width:50px;height:100px\\"><img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\"></div></li>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element",
+      "markdown": "Fix any of the following:
+- List item does not have a &lt;ul>, &lt;ol> or role=\\"list\\" parent element.",
       "text": "Fix any of the following: List item does not have a <ul>, <ol> or role=\\"list\\" parent element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "li[aria-posinset=\\"\\\\32 0\\"]",
-      "ruleId": "listitem",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "listitem",
+    "ruleIndex": 45,
   },
 ]
 `;
@@ -3811,82 +3526,76 @@ Array [
 exports[`a11y test checks accessibility of FocusZone (FocusZone.Tabbable.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField7",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#TextField7",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField7",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField26",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField26\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#TextField26",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField26",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -3930,221 +3639,203 @@ exports[`a11y test checks accessibility of Image (Image.None.Example) 1`] = `Arr
 exports[`a11y test checks accessibility of Keytip (Keytips.Button.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-1-a\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-1-a\\" data-ktp-execute-target=\\"ktp-1-a\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-2-a\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-2-a\\" data-ktp-execute-target=\\"ktp-2-a\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".css-18",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div aria-describedby=\\"ktp-layer-id ktp-2-b\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-2-b\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-18\\" tabindex=\\"0\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".css-18",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-18",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-29",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-29\\" aria-describedby=\\"ktp-layer-id ktp-0-0\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-0\\" data-ktp-execute-target=\\"ktp-0-0\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".root-29",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-29",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-0-1\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-1\\" data-ktp-execute-target=\\"ktp-0-1\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-22",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" data-ktp-execute-target=\\"ktp-2-b\\" tabindex=\\"-1\\" class=\\"ms-Button root-22\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".root-22",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-22",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -4154,189 +3845,174 @@ exports[`a11y test checks accessibility of Keytip (Keytips.CommandBar.Example) 1
 exports[`a11y test checks accessibility of Keytip (Keytips.Overflow.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[name=\\"Link\\\\ 1\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" name=\\"Link 1\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-q\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-q\\" data-ktp-execute-target=\\"ktp-q\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 1\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 1\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[name=\\"Link\\\\ 2\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" name=\\"Link 2\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-w\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-w\\" data-ktp-execute-target=\\"ktp-w\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 2\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 2\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[name=\\"Link\\\\ 3\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" name=\\"Link 3\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-e\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-e\\" data-ktp-execute-target=\\"ktp-e\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 3\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[name=\\"Link\\\\ 3\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-11",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".root-11",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-11",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-11",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".root-11",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-11",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -4344,39 +4020,36 @@ Fix any of the following:
 exports[`a11y test checks accessibility of Label (Label.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<label class=\\"ms-Label root-1\\">I'm a disabled Label</label>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".root-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1",
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
       "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-1",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "color-contrast",
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -4390,39 +4063,36 @@ exports[`a11y test checks accessibility of Layer (Layer.Hosted.Example) 1`] = `A
 exports[`a11y test checks accessibility of Layer (Layer.NestedLayers.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -4436,43 +4106,40 @@ exports[`a11y test checks accessibility of List (List.Grid.Example) 1`] = `Array
 exports[`a11y test checks accessibility of List (List.Scrolling.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField14",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField14\\" value=\\"0\\" class=\\"ms-TextField-field field-32\\" aria-invalid=\\"false\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField14",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField14",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -4480,39 +4147,36 @@ Array [
 exports[`a11y test checks accessibility of MarqueeSelection (MarqueeSelection.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "ul",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<ul>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "ul",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- List element has direct children that are not allowed inside &lt;li> elements",
+      "markdown": "Fix all of the following:
+- List element has direct children that are not allowed inside &lt;li> elements.",
       "text": "Fix all of the following: List element has direct children that are not allowed inside <li> elements.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "ul",
-      "ruleId": "list",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "list",
+    "ruleIndex": 44,
   },
 ]
 `;
@@ -4524,39 +4188,36 @@ exports[`a11y test checks accessibility of MessageBar (MessageBar.Styled.Example
 exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__4\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -4564,39 +4225,36 @@ Array [
 exports[`a11y test checks accessibility of Modal (Modal.Modeless.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__4\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -4604,39 +4262,36 @@ Array [
 exports[`a11y test checks accessibility of Nav (Nav.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div class=\\"ms-Nav-linkText linkText-1\\">Documents</div>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
       "text": "Fix any of the following: Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "color-contrast",
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -4650,49 +4305,46 @@ exports[`a11y test checks accessibility of Nav (Nav.Nested.Example) 1`] = `Array
 exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-Button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-Button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-Button",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -4700,49 +4352,46 @@ Fix any of the following:
 exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Custom.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".root-20",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-20\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".root-20",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".root-20",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -4750,184 +4399,172 @@ Fix any of the following:
 exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Vertical.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Add\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Upload\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Share\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-haspopup=\\"true\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-haspopup=\\"true\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-haspopup=\\"true\\"]",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -4939,39 +4576,36 @@ exports[`a11y test checks accessibility of Overlay (Overlay.Light.Example) 1`] =
 exports[`a11y test checks accessibility of Panel (Panel.Controlled.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -4979,39 +4613,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.Custom.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5019,39 +4650,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.CustomLeft.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5059,39 +4687,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.ExtraLarge.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5099,39 +4724,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5139,39 +4761,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.HandleDismissTarget.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5181,39 +4800,36 @@ exports[`a11y test checks accessibility of Panel (Panel.HiddenOnDismiss.Example)
 exports[`a11y test checks accessibility of Panel (Panel.Large.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5221,39 +4837,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.LargeFixed.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5265,39 +4878,36 @@ exports[`a11y test checks accessibility of Panel (Panel.LightDismissCustom.Examp
 exports[`a11y test checks accessibility of Panel (Panel.Medium.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5305,39 +4915,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5347,39 +4954,36 @@ exports[`a11y test checks accessibility of Panel (Panel.NonModal.Example) 1`] = 
 exports[`a11y test checks accessibility of Panel (Panel.PreventDefault.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5387,39 +4991,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.Scroll.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5427,39 +5028,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.SmallFluid.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5467,39 +5065,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.SmallLeft.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5507,39 +5102,36 @@ Array [
 exports[`a11y test checks accessibility of Panel (Panel.SmallRight.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -5567,49 +5159,46 @@ exports[`a11y test checks accessibility of Pivot (Pivot.Fabric.Example) 1`] = `A
 exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Pivot0-Tab2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"Pivot0-Tab2\\" class=\\"ms-Button ms-Button--action ms-Button--command ms-Pivot-link link-17\\" role=\\"tab\\" aria-selected=\\"false\\" data-content=\\" xx\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#Pivot0-Tab2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Pivot0-Tab2",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -5625,39 +5214,36 @@ exports[`a11y test checks accessibility of Pivot (Pivot.Remove.Example) 1`] = `A
 exports[`a11y test checks accessibility of Pivot (Pivot.Separate.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div aria-labelledby=\\"ShapeColorPivot_rectangleRed\\" role=\\"tabitem\\" style=\\"float:left;width:100px;height:200px;background:red\\"></div>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Role must be one of the valid ARIA roles",
+      "markdown": "Fix all of the following:
+- Role must be one of the valid ARIA roles.",
       "text": "Fix all of the following: Role must be one of the valid ARIA roles.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
-      "ruleId": "aria-roles",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-roles",
+    "ruleIndex": 10,
   },
 ]
 `;
@@ -5665,49 +5251,46 @@ Array [
 exports[`a11y test checks accessibility of Pivot (Pivot.SeparateNoSelectedKey.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-Button--icon",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-15\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-16\\"><i data-icon-name=\\"Settings\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-21\\" style=\\"color:blue\\"></i></div></button>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-Button--icon",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Element is in tab order and does not have accessible text
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
 Fix any of the following:
-- Element has a value attribute and the value attribute is empty
-- Element has no value attribute or the value attribute is empty
-- Element does not have inner text that is visible to screen readers
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Element's default semantics were not overridden with role=\\"presentation\\"
-- Element's default semantics were not overridden with role=\\"none\\"
-- Element has no title attribute or the title attribute is empty",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-Button--icon",
-      "ruleId": "button-name",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -5723,1404 +5306,1284 @@ exports[`a11y test checks accessibility of ProgressIndicator (ProgressIndicator.
 exports[`a11y test checks accessibility of Rating (Rating.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-0\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-1\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-2\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-3\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--large ratingStarIsLarge-8\\" id=\\"Rating0-star-4\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating3-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-0\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating3-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating3-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating3-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-1\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating3-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating3-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating3-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-2\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating3-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating3-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating3-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-3\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating3-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating3-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating3-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating3-star-4\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating3-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating3-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-0\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-1\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-2\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-3\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-4\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-5",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-5\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-5",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-5",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-6",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-6\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-6",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-6",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-7",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-7\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-7",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-7",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-8",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-8\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-8",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-8",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating6-star-9",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating6-star-9\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating6-star-9",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating6-star-9",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating9-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-0\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating9-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating9-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating9-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating9-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating9-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating9-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-2\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating9-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating9-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating9-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating9-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating9-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating9-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-16 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating9-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating9-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating9-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating12-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating12-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating12-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating12-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating12-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating12-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating12-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-2\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating12-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating12-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating12-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating12-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating12-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating12-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating12-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating12-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating12-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating15-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating15-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating15-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating15-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating15-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating15-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating15-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-2\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating15-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating15-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating15-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating15-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating15-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating15-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating15-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating15-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating18-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-0\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating18-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating18-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating18-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-1\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating18-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating18-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating18-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-2\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating18-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating18-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating18-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-3\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating18-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating18-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating18-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating18-star-4\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating18-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating18-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
 ]
 `;
@@ -7128,179 +6591,164 @@ Array [
 exports[`a11y test checks accessibility of Rating (Rating.ButtonControlled.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-2\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#Rating0-star-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#Rating0-star-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role presentation  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role presentation  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role presentation  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#Rating0-star-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
 ]
 `;
@@ -7328,39 +6776,36 @@ exports[`a11y test checks accessibility of SearchBox (SearchBox.Underlined.Examp
 exports[`a11y test checks accessibility of SelectedItemsList (SelectedPeopleList.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-PickerPersona-container",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div class=\\"ms-PickerPersona-container\\" data-is-focusable=\\"true\\" data-is-sub-focuszone=\\"true\\" data-selection-index=\\"0\\" role=\\"listitem\\" aria-labelledby=\\"selectedItemPersona-id__3\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parent role not present: list",
+      "markdown": "Fix any of the following:
+- Required ARIA parent role not present: list.",
       "text": "Fix any of the following: Required ARIA parent role not present: list.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
 ]
 `;
@@ -7368,39 +6813,36 @@ Array [
 exports[`a11y test checks accessibility of SelectedItemsList (SelectedPeopleList.Controlled.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".ms-PickerPersona-container",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<div class=\\"ms-PickerPersona-container\\" data-is-focusable=\\"true\\" data-is-sub-focuszone=\\"true\\" data-selection-index=\\"0\\" role=\\"listitem\\" aria-labelledby=\\"selectedItemPersona-id__3\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA parent role not present: list",
+      "markdown": "Fix any of the following:
+- Required ARIA parent role not present: list.",
       "text": "Fix any of the following: Required ARIA parent role not present: list.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-PickerPersona-container",
-      "ruleId": "aria-required-parent",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
   },
 ]
 `;
@@ -7440,39 +6882,36 @@ exports[`a11y test checks accessibility of SpinButton (SpinButton.CustomStyled.E
 exports[`a11y test checks accessibility of SpinButton (SpinButton.Stateful.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#input1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" value=\\"7 cm\\" id=\\"input1\\" class=\\"ms-spinButton-input css-5\\" autocomplete=\\"off\\" role=\\"spinbutton\\" aria-labelledby=\\"Label0\\" aria-valuetext=\\"7 cm\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-disabled=\\"false\\" data-lpignore=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#input1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Required ARIA attribute not present: aria-valuenow",
+      "markdown": "Fix any of the following:
+- Required ARIA attribute not present: aria-valuenow.",
       "text": "Fix any of the following: Required ARIA attribute not present: aria-valuenow.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#input1",
-      "ruleId": "aria-required-attr",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-required-attr",
+    "ruleIndex": 7,
   },
 ]
 `;
@@ -7528,1124 +6967,1028 @@ exports[`a11y test checks accessibility of Stack (Stack.Vertical.WrapNested.Exam
 exports[`a11y test checks accessibility of SwatchColorPicker (SwatchColorPicker.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker0-a-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker0-a-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker0-a-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker0-b-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker0-b-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker0-b-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker0-c-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker0-c-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker0-c-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker0-d-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-6\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker0-d-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker0-d-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker0-e-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker0-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-9\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker0-e-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker0-e-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker18-a-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker18-a-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker18-a-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker18-b-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker18-b-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker18-b-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker18-c-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker18-c-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker18-c-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker18-d-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker18-d-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker18-d-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker18-e-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-14\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker18-e-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker18-e-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker36-a-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker36-a-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker36-a-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker36-b-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker36-b-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker36-b-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker36-c-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker36-c-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker36-c-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker36-d-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker36-d-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker36-d-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker36-e-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-18\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker36-e-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker36-e-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-a-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"red\\" aria-label=\\"red\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-a-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-a-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-b-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-b-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-b-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-c-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orangeYellow\\" aria-label=\\"orangeYellow\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-c-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-c-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-d-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"yellowGreen\\" aria-label=\\"yellowGreen\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-d-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-d-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-e-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"green\\" aria-label=\\"green\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-e-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-e-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-f-5",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-f-5\\" data-index=\\"5\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-f-5",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-f-5",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-g-6",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-g-6\\" data-index=\\"6\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyanBlue\\" aria-label=\\"cyanBlue\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-g-6",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-g-6",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-h-7",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-h-7\\" data-index=\\"7\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-h-7",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-h-7",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-i-8",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-i-8\\" data-index=\\"8\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magentaPink\\" aria-label=\\"magentaPink\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-i-8",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-i-8",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-j-9",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-j-9\\" data-index=\\"9\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"black\\" aria-label=\\"black\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-j-9",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-j-9",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-k-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-k-10\\" data-index=\\"10\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray\\" aria-label=\\"gray\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-k-10",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-k-10",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker54-l-11",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-l-11\\" data-index=\\"11\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray20\\" aria-label=\\"gray20\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker54-l-11",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker54-l-11",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker93-a-0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-a-0\\" data-index=\\"0\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" disabled=\\"\\" aria-label=\\"orange\\" aria-disabled=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker93-a-0",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker93-a-0",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker93-b-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-b-1\\" data-index=\\"1\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" disabled=\\"\\" aria-label=\\"cyan\\" aria-disabled=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker93-b-1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker93-b-1",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker93-c-2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-c-2\\" data-index=\\"2\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" disabled=\\"\\" aria-label=\\"blueMagenta\\" aria-disabled=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker93-c-2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker93-c-2",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker93-d-3",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-d-3\\" data-index=\\"3\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" disabled=\\"\\" aria-label=\\"magenta\\" aria-disabled=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker93-d-3",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker93-d-3",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#swatchColorPicker93-e-4",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-e-4\\" data-index=\\"4\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-24\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" disabled=\\"\\" aria-label=\\"white\\" aria-disabled=\\"true\\">",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "#swatchColorPicker93-e-4",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element",
+      "markdown": "Fix any of the following:
+- ARIA role gridcell  is not allowed for given element.",
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#swatchColorPicker93-e-4",
-      "ruleId": "aria-allowed-role",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
 ]
 `;
@@ -8669,43 +8012,40 @@ exports[`a11y test checks accessibility of Text (Text.Wrap.Example) 1`] = `Array
 exports[`a11y test checks accessibility of TextField (TextField.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField12",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField12\\" required=\\"\\" value=\\"\\" class=\\"ms-TextField-field field-5\\" aria-invalid=\\"false\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField12",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField12",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -8717,113 +8057,104 @@ exports[`a11y test checks accessibility of TextField (TextField.Controlled.Examp
 exports[`a11y test checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField2",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Only title used to generate label for form element",
+      "markdown": "Fix all of the following:
+- Only title used to generate label for form element.",
       "text": "Fix all of the following: Only title used to generate label for form element.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField2",
-      "ruleId": "label-title-only",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label-title-only",
+    "ruleIndex": 35,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#TextField2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#TextField2",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- aria-label attribute does not exist or is empty
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-- Form element does not have an implicit (wrapped) &lt;label>
-- Form element does not have an explicit &lt;label>
-- Element has no title attribute or the title attribute is empty",
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#TextField2",
-      "ruleId": "label",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -8837,39 +8168,36 @@ exports[`a11y test checks accessibility of TextField (TextField.Multiline.Exampl
 exports[`a11y test checks accessibility of TextField (TextField.PrefixAndSuffix.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".prefix-15 > span",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<span style=\\"padding-bottom:1px\\">https://</span>",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": ".prefix-15 > span",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix any of the following:
-- Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1",
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
       "text": "Fix any of the following: Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".prefix-15 > span",
-      "ruleId": "color-contrast",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "color-contrast",
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -8881,39 +8209,36 @@ exports[`a11y test checks accessibility of Toggle (Toggle.Basic.Example) 1`] = `
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Absolute.Position.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "#targetButton1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" id=\\"targetButton1\\" aria-labelledby=\\"tooltipHost0\\" style=\\"position:absolute;top:50px;left:200px\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "#targetButton1",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "#targetButton1",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -8921,39 +8246,36 @@ Array [
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -8961,39 +8283,36 @@ Array [
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Custom.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -9001,74 +8320,68 @@ Array [
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Display.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"tooltipHost10\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost10\\">Hover Over Me</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost10\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost10\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"tooltipHost21\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost21\\">Hover Over Me</button>",
             },
           },
-        ],
-        "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost21\\"]",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
-          },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button[aria-labelledby=\\"tooltipHost21\\"]",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -9076,39 +8389,36 @@ Array [
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Interactive.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;
@@ -9116,39 +8426,36 @@ Array [
 exports[`a11y test checks accessibility of Tooltip (Tooltip.NoScroll.Example) 1`] = `
 Array [
   Object {
+    "kind": "fail",
     "level": "error",
     "locations": Array [
       Object {
-        "annotations": Array [
+        "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
             "snippet": Object {
               "text": "<button type=\\"button\\" aria-labelledby=\\"text-tooltip0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
             },
-          },
-        ],
-        "fullyQualifiedLogicalName": "button",
-        "physicalLocation": Object {
-          "fileLocation": Object {
-            "uri": "about:blank",
           },
         },
       },
     ],
     "message": Object {
-      "richText": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\"",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
       "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
     },
-    "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": "button",
-      "ruleId": "aria-valid-attr-value",
-    },
-    "properties": Object {
-      "tags": Array [
-        "Accessibility",
-      ],
-    },
     "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
 ]
 `;

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -79,6 +79,7 @@ dependencies:
   '@types/react-dom': 16.8.4
   '@types/react-test-renderer': 16.8.1
   '@types/resemblejs': 1.3.28
+  '@types/sarif': 2.1.1
   '@types/semver': 5.5.0
   '@types/sinon': 2.2.2
   '@types/storybook__react': 3.0.5
@@ -90,7 +91,7 @@ dependencies:
   awesome-typescript-loader: 3.5.0
   axe-core: 3.2.2
   axe-puppeteer: 1.0.0
-  axe-sarif-converter: 1.4.0
+  axe-sarif-converter: 2.0.1
   babel-core: 6.26.3
   babel-loader: 7.1.5
   babylon: 7.0.0-beta.47
@@ -170,7 +171,6 @@ dependencies:
   react-highlight: 0.10.0
   react-hooks-testing-library: 0.5.1
   react-loadable: 5.5.0
-  react-monaco-editor: 0.26.2
   react-syntax-highlighter: 10.3.0
   react-test-renderer: 16.8.6
   recast: 0.15.5
@@ -1269,6 +1269,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Lg2ztf2w8vPUVPXXLhMkEgnql60=
+  /@types/sarif/2.1.1:
+    dev: false
+    resolution:
+      integrity: sha512-OI9w+yqOhvT3Z9tF/4d+YVFbdYojotHMRfuKrVtAzeKu3L0kBiK6CnHADkNrfSeVOgkIMeg8OqIQFfcsm7HgCg==
   /@types/semver/5.5.0:
     dev: false
     resolution:
@@ -2191,6 +2195,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA==
+  /axe-core/3.3.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg==
   /axe-puppeteer/1.0.0:
     dependencies:
       axe-core: 3.2.2
@@ -2213,15 +2223,16 @@ packages:
       puppeteer: ^1.10.0
     resolution:
       integrity: sha512-hTF3u4mtatgTN7fsLVyVgbRdNc15ngjDcTEuqhn9A7ugqLhLCryJWp9fzqZkNlrW8awPcxugyTwLPR7mRdPZmA==
-  /axe-sarif-converter/1.4.0:
+  /axe-sarif-converter/2.0.1:
     dependencies:
-      axe-core: 3.2.2
+      '@types/sarif': 2.1.1
+      axe-core: 3.3.0
     dev: false
     engines:
       node: '>= 8'
       yarn: ^1.15.1
     resolution:
-      integrity: sha512-te2SXGX5+Yl0OcG/518WGxRYaesAwUB0ww1c6h5mlcCKxWWSItHNbjd6BX511CH7eus4ItnHe7xgilQSXokRSw==
+      integrity: sha512-Fd0wNxEc68K28B40KaCqSJiCnHfYRx0gmPn5aNgGaInRJQQWY9G0IRZcCF7cweHqc+1zDC1ZrkFWAQcOecVBaQ==
   /axios/0.15.3:
     dependencies:
       follow-redirects: 1.0.0
@@ -11959,16 +11970,6 @@ packages:
       react-dom: ^0.14.0 || ^15.0.0 || ^16
     resolution:
       integrity: sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
-  /react-monaco-editor/0.26.2:
-    dependencies:
-      '@types/react': 16.8.11
-      monaco-editor: 0.17.1
-      prop-types: 15.7.2
-    dev: false
-    peerDependencies:
-      react: ^15.x || ^16.x
-    resolution:
-      integrity: sha512-a7/w6l8873ankpa5cdAwXSRnwEis8V/2YVeQA0JdTh0edFhQ/2TKlgm8bOFYmGX3taBk+EVp9OMNQvYH1O73iA==
   /react-monaco-editor/0.26.2/react@16.8.6:
     dependencies:
       '@types/react': 16.8.11
@@ -15511,9 +15512,10 @@ packages:
       '@types/puppeteer': 1.12.3
       '@types/react': 16.8.11
       '@types/react-dom': 16.8.4
+      '@types/sarif': 2.1.1
       axe-core: 3.2.2
       axe-puppeteer: /axe-puppeteer/1.0.0/puppeteer@1.17.0
-      axe-sarif-converter: 1.4.0
+      axe-sarif-converter: 2.0.1
       glob: 7.1.4
       mkdirp: 0.5.1
       puppeteer: 1.17.0
@@ -15524,7 +15526,7 @@ packages:
     dev: false
     name: '@rush-temp/a11y-tests'
     resolution:
-      integrity: sha512-/lO+2sUOWLG8WvXi8E4gzPX6oioFaEj4e6Z5QqFry6jVgzSJhmzR36LG1kB0cS8/V9Pbzk0cQ2xTD12di38MuQ==
+      integrity: sha512-2VfAXF4w9wB3CQO47iYoqQSBOo25FT/AvFRNIdvvye4gNSvun2qD5qDKoyLxVDPF0gy4D3Mdyiz3V83QxF+Jsw==
       tarball: 'file:projects/a11y-tests.tgz'
     version: 0.0.0
   'file:projects/api-docs.tgz':
@@ -15537,7 +15539,7 @@ packages:
     dev: false
     name: '@rush-temp/api-docs'
     resolution:
-      integrity: sha512-+nVGovHs7TuNqlcW4H+CQPxpX+lef9RMgW+J1+QtXavFuyno7h/h0nIawRe97yKcOXska45gqtQwwFamk31yhg==
+      integrity: sha512-q4h4HMWkscR6EvTQ1tC2PjF9yG4Fc5FAFSoZfOo4KNCtaPgqDBS44EEvIg27pNLHTBpeeZLeX4g3nbTJVDjlgQ==
       tarball: 'file:projects/api-docs.tgz'
     version: 0.0.0
   'file:projects/azure-themes.tgz':
@@ -15547,7 +15549,7 @@ packages:
     dev: false
     name: '@rush-temp/azure-themes'
     resolution:
-      integrity: sha512-bqDCvNlYTsQu0n73i62hCX28BlBIyTgKU2bCqSUkpL+U90hh4uyIFGMsYcYoUMrq629DbCrjNAO4Hdje5Fukgw==
+      integrity: sha512-8jrJS7jtZ3LmCHO6NA6rBuSBz7ubxvdPrAk9Pghi2ppbZ0aHIMSZrVehnPqJreFWiYMTIaiElNSlEwomtd8pqg==
       tarball: 'file:projects/azure-themes.tgz'
     version: 0.0.0
   'file:projects/build.tgz':
@@ -15612,7 +15614,7 @@ packages:
     dev: false
     name: '@rush-temp/build'
     resolution:
-      integrity: sha512-vIGq4nVWonsB9QqBG9+crM2S25zReronzs5ApthHVrCV33KWSaXHwu8SgRNoz5yQPzRPg/WHoTmKOJoQkXoQ/g==
+      integrity: sha512-tLVkEcq7Ri9ptbKdtgEgX9UdaZ44bWTbY2urEwW8oodVGDZqmouGpgpgRy8OKsGE0l+SyratT4JdKn/hMwiirA==
       tarball: 'file:projects/build.tgz'
     version: 0.0.0
   'file:projects/charting.tgz':
@@ -15656,7 +15658,7 @@ packages:
     dev: false
     name: '@rush-temp/charting'
     resolution:
-      integrity: sha512-B1vSt3iGCT2PQ/SoztAujriexVWaMFp+AGBQ4HFN4FjzWNkMc3SsjliIYGE+nLZHFGXz6KeZlA2xFWJC5XtOww==
+      integrity: sha512-UbcbFok8S0yUmtdGVKSTLsoxWdfCOnoi5jMcIkat7aRIKF5wFd+mcHKW6RbfwP7j7B2iXgoJs5z5y+lRTiXBGg==
       tarball: 'file:projects/charting.tgz'
     version: 0.0.0
   'file:projects/codepen-loader.tgz':
@@ -15678,7 +15680,7 @@ packages:
     dev: false
     name: '@rush-temp/codepen-loader'
     resolution:
-      integrity: sha512-sL2AkJYFb9ZI24S4QbqkjdEwQk764jLIeIswKa//qYBnHuS64IpU5sPrICrZ7+/1oOnITw6yuMReEvdaj4B/eg==
+      integrity: sha512-6dZZroQsWpdd/a8PmE/CZIAdJjOk+8iaGq8eIFOd27/8lnR63aBpWc6vILBKPoqTT6QvMoJ6k6nn0uxwYr4G0A==
       tarball: 'file:projects/codepen-loader.tgz'
     version: 0.0.0
   'file:projects/date-time.tgz':
@@ -15704,7 +15706,7 @@ packages:
     dev: false
     name: '@rush-temp/date-time'
     resolution:
-      integrity: sha512-lMpd7TqxbpihVMKpnHsNntrxlumE0oOxceLSV4tmNCnQTfqUgWj+ZdOv37SsPv14q+5II+KfDXfGvtxCc6B/tw==
+      integrity: sha512-2y8Ny+XDQEY0C+A8CQYpuuaMD+6r117+6l7uvA6rb6WuYBwEiQ86eQ1DSOLX+IhYeeo+2quDhNJ5W87y8KuSZw==
       tarball: 'file:projects/date-time.tgz'
     version: 0.0.0
   'file:projects/dom-tests.tgz':
@@ -15730,7 +15732,7 @@ packages:
     dev: false
     name: '@rush-temp/dom-tests'
     resolution:
-      integrity: sha512-u5RwCI+yVy6fQuLqG6ntSkCRu/2+JYV85/WukRHXxbSHQQl3inr9QYS8vjZqcqJW6dF/SXCQa1dSeHVMJkoTMw==
+      integrity: sha512-jUq1XHtY7Fo981ICHkxJKgK7R7Z4g0zi+aGuxtQa2DsyGvWXv6cC02YpiycwZh7U2o/3ZpBO1ymYAmMu+C1Dmw==
       tarball: 'file:projects/dom-tests.tgz'
     version: 0.0.0
   'file:projects/example-app-base.tgz':
@@ -15759,7 +15761,7 @@ packages:
     dev: false
     name: '@rush-temp/example-app-base'
     resolution:
-      integrity: sha512-SDeaQY1gG+iQSpz7tCGqMLw6n8d7xDXq1ymtyw61tfawojA+zjPbXA46WMB/ZekEQvky7oSO34vK2JYBaSxJJQ==
+      integrity: sha512-GLepKoiK/IUQCyHFRMs4mUG3siFkoV5AKHNrtsfX6Q+s9/+5Clsdr7r/P0WkfWZnNuklxf6NRxKwNRADNCi1yA==
       tarball: 'file:projects/example-app-base.tgz'
     version: 0.0.0
   'file:projects/experiments.tgz':
@@ -15794,7 +15796,7 @@ packages:
     dev: false
     name: '@rush-temp/experiments'
     resolution:
-      integrity: sha512-JWaxetPKNH+dKCgV0+O0Ee9ZY/GpAhfvgSC/0jgGg6uchm2Jeyet7sYBPlgTNR095fiinZXyZdW2k/PQhsZPDA==
+      integrity: sha512-bPBviswiH79oXmzzvzuGGqBtkuUBfsP1dj+/vrDPAJYpt+t0ORtmuByZ4xMw1Qx+45F+2OlveKHdqtinEmVMVg==
       tarball: 'file:projects/experiments.tgz'
     version: 0.0.0
   'file:projects/fabric-website-resources.tgz':
@@ -15837,7 +15839,7 @@ packages:
     dev: false
     name: '@rush-temp/fabric-website-resources'
     resolution:
-      integrity: sha512-bDlNQ7UhJB24xl/9jss5oGvMYTb8tTDkNhTyuSZQlr4Vi901SYpXx4tBpjeLIysxRqBUNGHs/S1r64xvVYfPWQ==
+      integrity: sha512-Gb3BpanGBI3eDvQkYZ/1KDFIyKfFQoWRl5lmIVBQzzEtilGodgQWtga9xcYMVKGamSjzKacHO3rDooycCK4tPQ==
       tarball: 'file:projects/fabric-website-resources.tgz'
     version: 0.0.0
   'file:projects/fabric-website.tgz':
@@ -15864,7 +15866,7 @@ packages:
     dev: false
     name: '@rush-temp/fabric-website'
     resolution:
-      integrity: sha512-H8b1HU2yuLtmRuhDUUv2d0V1JfDCmj4nD0+MI1KU0Do/i2DTkyZxdbsh5tJk1fZ7THJoX7rrn7pNSY5kT3h6Zw==
+      integrity: sha512-1RC6th16oVGuLuMYNh47F6H0dl7M7wqmHHNkOHIFQE8arWrkpXXr4yGq9vQAKNno14xropZJF7WIvadASvOqCQ==
       tarball: 'file:projects/fabric-website.tgz'
     version: 0.0.0
   'file:projects/file-type-icons.tgz':
@@ -15879,7 +15881,7 @@ packages:
     dev: false
     name: '@rush-temp/file-type-icons'
     resolution:
-      integrity: sha512-94Wr/0q11McmZd2bO+KFO19iCQsZxbK8gDucdWkNEg3ogyGuQq6SWSYuyM2lT3QqRmS3K5qCzJPxOnRu3lTBBQ==
+      integrity: sha512-TAIfah1tqS9G4cErE0abqbtar7QWu9D9Cie4MBI85jKaHlkQl69QRK0rhkgwaOct6G0byWehiSIVHdlsIfisMg==
       tarball: 'file:projects/file-type-icons.tgz'
     version: 0.0.0
   'file:projects/fluent-theme.tgz':
@@ -15889,7 +15891,7 @@ packages:
     dev: false
     name: '@rush-temp/fluent-theme'
     resolution:
-      integrity: sha512-WbLEcXB5hP+ed653nBmcCcBqn2jGR/PsBmfE5vbJmCHVBPpYAxDecO5zrNiDgzGYQEkAdl3FMtjfXWatywPvgA==
+      integrity: sha512-GXBHnjk4LSnxoJyHbwY3pzXAK3WzZG+VTJRu7rt0lCA2vVZginZuiQVIkHHMzq5Ljf7owGgyA/lOgIxSSZPwAA==
       tarball: 'file:projects/fluent-theme.tgz'
     version: 0.0.0
   'file:projects/foundation-scenarios.tgz':
@@ -15914,7 +15916,7 @@ packages:
     dev: false
     name: '@rush-temp/foundation-scenarios'
     resolution:
-      integrity: sha512-qed1GHXSl97GqGYULduFpsZ5Jcus150LdbPrmWqJ42DPsXWcZp+QLUHEaQqYx8fIJqApiZ5Rkz14OXYsu5WejQ==
+      integrity: sha512-ZY75T4TduR5p5QUfxB/uZbGxd2kP6etGNJxU3W7lltegSP2/Xw3Laqgq+UorI+r6v466FGzk623Bn00ZzMiNmw==
       tarball: 'file:projects/foundation-scenarios.tgz'
     version: 0.0.0
   'file:projects/foundation.tgz':
@@ -15938,7 +15940,7 @@ packages:
     dev: false
     name: '@rush-temp/foundation'
     resolution:
-      integrity: sha512-zZXKyCdM+4FFbzK5EFUwwvp/KfmOYmB3QR1/bvNcIkwxyxVTsanr8GQ6TnamPaJDu0AnIbRGhs8Q76IOvc/jEA==
+      integrity: sha512-9fECEfAamG2GopP2cKS6R9LUIVMo7lzt8YVPE6zkFwodUaPnOiBHknl8Mb58mRBTR7acavbJMrHVH0gJ8zU0pQ==
       tarball: 'file:projects/foundation.tgz'
     version: 0.0.0
   'file:projects/icons.tgz':
@@ -15947,7 +15949,7 @@ packages:
     dev: false
     name: '@rush-temp/icons'
     resolution:
-      integrity: sha512-J8hKcVA3wWYxnUKltUUtPfEek/gE2b8IRcDVT/I/YasamPGkUtGZvqIMNwiLrMF/K14Jnzx3N17YDkI6b5wc9Q==
+      integrity: sha512-ZFOH2NRNWAh4Wyk1eY6cosh5Hb3PhI19Y1uNyutqhTWD6JzdLJoTKNg8Ok2hTzsN3tdb1VjR/ZoZ7/PVyjMsLA==
       tarball: 'file:projects/icons.tgz'
     version: 0.0.0
   'file:projects/jest-serializer-merge-styles.tgz':
@@ -15963,7 +15965,7 @@ packages:
     dev: false
     name: '@rush-temp/jest-serializer-merge-styles'
     resolution:
-      integrity: sha512-rrbtnRcWOjXDew6rPjKiYq6J/S7+ziM7/63OjwoxvcjJToDWYvx1wbSyZgLYTHMJmTeyOnpSSZL31SE/CVzKvQ==
+      integrity: sha512-wsCx9ZPkc/3B5XnZZL7MBIPcT1LejmJbfRdl+3LRlVeDaX/uegaAn8eq2on/f9Z5IJRiUg0qfUAVVaG4T0pWbA==
       tarball: 'file:projects/jest-serializer-merge-styles.tgz'
     version: 0.0.0
   'file:projects/lists.tgz':
@@ -15988,7 +15990,7 @@ packages:
     dev: false
     name: '@rush-temp/lists'
     resolution:
-      integrity: sha512-8NFSFaAPazr9QAcPxF0u0rB0785XHBHzJHVDjH18NVz3N5bFCNanXq4Dy30byPFD3a/4FCkyWaXecwimV4YNRg==
+      integrity: sha512-vB4dXvjoI60iD8hVGpKN4MNa+/1VlQaD6+COQeqtyFZEMy+NPzodOUsybokNB1F/vv7PvM77Z7dArg4882tVGg==
       tarball: 'file:projects/lists.tgz'
     version: 0.0.0
   'file:projects/mdl2-theme.tgz':
@@ -15997,7 +15999,7 @@ packages:
     dev: false
     name: '@rush-temp/mdl2-theme'
     resolution:
-      integrity: sha512-f2d5A3y1UvQLIUNdw0Sua4rivXqbtnmw/IVfFRPjB6l+NnqCZbiIXaIoMFsjFBjiGV3SWiDnDS44T97NfoFMCw==
+      integrity: sha512-8LgzbIsH+M5ujevRkASnntu1pL+dudVpKDZcOlUAZBvJeeYdhLmRAPH5ZrAQZai2iOu4w9AkvvxgqFo10hmscg==
       tarball: 'file:projects/mdl2-theme.tgz'
     version: 0.0.0
   'file:projects/merge-styles.tgz':
@@ -16007,7 +16009,7 @@ packages:
     dev: false
     name: '@rush-temp/merge-styles'
     resolution:
-      integrity: sha512-tgy3v5LbVRF1HIR0gLHk/Osa+gV/WoNz82fxI3jTl2KRgCtsIlz9FEtTyusuNr7ZT+exCh0uUDyC1pilDCwyhw==
+      integrity: sha512-cFZU0De1ITC+l6P/UsFNHCdqdT2RLE4zNbwnvl6yB3pALGYD0ewsyZ8BM07VP2iNgn28aMEn5/yl6JFg2p/Fbw==
       tarball: 'file:projects/merge-styles.tgz'
     version: 0.0.0
   'file:projects/migration.tgz':
@@ -16026,7 +16028,7 @@ packages:
     dev: false
     name: '@rush-temp/migration'
     resolution:
-      integrity: sha512-fqRqjL+WzpTyQMbAqvxgJ+TK5Zr/hXWKvUTUscaAG6uaHktFqj4DR6QGi1NyIjSAUHYTGaONc7aDhmeWziXlIg==
+      integrity: sha512-iZyIEUJQ21lgA3kdf+90Rp3UQ6xhnNv8ZUSaO1wH9rkSjf7im1kvI7znMKLINjA/OV5uoJ4tRJ9DeqxyMGHLaQ==
       tarball: 'file:projects/migration.tgz'
     version: 0.0.0
   'file:projects/office-ui-fabric-react.tgz':
@@ -16067,7 +16069,7 @@ packages:
     dev: false
     name: '@rush-temp/office-ui-fabric-react'
     resolution:
-      integrity: sha512-sjOyf8GjpTp23r5ttmbe8k0kvLWdl67ootb7XbXZMw4SRv3Oaq36e3JzGPIKR1DTqZFcrwyrx4irSWyiwNsonA==
+      integrity: sha512-0dWMor1kicS6XGC+t+6sL/01X0zzrYtChFbNpiTfQi7AGO+guBHedAT3GfwXA9hVUgoWMURKh0cAMbjFPjGpyA==
       tarball: 'file:projects/office-ui-fabric-react.tgz'
     version: 0.0.0
   'file:projects/perf-test.tgz':
@@ -16091,21 +16093,21 @@ packages:
     dev: false
     name: '@rush-temp/perf-test'
     resolution:
-      integrity: sha512-9AFFaY9EukwE1AFCbdRBM7wGFgHPhAzIerwlHMwkP0ySzwxt+PPpkCKspjDCHYd6qlliaOmWE2db+ThjwU08gg==
+      integrity: sha512-E7O7uSi4BM++IbitYWRYWXU7NP2RYPtn2dA5D2GLRmkHxxNJZvqwArVF7K6OdNP+L10m0h1SCf4dbV+pampeMg==
       tarball: 'file:projects/perf-test.tgz'
     version: 0.0.0
   'file:projects/pr-deploy-site.tgz':
     dev: false
     name: '@rush-temp/pr-deploy-site'
     resolution:
-      integrity: sha512-O4qRc1cUpxnstJLr+6OXDDqLuWvM3F1Ufk0P+p/re4T2RMYmJq4zd6EprE14WYCcl//9DOPd1haHR6p2riOTwQ==
+      integrity: sha512-LOp1VavTwN/pKJZ29RAL3SCIx31CSyu60GOnfTbrIw+A664RY2JyJ+Q/FrV24IaXC/K9qa3FM28X64FKPlPgqw==
       tarball: 'file:projects/pr-deploy-site.tgz'
     version: 0.0.0
   'file:projects/prettier-rules.tgz':
     dev: false
     name: '@rush-temp/prettier-rules'
     resolution:
-      integrity: sha512-7r4uNiMS8+omI76CKiVw7nJn2G0vs6Cd+CEAmTGmXDRT/FaMbDSIlsOpg+jzuO/fzg/zDB5GT7kwYff1IQWMiw==
+      integrity: sha512-jWWVmeywKZJiB8xv4ZdJ77AkTUoIgzr9ZNB2lGWp57zq/NqAGn6JVhkrf8Kp4GUPUyszGKn2NIVPx510n1eT7Q==
       tarball: 'file:projects/prettier-rules.tgz'
     version: 0.0.0
   'file:projects/react-cards.tgz':
@@ -16131,7 +16133,7 @@ packages:
     dev: false
     name: '@rush-temp/react-cards'
     resolution:
-      integrity: sha512-ooxuX35z0eEkKKO3RTJdiQ2Pfmo/AN0N402Py8LHffG0XU5Y+NsFpeplazh9ZPcPZ9ItYlqipR+Iw2Dl6fk6cg==
+      integrity: sha512-ay+Mr4h9Rnb0ObRTdP8dqrbKsiunPOQhcXgzGdtcZJii0Yq4+8u8aGLHkc2ZM/hMHUpdPQuPUACGO2wfcoj7/A==
       tarball: 'file:projects/react-cards.tgz'
     version: 0.0.0
   'file:projects/server-rendered-app.tgz':
@@ -16151,7 +16153,7 @@ packages:
     dev: false
     name: '@rush-temp/server-rendered-app'
     resolution:
-      integrity: sha512-jY+esupdxRxtdeNm18xaPBk2pPOOGbA1L143qgR9L5AY5rRxUyHImUjsHbamLaesL6XOC0cOOHGnWhyeer1rFA==
+      integrity: sha512-2xXESKI1exRANC2UC2IxdNnnWZd+cURldxswb+oMhE7MQ87PDmAcPVrpQZwJ92zsCeeo/paBiq/43xPqwDvHdg==
       tarball: 'file:projects/server-rendered-app.tgz'
     version: 0.0.0
   'file:projects/set-version.tgz':
@@ -16161,7 +16163,7 @@ packages:
     dev: false
     name: '@rush-temp/set-version'
     resolution:
-      integrity: sha512-G4Q01oYkqUzTOM/5sxh8/8DTowYHlp0TgnzgTP6Ze1rN0qFnvO/b50eLspFO+E9ZRCRu04bgEGkMOA12Dc0v2Q==
+      integrity: sha512-SHqbdGaU6e42PCUxMezocsjm1cBrN2oiDdpF4ukFfOUFVwBdkVW9nhIto81mXF3To3Io2+w7miCS+GWh+ju5dQ==
       tarball: 'file:projects/set-version.tgz'
     version: 0.0.0
   'file:projects/ssr-tests.tgz':
@@ -16181,7 +16183,7 @@ packages:
     dev: false
     name: '@rush-temp/ssr-tests'
     resolution:
-      integrity: sha512-p7W3PDgN3inncdj0a19L8sRUAruLlV43I0+nmdM2aPX2xJzZ/LLG3LZ5PbEYmy8Vvhn/OFo1WEBMt+vDwLBs7g==
+      integrity: sha512-Pu9hCPMUvh3lEHrjBKfFns0p9WTACzAv/alWqRbJr0LrRhz6Db3vB+gvgQlfR7BkgX4/q11oDdUYy4PwKwVtKg==
       tarball: 'file:projects/ssr-tests.tgz'
     version: 0.0.0
   'file:projects/styling.tgz':
@@ -16199,7 +16201,7 @@ packages:
     dev: false
     name: '@rush-temp/styling'
     resolution:
-      integrity: sha512-8K8ZhSL5P0tNlrOLGsKPZ7IhufZy6ErneFxrybVdRrlFNQEJWGIYA0a5mk7JRWGdLUtI/3TY/F5QISC3vxDaLA==
+      integrity: sha512-9N4Cstv3zR2qGSLWnY+qO7k62EFZvWKUbazel4dhCpXJjii2SXNf0aQN/y8y5BMOjS2mfai0lsepu/lHD/alUg==
       tarball: 'file:projects/styling.tgz'
     version: 0.0.0
   'file:projects/test-bundles.tgz':
@@ -16214,7 +16216,7 @@ packages:
     dev: false
     name: '@rush-temp/test-bundles'
     resolution:
-      integrity: sha512-3WzMPXbnDuHNCNgoBLJLqyi7Cz+vo2bkFRS5WyoMIi9jBjRaIG9NkX6+JvqHzxp018rl2qKFoCCvERsPqqN8dQ==
+      integrity: sha512-jXQEYAaTSPXNMNYPFZsS8ITh3Eyy+i3eZjJrp7RbVKLqj9ZQ+XZxHqafoBGIkClQ1Bt3vXF15nV1V1G+3Ue5ow==
       tarball: 'file:projects/test-bundles.tgz'
     version: 0.0.0
   'file:projects/test-utilities.tgz':
@@ -16237,7 +16239,7 @@ packages:
     dev: false
     name: '@rush-temp/test-utilities'
     resolution:
-      integrity: sha512-pIjJUgIvZ2zsvQJvobz5BgXDJsXHOpCkPGqIOHz6MCI2vtA5DLB7PJ/UrgB8FLGcYD8XsCQfpk78ifWKabltJg==
+      integrity: sha512-eYzdNQEpqkRiWV8rjBL53GOkDSUulTEAGqoBYBVrwrhGiu7AN0w+JGV/pueSGbHD4N15R7fn/+8phkPbsjbbGw==
       tarball: 'file:projects/test-utilities.tgz'
     version: 0.0.0
   'file:projects/theme-samples.tgz':
@@ -16247,7 +16249,7 @@ packages:
     dev: false
     name: '@rush-temp/theme-samples'
     resolution:
-      integrity: sha512-+ET+Z4ZZJz6fONAhh4g4TVM598Nr3VG+J30W+r7lbcGFZz1ec71RDIr3ssr/YN0lA1xJbXC3m1/5En0U3JSkKg==
+      integrity: sha512-3ue3uCi2MNoCXwYhwU9UKwsdjXvgqORrrpQ5QVLD/28UbLQfZkZnOhz5928ZS+s1LQlzdcPcrVkXcHlAevkpmA==
       tarball: 'file:projects/theme-samples.tgz'
     version: 0.0.0
   'file:projects/theming-designer.tgz':
@@ -16266,7 +16268,7 @@ packages:
     dev: false
     name: '@rush-temp/theming-designer'
     resolution:
-      integrity: sha512-TB1xphW1mtrJqpKJ/a5qjuO/fzwnZ8gmmJBfdCApGP8XgxY6dx5OOwMkdSI8vkGYjIfVNKwWPeWGAS3hH87zVQ==
+      integrity: sha512-qY/QRmycp8I7SxCZPV/5aNFS3nzEx3xu+9ir6jmUeLDPys/PziLsrhbslyIUOYWyM6ZGJrMKmD4MfugtT3kryw==
       tarball: 'file:projects/theming-designer.tgz'
     version: 0.0.0
   'file:projects/todo-app.tgz':
@@ -16286,7 +16288,7 @@ packages:
     dev: false
     name: '@rush-temp/todo-app'
     resolution:
-      integrity: sha512-9iLEjyoksdNzessZO8l+vIP+xCeG8Nyie1zmXOTBaXV4SyE65ykX93Wa9c71N4MBF7xmgS3GRX26zPJbk7KoMA==
+      integrity: sha512-QGlOKiRPEXSDdt/bTvrf6VcStnWoteH8xrhu1XAxrBblWSioYXAju/HdIDfXEOSvIIpIgjTTRjb6ffA8lWignA==
       tarball: 'file:projects/todo-app.tgz'
     version: 0.0.0
   'file:projects/tslint-rules.tgz':
@@ -16295,7 +16297,7 @@ packages:
     dev: false
     name: '@rush-temp/tslint-rules'
     resolution:
-      integrity: sha512-PvAjozxdNhd6l1j9qXTXSARvp69gU4RaH+7+ZEzJLXSQAS8NL5ZId6T+ssLv+jM7e7sHLf1u5bS4WBbG4illlQ==
+      integrity: sha512-h1+u9ClRusHyMiB0xMD6YrGIbRjN4EBNo4I9smahoftL1OjGB1rctcU889XPhxDYI+AkLF783mdhiF1DpFsMSQ==
       tarball: 'file:projects/tslint-rules.tgz'
     version: 0.0.0
   'file:projects/tsx-editor.tgz':
@@ -16325,7 +16327,7 @@ packages:
     dev: false
     name: '@rush-temp/tsx-editor'
     resolution:
-      integrity: sha512-HIXpQVvrQbT/Y4/uDg0gL5jWDk64u53qp1/JCR0SeksxzsQ5pkXu3GL9dspArgJ5VGL9ci2VWPHYu3rZ4HA5qg==
+      integrity: sha512-TZZeYvQc2lJvHVvsIjiqoJCW4ohpZX5R8Smx7hz1k7vFJaAb53786tPJaa9PI0q2jZRveKaB84LQK1uGq3l6oA==
       tarball: 'file:projects/tsx-editor.tgz'
     version: 0.0.0
   'file:projects/utilities.tgz':
@@ -16351,7 +16353,7 @@ packages:
     dev: false
     name: '@rush-temp/utilities'
     resolution:
-      integrity: sha512-6Fzbi/WJz6rUpVdYaqfxNJvpP93N6PxMod77woTohqh+8V3oY0KifGWV9RZ0ObXAQ5SsyfIUCUMTiaS5J+F2Yg==
+      integrity: sha512-ZG8IRSg8q+fZUhNb2qbCcjPjVl40Z97HVy5LLJbqoYD+Rji+KkWfbqSFEG/o06L8jhMC60bPp9rJK9mb+mlvRg==
       tarball: 'file:projects/utilities.tgz'
     version: 0.0.0
   'file:projects/variants.tgz':
@@ -16361,7 +16363,7 @@ packages:
     dev: false
     name: '@rush-temp/variants'
     resolution:
-      integrity: sha512-rJhyQdNBTjxD43vsywaIqJ4t/5JaD1kcSLk4a5gAENXf+J1qXPE1QHHv20R0ucVpHOhGVZBEpiFtoZ+93yuenQ==
+      integrity: sha512-F+rkoKiDBCgKfScdElu7f6xk5bko4IRuPJkITGMOomKCdS2Jz5uUtpdVzxleI4/fjDqi7IfbOXYscqe8V1ccJg==
       tarball: 'file:projects/variants.tgz'
     version: 0.0.0
   'file:projects/vr-tests.tgz':
@@ -16394,7 +16396,7 @@ packages:
     dev: false
     name: '@rush-temp/vr-tests'
     resolution:
-      integrity: sha512-HD2/PnHBxzYsbwW8Qr6sj7dhmebFsHJTURzehYo56RVCJ2kbl8lHaC6Hvwa0r0NmTz0DKJ6u1+ZmGwIQb1lfNw==
+      integrity: sha512-Er6Sf8oEm7RfP4pbdeDhqJx/EHU8Zgz5EkZ6uxHyTeV1CGk8mojjzt/Odp51jIkO78N10XV/mNqPqSscyiU+aw==
       tarball: 'file:projects/vr-tests.tgz'
     version: 0.0.0
   'file:projects/webpack-utils.tgz':
@@ -16409,7 +16411,7 @@ packages:
     dev: false
     name: '@rush-temp/webpack-utils'
     resolution:
-      integrity: sha512-iM1VarU+ux+5wgYvqPbHcwcybEGK0sxkh8zPBQ2Isol9pVVeTT3J4t9prNY+vrXngIlfdGrRGOIpKxj3r64lXA==
+      integrity: sha512-PS6VN/QcljUhaVq4j0KRK4i0FWJ2896jeb5+QvB3OenFZbt/C1dNJBasARn83Cfum5EKSHz5DoHK/7lp0C8dew==
       tarball: 'file:projects/webpack-utils.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -16496,6 +16498,7 @@ specifiers:
   '@types/react-dom': 16.8.4
   '@types/react-test-renderer': ^16.0.0
   '@types/resemblejs': ~1.3.28
+  '@types/sarif': ^2.1.1
   '@types/semver': ^5.5.0
   '@types/sinon': 2.2.2
   '@types/storybook__react': 3.0.5
@@ -16507,7 +16510,7 @@ specifiers:
   awesome-typescript-loader: ^3.2.3
   axe-core: ^3.2.2
   axe-puppeteer: ^1.0.0
-  axe-sarif-converter: ^1.0.0
+  axe-sarif-converter: ^2.0.1
   babel-core: ^6.26.3
   babel-loader: ^7.1.5
   babylon: ^7.0.0-beta.47
@@ -16587,7 +16590,6 @@ specifiers:
   react-highlight: 0.10.0
   react-hooks-testing-library: ^0.5.0
   react-loadable: '>=5.0.0'
-  react-monaco-editor: ^0.26.2
   react-syntax-highlighter: ^10.1.3
   react-test-renderer: ^16.3.0
   recast: ~0.15.0


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Currently, a newer version (2.1.0) of SARIF format is undergoing standardization, containing some breaking changes in output. In order to keep the sarif viewer in 'Scan' tab ([example here](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=19615&view=sariftools.sarif-viewer-build-tab.sariftools.sarif-viewer-build-tab)) working, this PR bumps `axe-sarif-converter` and updates a11y snapshots.


#### Focus areas to test

- Scan tab should keep working.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9667)