### PR TITLE
ProgressIndicator: Update description label font size

### DIFF
--- a/change/office-ui-fabric-react-2019-07-11-08-52-10-marygans-progessIndicator.json
+++ b/change/office-ui-fabric-react-2019-07-11-08-52-10-marygans-progessIndicator.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Update to progressBar indicator description label font size to match design toolkti spec.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "marygans@microsoft.com",
+  "commit": "48a333ccde37c619e7d75108d26c727299feb396",
+  "date": "2019-07-11T15:52:10.663Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
@@ -64,7 +64,7 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
       classNames.itemDescription,
       {
         color: semanticColors.bodySubtext,
-        fontSize: FontSizes.xSmall,
+        fontSize: FontSizes.small,
         lineHeight: textHeight
       }
     ],

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
         ms-ProgressIndicator-itemDescription
         {
           color: #605e5c;
-          font-size: 10px;
+          font-size: 12px;
           line-height: 18px;
         }
   >
@@ -177,7 +177,7 @@ exports[`ProgressIndicator renders React content 1`] = `
         ms-ProgressIndicator-itemDescription
         {
           color: #605e5c;
-          font-size: 10px;
+          font-size: 12px;
           line-height: 18px;
         }
   >
@@ -271,7 +271,7 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
         ms-ProgressIndicator-itemDescription
         {
           color: #605e5c;
-          font-size: 10px;
+          font-size: 12px;
           line-height: 18px;
         }
   >
@@ -378,7 +378,7 @@ exports[`ProgressIndicator renders with no progress 1`] = `
         ms-ProgressIndicator-itemDescription
         {
           color: #605e5c;
-          font-size: 10px;
+          font-size: 12px;
           line-height: 18px;
         }
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
@@ -83,7 +83,7 @@ exports[`Component Examples renders ProgressIndicator.Basic.Example.tsx correctl
         ms-ProgressIndicator-itemDescription
         {
           color: #605e5c;
-          font-size: 10px;
+          font-size: 12px;
           line-height: 18px;
         }
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
@@ -83,7 +83,7 @@ exports[`Component Examples renders ProgressIndicator.Indeterminate.Example.tsx 
         ms-ProgressIndicator-itemDescription
         {
           color: #605e5c;
-          font-size: 10px;
+          font-size: 12px;
           line-height: 18px;
         }
   >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

Updates  progressbar indicator description label font size from xSmall to small to match toolkit spec.
**Before**
![progressindicator-before](https://user-images.githubusercontent.com/38991459/61066242-04b92d80-a3ba-11e9-993e-77f505122605.png)
**After**
![progressIndicator-after](https://user-images.githubusercontent.com/38991459/61066241-04b92d80-a3ba-11e9-835d-efb88cb80dc3.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9774)