### PR TITLE
Disable unreliable TextField tests

### DIFF
--- a/change/office-ui-fabric-react-2019-07-09-18-22-25-textfield-test.json
+++ b/change/office-ui-fabric-react-2019-07-09-18-22-25-textfield-test.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Disable unreliable TextField tests",
+  "type": "none",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "7e7d86e0b755d16cc9a52d78ede02164a06da891",
+  "date": "2019-07-10T01:22:25.645Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -323,7 +323,8 @@ describe('TextField with error message', () => {
     assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX);
   });
 
-  it('should render error message when onGetErrorMessage returns a Promise<string>', () => {
+  // disabling due to inconsistent behavior
+  xit('should render error message when onGetErrorMessage returns a Promise<string>', () => {
     function validator(value: string): Promise<string> {
       return Promise.resolve(value.length > 3 ? errorMessage : '');
     }
@@ -337,19 +338,20 @@ describe('TextField with error message', () => {
     return delay(20).then(() => assertErrorMessage(wrapper!.getDOMNode(), errorMessage));
   });
 
-  // it('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
-  //   function validator(value: string): Promise<string | JSX.Element> {
-  //     return Promise.resolve(value.length > 3 ? errorMessageJSX : '');
-  //   }
+  // disabling due to inconsistent behavior
+  xit('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
+    function validator(value: string): Promise<string | JSX.Element> {
+      return Promise.resolve(value.length > 3 ? errorMessageJSX : '');
+    }
 
-  //   wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />);
+    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />);
 
-  //   const inputDOM = wrapper.getDOMNode().querySelector('input');
-  //   ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
+    const inputDOM = wrapper.getDOMNode().querySelector('input');
+    ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
 
-  //   // TODO: make this work with fake timers not real timers
-  //   return delay(20).then(() => assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX));
-  // });
+    // TODO: make this work with fake timers not real timers
+    return delay(20).then(() => assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX));
+  });
 
   it('should render error message on first render when onGetErrorMessage returns a string', () => {
     jest.useFakeTimers();
@@ -359,7 +361,8 @@ describe('TextField with error message', () => {
     assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
   });
 
-  it('should render error message on first render when onGetErrorMessage returns a Promise<string>', () => {
+  // disabling due to inconsistent behavior
+  xit('should render error message on first render when onGetErrorMessage returns a Promise<string>', () => {
     wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={() => Promise.resolve(errorMessage)} />);
 
     // TODO: make this work with fake timers not real timers


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ npm run change`

#### Description of changes

Disabling some of the TextField tests involving async operations because they're unreliable.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9752)