### PR TITLE
Breadcrumb: Setting overflowAriaLabel to examples

### DIFF
--- a/change/office-ui-fabric-react-2019-07-02-16-58-34-breadcrumbExampleScreenReader.json
+++ b/change/office-ui-fabric-react-2019-07-02-16-58-34-breadcrumbExampleScreenReader.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Breadcrumb: Adding overflowAriaLabel to examples.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "623b6e19cf9f0935facb8ae53d6092e6c4e8f450",
+  "date": "2019-07-02T23:58:34.565Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -27,6 +27,7 @@ export const BreadcrumbBasicExample: React.FunctionComponent = () => {
           { text: 'This is folder 5 another', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
         ]}
         ariaLabel="Breadcrumb with no maxDisplayedItems"
+        overflowAriaLabel="More links"
       />
 
       <Label styles={labelStyles}>With Custom Divider Icon</Label>
@@ -41,6 +42,7 @@ export const BreadcrumbBasicExample: React.FunctionComponent = () => {
         ]}
         dividerAs={_getCustomDivider}
         ariaLabel="Breadcrumb with custom divider icon"
+        overflowAriaLabel="More links"
       />
 
       <Label styles={labelStyles}>With maxDisplayedItems set to three</Label>
@@ -94,8 +96,8 @@ export const BreadcrumbBasicExample: React.FunctionComponent = () => {
         ]}
         maxDisplayedItems={2}
         overflowIndex={1}
-        overflowAriaLabel="More items"
         ariaLabel="Breadcrumb with maxDisplayedItems set to 2 and overflowIndex set to 1"
+        overflowAriaLabel="More links"
       />
     </div>
   );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -2935,7 +2935,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 <button
                   aria-expanded={false}
                   aria-haspopup={true}
-                  aria-label="More items"
+                  aria-label="More links"
                   aria-owns={null}
                   className=
                       ms-Button


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9657 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Setting `overflowAriaLabel` prop in all examples to meet accessibility standards.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9676)