### PR TITLE
FocusTrapZone: Updating overview description to indicate restriction of website interaction

### DIFF
--- a/change/office-ui-fabric-react-2019-07-08-14-00-46-focusTrapZoneOverview.json
+++ b/change/office-ui-fabric-react-2019-07-08-14-00-46-focusTrapZoneOverview.json
@@ -1,0 +1,8 @@
+{
+  "comment": "FocusTrapZone: Updating overview description to indicate restriction of website interaction.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "a56fc9fb319b8d938d6c92af516c015d4b4c00a3",
+  "date": "2019-07-08T21:00:46.779Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md
@@ -1,1 +1,3 @@
 FocusTrapZone is used to trap the focus in any html element. Pressing tab will circle focus within the inner focusable elements of the FocusTrapZone.
+
+**Note:** Trapping focus will restrict interaction with other elements in the website such as the side nav. Exit trapped focus state to allow this interaction to happen again.

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md
@@ -1,3 +1,3 @@
 FocusTrapZone is used to trap the focus in any html element. Pressing tab will circle focus within the inner focusable elements of the FocusTrapZone.
 
-**Note:** Trapping focus will restrict interaction with other elements in the website such as the side nav. Exit trapped focus state to allow this interaction to happen again.
+**Note:** Trapping focus will restrict interaction with other elements in the website such as the side nav. Turn off the "Use trap zone" toggle control to allow this interaction to happen again.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9633
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds a description in the overview section of the `FocusTrapZone` component page to indicate that interaction with the website will be restricted while focus is trapped so that users are not caught off-guard by this.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9732)