### PR TITLE
Update persona initial colors to be aligned with those in Fabric 6 branch

### DIFF
--- a/change/@uifabric-experiments-2019-07-04-09-40-29-ivdijan-alignPersonaCoinPaletteWith6.json
+++ b/change/@uifabric-experiments-2019-07-04-09-40-29-ivdijan-alignPersonaCoinPaletteWith6.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Update persona initial colors to be aligned with those in Fabric 6 branch",
+  "type": "patch",
+  "packageName": "@uifabric/experiments",
+  "email": "ivdijan@microsoft.com",
+  "commit": "5a0f5edaf1ad44beadbc2f53db4318d8f715304e",
+  "date": "2019-07-04T07:39:51.712Z"
+}

--- a/change/office-ui-fabric-react-2019-07-03-14-36-19-ivdijan-alignPersonaCoinPaletteWith6.json
+++ b/change/office-ui-fabric-react-2019-07-03-14-36-19-ivdijan-alignPersonaCoinPaletteWith6.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Update persona initial colors to be aligned with those in Fabric 6 branch",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "ivdijan@microsoft.com",
+  "commit": "2174ca63be82604ced1b9b6d2d54018e65769460",
+  "date": "2019-07-03T12:36:19.467Z"
+}

--- a/change/office-ui-fabric-react-2019-07-04-09-40-29-ivdijan-alignPersonaCoinPaletteWith6.json
+++ b/change/office-ui-fabric-react-2019-07-04-09-40-29-ivdijan-alignPersonaCoinPaletteWith6.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Update persona initial colors to be aligned with those in Fabric 6 branch",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "ivdijan@microsoft.com",
+  "commit": "5a0f5edaf1ad44beadbc2f53db4318d8f715304e",
+  "date": "2019-07-04T07:40:29.036Z"
+}

