### PR TITLE
Add List scenarios to perf-test suite

### DIFF
--- a/apps/perf-test/src/scenarioNames.js
+++ b/apps/perf-test/src/scenarioNames.js
@@ -2,6 +2,8 @@ const scenarioNames = {
   BaseButtonNew: 'BaseButton (experiments)',
   DefaultButtonNew: 'DefaultButton (experiments)',
   DetailsRowNoStyles: 'DetailsRow without styles',
+  DetailsHeaderFixed: 'DetailsHeader (fixed layout)',
+  DetailsHeaderJustified: 'DetailsHeader (justified layout)',
   DocumentCardTitle: 'DocumentCardTitle with truncation',
   MenuButtonNew: 'MenuButton (experiments)',
   PrimaryButtonNew: 'PrimaryButton (experiments)',

--- a/apps/perf-test/src/scenarios/DetailsHeaderFixed.tsx
+++ b/apps/perf-test/src/scenarios/DetailsHeaderFixed.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { DetailsHeader, DetailsListLayoutMode, Selection } from 'office-ui-fabric-react';
+
+// tslint:disable-next-line:typedef
+const Items = Array.from({ length: 10 }, (n, i) => ({
+  key: `Item ${i}`,
+  name: `Item ${i}`,
+  modified: new Date().toString(),
+  shared: 'Private',
+  size: `${Math.round(Math.random() * 1000) / 10}KB`
+}));
+
+const Columns = [
+  { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+  { key: 'column2', name: 'Modified', fieldName: 'modified', minWidth: 100, maxWidth: 200, isResizable: true },
+  { key: 'column2', name: 'Shared', fieldName: 'shared', minWidth: 100, maxWidth: 200, isResizable: true },
+  { key: 'column2', name: 'Size', fieldName: 'size', minWidth: 100, maxWidth: 200, isResizable: true }
+];
+
+const selection = new Selection();
+selection.setItems(Items);
+
+const scenario = <DetailsHeader selection={selection} columns={Columns} layoutMode={DetailsListLayoutMode.fixedColumns} />;
+
+export default scenario;

--- a/apps/perf-test/src/scenarios/DetailsHeaderJustified.tsx
+++ b/apps/perf-test/src/scenarios/DetailsHeaderJustified.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { DetailsHeader, DetailsListLayoutMode, Selection } from 'office-ui-fabric-react';
+
+// tslint:disable-next-line:typedef
+const Items = Array.from({ length: 10 }, (n, i) => ({
+  key: `Item ${i}`,
+  name: `Item ${i}`,
+  modified: new Date().toString(),
+  shared: 'Private',
+  size: `${Math.round(Math.random() * 1000) / 10}KB`
+}));
+
+const Columns = [
+  { key: 'column1', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
+  { key: 'column2', name: 'Modified', fieldName: 'modified', minWidth: 100, maxWidth: 200, isResizable: true },
+  { key: 'column2', name: 'Shared', fieldName: 'shared', minWidth: 100, maxWidth: 200, isResizable: true },
+  { key: 'column2', name: 'Size', fieldName: 'size', minWidth: 100, maxWidth: 200, isResizable: true }
+];
+
+const selection = new Selection();
+selection.setItems(Items);
+
+const scenario = <DetailsHeader selection={selection} columns={Columns} layoutMode={DetailsListLayoutMode.justified} />;
+
+export default scenario;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Adds `DetailsHeader` scenarios for "justified" and "fixed" layout modes to perf test scenarios.

I'm interested to see the results for a successful run.

Additional scenarios I'm looking to add without regressing build time, ideally to this PR:

- `StaticList`
- `FixedList`
- `DetailsList` (virtualized)
    - Currently hangs indefinitely when run (continuing to debug)
- `GroupedList`

#### Focus areas to test

- CI should pass.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9776)