### PR TITLE
Dialog: Deprecating componentRef prop

### DIFF
--- a/change/office-ui-fabric-react-2019-07-08-11-10-48-dialogComponentRef.json
+++ b/change/office-ui-fabric-react-2019-07-08-11-10-48-dialogComponentRef.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Dialog: Deprecating componentRef prop.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "ce7e6ffc84e7272a193d9cde863767dfc91fac7a",
+  "date": "2019-07-08T18:10:48.693Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3733,6 +3733,7 @@ export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithRe
     ariaLabelledById?: string;
     // @deprecated
     className?: string;
+    // @deprecated
     componentRef?: IRefObject<IDialog>;
     // @deprecated
     containerClassName?: string;

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -21,7 +21,7 @@ export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithRe
   /**
    * Optional callback to access the IDialog interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
-   * @deprecated Deprecating because the ref was returning an empty object given that IDialog interface is empty.
+   * @deprecated Unused, returns no value
    */
   componentRef?: IRefObject<IDialog>;
 

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -21,6 +21,7 @@ export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithRe
   /**
    * Optional callback to access the IDialog interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
+   * @deprecated Deprecating because the ref was returning an empty object given that IDialog interface is empty.
    */
   componentRef?: IRefObject<IDialog>;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Issue #9703 made it apparent that the `componentRef` prop of the `Dialog` component was returning an empty object because the `IDialog` interface was empty. This PR deprecates `componentRef` so that its inclusion doesn't cause confusion anymore.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9730)