### PR TITLE
Properly mock Date class in snapshot tests

### DIFF
--- a/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
+++ b/apps/a11y-tests/src/tests/ComponentExamples.test.tsx
@@ -42,6 +42,7 @@ const excludedExampleFiles: string[] = ['Keytips.Basic.Example', 'List.Basic.Exa
 declare const global: any;
 
 describe('a11y test', () => {
+  const RealDate = Date;
   const constantDate = new Date(Date.UTC(2017, 0, 6, 4, 41, 20));
 
   beforeAll(() => {
@@ -62,11 +63,11 @@ describe('a11y test', () => {
     // Prevent random and time elements from failing repeated tests.
     global.Date = class {
       public static now() {
-        return constantDate;
+        return new RealDate(constantDate);
       }
 
       constructor() {
-        return constantDate;
+        return new RealDate(constantDate);
       }
     };
 

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -705,11 +705,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jan</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"July 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jan</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(1)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"July\\\\ 2016\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -723,7 +723,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(1)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"July\\\\ 2016\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -740,11 +740,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"December 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Feb</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"August 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Feb</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"December\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(2)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"August\\\\ 2016\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -758,7 +758,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"December\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(2)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"August\\\\ 2016\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -775,11 +775,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"August 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Mar</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"September 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Mar</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(3)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"September\\\\ 2016\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -793,7 +793,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(3)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"September\\\\ 2016\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -810,11 +810,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Apr</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"October 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Apr</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(4)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"October\\\\ 2016\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -828,7 +828,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(4)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"October\\\\ 2016\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -845,11 +845,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"March 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">May</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"November 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">May</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"March\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(5)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"November\\\\ 2016\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -863,7 +863,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"March\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(5)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"November\\\\ 2016\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -880,11 +880,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"February 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jun</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"December 2016\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Jun</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(6)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"December\\\\ 2016\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -898,7 +898,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(6)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"December\\\\ 2016\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -915,11 +915,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"February 2019\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" type=\\"button\\">Jul</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"January 2017\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" type=\\"button\\">Jul</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(7)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"January\\\\ 2017\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -933,7 +933,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"February\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(7)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"January\\\\ 2017\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -950,11 +950,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"March 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Aug</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"February 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Aug</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"March\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(8)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"February\\\\ 2017\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -968,7 +968,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"March\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(8)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"February\\\\ 2017\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -985,11 +985,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Sep</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"March 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Sep</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(9)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"March\\\\ 2017\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -1003,7 +1003,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(9)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"March\\\\ 2017\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -1020,11 +1020,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"August 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Oct</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"April 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Oct</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(10)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"April\\\\ 2017\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -1038,7 +1038,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"August\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(10)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"April\\\\ 2017\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -1055,11 +1055,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"December 2019\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Nov</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Nov</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"December\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(11)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"May\\\\ 2017\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -1073,7 +1073,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"December\\\\ 2019\\"][role=\\"gridcell\\"]:nth-child(11)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"May\\\\ 2017\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {
@@ -1090,11 +1090,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"May 2020\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Dec</button>",
+              "text": "<button role=\\"gridcell\\" class=\\"ms-DatePicker-monthOption\\" aria-label=\\"June 2017\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" type=\\"button\\">Dec</button>",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(12)",
+        "fullyQualifiedLogicalName": "button[aria-label=\\"June\\\\ 2017\\"]",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -1108,7 +1108,7 @@ Array [
       "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".ms-DatePicker-monthOption[aria-label=\\"May\\\\ 2020\\"][role=\\"gridcell\\"]:nth-child(12)",
+      "fullyQualifiedLogicalName": "button[aria-label=\\"June\\\\ 2017\\"]",
       "ruleId": "aria-allowed-role",
     },
     "properties": Object {

--- a/change/office-ui-fabric-react-2019-07-05-14-14-29-a11y-date-mock.json
+++ b/change/office-ui-fabric-react-2019-07-05-14-14-29-a11y-date-mock.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix mock Date class",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "rezha@microsoft.com",
+  "commit": "ffeec1a5e02aa849b7927442b1cfb554d4c8bc9d",
+  "date": "2019-07-05T21:14:29.496Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
@@ -129,11 +129,11 @@ describe('Component Examples', () => {
     // Prevent random and time elements from failing repeated tests.
     global.Date = class {
       public static now() {
-        return constantDate;
+        return new realDate(constantDate);
       }
 
       constructor() {
-        return constantDate;
+        return new realDate(constantDate);
       }
     };
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -7,7 +7,7 @@ exports[`Component Examples renders DatePicker.Bounded.Example.tsx correctly 1`]
   <p>
     When date boundaries are set (via minDate and maxDate props) the DatePicker will not allow
 out-of-bounds dates to be picked or entered. In this example, the allowed dates are
-Wed, 06 Dec 2017 04:41:20 GMT-Wed, 06 Dec 2017 04:41:20 GMT
+Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
   </p>
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1638,7 +1638,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -1957,7 +1957,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -2276,7 +2276,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -2595,7 +2595,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -2914,7 +2914,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -3233,7 +3233,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -3552,7 +3552,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -3871,7 +3871,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -4190,7 +4190,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>
@@ -4509,7 +4509,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                               }
                             >
                               <span>
-                                Wed, 06 Dec 2017 04:41:20 GMT
+                                Fri, 06 Jan 2017 04:41:20 GMT
                               </span>
                             </div>
                           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -146,7 +146,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
       Hello world.
     </div>
     <div>
-      Wed, 06 Dec 2017 04:41:20 GMT
+      Fri, 06 Jan 2017 04:41:20 GMT
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

**Mock version of `Date.now()` and `constructor()` should return new objects each time they are called**, instead of reusing a single object. Otherwise, util functions such as `addYears` or `addWeeks` in DateMath.ts will mutate the reused object, resulting in test-execution-order-related, unstable snapshots (one example is this fix https://github.com/OfficeDev/office-ui-fabric-react/pull/9640).

#### Focus areas to test

No weird date mismatches in future snapshot tests.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9721)