### PR TITLE
 Adding calloutProps as a prop to the Breadcrumb component.

### DIFF
--- a/change/office-ui-fabric-react-2019-07-03-17-47-46-breadcrumb-callout-props.json
+++ b/change/office-ui-fabric-react-2019-07-03-17-47-46-breadcrumb-callout-props.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Adding calloutProps as a prop to the Breadcrumb component.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "Heather.HoaglundBiron@microsoft.com",
+  "commit": "0e7737eb466ec78bea0f7174049499aa792fbddb",
+  "date": "2019-07-04T00:47:46.188Z"
+}

--- a/change/office-ui-fabric-react-2019-07-03-17-47-46-breadcrumb-callout-props.json
+++ b/change/office-ui-fabric-react-2019-07-03-17-47-46-breadcrumb-callout-props.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Adding calloutProps as a prop to the Breadcrumb component.",
+  "comment": "Adding tooltipHostProps as a prop to the Breadcrumb component.",
   "type": "minor",
   "packageName": "office-ui-fabric-react",
   "email": "Heather.HoaglundBiron@microsoft.com",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1784,7 +1784,6 @@ export interface IBreadcrumbItem {
 // @public (undocumented)
 export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     ariaLabel?: string;
-    calloutProps?: ICalloutProps;
     className?: string;
     componentRef?: IRefObject<IBreadcrumb>;
     dividerAs?: IComponentAs<IDividerAsProps>;
@@ -1799,6 +1798,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     styles?: IStyleFunctionOrObject<IBreadcrumbStyleProps, IBreadcrumbStyles>;
     // (undocumented)
     theme?: ITheme;
+    tooltipHostProps?: ITooltipHostProps;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1784,6 +1784,7 @@ export interface IBreadcrumbItem {
 // @public (undocumented)
 export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     ariaLabel?: string;
+    calloutProps?: ICalloutProps;
     className?: string;
     componentRef?: IRefObject<IBreadcrumb>;
     dividerAs?: IComponentAs<IDividerAsProps>;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -161,7 +161,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
           aria-current={item.isCurrentItem ? 'page' : undefined}
           onClick={this._onBreadcrumbClicked.bind(this, item)}
         >
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent}>
+          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} calloutProps={this.props.calloutProps}>
             {item.text}
           </TooltipHost>
         </Link>
@@ -169,7 +169,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
     } else {
       return (
         <span className={this._classNames.item}>
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent}>
+          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} calloutProps={this.props.calloutProps}>
             {item.text}
           </TooltipHost>
         </span>

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -161,7 +161,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
           aria-current={item.isCurrentItem ? 'page' : undefined}
           onClick={this._onBreadcrumbClicked.bind(this, item)}
         >
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} calloutProps={this.props.calloutProps}>
+          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {item.text}
           </TooltipHost>
         </Link>
@@ -169,7 +169,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
     } else {
       return (
         <span className={this._classNames.item}>
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} calloutProps={this.props.calloutProps}>
+          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {item.text}
           </TooltipHost>
         </span>

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -3,7 +3,7 @@ import { IIconProps } from '../../Icon';
 import { IRefObject, IRenderFunction, IComponentAs, IStyleFunctionOrObject } from '../../Utilities';
 import { ITheme, IStyle } from '../../Styling';
 import { IFocusZoneProps } from '../../FocusZone';
-import { ICalloutProps } from '../../Callout';
+import { ITooltipHostProps } from '../../Tooltip';
 
 /**
  * {@docCategory Breadcrumb}
@@ -89,9 +89,9 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   focusZoneProps?: IFocusZoneProps;
 
   /**
-   * Callout props that will get passed through to overflow tooltips.
+   * TooltipHost props that will get passed through to overflow tooltips.
    */
-  calloutProps?: ICalloutProps;
+  tooltipHostProps?: ITooltipHostProps;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -3,6 +3,7 @@ import { IIconProps } from '../../Icon';
 import { IRefObject, IRenderFunction, IComponentAs, IStyleFunctionOrObject } from '../../Utilities';
 import { ITheme, IStyle } from '../../Styling';
 import { IFocusZoneProps } from '../../FocusZone';
+import { ICalloutProps } from '../../Callout';
 
 /**
  * {@docCategory Breadcrumb}
@@ -86,6 +87,11 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    * Focuszone props that will get passed through to the root focus zone.
    */
   focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * Callout props that will get passed through to overflow tooltips.
+   */
+  calloutProps?: ICalloutProps;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added `calloutProps` as a prop to the `Breadcrumb` component. This way, we can pass props/options to the tooltips that appear when the text in a breadcrumb doesn't fit the visible area and the user hovers over it.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9701)