### PR TITLE
Cherry-pick #9517 to 6.0

### DIFF
--- a/apps/vr-tests/src/stories/Tile.stories.tsx
+++ b/apps/vr-tests/src/stories/Tile.stories.tsx
@@ -5,7 +5,8 @@ import {
   TrendingSignal,
   CommentsSignal,
   NewSignal,
-  SharedSignal
+  SharedSignal,
+  ITileBackgroundProps
 } from '@uifabric/experiments';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
@@ -13,13 +14,19 @@ import { ISize, fitContentToBounds, Fabric } from 'office-ui-fabric-react';
 import { FabricDecorator } from '../utilities';
 
 interface IDocumentItem {
-  name: string;
-  activity: string;
+  name: JSX.Element;
+  activity: JSX.Element;
 }
 
 interface IDocumentTileWithThumbnailProps {
   originalImageSize: ISize;
   item: IDocumentItem;
+}
+
+interface IMediaTileWithThumbnailProps {
+  imageSize: ISize;
+  item: IDocumentItem;
+  nameplateOnlyOnHover: boolean;
 }
 
 const DocumentTileBox = (props: { children: React.ReactNode }): JSX.Element => {
@@ -29,6 +36,23 @@ const DocumentTileBox = (props: { children: React.ReactNode }): JSX.Element => {
         position: 'relative',
         width: '176px',
         height: '171px'
+      }}
+    >
+      {props.children}
+    </div>
+  );
+};
+
+const MEDIA_TILE_WIDTH = 200;
+const MEDIA_TILE_HEIGHT = 150;
+
+const MediaTileBox = (props: { children: React.ReactNode }): JSX.Element => {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: `${MEDIA_TILE_WIDTH}px`,
+        height: `${MEDIA_TILE_HEIGHT}px`
       }}
     >
       {props.children}
@@ -76,6 +100,33 @@ const DocumentTileWithThumbnail: React.StatelessComponent<IDocumentTileWithThumb
   );
 };
 
+const MediaTileWithThumbnail: React.StatelessComponent<IMediaTileWithThumbnailProps> = (
+  props: IMediaTileWithThumbnailProps
+): JSX.Element => {
+  const { imageSize, item, nameplateOnlyOnHover } = props;
+
+  function renderBackground(backgroundProps: ITileBackgroundProps) {
+    return (
+      <img
+        src={`//placehold.it/${Math.round(imageSize.width)}x${Math.round(imageSize.height)}`}
+        style={{ display: 'block' }}
+      />
+    );
+  }
+
+  return (
+    <MediaTileBox>
+      <Tile
+        itemName={item.name}
+        itemActivity={item.activity}
+        background={renderBackground}
+        showBackgroundFrame={true}
+        nameplateOnlyOnHover={nameplateOnlyOnHover}
+      />
+    </MediaTileBox>
+  );
+};
+
 storiesOf('Tile', module)
   .addDecorator(story => <Fabric>{story()}</Fabric>)
   .addDecorator(FabricDecorator)
