### PR TITLE
SearchBox: Accept id for input from props

### DIFF
--- a/change/office-ui-fabric-react-2019-07-02-11-52-50-searchbox.json
+++ b/change/office-ui-fabric-react-2019-07-02-11-52-50-searchbox.json
@@ -1,0 +1,8 @@
+{
+  "comment": "SearchBox: allow passing in id for input",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "c8ea3dd79fc6a2508dacdab123d1226dfbb70f7f",
+  "date": "2019-07-02T18:52:50.961Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6399,8 +6399,6 @@ export interface ISearchBoxState {
     // (undocumented)
     hasFocus?: boolean;
     // (undocumented)
-    id?: string;
-    // (undocumented)
     value?: string;
 }
 
@@ -8547,8 +8545,10 @@ export type ScrollToMode = typeof ScrollToMode[keyof typeof ScrollToMode];
 export const SearchBox: React.StatelessComponent<ISearchBoxProps>;
 
 // @public (undocumented)
-export class SearchBoxBase extends BaseComponent<ISearchBoxProps, ISearchBoxState> {
+export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxState> {
     constructor(props: ISearchBoxProps);
+    // (undocumented)
+    componentWillMount(): void;
     // (undocumented)
     componentWillReceiveProps(newProps: ISearchBoxProps): void;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.test.tsx
@@ -102,6 +102,16 @@ describe('SearchBox', () => {
     expect(placeholderVal).toBe(placeholder);
   });
 
+  it('supports setting id on input', () => {
+    wrapper = mount(<SearchBox id="foo" />);
+    expect(wrapper.find('input').prop('id')).toBe('foo');
+  });
+
+  it('generates id for input if none passed in', () => {
+    wrapper = mount(<SearchBox />);
+    expect(wrapper.find('input').prop('id')).toBeTruthy();
+  });
+
   it('only invokes onFocus callback once per focus event', () => {
     const onFocus = jest.fn();
     wrapper = mount(<SearchBox onFocus={onFocus} />);

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.test.tsx
@@ -120,14 +120,6 @@ describe('SearchBox', () => {
     expect(onFocus.mock.calls.length).toBe(1);
   });
 
-  it('generates id internally and cannot be set via props', () => {
-    wrapper = mount(<SearchBox id={'foo'} />);
-    const inputEl = wrapper.find('input').getDOMNode();
-    const idVal = inputEl.getAttribute('id');
-
-    expect(idVal).toBe('SearchBox12');
-  });
-
   it('can be disabled via props', () => {
     wrapper = mount(<SearchBox disabled />);
     const inputEl = wrapper.find('input').getDOMNode();


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

The SearchBox should apply its `id` prop to the `<input>` and only use the generated `id` as a fallback.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9677)