### PR TITLE
Fix calendar day grid date conversion

### DIFF
--- a/change/@uifabric-date-time-2019-07-02-16-20-40-lorejoh12-fixCalendarDayGridDateConversion.json
+++ b/change/@uifabric-date-time-2019-07-02-16-20-40-lorejoh12-fixCalendarDayGridDateConversion.json
@@ -1,0 +1,8 @@
+{
+  "comment": "fix date conversion for weeklydaypicker",
+  "type": "patch",
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com",
+  "commit": "f1273794e8c4402a86656689185bc7deb01151e4",
+  "date": "2019-07-02T23:20:40.492Z"
+}

--- a/packages/date-time/src/components/Calendar/Calendar.styles.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.styles.ts
@@ -6,7 +6,7 @@ export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
   const { palette } = theme;
 
   let totalWidth = isDayPickerVisible && isMonthPickerVisible ? 440 : 220;
-  if (showWeekNumbers) {
+  if (showWeekNumbers && isDayPickerVisible) {
     totalWidth += 30;
   }
 

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -316,7 +316,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     let date;
     if (weeksToShow && weeksToShow <= 4) {
       // if showing less than a full month, just use date == navigatedDate
-      date = new Date(navigatedDate.toDateString());
+      date = new Date(navigatedDate.toString());
     } else {
       date = new Date(navigatedDate.getFullYear(), navigatedDate.getMonth(), 1);
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

_getWeeks function calculates the dates to show in the grid given some date that's supposed to be inside of it. When passing in a date with a time zone on it, like date=2019-07-21T00:00:00.000-00:00 (7/21/2019 in GMT), we create a new date from it by doing new Date(navigatedDate.toDateString()). However, toDateString strips out all the time and timezone information. If we instead use PST: navigatedDate: 2019-07-21T00:00:00.000-07:00
doing navigatedDate.toDateString() returns 2019-07-21 (time zone gets stripped out), so then new Date(string) assumes it was GMT, and creates a new date at 2019-07-20:17:00:00.000-07:00 (subtracts the 7 hours for the time zone).

Result of this is that when you pass in an initial date of Sunday to the WeeklyDayPicker (only control that uses this currently), the control would display the previous week.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9673)