### PR TITLE
T mashia/groupheader add role and name

### DIFF
--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -87,7 +87,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     }
     // set default aria label if expandButtonProps['aria-label'] is not defined.
     if (!expandButtonProps['aria-label']) {
-      expandButtonProps['aria-label'] = group.isCollapsed ? 'expand list' : 'collapse list';
+      expandButtonProps['aria-label'] = group.isCollapsed ? 'expand group' : 'collapse group';
     }
 
     return (

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -16,10 +16,6 @@ export interface IGroupHeaderState {
 }
 
 export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHeaderState> {
-  public static defaultProps: IGroupHeaderProps = {
-    expandButtonProps: { 'aria-label': 'expand collapse group' }
-  };
-
   private _classNames: IClassNames<IGroupHeaderStyles>;
 
   constructor(props: IGroupHeaderProps) {
@@ -56,7 +52,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       indentWidth,
       onRenderTitle = this._onRenderTitle,
       isCollapsedGroupSelectVisible = true,
-      expandButtonProps,
       selectAllButtonProps,
       theme,
       styles,
@@ -64,6 +59,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       groupedListId,
       compact
     } = this.props;
+
+    let { expandButtonProps } = this.props;
 
     const { isCollapsed, isLoadingVisible } = this.state;
 
@@ -84,6 +81,15 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     if (!group) {
       return null;
     }
+
+    if (!expandButtonProps) {
+      expandButtonProps = {};
+    }
+    // set default aria label if expandButtonProps['aria-label'] is not defined.
+    if (!expandButtonProps['aria-label']) {
+      expandButtonProps['aria-label'] = group.isCollapsed ? 'expand list' : 'collapse list';
+    }
+
     return (
       <div
         className={this._classNames.root}
@@ -110,7 +116,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
           )}
 
           <GroupSpacer indentWidth={indentWidth} count={groupLevel!} />
-
           <div className={this._classNames.dropIcon}>
             <Icon iconName="Tag" />
           </div>
@@ -120,7 +125,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
             onClick={this._onToggleCollapse}
             aria-expanded={group ? !group.isCollapsed : undefined}
             aria-controls={group && !group.isCollapsed ? groupedListId : undefined}
-            aria-label={group.isCollapsed ? 'expand list' : 'collapse list'}
+            {...expandButtonProps}
           >
             <Icon className={this._classNames.expandIsCollapsed} iconName={isRTL ? 'ChevronLeftMed' : 'ChevronRightMed'} />
           </button>

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -118,11 +118,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
             type="button"
             className={this._classNames.expand}
             onClick={this._onToggleCollapse}
-            aria-role={group.isCollapsed ? 'expand' : 'close'}
-            aria-name="button to expand or close"
             aria-expanded={group ? !group.isCollapsed : undefined}
             aria-controls={group && !group.isCollapsed ? groupedListId : undefined}
-            {...expandButtonProps}
+            aria-label={group.isCollapsed ? 'expand list' : 'collapse list'}
           >
             <Icon className={this._classNames.expandIsCollapsed} iconName={isRTL ? 'ChevronLeftMed' : 'ChevronRightMed'} />
           </button>

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -118,6 +118,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
             type="button"
             className={this._classNames.expand}
             onClick={this._onToggleCollapse}
+            aria-role={group.isCollapsed ? 'expand' : 'close'}
+            aria-name="button to expand or close"
             aria-expanded={group ? !group.isCollapsed : undefined}
             aria-controls={group && !group.isCollapsed ? groupedListId : undefined}
             {...expandButtonProps}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
@@ -17,7 +17,10 @@ export interface IGroupHeaderProps extends IGroupDividerProps {
    */
   groupedListId?: string;
 
-  /** Native props for the GroupHeader expand and collapse button */
+  /** 
+  * Native props for the GroupHeader expand and collapse button 
+  * 'aria-label' defaults to 'expand group' if `group.isCollapsed` is true and 'collapse group' if `group.isCollapsed' is false
+  */
   expandButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
 
   /** Native props for the GroupHeader select all button */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
This PR fixes an accessibility bug found on SharePoint with the 'ChevronRightMed' header cell icon on specific lists. This helps properly define the name and role of this button so that screen reader users will be able to get better information about this control and how they can use it. Previously, the ARIA-label was "expand collapse group", which was generic.
(When I ran npm run change, the output said "no change files are needed")

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9758)