--- a/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
+++ b/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`VerticalPersona renders correctly with a text and secondary text 1`] = 
 
         {
           align-items: center;
-          background-color: #8764B8;
+          background-color: #5E4B8B;
           border-radius: 50%;
           color: white;
           display: flex;
@@ -122,7 +122,7 @@ exports[`VerticalPersona renders correctly with only a text 1`] = `
 
         {
           align-items: center;
-          background-color: #8764B8;
+          background-color: #5E4B8B;
           border-radius: 50%;
           color: white;
           display: flex;

--- a/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
+++ b/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`VerticalPersona renders correctly with a text and secondary text 1`] = 
 
         {
           align-items: center;
-          background-color: #A4262C;
+          background-color: #8764B8;
           border-radius: 50%;
           color: white;
           display: flex;
@@ -122,7 +122,7 @@ exports[`VerticalPersona renders correctly with only a text 1`] = `
 
         {
           align-items: center;
-          background-color: #A4262C;
+          background-color: #8764B8;
           border-radius: 50%;
           color: white;
           display: flex;

--- a/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`PersonaCoin renders a coin with a contact icon for a Chinese name 1`] =
       test-cn-root
       {
         align-items: center;
-        background-color: #69797E;
+        background-color: #498205;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -118,7 +118,7 @@ exports[`PersonaCoin renders a correct persona 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #A4262C;
+        background-color: #8764B8;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -190,7 +190,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
       test-cn-root
       {
         align-items: center;
-        background-color: #69797E;
+        background-color: #498205;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -289,7 +289,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #69797E;
+        background-color: #498205;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -388,7 +388,7 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #69797E;
+        background-color: #498205;
         border-radius: 50%;
         color: white;
         display: flex;

--- a/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PersonaCoin renders a coin with a contact icon 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #0078D4;
+        background-color: #2D89EF;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -44,7 +44,7 @@ exports[`PersonaCoin renders a coin with a contact icon for a Chinese name 1`] =
       test-cn-root
       {
         align-items: center;
-        background-color: #498205;
+        background-color: #00A300;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -82,7 +82,7 @@ exports[`PersonaCoin renders a coin with the initials JB 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #0078D4;
+        background-color: #2D89EF;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -118,7 +118,7 @@ exports[`PersonaCoin renders a correct persona 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #8764B8;
+        background-color: #5E4B8B;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -190,7 +190,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
       test-cn-root
       {
         align-items: center;
-        background-color: #498205;
+        background-color: #00A300;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -289,7 +289,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #498205;
+        background-color: #00A300;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -388,7 +388,7 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #498205;
+        background-color: #00A300;
         border-radius: 50%;
         color: white;
         display: flex;

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -250,7 +250,7 @@ Array [
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #A4262C;
+                      background-color: #B91D47;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -748,7 +748,7 @@ Array [
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #0078D4;
+                      background-color: #2D89EF;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -250,7 +250,7 @@ Array [
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #69797E;
+                      background-color: #A4262C;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -748,7 +748,7 @@ Array [
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #CA5010;
+                      background-color: #0078D4;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0078D4;
+                  background-color: #2D89EF;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -378,7 +378,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0078D4;
+                  background-color: #2D89EF;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -539,7 +539,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0078D4;
+                  background-color: #2D89EF;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -695,7 +695,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #038387;
+                  background-color: #00ABA9;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -819,7 +819,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0078D4;
+                  background-color: #2D89EF;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 14px;
@@ -1060,7 +1060,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0078D4;
+                  background-color: #2D89EF;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -1194,7 +1194,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #038387;
+                  background-color: #00ABA9;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #4F6BED;
+                  background-color: #0078D4;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -378,7 +378,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #4F6BED;
+                  background-color: #0078D4;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -539,7 +539,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #4F6BED;
+                  background-color: #0078D4;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -695,7 +695,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #D13438;
+                  background-color: #038387;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -819,7 +819,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #4F6BED;
+                  background-color: #0078D4;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 14px;
@@ -1060,7 +1060,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #4F6BED;
+                  background-color: #0078D4;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;
@@ -1194,7 +1194,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #D13438;
+                  background-color: #038387;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
               className=
                   ms-Persona-initials
                   {
-                    background-color: #0078D4;
+                    background-color: #2D89EF;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #8E562E;
+                        background-color: #0B6A0B;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #0B6A0B;
+                        background-color: #1E7145;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`PersonaCoin renders correctly 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #0078D4;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -180,7 +180,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #0078D4;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -236,7 +236,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #8764B8;
+            background-color: #5E4B8B;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #498205;
+            background-color: #8764B8;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #498205;
+              background-color: #8764B8;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -636,7 +636,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #498205;
+              background-color: #8764B8;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -991,7 +991,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #8E562E;
+              background-color: #881798;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;
@@ -1812,7 +1812,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #8E562E;
+            background-color: #881798;
             border-radius: 50%;
             color: #ffffff;
             font-size: 42px;
@@ -1924,7 +1924,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #498205;
+            background-color: #8764B8;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -1980,7 +1980,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #498205;
+            background-color: #8764B8;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #8764B8;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -636,7 +636,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #8764B8;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -813,7 +813,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #0078D4;
+              background-color: #2D89EF;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -991,7 +991,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #881798;
+              background-color: #7E3878;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;
@@ -1661,7 +1661,7 @@ exports[`PersonaCoin renders correctly 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #0078D4;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -1812,7 +1812,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #881798;
+            background-color: #7E3878;
             border-radius: 50%;
             color: #ffffff;
             font-size: 42px;
@@ -1868,7 +1868,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #0078D4;
+            background-color: #2D89EF;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -1924,7 +1924,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #8764B8;
+            background-color: #5E4B8B;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;
@@ -1980,7 +1980,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #8764B8;
+            background-color: #5E4B8B;
             border-radius: 50%;
             color: #ffffff;
             font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,10 +4,10 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#8764B8');
+    expect(colorCode).toEqual('#5E4B8B');
 
     const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
-    expect(colorCode2).toEqual('#498205');
+    expect(colorCode2).toEqual('#00A300');
   });
 
   it('uses provided enum initialsColor if one was specified', () => {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,10 +4,10 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = initialsColorPropToColorCode({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#498205');
+    expect(colorCode).toEqual('#8764B8');
 
     const colorCode2 = initialsColorPropToColorCode({ text: 'Annie Lindqvist' });
-    expect(colorCode2).toEqual('#038387');
+    expect(colorCode2).toEqual('#498205');
   });
 
   it('uses provided enum initialsColor if one was specified', () => {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -9,26 +9,20 @@ import { PersonaInitialsColor, IPersonaProps } from './Persona.types';
  *   its primary use is for Facepile overflow buttons.
  */
 const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [
+  PersonaInitialsColor.lightGreen,
   PersonaInitialsColor.lightBlue,
-  PersonaInitialsColor.blue,
-  PersonaInitialsColor.darkBlue,
-  PersonaInitialsColor.teal,
+  PersonaInitialsColor.lightPink,
   PersonaInitialsColor.green,
   PersonaInitialsColor.darkGreen,
-  PersonaInitialsColor.lightPink,
   PersonaInitialsColor.pink,
   PersonaInitialsColor.magenta,
   PersonaInitialsColor.purple,
-  PersonaInitialsColor.orange,
-  PersonaInitialsColor.lightRed,
-  PersonaInitialsColor.darkRed,
   PersonaInitialsColor.violet,
-  PersonaInitialsColor.gold,
-  PersonaInitialsColor.burgundy,
-  PersonaInitialsColor.warmGray,
-  PersonaInitialsColor.cyan,
-  PersonaInitialsColor.rust,
-  PersonaInitialsColor.coolGray
+  PersonaInitialsColor.teal,
+  PersonaInitialsColor.blue,
+  PersonaInitialsColor.darkBlue,
+  PersonaInitialsColor.orange,
+  PersonaInitialsColor.darkRed
 ];
 
 const COLOR_SWATCHES_NUM_ENTRIES = COLOR_SWATCHES_LOOKUP.length;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -49,38 +49,36 @@ function getInitialsColorFromName(displayName: string | undefined): PersonaIniti
 function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColor): string {
   switch (personaInitialsColor) {
     case PersonaInitialsColor.lightBlue:
-      return '#4F6BED';
+      return '#6BA5E7';
     case PersonaInitialsColor.blue:
-      return '#0078D4';
+      return '#2D89EF';
     case PersonaInitialsColor.darkBlue:
-      return '#004E8C';
+      return '#2B5797';
     case PersonaInitialsColor.teal:
-      return '#038387';
+      return '#00ABA9';
     case PersonaInitialsColor.lightGreen:
     case PersonaInitialsColor.green:
-      return '#498205';
+      return '#00A300';
     case PersonaInitialsColor.darkGreen:
-      return '#0B6A0B';
+      return '#1E7145';
     case PersonaInitialsColor.lightPink:
-      return '#C239B3';
+      return '#E773BD';
     case PersonaInitialsColor.pink:
-      return '#E3008C';
+      return '#FF0097';
     case PersonaInitialsColor.magenta:
-      return '#881798';
+      return '#7E3878';
     case PersonaInitialsColor.purple:
-      return '#5C2E91';
+      return '#603CBA';
     case PersonaInitialsColor.orange:
-      return '#CA5010';
+      return '#DA532C';
     case PersonaInitialsColor.red:
-      return '#EE1111';
-    case PersonaInitialsColor.lightRed:
       return '#D13438';
     case PersonaInitialsColor.darkRed:
-      return '#A4262C';
+      return '#B91D47';
     case PersonaInitialsColor.transparent:
       return 'transparent';
     case PersonaInitialsColor.violet:
-      return '#8764B8';
+      return '#5E4B8B';
     case PersonaInitialsColor.gold:
       return '#986F0B';
     case PersonaInitialsColor.burgundy:

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -72,6 +72,8 @@ function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColo
     case PersonaInitialsColor.orange:
       return '#DA532C';
     case PersonaInitialsColor.red:
+      return '#EE1111';
+    case PersonaInitialsColor.lightRed:
       return '#D13438';
     case PersonaInitialsColor.darkRed:
       return '#B91D47';

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #8764B8;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -441,7 +441,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #0078D4;
+              background-color: #2D89EF;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #498205;
+              background-color: #8764B8;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #498205;
+              background-color: #8764B8;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -636,7 +636,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #498205;
+              background-color: #8764B8;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -991,7 +991,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #8E562E;
+              background-color: #881798;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #8764B8;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -636,7 +636,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #8764B8;
+              background-color: #5E4B8B;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -813,7 +813,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #0078D4;
+              background-color: #2D89EF;
               border-radius: 50%;
               color: #ffffff;
               font-size: 16px;
@@ -991,7 +991,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #881798;
+              background-color: #7E3878;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -293,7 +293,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #498205;
+                    background-color: #00A300;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -449,7 +449,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #5C2E91;
+                    background-color: #603CBA;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -293,7 +293,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #5C2E91;
+                    background-color: #498205;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -449,7 +449,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #0B6A0B;
+                    background-color: #5C2E91;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -304,7 +304,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #A4262C;
+                    background-color: #B91D47;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -692,7 +692,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #498205;
+                    background-color: #00A300;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -1099,7 +1099,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #0B6A0B;
+                    background-color: #1E7145;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -1233,7 +1233,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #498205;
+                    background-color: #00A300;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -304,7 +304,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #E3008C;
+                    background-color: #A4262C;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -692,7 +692,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #5C2E91;
+                    background-color: #498205;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -1099,7 +1099,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #4F6BED;
+                    background-color: #0B6A0B;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;
@@ -1233,7 +1233,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #038387;
+                    background-color: #498205;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 10px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-520:hover + .headerDividerBar-521 {
+      & .headerDivider-519:hover + .headerDividerBar-520 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -279,7 +279,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #038387;
+                        background-color: #00ABA9;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;
@@ -1444,7 +1444,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #881798;
+                        background-color: #7E3878;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -279,7 +279,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #0B6A0B;
+                        background-color: #038387;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;
@@ -1444,7 +1444,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #A4262C;
+                        background-color: #881798;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -256,7 +256,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #0B6A0B;
+                      background-color: #038387;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -782,7 +782,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #A4262C;
+                      background-color: #881798;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -1172,7 +1172,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #005B70;
+                      background-color: #4F6BED;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -256,7 +256,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #038387;
+                      background-color: #00ABA9;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -782,7 +782,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #881798;
+                      background-color: #7E3878;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -1172,7 +1172,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #4F6BED;
+                      background-color: #6BA5E7;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -241,7 +241,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #038387;
+                      background-color: #00ABA9;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -620,7 +620,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #881798;
+                      background-color: #7E3878;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -241,7 +241,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #0B6A0B;
+                      background-color: #038387;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -620,7 +620,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #A4262C;
+                      background-color: #881798;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
@@ -165,7 +165,7 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
               className=
                   ms-Persona-initials
                   {
-                    background-color: #0078D4;
+                    background-color: #2D89EF;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -432,7 +432,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #8E562E;
+                          background-color: #0B6A0B;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -432,7 +432,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #0B6A0B;
+                          background-color: #1E7145;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -432,7 +432,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #0B6A0B;
+                          background-color: #1E7145;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;
@@ -531,7 +531,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #038387;
+                        background-color: #00ABA9;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;
@@ -629,7 +629,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #498205;
+                        background-color: #00A300;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -432,7 +432,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #8E562E;
+                          background-color: #0B6A0B;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;
@@ -531,7 +531,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #0B6A0B;
+                        background-color: #038387;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Colors.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Colors.Example.tsx.shot
@@ -104,7 +104,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #498205;
+                  background-color: #00A300;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -279,7 +279,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0B6A0B;
+                  background-color: #1E7145;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -454,7 +454,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #038387;
+                  background-color: #00ABA9;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -804,7 +804,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #4F6BED;
+                  background-color: #6BA5E7;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -979,7 +979,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #0078D4;
+                  background-color: #2D89EF;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -1154,7 +1154,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #004E8C;
+                  background-color: #2B5797;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -1329,7 +1329,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #8764B8;
+                  background-color: #5E4B8B;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -1504,7 +1504,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #5C2E91;
+                  background-color: #603CBA;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -1679,7 +1679,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #881798;
+                  background-color: #7E3878;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -1854,7 +1854,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #C239B3;
+                  background-color: #E773BD;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -2029,7 +2029,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #E3008C;
+                  background-color: #FF0097;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -2554,7 +2554,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #A4262C;
+                  background-color: #B91D47;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;
@@ -2729,7 +2729,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #CA5010;
+                  background-color: #DA532C;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #498205;
+                background-color: #8764B8;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 10px;
@@ -304,7 +304,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #0078D4;
+                background-color: #498205;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 10px;
@@ -524,7 +524,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #498205;
+                background-color: #881798;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 14px;
@@ -744,7 +744,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #E3008C;
+                background-color: #038387;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 14px;
@@ -964,7 +964,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #0078D4;
+                background-color: #A4262C;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1183,7 +1183,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #E3008C;
+                background-color: #4F6BED;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1636,7 +1636,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #986F0B;
+                background-color: #0B6A0B;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1870,7 +1870,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #881798;
+                background-color: #CA5010;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 20px;
@@ -2104,7 +2104,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #D13438;
+                background-color: #004E8C;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 20px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -84,7 +84,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #8764B8;
+                background-color: #5E4B8B;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 10px;
@@ -304,7 +304,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #498205;
+                background-color: #00A300;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 10px;
@@ -524,7 +524,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #881798;
+                background-color: #7E3878;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 14px;
@@ -744,7 +744,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #038387;
+                background-color: #00ABA9;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 14px;
@@ -964,7 +964,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #A4262C;
+                background-color: #B91D47;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1183,7 +1183,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #4F6BED;
+                background-color: #6BA5E7;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1417,7 +1417,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #C239B3;
+                background-color: #E773BD;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1636,7 +1636,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #0B6A0B;
+                background-color: #1E7145;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 16px;
@@ -1870,7 +1870,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #CA5010;
+                background-color: #DA532C;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 20px;
@@ -2104,7 +2104,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #004E8C;
+                background-color: #2B5797;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 20px;
@@ -2338,7 +2338,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #4F6BED;
+                background-color: #6BA5E7;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 28px;
@@ -2557,7 +2557,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #881798;
+                background-color: #7E3878;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 42px;
@@ -2788,7 +2788,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #038387;
+                background-color: #00ABA9;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -379,7 +379,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                       className=
                           ms-Persona-initials
                           {
-                            background-color: #5C2E91;
+                            background-color: #603CBA;
                             border-radius: 50%;
                             color: #ffffff;
                             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -379,7 +379,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                       className=
                           ms-Persona-initials
                           {
-                            background-color: #E3008C;
+                            background-color: #5C2E91;
                             border-radius: 50%;
                             color: #ffffff;
                             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -1005,7 +1005,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               className=
                   ms-Persona-initials
                   {
-                    background-color: #0078D4;
+                    background-color: #2D89EF;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 16px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9691 
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update persona initial colors to be aligned with those in Fabric 6 branch

Having a different set here while some O365 apps still use Fabric React 6 leads to color inconsistencies. For example, persona card is using FR6, while OWA is using FR7. Coin for same person on the page ends up having different background.

This change is aimed at mitigating the current color incoherence.
Later on, we want to apply the update in a controlled manner across all consumers, including the persona card which appears inside other applications.

#### Focus areas to test

Persona component
PersonaCoin component


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9692)