### PR TITLE
Port PR 9519 to V6.0 - Tooltip: fix closeDelay bug

### DIFF
--- a/common/changes/office-ui-fabric-react/cicciodm-6.0-backport-9519_2019-07-08-16-09.json
+++ b/common/changes/office-ui-fabric-react/cicciodm-6.0-backport-9519_2019-07-08-16-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Tooltip: fix closeDelay bug",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "frdim@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -156,13 +156,14 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
       }
     }
 
+    this._clearDismissTimer();
+
     if (ev.target && portalContainsElement(ev.target as HTMLElement, this._getTargetElement())) {
       // Do not show tooltip when target is inside a portal relative to TooltipHost.
       return;
     }
 
     this._toggleTooltip(true);
-    this._clearDismissTimer();
   };
 
   // Hide Tooltip


### PR DESCRIPTION
This PR is a port of #9519 to 6.0

Pull request checklist
- [x] Addresses an existing issue: Fixes #9464
- [x] Include a change request file using $ npm run change

Description of changes
This PR moves the clear dismiss timer before the portals if condition check.

Before these changes, the portals if condition check was short-circuiting the clear dismiss timer that the tooltips with a closeDelay prop are dependent on. Even when a user was interacting with a tooltip, the tooltip would close after the delay time specified by closeDelay.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9727)