### PR TITLE
Tooltip: Fixing 'persist on scroll' issues

### DIFF
--- a/change/office-ui-fabric-react-2019-07-09-16-44-29-tooltipHover.json
+++ b/change/office-ui-fabric-react-2019-07-09-16-44-29-tooltipHover.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Tooltip: Fixing 'persist on scroll' issues.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "eca43a063b66456426959e89bc1c32df7de9fc67",
+  "date": "2019-07-09T23:44:29.420Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -332,8 +332,8 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
       this._disposables.push(
         on(this._targetWindow, 'scroll', this._dismissOnScroll, true),
         on(this._targetWindow, 'resize', this._dismissOnResize, true),
-        on(this._targetWindow.document.documentElement as any, 'focus', this._dismissOnLostFocus, true), // FABRIC7TODO remove any
-        on(this._targetWindow.document.documentElement as any, 'click', this._dismissOnLostFocus, true) // FABRIC7TODO remove any
+        on(this._targetWindow.document.documentElement, 'focus', this._dismissOnLostFocus, true),
+        on(this._targetWindow.document.documentElement, 'click', this._dismissOnLostFocus, true)
       );
       this._hasListeners = true;
     }, 0);

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -93,6 +93,7 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
             directionalHint={directionalHint}
             directionalHintForRTL={directionalHintForRTL}
             calloutProps={assign({}, calloutProps, {
+              onDismiss: this._hideTooltip,
               onMouseEnter: this._onTooltipMouseEnter,
               onMouseLeave: this._onTooltipMouseLeave
             })}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -99,6 +99,7 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
             })}
             onMouseEnter={this._onTooltipMouseEnter}
             onMouseLeave={this._onTooltipMouseLeave}
+            onWheel={this._hideTooltip}
             {...getNativeProps(this.props, divProperties)}
             {...tooltipProps}
           />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9694
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR fixes some issues that existed on the `Tooltip` component:
- The `Tooltip` was not dismissing on scroll when the focus was on the element
- The `Tooltip` was not dismissing on scroll until the scroll stopped
- You couldn't scroll the document when hovering over a `Tooltip`

The first two bugs was introduced in Fabric 5.77.0 as part of PR #4364.

#### Focus areas to test

- Hover over a component with a `Tooltip` in the `Tooltip` examples page and notice the difference between the live website and this PR when scrolling after the `Tooltip` appears.
- Move focus with your keyboard over a component with a `Tooltip` in the `Tooltip` examples page and notice the difference between the live website and this PR when scrolling after the `Tooltip` appears.
- Hover over a `Tooltip` in the `Tooltip` examples page (easiest to do this is the `Tooltip with delay closing`). Once you are hovering the `Tooltip`, start scrolling and notice the difference between the live website and this PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9749)