### PR TITLE
 Adding toopltipHostProps as a prop to the Breadcrumb component. (#9701)

### DIFF
--- a/change/office-ui-fabric-react-2019-07-03-17-47-46-breadcrumb-callout-props.json
+++ b/change/office-ui-fabric-react-2019-07-03-17-47-46-breadcrumb-callout-props.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Adding tooltipHostProps as a prop to the Breadcrumb component.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "Heather.HoaglundBiron@microsoft.com",
+  "commit": "0e7737eb466ec78bea0f7174049499aa792fbddb",
+  "date": "2019-07-04T00:47:46.188Z"
+}

--- a/common/changes/office-ui-fabric-react/port-breadcrumb-update_2019-07-08-18-34.json
+++ b/common/changes/office-ui-fabric-react/port-breadcrumb-update_2019-07-08-18-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Adding toopltipHostProps as a prop to the Breadcrumb component.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "heath@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1791,6 +1791,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     styles?: IStyleFunctionOrObject<IBreadcrumbStyleProps, IBreadcrumbStyles>;
     // (undocumented)
     theme?: ITheme;
+    tooltipHostProps?: ITooltipHostProps;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -163,7 +163,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
           aria-current={item.isCurrentItem ? 'page' : undefined}
           onClick={this._onBreadcrumbClicked.bind(this, item)}
         >
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent}>
+          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {item.text}
           </TooltipHost>
         </Link>
@@ -171,7 +171,7 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
     } else {
       return (
         <span className={this._classNames.item}>
-          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent}>
+          <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {item.text}
           </TooltipHost>
         </span>

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -3,6 +3,7 @@ import { IIconProps } from '../../Icon';
 import { IRefObject, IRenderFunction, IComponentAs, IStyleFunctionOrObject } from '../../Utilities';
 import { ITheme, IStyle } from '../../Styling';
 import { IFocusZoneProps } from '../../FocusZone';
+import { ITooltipHostProps } from '../../Tooltip';
 
 /**
  * {@docCategory Breadcrumb}
@@ -86,6 +87,11 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    * Focuszone props that will get passed through to the root focus zone.
    */
   focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * TooltipHost props that will get passed through to overflow tooltips.
+   */
+  tooltipHostProps?: ITooltipHostProps;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Porting over the change I made here: https://github.com/OfficeDev/office-ui-fabric-react/pull/9701

We want to be able to use this change in my team's library, which is currently using 6.x.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9729)