### PR TITLE
Dropdown: adding onRenderLabel custom renderer prop

### DIFF
--- a/change/office-ui-fabric-react-2019-07-10-18-58-24-shield-DropdownLabelRenderer.json
+++ b/change/office-ui-fabric-react-2019-07-10-18-58-24-shield-DropdownLabelRenderer.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Dropdown: adds an `onRenderLabel` custom renderer prop.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "5c848eb0915176ae13977801c9574dd9fc9f8895",
+  "date": "2019-07-11T01:58:24.774Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4253,6 +4253,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
     onChanged?: (option: IDropdownOption, index?: number) => void;
     onDismiss?: () => void;
     onRenderCaretDown?: IRenderFunction<IDropdownProps>;
+    onRenderLabel?: IRenderFunction<IDropdownProps>;
     // @deprecated
     onRenderPlaceHolder?: IRenderFunction<IDropdownProps>;
     onRenderPlaceholder?: IRenderFunction<IDropdownProps>;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -200,7 +200,8 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       calloutProps,
       onRenderTitle = this._onRenderTitle,
       onRenderContainer = this._onRenderContainer,
-      onRenderCaretDown = this._onRenderCaretDown
+      onRenderCaretDown = this._onRenderCaretDown,
+      onRenderLabel = this._onRenderLabel
     } = props;
     const { isOpen, selectedIndices, hasFocus, calloutRenderEdge } = this.state;
     const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._onRenderPlaceholder;
@@ -246,23 +247,9 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       calloutRenderEdge: calloutRenderEdge
     });
 
-    const labelStyles = this._classNames.subComponentStyles
-      ? (this._classNames.subComponentStyles.label as IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>)
-      : undefined;
     return (
       <div className={this._classNames.root}>
-        {label && (
-          <Label
-            className={this._classNames.label}
-            id={id + '-label'}
-            htmlFor={id}
-            required={required}
-            styles={labelStyles}
-            disabled={disabled}
-          >
-            {label}
-          </Label>
-        )}
+        {onRenderLabel(this.props, this._onRenderLabel)}
         <KeytipData keytipProps={keytipProps} disabled={disabled}>
           {(keytipAttributes: any): JSX.Element => (
             <div
@@ -627,7 +614,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
         }}
         label={item.text}
         title={item.title ? item.title : item.text}
-        onRenderLabel={this._onRenderLabel.bind(this, item)}
+        onRenderLabel={this._onRenderItemLabel.bind(this, item)}
         className={itemClassName}
         role="option"
         aria-selected={isItemSelected ? 'true' : 'false'}
@@ -642,7 +629,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   };
 
   /** Render custom label for drop down item */
-  private _onRenderLabel = (item: IDropdownOption): JSX.Element | null => {
+  private _onRenderItemLabel = (item: IDropdownOption): JSX.Element | null => {
     const { onRenderOption = this._onRenderOption } = this.props;
     return onRenderOption(item, this._onRenderOption);
   };
@@ -1077,5 +1064,20 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     }
 
     return disabled;