@@ -92,8 +143,8 @@ storiesOf('Tile', module)
   .addStory('Document tile with fit landscape image', () => (
     <DocumentTileWithThumbnail
       item={{
-        name: 'Test Name',
-        activity: 'Test Activity'
+        name: <>Test Name</>,
+        activity: <>Test Activity</>
       }}
       originalImageSize={{
         width: 200,
@@ -104,8 +155,8 @@ storiesOf('Tile', module)
   .addStory('Document tile with fit portrait image', () => (
     <DocumentTileWithThumbnail
       item={{
-        name: 'Test Name',
-        activity: 'Test Activity'
+        name: <>Test Name</>,
+        activity: <>Test Activity</>
       }}
       originalImageSize={{
         width: 150,
@@ -116,8 +167,8 @@ storiesOf('Tile', module)
   .addStory('Document tile with icon-sized image', () => (
     <DocumentTileWithThumbnail
       item={{
-        name: 'Test Name',
-        activity: 'Test Activity'
+        name: <>Test Name</>,
+        activity: <>Test Activity</>
       }}
       originalImageSize={{
         width: 16,
@@ -159,4 +210,93 @@ storiesOf('Tile', module)
         showForegroundFrame={false}
       />
     </DocumentTileBox>
+  ));
+
+storiesOf('MediaTile', module)
+  .addDecorator(story => <Fabric>{story()}</Fabric>)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story =>
+    // prettier-ignore
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.ms-Tile')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  )
+  .addStory('Media tile with single activity line', () => (
+    <MediaTileBox>
+      <MediaTileWithThumbnail
+        item={{
+          name: <SignalField before={<NewSignal />}>{'Test Name'}</SignalField>,
+          activity: <SignalField before={<SharedSignal />}>{'Test Activity'}</SignalField>
+        }}
+        imageSize={{
+          width: MEDIA_TILE_WIDTH,
+          height: MEDIA_TILE_HEIGHT
+        }}
+        nameplateOnlyOnHover={false}
+      />
+    </MediaTileBox>
+  ))
+  .addStory('Media tile with two activity lines', () => (
+    <MediaTileBox>
+      <MediaTileWithThumbnail
+        item={{
+          name: <SignalField before={<NewSignal />}>{'Test Name'}</SignalField>,
+          activity: (
+            <>
+              <SignalField before={<SharedSignal />}>{'Test Activity'}</SignalField>
+              <span style={{ display: 'block' }}>{'Test Activity Second Line'}</span>
+            </>
+          )
+        }}
+        imageSize={{
+          width: MEDIA_TILE_WIDTH,
+          height: MEDIA_TILE_HEIGHT
+        }}
+        nameplateOnlyOnHover={false}
+      />
+    </MediaTileBox>
+  ))
+  .addStory('Media tile with very long name and activity', () => (
+    <MediaTileBox>
+      <MediaTileWithThumbnail
+        item={{
+          name: (
+            <SignalField before={<NewSignal />}>
+              {'Lorem ipsum dolor sit amet, consectetur adipiscing elit'}
+            </SignalField>
+          ),
+          activity: (
+            <SignalField before={<SharedSignal />}>
+              {'Proin elementum erat gravida libero luctus, id consequat risus aliquam'}
+            </SignalField>
+          )
+        }}
+        imageSize={{
+          width: MEDIA_TILE_WIDTH,
+          height: MEDIA_TILE_HEIGHT
+        }}
+        nameplateOnlyOnHover={false}
+      />
+    </MediaTileBox>
+  ))
+  .addStory('Media tile with nameplate hidden until hover', () => (
+    <MediaTileBox>
+      <MediaTileWithThumbnail
+        item={{
+          name: <SignalField before={<NewSignal />}>{'Test Name'}</SignalField>,
+          activity: <SignalField before={<SharedSignal />}>{'Test Activity'}</SignalField>
+        }}
+        imageSize={{
+          width: MEDIA_TILE_WIDTH,
+          height: MEDIA_TILE_HEIGHT
+        }}
+        nameplateOnlyOnHover={true}
+      />
+    </MediaTileBox>
   ));

--- a/common/changes/@uifabric/experiments/jocobb-tile-meta-hover_2019-06-19-23-23.json
+++ b/common/changes/@uifabric/experiments/jocobb-tile-meta-hover_2019-06-19-23-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/experiments",
+      "comment": "Change media tile to show metadata only on hover",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@uifabric/experiments",
+  "email": "jocobb@microsoft.com"
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -373,11 +373,41 @@
 
 .hasBackgroundFrame {
   .name {
-    justify-content: flex-start;
+    display: block;
+    @include LTR {
+      justify-content: left;
+    }
+    @include RTL {
+      justify-content: right;
+    }
+
+    &,
+    .isLarge .isSmall & {
+      font-size: $ms-font-size-m;
+      height: auto;
+      padding-top: 6px;
+      margin-top: 0px;
+      margin-bottom: 0px;
+      line-height: $ms-font-size-m + 8px;
+    }
   }
 
   .activity {
-    justify-content: flex-start;
+    font-size: $ms-font-size-s;
+    display: block;
+    @include LTR {
+      justify-content: left;
+      text-align: left;
+    }
+    @include RTL {
+      justify-content: left;
+      text-align: left;
+    }
+
+    height: auto;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    line-height: $ms-font-size-s + 8px;
   }
 }
 
@@ -387,7 +417,7 @@
       position: absolute;
       content: '';
       display: block;
-      top: -12px;
+      top: -4px;
       bottom: 0;
       left: 0;
       right: 0;
@@ -404,7 +434,45 @@
     }
   }
 
+  .onlyOnHover {
+    .name {
+      opacity: 0;
+      transition: transform 0.25s ease-out, opacity 0.2s linear, color 0.2s linear;
+      transform: translateY(1rem);
+    }
+
+    .activity {
+      opacity: 0;
+      transition: transform 0.25s ease-out, opacity 0.2s linear, color 0.2s linear;
+      transform: translateY(1rem);
+    }
+  }
+
+  &:hover,
+  &.selected {
+    .name.onlyOnHover {
+      opacity: 1;
+      transform: translateY(0px);
+    }
+
+    .activity.onlyOnHover {
+      opacity: 1;
+      transform: translateY(0px);
+    }
+  }
+
   &.showBackground {
+    &:hover,
+    &.selected {
+      .onlyOnHover.nameplate:before {
+        opacity: 1;
+      }
+    }
+
+    .nameplate:not(.onlyOnHover):before {
+      opacity: 1;
+    }
+
     .name {
       color: $ms-color-white;
       text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
@@ -413,12 +481,6 @@
     .activity {
       color: $ms-color-white;
       text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
-    }
-
-    .nameplate {
-      &:before {
-        opacity: 1;
-      }
     }
   }
 }

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -151,6 +151,7 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
       href,
       onClick,
       isFluentStyling,
+      nameplateOnlyOnHover,
       ...divProps
     } = this.props;
 
@@ -181,7 +182,8 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
         {itemName || itemActivity
           ? this._onRenderNameplate({
               name: itemName,
-              activity: itemActivity
+              activity: itemActivity,
+              onlyOnHover: !!nameplateOnlyOnHover
             })
           : null}
       </>
@@ -289,16 +291,24 @@ export class Tile extends BaseComponent<ITileProps, ITileState> {
     ) : null;
   }
 
-  private _onRenderNameplate({ name, activity }: { name: React.ReactNode; activity: React.ReactNode }): JSX.Element {
+  private _onRenderNameplate({
+    name,
+    activity,
+    onlyOnHover
+  }: {
+    name: React.ReactNode;
+    activity: React.ReactNode;
+    onlyOnHover: boolean;
+  }): JSX.Element {
     return (
-      <span key="nameplate" className={css('ms-Tile-nameplate', TileStyles.nameplate)}>
+      <span key="nameplate" className={css('ms-Tile-nameplate', TileStyles.nameplate, { [TileStyles.onlyOnHover]: onlyOnHover })}>
         {name ? (
-          <span id={this._nameId} className={css('ms-Tile-name', TileStyles.name)}>
+          <span id={this._nameId} className={css('ms-Tile-name', TileStyles.name, { [TileStyles.onlyOnHover]: onlyOnHover })}>
             {name}
           </span>
         ) : null}
         {activity ? (
-          <span id={this._activityId} className={css('ms-Tile-activity', TileStyles.activity)}>
+          <span id={this._activityId} className={css('ms-Tile-activity', TileStyles.activity, { [TileStyles.onlyOnHover]: onlyOnHover })}>
             {activity}
           </span>
         ) : null}

--- a/packages/experiments/src/components/Tile/Tile.types.ts
+++ b/packages/experiments/src/components/Tile/Tile.types.ts
@@ -94,4 +94,9 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    * Whether the component should render with Fluent styling or not
    */
   isFluentStyling?: boolean;
+
+  /**
+   * Hide nameplate and activity until the tile is hovered or selected (applies only to media tiles)
+   */
+  nameplateOnlyOnHover?: boolean;
 }

--- a/packages/experiments/src/components/Tile/examples/Tile.Example.scss
+++ b/packages/experiments/src/components/Tile/examples/Tile.Example.scss
@@ -23,3 +23,10 @@
 .tileImage {
   display: block;
 }
+
+.activityBlock {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
@@ -13,22 +13,78 @@ import {
 import { lorem } from '@uifabric/example-app-base';
 import * as TileExampleStylesModule from './Tile.Example.scss';
 
-const ITEMS: { name: string; activity: string }[] = [
+const ITEMS: { name: JSX.Element; activity: JSX.Element }[] = [
   {
-    name: lorem(2),
-    activity: lorem(6)
+    name: <>{lorem(2)}</>,
+    activity: (
+      <>
+        <span className={TileExampleStylesModule.activityBlock}>267&#x205F;&times;&#x205F;200&ensp;&middot;&ensp;3.14&nbsp;MB</span>
+        <SignalField
+          before={[
+            <Signal key={0}>
+              <Icon iconName="play" />
+            </Signal>,
+            <MentionSignal key={1} />
+          ]}
+        >
+          {lorem(6)}
+        </SignalField>
+      </>
+    )
   },
   {
-    name: lorem(2),
-    activity: lorem(6)
+    name: <>{lorem(2)}</>,
+    activity: (
+      <>
+        <span className={TileExampleStylesModule.activityBlock}>200&#x205F;&times;&#x205F;267&ensp;&middot;&ensp;3.14&nbsp;MB</span>
+        <SignalField
+          before={[
+            <Signal key={0}>
+              <Icon iconName="play" />
+            </Signal>,
+            <SharedSignal key={1} />
+          ]}
+        >
+          {lorem(6)}
+        </SignalField>
+      </>
+    )
   },
   {
-    name: lorem(2),
-    activity: lorem(6)
+    name: <>{lorem(2)}</>,
+    activity: (
+      <>
+        <span className={TileExampleStylesModule.activityBlock}>200&#x205F;&times;&#x205F;200&ensp;&middot;&ensp;3.14&nbsp;MB</span>
+        <SignalField
+          before={[
+            <Signal key={0}>
+              <Icon iconName="play" />
+            </Signal>,
+            <MentionSignal key={1} />
+          ]}
+        >
+          {lorem(6)}
+        </SignalField>
+      </>
+    )
   },
   {
-    name: lorem(2),
-    activity: lorem(6)
+    name: <>{lorem(2)}</>,
+    activity: (
+      <>
+        <span className={TileExampleStylesModule.activityBlock}>180&#x205F;&times;&#x205F;180&ensp;&middot;&ensp;3.14&nbsp;MB</span>
+        <SignalField
+          before={[
+            <Signal key={0}>
+              <Icon iconName="play" />
+            </Signal>,
+            <SharedSignal key={1} />
+          ]}
+        >
+          {lorem(6)}
+        </SignalField>
+      </>
+    )
   }
 ];
 
@@ -39,6 +95,7 @@ interface IImageTileProps {
   tileSize: ISize;
   originalImageSize: ISize;
   showBackground: boolean;
+  nameplateOnlyOnHover: boolean;
   item: typeof ITEMS[0];
 }
 
@@ -47,23 +104,13 @@ const ImageTile: React.StatelessComponent<IImageTileProps> = (props: IImageTileP
     <Tile
       contentSize={props.tileSize}
       itemName={<SignalField before={<NewSignal />}>{props.item.name}</SignalField>}
-      itemActivity={
-        <SignalField
-          before={[
-            <Signal key={0}>
-              <Icon iconName="play" />
-            </Signal>,
-            <MentionSignal key={1} />
-          ]}
-        >
-          {props.item.activity}
-        </SignalField>
-      }
+      itemActivity={props.item.activity}
       background={
         <span /> // Placeholder content
       }
       hideBackground={!props.showBackground}
       showBackgroundFrame={true}
+      nameplateOnlyOnHover={props.nameplateOnlyOnHover}
     />
   );
 
@@ -98,6 +145,7 @@ const ImageTile: React.StatelessComponent<IImageTileProps> = (props: IImageTileP
 
 export interface ITileMediaExampleState {
   imagesLoaded: boolean;
+  nameplateOnlyOnHover: boolean;
 }
 
 export class TileMediaExample extends React.Component<{}, ITileMediaExampleState> {
@@ -105,16 +153,18 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
     super(props);
 
     this.state = {
-      imagesLoaded: true
+      imagesLoaded: true,
+      nameplateOnlyOnHover: false
     };
   }
 
   public render(): JSX.Element {
-    const { imagesLoaded } = this.state;
+    const { imagesLoaded, nameplateOnlyOnHover } = this.state;
 
     return (
       <div>
         <Checkbox label="Show images as loaded" checked={imagesLoaded} onChange={this._onImagesLoadedChanged} />
+        <Checkbox label="Show nameplate only on hover" checked={nameplateOnlyOnHover} onChange={this._onNameplateOnlyOnHoverChanged} />
         <h3>Landscape</h3>
         <ImageTile
           tileSize={{
@@ -127,6 +177,7 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
             height: 300
           }}
           showBackground={imagesLoaded}
+          nameplateOnlyOnHover={nameplateOnlyOnHover}
         />
         <h3>Portrait</h3>
         <ImageTile
@@ -140,6 +191,7 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
             height: 400
           }}
           showBackground={imagesLoaded}
+          nameplateOnlyOnHover={nameplateOnlyOnHover}
         />
         <h3>Small Image</h3>
         <ImageTile
@@ -153,25 +205,16 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
             height: 16
           }}
           showBackground={imagesLoaded}
+          nameplateOnlyOnHover={nameplateOnlyOnHover}
         />
         <h3>No preview</h3>
         <div className={css(TileExampleStyles.tile, TileExampleStyles.largeTile)}>
           <Tile
             itemName={<SignalField before={<NewSignal />}>{ITEMS[3].name}</SignalField>}
-            itemActivity={
-              <SignalField
-                before={[
-                  <Signal key={0}>
-                    <Icon iconName="play" />
-                  </Signal>,
-                  <SharedSignal key={1} />
-                ]}
-              >
-                {ITEMS[3].name}
-              </SignalField>
-            }
+            itemActivity={ITEMS[3].activity}
             foreground={<Icon iconName="play" style={{ margin: '11px', fontSize: '40px' }} />}
             showBackgroundFrame={true}
+            nameplateOnlyOnHover={this.state.nameplateOnlyOnHover}
           />
         </div>
       </div>
@@ -181,6 +224,12 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
   private _onImagesLoadedChanged = (event: React.FormEvent<HTMLInputElement>, checked: boolean): void => {
     this.setState({
       imagesLoaded: checked
+    });
+  };
+
+  private _onNameplateOnlyOnHoverChanged = (event: React.FormEvent<HTMLInputElement>, checked: boolean): void => {
+    this.setState({
+      nameplateOnlyOnHover: checked
     });
   };
 }

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
@@ -7,6 +7,8 @@ import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { AnimationClassNames } from 'office-ui-fabric-react/lib/Styling';
 import { IExampleGroup, IExampleItem, createGroup, createMediaItems, getTileCells } from './ExampleHelpers';
 import * as TilesListExampleStylesModule from './TilesList.Example.scss';
+import { lorem } from '@uifabric/example-app-base';
+import { SignalField, SharedSignal, CommentsSignal } from '../../signals/Signals';
 
 // tslint:disable-next-line:no-any
 const TilesListExampleStyles = TilesListExampleStylesModule as any;
@@ -37,6 +39,7 @@ const TilesListType: typeof TilesListClass = TilesList;
 
 export interface ITilesListMediaExampleState {
   isModalSelection: boolean;
+  nameplateOnlyOnHover: boolean;
   cells: (ITilesGridItem<IExampleItem> | ITilesGridSegment<IExampleItem>)[];
 }
 
@@ -55,6 +58,7 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
 
     this.state = {
       isModalSelection: this._selection.isModal(),
+      nameplateOnlyOnHover: false,
       cells: getTileCells(GROUPS, {
         onRenderCell: this._onRenderMediaCell,
         onRenderHeader: this._onRenderHeader
@@ -73,6 +77,13 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
           onText="Modal"
           offText="Normal"
         />
+        <Toggle
+          label="Hide Nameplates Until Hovered"
+          checked={this.state.nameplateOnlyOnHover}
+          onChange={this._onToggleNameplateOnlyOnHover}
+          onText="Shown on hover"
+          offText="Always shown"
+        />
         <MarqueeSelection selection={this._selection}>
           <SelectionZone selection={this._selection} onItemInvoked={this._onItemInvoked} enterModalOnTouch={true}>
             <TilesListType role="list" items={this.state.cells} />
@@ -84,6 +95,16 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
 
   private _onToggleIsModalSelection = (event: React.MouseEvent<HTMLElement>, checked: boolean): void => {
     this._selection.setModal(checked);
+  };
+
+  private _onToggleNameplateOnlyOnHover = (event: React.MouseEvent<HTMLElement>, checked: boolean): void => {
+    this.setState({
+      nameplateOnlyOnHover: checked,
+      cells: getTileCells(GROUPS, {
+        onRenderCell: this._onRenderMediaCell,
+        onRenderHeader: this._onRenderHeader
+      })
+    });
   };
 
   private _onSelectionChange = (): void => {
@@ -100,6 +121,9 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
   };
 
   private _onRenderMediaCell = (item: IExampleItem, finalSize: ITileSize): JSX.Element => {
+    const pixelWidth = Math.round(finalSize.width);
+    const pixelHeight = Math.round(finalSize.height);
+
     const tile = (
       <Tile
         role="listitem"
@@ -115,7 +139,24 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
         }
         showBackgroundFrame={true}
         itemName={item.name}
-        itemActivity={item.key}
+        itemActivity={
+          <>
+            <div style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {pixelWidth}&#x205F;&times;&#x205F;{pixelHeight}&ensp;&middot;&ensp;3.14&nbsp;MB
+            </div>
+            <SignalField
+              before={
+                <>
+                  <SharedSignal key={1} />
+                  <CommentsSignal key={2} />
+                </>
+              }
+            >
+              {lorem(7)}
+            </SignalField>
+          </>
+        }
+        nameplateOnlyOnHover={this.state.nameplateOnlyOnHover}
       />
     );
 


### PR DESCRIPTION
This applies the changes from **#9517 "Change media tile to show metadata only on hover"** to the 6.0 branch

> This changes the media tile (those with background thumbnails) to show the shadowed name and activity metadata only when hovered. It also restyles the control to allow multiple lines of activity metadata.
> 
> ![Annotation 2019-06-19 161435](https://user-images.githubusercontent.com/35116398/59807583-6996d180-92ad-11e9-94c9-ffb4bd6ecc30.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9782)