### PR TITLE
Automatically generate webpack alias for a single webpack.serve.config.js

### DIFF
--- a/apps/fabric-website-resources/webpack.serve.config.js
+++ b/apps/fabric-website-resources/webpack.serve.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
 const resources = require('../../scripts/webpack/webpack-resources');
 
 module.exports = resources.createServeConfig({
@@ -14,15 +14,6 @@ module.exports = resources.createServeConfig({
   },
 
   resolve: {
-    alias: {
-      'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
-      'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
-      'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
-      '@uifabric/fluent-theme$': path.resolve(__dirname, '../../packages/fluent-theme/src'),
-      '@uifabric/mdl2-theme$': path.resolve(__dirname, '../../packages/mdl2-theme/src'),
-      '@uifabric/theme-samples$': path.resolve(__dirname, '../../packages/theme-samples/src'),
-      'Props.ts.js': 'Props',
-      'Example.tsx.js': 'Example'
-    }
+    alias: getResolveAlias()
   }
 });

--- a/change/@uifabric-fabric-website-resources-2019-07-08-15-55-51-alias.json
+++ b/change/@uifabric-fabric-website-resources-2019-07-08-15-55-51-alias.json
@@ -1,0 +1,8 @@
+{
+  "comment": "automatically generate webpack alias for npm start - part 1",
+  "type": "none",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "kchau@microsoft.com",
+  "commit": "b103de0cb556f6cf4dfe2648b990c07b37d6b988",
+  "date": "2019-07-08T22:55:51.178Z"
+}

--- a/scripts/monorepo/findGitRoot.js
+++ b/scripts/monorepo/findGitRoot.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+function findGitRoot() {
+  let cwd = process.cwd();
+  const root = path.parse(cwd).root;
+  let found = false;
+  while (!found && cwd !== root) {
+    if (fs.existsSync(path.join(cwd, '.git'))) {
+      found = true;
+      break;
+    }
+
+    cwd = path.dirname(cwd);
+  }
+
+  return cwd;
+}
+
+module.exports = findGitRoot;

--- a/scripts/monorepo/findRepoDeps.js
+++ b/scripts/monorepo/findRepoDeps.js
@@ -1,5 +1,5 @@
 const { spawnSync } = require('child_process');
-const fs = require('fs');
+const { readConfig } = require('../read-config');
 const path = require('path');
 const findGitRoot = require('./findGitRoot');
 
@@ -39,7 +39,7 @@ function getDeps(packageJson) {
 function findRepoDeps() {
   const packageInfo = getAllPackageInfo();
   let cwd = process.cwd();
-  const packageJson = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
+  const packageJson = readConfig(path.join(cwd, 'package.json'));
   const packageDeps = getDeps(packageJson);
   const result = new Set();
 

--- a/scripts/monorepo/findRepoDeps.js
+++ b/scripts/monorepo/findRepoDeps.js
@@ -14,7 +14,7 @@ function getAllPackageInfo() {
     .map(line => line.trim())
     .filter(line => line.endsWith('package.json'))
     .forEach(packageJsonFile => {
-      const packageJson = JSON.parse(fs.readFileSync(path.join(gitRoot, packageJsonFile), 'utf-8'));
+      const packageJson = readConfig(path.join(gitRoot, packageJsonFile));
       packageInfo[packageJson.name] = {
         packagePath: path.dirname(packageJsonFile),
         packageJson
@@ -32,6 +32,10 @@ function getDeps(packageJson) {
   return Object.keys({ ...(packageJson.dependencies || {}), ...(packageJson.devDependencies || {}) });
 }
 
+/**
+ * Find all the dependencies (and their dependencies) within the repo for a specific package (in the CWD when this was called)
+ * @returns {{ packagePath: string; packageJson: any }[]}
+ */
 function findRepoDeps() {
   const packageInfo = getAllPackageInfo();
   let cwd = process.cwd();

--- a/scripts/monorepo/findRepoDeps.js
+++ b/scripts/monorepo/findRepoDeps.js
@@ -29,7 +29,7 @@ function getDeps(packageJson) {
     return [];
   }
 
-  return [...Object.keys(packageJson.dependencies || {}), ...Object.keys(packageJson.devDependencies || {})];
+  return Object.keys({ ...(packageJson.dependencies || {}), ...(packageJson.devDependencies || {}) });
 }
 
 function findRepoDeps() {

--- a/scripts/monorepo/findRepoDeps.js
+++ b/scripts/monorepo/findRepoDeps.js
@@ -1,0 +1,63 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const findGitRoot = require('./findGitRoot');
+
+function getAllPackageInfo() {
+  const gitRoot = findGitRoot();
+  const results = spawnSync('git', ['ls-tree', '-r', '--name-only', '--full-tree', 'HEAD']);
+  const packageInfo = {};
+
+  results.stdout
+    .toString()
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.endsWith('package.json'))
+    .forEach(packageJsonFile => {
+      const packageJson = JSON.parse(fs.readFileSync(path.join(gitRoot, packageJsonFile), 'utf-8'));
+      packageInfo[packageJson.name] = {
+        packagePath: path.dirname(packageJsonFile),
+        packageJson
+      };
+    });
+
+  return packageInfo;
+}
+
+function getDeps(packageJson) {
+  if (!packageJson) {
+    return [];
+  }
+
+  return [...Object.keys(packageJson.dependencies || {}), ...Object.keys(packageJson.devDependencies || {})];
+}
+
+function findRepoDeps() {
+  const packageInfo = getAllPackageInfo();
+  let cwd = process.cwd();
+  const packageJson = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
+  const packageDeps = getDeps(packageJson);
+  const result = new Set();
+
+  while (packageDeps.length > 0) {
+    const dep = packageDeps.pop();
+
+    if (dep && packageInfo[dep]) {
+      result.add(dep);
+    }
+
+    getDeps(dep.packageJson).forEach(child => {
+      if (!result.has(child)) {
+        packageDeps.push(child);
+      }
+    });
+  }
+
+  return [...result].map(dep => packageInfo[dep]);
+}
+
+module.exports = findRepoDeps;
+
+if (require.main === module) {
+  console.log(findRepoDeps());
+}

--- a/scripts/webpack/getResolveAlias.js
+++ b/scripts/webpack/getResolveAlias.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const findRepoDeps = require('../monorepo/findRepoDeps');
+const findGitRoot = require('../monorepo/findGitRoot');
+
+function getResolveAlias() {
+  const gitRoot = findGitRoot();
+  const deps = findRepoDeps();
+  const alias = {};
+  const excludedPackages = ['@uifabric/api-docs'];
+
+  deps.forEach(depInfo => {
+    if (!depInfo.packageJson.private && !excludedPackages.includes(depInfo.packageJson.name)) {
+      alias[`${depInfo.packageJson.name}$`] = path.join(gitRoot, depInfo.packagePath, 'src');
+      alias[`${depInfo.packageJson.name}/src`] = path.join(gitRoot, depInfo.packagePath, 'src');
+      alias[`${depInfo.packageJson.name}/lib`] = path.join(gitRoot, depInfo.packagePath, 'src');
+    }
+  });
+
+  return alias;
+}
+
+module.exports = getResolveAlias;
+
+if (require.main === module) {
+  console.log(getResolveAlias());
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

We are now able to generate dependent packages for the alias path so that when those changes are modified, the app will rebundle - previously, multiple tsc watches had to run to get this experience.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9735)