+  };
+
+  private _onRenderLabel = (props: IDropdownProps): JSX.Element | null => {
+    const id = this._id;
+    const { label, required } = props;
+
+    const labelStyles = this._classNames.subComponentStyles
+      ? (this._classNames.subComponentStyles.label as IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>)
+      : undefined;
+
+    return label ? (
+      <Label className={this._classNames.label} id={id + '-label'} htmlFor={id} required={required} styles={labelStyles}>
+        {label}
+      </Label>
+    ) : null;
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -1068,14 +1068,21 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
 
   private _onRenderLabel = (props: IDropdownProps): JSX.Element | null => {
     const id = this._id;
-    const { label, required } = props;
+    const { label, required, disabled } = props;
 
     const labelStyles = this._classNames.subComponentStyles
       ? (this._classNames.subComponentStyles.label as IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles>)
       : undefined;
 
     return label ? (
-      <Label className={this._classNames.label} id={id + '-label'} htmlFor={id} required={required} styles={labelStyles}>
+      <Label
+        className={this._classNames.label}
+        id={id + '-label'}
+        htmlFor={id}
+        required={required}
+        styles={labelStyles}
+        disabled={disabled}
+      >
         {label}
       </Label>
     ) : null;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -57,6 +57,11 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   onDismiss?: () => void;
 
   /**
+   * Custom render function for the label.
+   */
+  onRenderLabel?: IRenderFunction<IDropdownProps>;
+
+  /**
    * Optional custom renderer for placeholder text
    */
   onRenderPlaceholder?: IRenderFunction<IDropdownProps>;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/examples/Dropdown.Custom.Example.tsx
@@ -1,35 +1,52 @@
 import * as React from 'react';
 import { Dropdown, DropdownMenuItemType, IDropdownOption, IDropdownProps } from 'office-ui-fabric-react/lib/Dropdown';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { IStackTokens, Stack } from 'office-ui-fabric-react/lib/Stack';
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
+
+const exampleOptions: IDropdownOption[] = [
+  { key: 'Header', text: 'Options', itemType: DropdownMenuItemType.Header },
+  { key: 'A', text: 'Option a', data: { icon: 'Memo' } },
+  { key: 'B', text: 'Option b', data: { icon: 'Print' } },
+  { key: 'C', text: 'Option c', data: { icon: 'ShoppingCart' } },
+  { key: 'D', text: 'Option d', data: { icon: 'Train' } },
+  { key: 'E', text: 'Option e', data: { icon: 'Repair' } },
+  { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
+  { key: 'Header2', text: 'More options', itemType: DropdownMenuItemType.Header },
+  { key: 'F', text: 'Option f', data: { icon: 'Running' } },
+  { key: 'G', text: 'Option g', data: { icon: 'EmojiNeutral' } },
+  { key: 'H', text: 'Option h', data: { icon: 'ChatInviteFriend' } },
+  { key: 'I', text: 'Option i', data: { icon: 'SecurityGroup' } },
+  { key: 'J', text: 'Option j', data: { icon: 'AddGroup' } }
+];
+
+const stackTokens: IStackTokens = { childrenGap: 20 };
 
 export class DropdownCustomExample extends React.PureComponent {
   public render(): JSX.Element {
     return (
-      <Dropdown
-        placeholder="Select an option"
-        label="Custom example"
-        ariaLabel="Custom dropdown example"
-        onRenderPlaceholder={this._onRenderPlaceholder}
-        onRenderTitle={this._onRenderTitle}
-        onRenderOption={this._onRenderOption}
-        onRenderCaretDown={this._onRenderCaretDown}
-        styles={{ dropdown: { width: 300 } }}
-        options={[
-          { key: 'Header', text: 'Options', itemType: DropdownMenuItemType.Header },
-          { key: 'A', text: 'Option a', data: { icon: 'Memo' } },
-          { key: 'B', text: 'Option b', data: { icon: 'Print' } },
-          { key: 'C', text: 'Option c', data: { icon: 'ShoppingCart' } },
-          { key: 'D', text: 'Option d', data: { icon: 'Train' } },
-          { key: 'E', text: 'Option e', data: { icon: 'Repair' } },
-          { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
-          { key: 'Header2', text: 'More options', itemType: DropdownMenuItemType.Header },
-          { key: 'F', text: 'Option f', data: { icon: 'Running' } },
-          { key: 'G', text: 'Option g', data: { icon: 'EmojiNeutral' } },
-          { key: 'H', text: 'Option h', data: { icon: 'ChatInviteFriend' } },
-          { key: 'I', text: 'Option i', data: { icon: 'SecurityGroup' } },
-          { key: 'J', text: 'Option j', data: { icon: 'AddGroup' } }
-        ]}
-      />
+      <Stack tokens={stackTokens}>
+        <Dropdown
+          placeholder="Select an option"
+          label="Custom example"
+          ariaLabel="Custom dropdown example"
+          onRenderPlaceholder={this._onRenderPlaceholder}
+          onRenderTitle={this._onRenderTitle}
+          onRenderOption={this._onRenderOption}
+          onRenderCaretDown={this._onRenderCaretDown}
+          styles={{ dropdown: { width: 300 } }}
+          options={exampleOptions}
+        />
+
+        <Dropdown
+          placeholder="Select an option"
+          label="Custom label"
+          ariaLabel="Custom dropdown label example"
+          styles={{ dropdown: { width: 300 } }}
+          options={exampleOptions}
+          onRenderLabel={this._onRenderLabel}
+        />
+      </Stack>
     );
   }
 
@@ -68,5 +85,14 @@ export class DropdownCustomExample extends React.PureComponent {
 
   private _onRenderCaretDown = (props: IDropdownProps): JSX.Element => {
     return <Icon iconName="CirclePlus" />;
+  };
+
+  private _onRenderLabel = (props: IDropdownProps): JSX.Element => {
+    return (
+      <Stack horizontal verticalAlign="center">
+        <span style={{ fontWeight: 600 }}>{props.label}</span>
+        <IconButton iconProps={{ iconName: 'Info' }} title="Info" ariaLabel="Info" styles={{ root: { marginBottom: -3 } }} />
+      </Stack>
+    );
   };
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -3,239 +3,598 @@
 exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = `
 <div
   className=
-      ms-Dropdown-container
-
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: auto;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 20px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
-  <label
-    className=
-        ms-Label
-        ms-Dropdown-label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: inline-block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-    htmlFor="Dropdown0"
-    id="Dropdown0-label"
-  >
-    Custom example
-  </label>
   <div
-    aria-describedby="Dropdown0-option"
-    aria-expanded="false"
-    aria-label="Custom dropdown example"
     className=
-        ms-Dropdown
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          border-color: #605e5c;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          outline: 0px;
-          padding-bottom: 0px;
-          padding-left: 0px;
-          padding-right: 0px;
-          padding-top: 0px;
-          position: relative;
-          user-select: none;
-          width: 300px;
-        }
-        &:hover .ms-Dropdown-title {
-          border-color: #323130;
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-          border-color: Highlight;
-        }
-        &:focus .ms-Dropdown-title {
-          border-color: #0078d4;
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-          background-color: Highlight;
-          border-color: Highlight;
-          color: HighlightText;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-          color: HighlightText;
-        }
-        @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-          -ms-high-contrast-adjust: none;
-        }
-        &:active .ms-Dropdown-title {
-          border-color: #0078d4;
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-          border-color: Highlight;
-        }
-        &:hover .ms-Dropdown-caretDown {
-          color: #323130;
-        }
-        &:focus .ms-Dropdown-caretDown {
-          color: #323130;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-          color: HighlightText;
-        }
-        @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-          -ms-high-contrast-adjust: none;
-        }
-        &:active .ms-Dropdown-caretDown {
-          color: #323130;
-        }
-        &:hover .ms-Dropdown-titleIsPlaceHolder {
-          color: #323130;
-        }
-        &:focus .ms-Dropdown-titleIsPlaceHolder {
-          color: #323130;
-        }
-        &:active .ms-Dropdown-titleIsPlaceHolder {
-          color: #323130;
-        }
-        &:hover .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
-        &:active .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
-        &:focus .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
-    data-is-focusable={true}
-    id="Dropdown0"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    role="listbox"
-    tabIndex={0}
+        ms-Dropdown-container
+
   >
-    <span
-      aria-atomic={true}
-      aria-label="Select an option"
-      aria-live="off"
-      aria-setsize={10}
+    <label
       className=
-          ms-Dropdown-title
-          ms-Dropdown-titleIsPlaceHolder
+          ms-Label
+          ms-Dropdown-label
           {
-            background-color: #ffffff;
-            border-color: #8a8886;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
             box-shadow: none;
             box-sizing: border-box;
-            color: #605e5c;
-            cursor: pointer;
-            display: block;
-            height: 32px;
-            line-height: 30px;
+            color: #323130;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
             margin-bottom: 0px;
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
-            overflow: hidden;
-            padding-bottom: 0;
-            padding-left: 8px;
-            padding-right: 28px;
-            padding-top: 0;
-            position: relative;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
           }
-      id="Dropdown0-option"
-      role="option"
+      htmlFor="Dropdown0"
+      id="Dropdown0-label"
     >
-      <div
-        className="dropdownExample-placeholder"
+      Custom example
+    </label>
+    <div
+      aria-describedby="Dropdown0-option"
+      aria-expanded="false"
+      aria-label="Custom dropdown example"
+      className=
+          ms-Dropdown
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-color: #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            user-select: none;
+            width: 300px;
+          }
+          &:hover .ms-Dropdown-title {
+            border-color: #323130;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:focus .ms-Dropdown-title {
+            border-color: #0078d4;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
+            -ms-high-contrast-adjust: none;
+          }
+          &:active .ms-Dropdown-title {
+            border-color: #0078d4;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:hover .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          &:focus .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
+            -ms-high-contrast-adjust: none;
+          }
+          &:active .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          &:hover .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:focus .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:active .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:hover .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+          &:active .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+          &:focus .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+      data-is-focusable={true}
+      id="Dropdown0"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      role="listbox"
+      tabIndex={0}
+    >
+      <span
+        aria-atomic={true}
+        aria-label="Select an option"
+        aria-live="off"
+        aria-setsize={10}
+        className=
+            ms-Dropdown-title
+            ms-Dropdown-titleIsPlaceHolder
+            {
+              background-color: #ffffff;
+              border-color: #8a8886;
+              border-radius: 2px;
+              border-style: solid;
+              border-width: 1px;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: pointer;
+              display: block;
+              height: 32px;
+              line-height: 30px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 28px;
+              padding-top: 0;
+              position: relative;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        id="Dropdown0-option"
+        role="option"
+      >
+        <div
+          className="dropdownExample-placeholder"
+        >
+          <i
+            aria-hidden="true"
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-5";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+            data-icon-name="MessageFill"
+            role="presentation"
+            style={
+              Object {
+                "marginRight": "8px",
+              }
+            }
+          >
+            
+          </i>
+          <span>
+            Select an option
+          </span>
+        </div>
+      </span>
+      <span
+        className=
+            ms-Dropdown-caretDownWrapper
+            {
+              cursor: pointer;
+              height: 32px;
+              line-height: 30px;
+              position: absolute;
+              right: 8px;
+              top: 1px;
+            }
       >
         <i
-          aria-hidden="true"
+          aria-hidden={true}
           className=
 
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 display: inline-block;
-                font-family: "FabricMDL2Icons-5";
+                font-family: "FabricMDL2Icons-4";
                 font-style: normal;
                 font-weight: normal;
                 speak: none;
               }
-          data-icon-name="MessageFill"
+          data-icon-name="CirclePlus"
           role="presentation"
-          style={
-            Object {
-              "marginRight": "8px",
-            }
-          }
         >
-          
+          
         </i>
-        <span>
-          Select an option
-        </span>
-      </div>
-    </span>
-    <span
+      </span>
+    </div>
+  </div>
+  <div
+    className=
+        ms-Dropdown-container
+
+  >
+    <div
       className=
-          ms-Dropdown-caretDownWrapper
+          ms-Stack
           {
-            cursor: pointer;
-            height: 32px;
-            line-height: 30px;
-            position: absolute;
-            right: 8px;
-            top: 1px;
+            align-items: center;
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-left: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
           }
     >
-      <i
-        aria-hidden={true}
+      <span
+        style={
+          Object {
+            "fontWeight": 600,
+          }
+        }
+      >
+        Custom label
+      </span>
+      <button
+        aria-label="Info"
         className=
-
+            ms-Button
+            ms-Button--icon
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #0078d4;
+              cursor: pointer;
               display: inline-block;
-              font-family: "FabricMDL2Icons-4";
-              font-style: normal;
-              font-weight: normal;
-              speak: none;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 32px;
+              margin-bottom: -3px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
             }
-        data-icon-name="CirclePlus"
-        role="presentation"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #106ebe;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #005a9e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        title="Info"
+        type="button"
       >
-        
-      </i>
-    </span>
+        <div
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Button-icon
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  flex-shrink: 0;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  speak: none;
+                  text-align: center;
+                  vertical-align: middle;
+                }
+            data-icon-name="Info"
+            role="presentation"
+          >
+            
+          </i>
+        </div>
+      </button>
+    </div>
+    <div
+      aria-describedby="Dropdown1-option"
+      aria-expanded="false"
+      aria-label="Custom dropdown label example"
+      className=
+          ms-Dropdown
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            border-color: #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            outline: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            user-select: none;
+            width: 300px;
+          }
+          &:hover .ms-Dropdown-title {
+            border-color: #323130;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:focus .ms-Dropdown-title {
+            border-color: #0078d4;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
+            background-color: Highlight;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
+            -ms-high-contrast-adjust: none;
+          }
+          &:active .ms-Dropdown-title {
+            border-color: #0078d4;
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
+            border-color: Highlight;
+          }
+          &:hover .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          &:focus .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
+            color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
+            -ms-high-contrast-adjust: none;
+          }
+          &:active .ms-Dropdown-caretDown {
+            color: #323130;
+          }
+          &:hover .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:focus .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:active .ms-Dropdown-titleIsPlaceHolder {
+            color: #323130;
+          }
+          &:hover .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+          &:active .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+          &:focus .ms-Dropdown-title--hasError {
+            border-color: #a4262c;
+          }
+      data-is-focusable={true}
+      id="Dropdown1"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      role="listbox"
+      tabIndex={0}
+    >
+      <span
+        aria-atomic={true}
+        aria-label="Select an option"
+        aria-live="off"
+        aria-setsize={10}
+        className=
+            ms-Dropdown-title
+            ms-Dropdown-titleIsPlaceHolder
+            {
+              background-color: #ffffff;
+              border-color: #8a8886;
+              border-radius: 2px;
+              border-style: solid;
+              border-width: 1px;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: pointer;
+              display: block;
+              height: 32px;
+              line-height: 30px;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow: hidden;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 28px;
+              padding-top: 0;
+              position: relative;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+        id="Dropdown1-option"
+        role="option"
+      >
+        <span>
+          Select an option
+        </span>
+      </span>
+      <span
+        className=
+            ms-Dropdown-caretDownWrapper
+            {
+              cursor: pointer;
+              height: 32px;
+              line-height: 30px;
+              position: absolute;
+              right: 8px;
+              top: 1px;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Dropdown-caretDown
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #605e5c;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-size: 12px;
+                font-style: normal;
+                font-weight: normal;
+                pointer-events: none;
+                speak: none;
+              }
+          data-icon-name="ChevronDown"
+          role="presentation"
+        >
+          
+        </i>
+      </span>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9755 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Adding a new prop to allow a custom renderer of the `Dropdown` label and an example of its usage.
![Screen Shot 2019-07-10 at 19 16 21](https://user-images.githubusercontent.com/29514833/61017303-8b80f280-a347-11e9-8ab1-2574232e5f26.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9772)