### PR TITLE
Removing exports of 'utilities/selection' from DetailsList and MarqueeSelection and updating imports where used

### DIFF
--- a/apps/theming-designer/src/components/AccessibilityDetailsList.tsx
+++ b/apps/theming-designer/src/components/AccessibilityDetailsList.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
-import {
-  DetailsList,
-  DetailsRow,
-  IDetailsRowStyles,
-  IDetailsRowProps,
-  IColumn,
-  IGroup,
-  SelectionMode
-} from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsRow, IDetailsRowStyles, IDetailsRowProps, IColumn, IGroup } from 'office-ui-fabric-react/lib/DetailsList';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
+import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 import { ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { IContrastRatioPair } from './AccessibilityChecker';
 

--- a/apps/theming-designer/src/components/SemanticSlotsDetailsList.tsx
+++ b/apps/theming-designer/src/components/SemanticSlotsDetailsList.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 
-import {
-  DetailsList,
-  DetailsRow,
-  IDetailsRowStyles,
-  IDetailsRowProps,
-  IColumn,
-  IGroup,
-  SelectionMode
-} from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsRow, IDetailsRowStyles, IDetailsRowProps, IColumn, IGroup } from 'office-ui-fabric-react/lib/DetailsList';
+import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 
 export interface ISemanticSlotsDetailsListProps {
   slotNames: string[];

--- a/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.DetailsList.stories.tsx
@@ -7,7 +7,6 @@ import {
   DetailsList,
   DetailsListLayoutMode,
   IDetailsHeaderProps,
-  Selection,
   IColumn,
   ConstrainMode,
   IDetailsFooterProps,
@@ -18,7 +17,7 @@ import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Toolt
 import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
+import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { getTheme, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 

--- a/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
@@ -7,7 +7,6 @@ import {
   DetailsList,
   DetailsListLayoutMode,
   IDetailsHeaderProps,
-  Selection,
   IColumn,
   ConstrainMode,
   IDetailsFooterProps,
@@ -20,7 +19,7 @@ import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Toolt
 import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
+import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';
 import { createGroups } from 'office-ui-fabric-react/lib/utilities/exampleData';

--- a/apps/vr-tests/src/stories/Sticky.Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Sticky.Breadcrumb.stories.tsx
@@ -7,7 +7,6 @@ import {
   DetailsList,
   DetailsListLayoutMode,
   IDetailsHeaderProps,
-  Selection,
   IColumn,
   ConstrainMode,
   IDetailsFooterProps,
@@ -18,7 +17,7 @@ import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Toolt
 import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
+import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 import { Breadcrumb } from 'office-ui-fabric-react/lib/Breadcrumb';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';

--- a/change/office-ui-fabric-react-2019-07-09-17-40-18-selectionExport.json
+++ b/change/office-ui-fabric-react-2019-07-09-17-40-18-selectionExport.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Removing exports of 'utilities/selection' from DetailsList and MarqueeSelection and updating imports where used.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "8a22d83102415aff23f9aba888adb70c3c9b8aaa",
+  "date": "2019-07-10T00:40:18.085Z"
+}

--- a/packages/office-ui-fabric-react/src/MarqueeSelection.ts
+++ b/packages/office-ui-fabric-react/src/MarqueeSelection.ts
@@ -1,3 +1,2 @@
 export * from './components/MarqueeSelection/MarqueeSelection';
 export * from './components/MarqueeSelection/MarqueeSelection.types';
-export * from './utilities/selection/index';

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.BulkOperations.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.BulkOperations.Example.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { Announced } from 'office-ui-fabric-react/lib/Announced';
+import { DetailsList, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { DetailsList, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
-import { Text } from 'office-ui-fabric-react/lib/Text';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { IStackTokens, Stack } from 'office-ui-fabric-react/lib/Stack';
-import { IDragDropEvents } from 'office-ui-fabric-react/lib/utilities/dragdrop/interfaces';
 import { mergeStyles, getTheme } from 'office-ui-fabric-react/lib/Styling';
+import { Text } from 'office-ui-fabric-react/lib/Text';
+import { IDragDropEvents } from 'office-ui-fabric-react/lib/utilities/dragdrop/interfaces';
 
 const _items: IFileExampleItem[] = [];
 

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.QuickActions.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.QuickActions.Example.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { Announced } from 'office-ui-fabric-react/lib/Announced';
+import { IconButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import {
   DetailsList,
   DetailsListLayoutMode,
-  Selection,
   IColumn,
   IDetailsList,
   IDetailsRowProps,
   DetailsRow
 } from 'office-ui-fabric-react/lib/DetailsList';
-import { Async } from 'office-ui-fabric-react/lib/Utilities';
-import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { IconButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { TextField, ITextField } from 'office-ui-fabric-react/lib/TextField';
+import { Async } from 'office-ui-fabric-react/lib/Utilities';
 
 const _items: IAnnouncedQuickActionsExampleItem[] = [];
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { Link } from 'office-ui-fabric-react/lib/Link';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
 import { IContextualMenuProps, IContextualMenuItem, DirectionalHint, ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
 import {
@@ -10,15 +8,16 @@ import {
   DetailsList,
   DetailsListLayoutMode,
   IColumn,
+  IDetailsColumnProps,
   IGroup,
-  Selection,
-  SelectionMode,
   buildColumns
 } from 'office-ui-fabric-react/lib/DetailsList';
-import { createListItems, isGroupable, IExampleItem } from 'office-ui-fabric-react/lib/utilities/exampleData';
-import { IDetailsColumnProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
-import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 import { getTheme, mergeStyles, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { createListItems, isGroupable, IExampleItem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 
 const theme = getTheme();
 const classNames = mergeStyleSets({

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
-import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { DetailsList, DetailsListLayoutMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
 
 const exampleChildClass = mergeStyles({
   display: 'block',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
-import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { DetailsList, DetailsListLayoutMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
 
 const exampleChildClass = mergeStyles({
   display: 'block',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
@@ -5,10 +5,10 @@ import {
   IColumn,
   IDetailsFooterProps,
   DetailsRow,
-  SelectionMode,
   IDetailsRowCheckProps,
   DetailsRowCheck
 } from 'office-ui-fabric-react/lib/DetailsList';
+import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
 
 export interface IDetailsListCustomFooterExampleItem {
   key: number;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
+import { DetailsList, DetailsListLayoutMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
+import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
-import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
-import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
-import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 
 const classNames = mergeStyleSets({
   fileIconHeaderIcon: {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
+import { DetailsList, IColumn, buildColumns, IColumnReorderOptions } from 'office-ui-fabric-react/lib/DetailsList';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { DetailsList, Selection, IColumn, buildColumns, IColumnReorderOptions } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { IDragDropEvents, IDragDropContext } from 'office-ui-fabric-react/lib/utilities/dragdrop/interfaces';
-import { createListItems, IExampleItem } from 'office-ui-fabric-react/lib/utilities/exampleData';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
+import { getTheme, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 import { TextField, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
-import { getTheme, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { IDragDropEvents, IDragDropContext } from 'office-ui-fabric-react/lib/utilities/dragdrop/interfaces';
+import { createListItems, IExampleItem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 
 const theme = getTheme();
 const margin = '0 30px 20px 0';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -1,4 +1,3 @@
-export * from '../../utilities/selection/index';
 export * from '../GroupedList/GroupedList.types';
 export * from './DetailsHeader';
 export * from './DetailsHeader.base';

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { KeyCodes, createArray, getRTLSafeKeyCode } from 'office-ui-fabric-react/lib/Utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { DetailsRow, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
-import { DetailsRow, IColumn, Selection, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
+import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Selection, SelectionMode } from 'office-ui-fabric-react/lib/Selection';
+import { KeyCodes, createArray, getRTLSafeKeyCode } from 'office-ui-fabric-react/lib/Utilities';
 
 const ITEMS = createArray(10, index => ({
   key: index.toString(),

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/examples/MarqueeSelection.Basic.Example.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
-import { css, createArray } from 'office-ui-fabric-react/lib/Utilities';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { MarqueeSelection, Selection, IObjectWithKey } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
+import { Selection, IObjectWithKey } from 'office-ui-fabric-react/lib/Selection';
+import { css, createArray } from 'office-ui-fabric-react/lib/Utilities';
 import * as styles from './MarqueeSelection.Basic.Example.scss';
 
 interface IPhoto extends IObjectWithKey {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/examples/ScrollablePane.DetailsList.Example.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import {
   DetailsList,
   DetailsListLayoutMode,
   IDetailsHeaderProps,
-  Selection,
   IColumn,
   ConstrainMode,
   IDetailsFooterProps,
   DetailsRow
 } from 'office-ui-fabric-react/lib/DetailsList';
-import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
-import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
-import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
-import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
-import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
+import { ScrollablePane, ScrollbarVisibility } from 'office-ui-fabric-react/lib/ScrollablePane';
+import { Selection } from 'office-ui-fabric-react/lib/Selection';
+import { Sticky, StickyPositionType } from 'office-ui-fabric-react/lib/Sticky';
 import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { TooltipHost, ITooltipHostProps } from 'office-ui-fabric-react/lib/Tooltip';
+import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { SelectionMode } from 'office-ui-fabric-react/lib/utilities/selection/index';
 
 const classNames = mergeStyleSets({
   wrapper: {

--- a/packages/office-ui-fabric-react/src/components/Text/examples/Text.Ramp.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Text/examples/Text.Ramp.Example.tsx
@@ -1,14 +1,8 @@
-import { Text } from 'office-ui-fabric-react/lib/Text';
-import { IFontStyles } from 'office-ui-fabric-react/lib/Styling';
-import {
-  DetailsList,
-  IColumn,
-  DetailsListLayoutMode,
-  SelectionMode,
-  DetailsRow,
-  IDetailsRowProps
-} from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
+import { DetailsList, IColumn, DetailsListLayoutMode, DetailsRow, IDetailsRowProps } from 'office-ui-fabric-react/lib/DetailsList';
+import { SelectionMode } from 'office-ui-fabric-react/lib/Selection';
+import { IFontStyles } from 'office-ui-fabric-react/lib/Styling';
+import { Text } from 'office-ui-fabric-react/lib/Text';
 
 const TestText = 'The quick brown fox jumped over the lazy dog.';
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9661
- [x] Include a change request file using `$ npm run change`

#### Description of changes

While investigating issue #9661, it became clear that we had multiple exports of `utilities/selection/index` in:
- `office-ui-fabric-react/lib/DetailsList`
- `office-ui-fabric-react/lib/MarqueeSelection`
- `office-ui-fabric-react/lib/Selection`

This created an issue where trying to access any component from these paths gave an error saying that it was redefining a property. To avoid this I'm removing the exports in both `DetailsList` and `MarqueeSelection` and updating all the places where these imports were being used.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9750)