### PR TITLE
Fix Marquee selection clobbering Selection events

### DIFF
--- a/change/office-ui-fabric-react-2019-07-10-13-22-00-marquee-selection.json
+++ b/change/office-ui-fabric-react-2019-07-10-13-22-00-marquee-selection.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Only clear selection in MarqueeSelection when starting a new marquee",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "ed153240bd10909f2879139cfc2b58822730140b",
+  "date": "2019-07-10T20:22:00.499Z"
+}

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -139,10 +139,6 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
       return;
     }
 
-    if (!ev.shiftKey) {
-      this.props.selection.setAllSelected(false);
-    }
-
     if (!this._isTouch && isEnabled && !this._isDragStartInSelection(ev) && (!onShouldStartSelection || onShouldStartSelection(ev))) {
       if (this._scrollableSurface && ev.button === 0 && this._root.current) {
         this._selectedIndicies = {};
@@ -218,6 +214,10 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
       if (this.state.dragRect || getDistanceBetweenPoints(this._dragOrigin, currentPoint) > MIN_DRAG_DISTANCE) {
         if (!this.state.dragRect) {
           const { selection } = this.props;
+
+          if (!ev.shiftKey) {
+            selection.setAllSelected(false);
+          }
 
           this._preservedIndicies = selection && selection.getSelectedIndices && selection.getSelectedIndices();
         }


### PR DESCRIPTION
Fixed an issue where recent additions to `MarqueeSelection` to support shift-select were clobbering multi-select behaviors and clearing selection prematurely.

Moved the logic added in `MarqueeSelection` to clear selection only once the drag threshold has been met and a new marquee drag is started.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9762)