### PR TITLE
updateReleaseNotes updates and other build things

### DIFF
--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -111,6 +111,8 @@
     var scripts = [appPath + entryPointFilename + '.min.js'];
 
     if (!window.React) {
+      // Only needed for Fabric 5 and 6 (7 bundles React)
+      // DO NOT replace 16.3.2 with a newer version!
       var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.3.2/umd/react';
       var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.2/umd/react-dom';
 

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -1,3 +1,20 @@
+<div id="metadata" title="Home - Office UI Fabric" description="The official front-end framework for building experiences that fit seamlessly into Office and Office 365." style="visibility:hidden"></div>
+<style>
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+  }
+  .loading {
+    align-items: center;
+    background-color: #212121;
+    border-top: 50px solid #000;
+    display: flex;
+    height: 100vh;
+    justify-content: center;
+  }
+</style>
+
 <div id="main">
   <div class="loading">
     <img
@@ -81,7 +98,7 @@
     (function run() {
       if (array.length != 0) {
         const scriptName = array.shift();
-        loader(scriptName, run, () => {
+        loader(scriptName, run, function() {
           loader(scriptName.replace('.min.js', '.js'), run);
         });
       } else {
@@ -94,8 +111,8 @@
     var scripts = [appPath + entryPointFilename + '.min.js'];
 
     if (!window.React) {
-      var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react';
-      var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom';
+      var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.3.2/umd/react';
+      var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.2/umd/react-dom';
 
       reactPath = reactPath + '.production.min.js';
       reactDomPath = reactDomPath + '.production.min.js';

--- a/change/@uifabric-codepen-loader-2019-07-11-18-19-16-releasenotes.json
+++ b/change/@uifabric-codepen-loader-2019-07-11-18-19-16-releasenotes.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Build config updates",
+  "type": "none",
+  "packageName": "@uifabric/codepen-loader",
+  "email": "elcraig@microsoft.com",
+  "commit": "75c2288c35828886d8340d3976dc340f120ad419",
+  "date": "2019-07-12T01:19:16.253Z"
+}

--- a/change/@uifabric-fabric-website-2019-07-11-18-19-16-releasenotes.json
+++ b/change/@uifabric-fabric-website-2019-07-11-18-19-16-releasenotes.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Update homepage.htm to match real one",
+  "type": "none",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "75c2288c35828886d8340d3976dc340f120ad419",
+  "date": "2019-07-12T01:19:03.589Z"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -5,6 +5,7 @@ dependencies:
   '@microsoft/loader-load-themed-styles': 1.7.165
   '@microsoft/node-core-library': 3.9.0
   '@microsoft/tsdoc': 0.12.9
+  '@octokit/rest': 16.28.4
   '@rush-temp/a11y-tests': 'file:projects/a11y-tests.tgz'
   '@rush-temp/api-docs': 'file:projects/api-docs.tgz'
   '@rush-temp/azure-themes': 'file:projects/azure-themes.tgz'
@@ -126,7 +127,6 @@ dependencies:
   flamebearer: 1.1.3
   fork-ts-checker-webpack-plugin: 0.4.15
   fs-extra: 7.0.1
-  github: 7.3.2
   glob: 7.1.4
   gzip-size: 3.0.0
   highlight.js: 9.15.8
@@ -200,7 +200,7 @@ dependencies:
   webpack-notifier: 1.7.0
   whatwg-fetch: 2.0.4
   write-file-webpack-plugin: 4.5.0
-  yargs: 6.6.0
+  yargs: 13.3.0
 packages:
   /@babel/code-frame/7.0.0:
     dependencies:
@@ -513,6 +513,52 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sDhulvuVk65eMppYOE6fr6mMI6RUqs53KUg9deYzNCBpP+2FhR0OFB5innEfdtSedk0LK+1Ppu6MxkfiNjS/Cw==
+  /@octokit/endpoint/5.2.2:
+    dependencies:
+      deepmerge: 4.0.0
+      is-plain-object: 3.0.0
+      universal-user-agent: 3.0.0
+      url-template: 2.0.8
+    dev: false
+    resolution:
+      integrity: sha512-VhKxM4CQanIUZDffExqpdpgqu3heF51qbY1wazoNtvIKXAAVoFjqLq2BOhesXkTqxXMO1Ze1XbS8DkIjUxAB+g==
+  /@octokit/request-error/1.0.4:
+    dependencies:
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+    resolution:
+      integrity: sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==
+  /@octokit/request/5.0.1:
+    dependencies:
+      '@octokit/endpoint': 5.2.2
+      '@octokit/request-error': 1.0.4
+      deprecation: 2.3.1
+      is-plain-object: 3.0.0
+      node-fetch: 2.6.0
+      once: 1.4.0
+      universal-user-agent: 3.0.0
+    dev: false
+    resolution:
+      integrity: sha512-SHOk/APYpfrzV1RNf7Ux8SZi+vZXhMIB2dBr4TQR6ExMX8R4jcy/0gHw26HLe1dWV7Wxe9WzYyDSEC0XwnoCSQ==
+  /@octokit/rest/16.28.4:
+    dependencies:
+      '@octokit/request': 5.0.1
+      '@octokit/request-error': 1.0.4
+      atob-lite: 2.0.0
+      before-after-hook: 2.1.0
+      btoa-lite: 1.0.0
+      deprecation: 2.3.1
+      lodash.get: 4.4.2
+      lodash.set: 4.3.2
+      lodash.uniq: 4.5.0
+      octokit-pagination-methods: 1.1.0
+      once: 1.4.0
+      universal-user-agent: 3.0.0
+      url-template: 2.0.8
+    dev: false
+    resolution:
+      integrity: sha512-ZBsfD46t3VNkwealxm5zloVgQta8d8o4KYBR/hMAZ582IgjmSDKZdkjyv5w37IUCM3tcPZWKUT+kml9pEIC2GA==
   /@samverschueren/stream-to-observable/0.3.0:
     dependencies:
       any-observable: 0.3.0
@@ -2138,6 +2184,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=
+  /atob-lite/2.0.0:
+    dev: false
+    resolution:
+      integrity: sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
   /atob/2.1.2:
     dev: false
     engines:
@@ -3332,6 +3382,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-wOvfOhtP7vcdVOGKKXwVmmbmrznF00nOCnudlZ8L8cQBva/wDZNPOZ3Fx1623HKbtDu+dlvvZAdeipYdEt5kDQ==
+  /before-after-hook/2.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
   /bfj/6.1.1:
     dependencies:
       bluebird: 3.5.5
@@ -3579,6 +3633,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
+  /btoa-lite/1.0.0:
+    dev: false
+    resolution:
+      integrity: sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
   /buffer-equal/0.0.1:
     dev: false
     engines:
@@ -4097,6 +4155,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+  /cliui/5.0.0:
+    dependencies:
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+      wrap-ansi: 5.1.0
+    dev: false
+    resolution:
+      integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
   /clone-deep/0.2.4:
     dependencies:
       for-own: 0.1.5
@@ -4890,6 +4956,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  /deepmerge/4.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
   /default-gateway/2.7.2:
     dependencies:
       execa: 0.10.0
@@ -4984,6 +5056,10 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+  /deprecation/2.3.1:
+    dev: false
+    resolution:
+      integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
   /des.js/1.0.0:
     dependencies:
       inherits: 2.0.3
@@ -5248,6 +5324,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
+  /emoji-regex/7.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
   /emojis-list/2.1.0:
     dev: false
     engines:
@@ -6529,6 +6609,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+  /get-caller-file/2.0.5:
+    dev: false
+    engines:
+      node: 6.* || 8.* || >= 10.*
+    resolution:
+      integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
   /get-own-enumerable-property-symbols/3.0.0:
     dev: false
     resolution:
@@ -7810,6 +7896,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  /is-plain-object/3.0.0:
+    dependencies:
+      isobject: 4.0.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==
   /is-posix-bracket/0.1.1:
     dev: false
     engines:
@@ -7950,6 +8044,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+  /isobject/4.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
   /isomorphic-fetch/2.2.1:
     dependencies:
       node-fetch: 1.7.3
@@ -9272,6 +9372,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+  /lodash.set/4.3.2:
+    dev: false
+    resolution:
+      integrity: sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
   /lodash.some/4.6.0:
     dev: false
     resolution:
@@ -9390,6 +9494,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  /macos-release/2.3.0:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==
   /magic-string/0.22.5:
     dependencies:
       vlq: 0.2.3
@@ -10480,6 +10590,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+  /octokit-pagination-methods/1.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
   /office-ui-fabric-core/10.1.0:
     dev: false
     resolution:
@@ -10624,6 +10738,15 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+  /os-name/3.1.0:
+    dependencies:
+      macos-release: 2.3.0
+      windows-release: 3.2.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
   /os-tmpdir/1.0.2:
     dev: false
     engines:
@@ -13702,6 +13825,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  /string-width/3.1.0:
+    dependencies:
+      emoji-regex: 7.0.3
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 5.2.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
   /string.prototype.matchall/3.0.1:
     dependencies:
       define-properties: 1.1.3
@@ -14639,6 +14772,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  /universal-user-agent/3.0.0:
+    dependencies:
+      os-name: 3.1.0
+    dev: false
+    resolution:
+      integrity: sha512-T3siHThqoj5X0benA5H0qcDnrKGXzU8TKoX15x/tQHw1hQBvIEBHjxQ2klizYsqBOO/Q+WuxoQUihadeeqDnoA==
   /universalify/0.1.2:
     dev: false
     engines:
@@ -14703,6 +14842,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  /url-template/2.0.8:
+    dev: false
+    resolution:
+      integrity: sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
   /url/0.11.0:
     dependencies:
       punycode: 1.3.2
@@ -15280,6 +15423,14 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
+  /windows-release/3.2.0:
+    dependencies:
+      execa: 1.0.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
   /wordwrap/0.0.2:
     dev: false
     engines:
@@ -15320,6 +15471,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  /wrap-ansi/5.1.0:
+    dependencies:
+      ansi-styles: 3.2.1
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
   /wrappy/1.0.2:
     dev: false
     resolution:
@@ -15431,12 +15592,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
-  /yargs-parser/4.2.1:
-    dependencies:
-      camelcase: 3.0.0
-    dev: false
-    resolution:
-      integrity: sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=
   /yargs-parser/5.0.0:
     dependencies:
       camelcase: 3.0.0
@@ -15483,6 +15638,21 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  /yargs/13.3.0:
+    dependencies:
+      cliui: 5.0.0
+      find-up: 3.0.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 3.1.0
+      which-module: 2.0.0
+      y18n: 4.0.0
+      yargs-parser: 13.1.1
+    dev: false
+    resolution:
+      integrity: sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
   /yargs/3.10.0:
     dependencies:
       camelcase: 1.2.1
@@ -15492,24 +15662,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
-  /yargs/6.6.0:
-    dependencies:
-      camelcase: 3.0.0
-      cliui: 3.2.0
-      decamelize: 1.2.0
-      get-caller-file: 1.0.3
-      os-locale: 1.4.0
-      read-pkg-up: 1.0.1
-      require-directory: 2.1.1
-      require-main-filename: 1.0.1
-      set-blocking: 2.0.0
-      string-width: 1.0.2
-      which-module: 1.0.0
-      y18n: 3.2.1
-      yargs-parser: 4.2.1
-    dev: false
-    resolution:
-      integrity: sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=
   /yargs/7.1.0:
     dependencies:
       camelcase: 3.0.0
@@ -15585,7 +15737,7 @@ packages:
     dev: false
     name: '@rush-temp/a11y-tests'
     resolution:
-      integrity: sha512-F8K8haqaveXW5CelSDm7C/9wfH4wwV9AdLJyxnRNeBndoheDuv8W6v02hxQOxB0dBjqoguwG81GpQzmOe5Eq8Q==
+      integrity: sha512-zBG+xxeNOwYW+qzmxhGTI6p7dUErCkk76VZsOrMGC42peqhG7qcm90fJwXHgsEHNKaw4q0jzwpHJ4c6u1AG/vA==
       tarball: 'file:projects/a11y-tests.tgz'
     version: 0.0.0
   'file:projects/api-docs.tgz':
@@ -15598,7 +15750,7 @@ packages:
     dev: false
     name: '@rush-temp/api-docs'
     resolution:
-      integrity: sha512-QUkUigT/Bnr2IMx+HqL9zWMC4UZ4WQr5QRGo/G9qEe6SiexyMT/56npTXPc/CyXQlBWSR1dxlr5pUxwLXYgCsA==
+      integrity: sha512-F3TbHE1YJA/SSerT0cHCQOqkY3omaDP/L2K5TvFw3CNXHgDIEfX1w4ntavwgOEH7ExyvHmsSD52Bu0hdb6CXUg==
       tarball: 'file:projects/api-docs.tgz'
     version: 0.0.0
   'file:projects/azure-themes.tgz':
@@ -15608,7 +15760,7 @@ packages:
     dev: false
     name: '@rush-temp/azure-themes'
     resolution:
-      integrity: sha512-fVG9UIW8LCcm83ctjmCOJRe9rIGQER5qZiHfKl5yARUg9rqpENy8v7VoaTL+W4OTjx+cEKLh/dpP3n655+2pxg==
+      integrity: sha512-JhTMx4Sf1ti9Yzw9X0d9d7q+negx8rJQ/6/NzX4SyXshHUDevPcPk5BQpafbjzBNxbRWiQN1N2Vj61T88oq2NQ==
       tarball: 'file:projects/azure-themes.tgz'
     version: 0.0.0
   'file:projects/build.tgz':
@@ -15616,6 +15768,7 @@ packages:
       '@microsoft/api-extractor': 7.1.6
       '@microsoft/load-themed-styles': 1.9.7
       '@microsoft/loader-load-themed-styles': 1.7.165
+      '@octokit/rest': 16.28.4
       async: 2.6.2
       autoprefixer: 7.2.6
       babylon: 7.0.0-beta.47
@@ -15669,11 +15822,11 @@ packages:
       webpack-cli: /webpack-cli/3.2.3/webpack@4.29.5
       webpack-dev-server: /webpack-dev-server/3.1.14/webpack@4.29.5
       webpack-notifier: 1.7.0
-      yargs: 6.6.0
+      yargs: 13.3.0
     dev: false
     name: '@rush-temp/build'
     resolution:
-      integrity: sha512-CuCBvrl8yFVVzgO8Jp/i8qaKyCZEMDP1h0apIACaiTdUF+ITYi2/HndbSUlifpS0InwekViVzAmCudy3FyzcGg==
+      integrity: sha512-/H4cFPxARZEddTc3Nr3Wkpo5KwMEkFVxS56RMSMkmmY9P9sn8g2ADwFiLq8RV4XO+G4fgOVEO2RMqf91/F+qSQ==
       tarball: 'file:projects/build.tgz'
     version: 0.0.0
   'file:projects/charting.tgz':
@@ -15717,7 +15870,7 @@ packages:
     dev: false
     name: '@rush-temp/charting'
     resolution:
-      integrity: sha512-xpuJyuvbiGcnyxjFmdj2vdPGRVIQF0Ng71MoYjVSboxhpfM64IaqwCu9YPNDhDQiKFQCkTCN9dPLWyrh2rKimg==
+      integrity: sha512-/egqVJCdbkviZGnrEcobLLBZgJAJnQP86jd1vgTQew60bsFukKoEcVWAdrAf3Nj0CY1cSVVmyNLeqdiFSuUs0Q==
       tarball: 'file:projects/charting.tgz'
     version: 0.0.0
   'file:projects/codepen-loader.tgz':
@@ -15766,7 +15919,7 @@ packages:
     dev: false
     name: '@rush-temp/date-time'
     resolution:
-      integrity: sha512-AAf4v4SZzuxTmoAFuP7eUEaNhszduy7h+0dIot6EF8c98mBqWgV1IPhhG3dJqV3E8ghfG9jJ+OwfVgs1gk79LA==
+      integrity: sha512-1c28Uhx8Tcat/r+HvX5pd+zfR6hPqLr6Qse1wJAlg0jUlydQ6rwGznblWxkf/Va2kje1hDVhOJipTHTaqDSEBw==
       tarball: 'file:projects/date-time.tgz'
     version: 0.0.0
   'file:projects/dom-tests.tgz':
@@ -15792,7 +15945,7 @@ packages:
     dev: false
     name: '@rush-temp/dom-tests'
     resolution:
-      integrity: sha512-Mr3tx4HF6ZVOe8djma3tAcakzONwm2a6wIhjo4axTB0eXaR4RqfSeA3y07sbnMiRHO8yQlr6au4OjvVYPNTqNQ==
+      integrity: sha512-y7oa5saMBkcHaDihASrppel3/lOkv2SCvWpR4jToXbzFHfV5FKU7zBP5mYpMhJm2skeRU3EFr/5A61Ai1Xq1Zw==
       tarball: 'file:projects/dom-tests.tgz'
     version: 0.0.0
   'file:projects/example-app-base.tgz':
@@ -15821,7 +15974,7 @@ packages:
     dev: false
     name: '@rush-temp/example-app-base'
     resolution:
-      integrity: sha512-f2cXoVMTq5fZzXvmQCileIq30PhHzfxVijMlvF6W2h8MHNtixGy72RLdEJTRQnsB4jWJ4sMB2V4W7XjWeSZJgg==
+      integrity: sha512-ByOIZK1PTDlDdJfNXAU1+Y5MsDV5/Xp2JZYKO7qNJJkjKngGPZW0fARXfyHZHbIBYtSyLxQARNYF3fk9GJGJgA==
       tarball: 'file:projects/example-app-base.tgz'
     version: 0.0.0
   'file:projects/experiments.tgz':
@@ -15856,7 +16009,7 @@ packages:
     dev: false
     name: '@rush-temp/experiments'
     resolution:
-      integrity: sha512-U9K0x/GF8r2yWWFI2QxbQJ0z6l7PYX1CQlXxpKTZ5rqcedvm6ZxHrswoxnCUJw1T5zohXDuxX7Dtsx787/e7Mw==
+      integrity: sha512-DN7TsXglmtbAuJdezXFEr1Oagzx3phkzw4Goq3gvU7QYP70Nhet/2hgrXxMghSDk5d4BmSIT6A5/+S4fm0T4+Q==
       tarball: 'file:projects/experiments.tgz'
     version: 0.0.0
   'file:projects/fabric-website-resources.tgz':
@@ -15899,7 +16052,7 @@ packages:
     dev: false
     name: '@rush-temp/fabric-website-resources'
     resolution:
-      integrity: sha512-yzaEivyxG6VlvsjeWx0zrzrQgIs9Df4Kqmo3cLNR3Ob7swPjOw5qppj0U+fum0+lz7ZGO18P349t26oQKD4fjg==
+      integrity: sha512-VmYsZG2WfCiLtRteDIlycu+l2Riw/SIRVHmd+85iZhQdZHhbBvyaN9zmmB6NDiv/JbpND/QzPj4sGM3irbXanQ==
       tarball: 'file:projects/fabric-website-resources.tgz'
     version: 0.0.0
   'file:projects/fabric-website.tgz':
@@ -15926,7 +16079,7 @@ packages:
     dev: false
     name: '@rush-temp/fabric-website'
     resolution:
-      integrity: sha512-OJIgpYU3aQxi4WJVUhwB4FKpUokKg/yn8MeCv5p05vBKV1q5X7D58O0P3w8qvqm/I8KpDv3acl+EtLOHTEwVgQ==
+      integrity: sha512-XjMVlG1+YVEYFi0tXXK9ACHeSopcLQiA/HlzUWtO6EOENMYOsM2yeSxzB216WBFkK1mF/PMwpFISj4dLMEjBYw==
       tarball: 'file:projects/fabric-website.tgz'
     version: 0.0.0
   'file:projects/file-type-icons.tgz':
@@ -15941,7 +16094,7 @@ packages:
     dev: false
     name: '@rush-temp/file-type-icons'
     resolution:
-      integrity: sha512-94Wr/0q11McmZd2bO+KFO19iCQsZxbK8gDucdWkNEg3ogyGuQq6SWSYuyM2lT3QqRmS3K5qCzJPxOnRu3lTBBQ==
+      integrity: sha512-oQDd0T7SGK8hX9zJakssV4Z9iGiGFSK9epIt+v9HkyQIts/4iVpoEgB1SRdEhONlNYw0L5l6rU6mMV7l5dhVcw==
       tarball: 'file:projects/file-type-icons.tgz'
     version: 0.0.0
   'file:projects/fluent-theme.tgz':
@@ -15951,7 +16104,7 @@ packages:
     dev: false
     name: '@rush-temp/fluent-theme'
     resolution:
-      integrity: sha512-jdyxi3eNFyYJlZkiTv5qd9ildr0IuU7DbaETa1RMy2+eIJZvRB4F7qp9iyGt6JlgttkdiUw8sapoNsSkwRtcAA==
+      integrity: sha512-YYjSQYVm6GVF2g1uF/9oWuqn3/9kmatHORDEf2h4Jtk46MrmNMm95zK/OPrEiWw6jy1urvfoZWN6dLFJfLO4xg==
       tarball: 'file:projects/fluent-theme.tgz'
     version: 0.0.0
   'file:projects/foundation-scenarios.tgz':
@@ -15976,7 +16129,7 @@ packages:
     dev: false
     name: '@rush-temp/foundation-scenarios'
     resolution:
-      integrity: sha512-ls0qKl/bZrKYllt/ltV7HOvpuCUWmKmti2iMx9qPY+NsscbgeU8pEzCV5Z+J8s8jGLOz1e/s0JRyaSr4dJQ4IQ==
+      integrity: sha512-qYLOKL4Oqfoo5XfB72+fV9y0hyniA34moHCriSW+xP1xsI0ATN7sFQH5zVXSQ7I1GmfgpOIj3tnuSd2YYhdr0w==
       tarball: 'file:projects/foundation-scenarios.tgz'
     version: 0.0.0
   'file:projects/foundation.tgz':
@@ -16000,7 +16153,7 @@ packages:
     dev: false
     name: '@rush-temp/foundation'
     resolution:
-      integrity: sha512-zZXKyCdM+4FFbzK5EFUwwvp/KfmOYmB3QR1/bvNcIkwxyxVTsanr8GQ6TnamPaJDu0AnIbRGhs8Q76IOvc/jEA==
+      integrity: sha512-fz+R2lQ9oxvQqcZN3/C0oWN9T9rEp+bhXyZ3Uo8747eFe5JsRU436cNEr0uTgHaLyn5Aw4FJ0k/crgrF/KFWmA==
       tarball: 'file:projects/foundation.tgz'
     version: 0.0.0
   'file:projects/icons.tgz':
@@ -16009,7 +16162,7 @@ packages:
     dev: false
     name: '@rush-temp/icons'
     resolution:
-      integrity: sha512-J8hKcVA3wWYxnUKltUUtPfEek/gE2b8IRcDVT/I/YasamPGkUtGZvqIMNwiLrMF/K14Jnzx3N17YDkI6b5wc9Q==
+      integrity: sha512-5Hqt6ckK44YIwurq0MjOatFid7+h4xIDrBu1jrN5wewsFNaVF3HKNBEVux0FKeQqlttEtolV1gJKQdg95hv4pQ==
       tarball: 'file:projects/icons.tgz'
     version: 0.0.0
   'file:projects/jest-serializer-merge-styles.tgz':
@@ -16050,7 +16203,7 @@ packages:
     dev: false
     name: '@rush-temp/lists'
     resolution:
-      integrity: sha512-54zNUMtNxD+Ce7fiPPauX6RAHz8IR1lIblqczpTBJ7cwWm1H8tV5vGIiCyfEY1WQBVwnUur5G8KL4V7F0bVHxA==
+      integrity: sha512-C2kNWefokhrBsHjXmHzeYKCDuIBs1LHX6tJIWY1aWha/y4AQ3W8yqu5DcsNpdGZ8Ob3YHVPwNvlg56WUPSz75Q==
       tarball: 'file:projects/lists.tgz'
     version: 0.0.0
   'file:projects/mdl2-theme.tgz':
@@ -16059,7 +16212,7 @@ packages:
     dev: false
     name: '@rush-temp/mdl2-theme'
     resolution:
-      integrity: sha512-11h8xonCd9NTE8zbbc3OzTBO3fysJiyJbAF5sTIAywr5+WrpfFaTlnhVXZgXFoAPTiDYQRbA1kvbS9uhG4vCEQ==
+      integrity: sha512-iEzPm2z553rO/pRP7XosjdP2tCA1Te+DU1zQCB1L8yXj5BuNXplxJxnSHkh+UiIEMPSjd/nWuHCF8jPtkhktBg==
       tarball: 'file:projects/mdl2-theme.tgz'
     version: 0.0.0
   'file:projects/merge-styles.tgz':
@@ -16129,7 +16282,7 @@ packages:
     dev: false
     name: '@rush-temp/office-ui-fabric-react'
     resolution:
-      integrity: sha512-sjOyf8GjpTp23r5ttmbe8k0kvLWdl67ootb7XbXZMw4SRv3Oaq36e3JzGPIKR1DTqZFcrwyrx4irSWyiwNsonA==
+      integrity: sha512-3c17zj02gzy/ttmPDm5Sn1E0YLdMB03D3r6kCZVos8S82RwF8lYhAGGeo32YikwDxBy64+MQAa61MGVqliBrgA==
       tarball: 'file:projects/office-ui-fabric-react.tgz'
     version: 0.0.0
   'file:projects/perf-test.tgz':
@@ -16153,14 +16306,14 @@ packages:
     dev: false
     name: '@rush-temp/perf-test'
     resolution:
-      integrity: sha512-62QhB7s1jholbQ5MoWYNVFzojYf+T8D0z6IUvZ1pwIPLu04I914DMJvLACmcEIlyXiVIw7zqTTVnXhzUotCQcw==
+      integrity: sha512-O6aa6AUcdSZG71ZfIur0YpbsGkVD8TDnCqzYdLHCqSVPUHhZ9/MGVwjj50xPGzI0WgmMBnzt1+QS4jKtW2ARVQ==
       tarball: 'file:projects/perf-test.tgz'
     version: 0.0.0
   'file:projects/pr-deploy-site.tgz':
     dev: false
     name: '@rush-temp/pr-deploy-site'
     resolution:
-      integrity: sha512-RNPY2cFEGKnbpdb2HPQb0DGTZVQ08lE6eyNdZGQ7vQ1Os7fx8PcVLJ+c23hZHcz4k/KgLJ5gtZ8MB2mShpFI5A==
+      integrity: sha512-eEhV05ZMlTVl1jl78mmHtNDBVYAmtNsL6zfufMpz0nmvXtt8dWXC0EMM8vf+DqGwp0ntUToY+Ox3J8W5V1MeDg==
       tarball: 'file:projects/pr-deploy-site.tgz'
     version: 0.0.0
   'file:projects/prettier-rules.tgz':
@@ -16195,7 +16348,7 @@ packages:
     dev: false
     name: '@rush-temp/react-cards'
     resolution:
-      integrity: sha512-Ov950PltgGXtz4CCmhuqtYGzUmZvPjScx/ZemaDxZlNgttQxE45MsOTNim/V88oG6xyPVc7c56kOutP6bFc+ew==
+      integrity: sha512-azO0mKT+36TU0ywq8IEtWvUH7YT7jgWGVyRYSWCy3sCII2b1bjSaq6x3Bshf9/8j0Jyhfzy/vOSwPR6W/sJBMg==
       tarball: 'file:projects/react-cards.tgz'
     version: 0.0.0
   'file:projects/server-rendered-app.tgz':
@@ -16215,7 +16368,7 @@ packages:
     dev: false
     name: '@rush-temp/server-rendered-app'
     resolution:
-      integrity: sha512-L111Wg6hBn1tsjRiA/D1wC52/Kb/1KM0GBR9M65OpFK/gaceP/7MtlNbT/f9vZmk1AuEH3CKeGSEkqDH0TnF2Q==
+      integrity: sha512-voYAEfWS39Ir0xGRvQJ6odRkYrcRUBwUl8BK9xA3tIzmdi5DR8nDn0ebrGB3dYWqdYP62W4pK37JcomQRUho4A==
       tarball: 'file:projects/server-rendered-app.tgz'
     version: 0.0.0
   'file:projects/set-version.tgz':
@@ -16245,7 +16398,7 @@ packages:
     dev: false
     name: '@rush-temp/ssr-tests'
     resolution:
-      integrity: sha512-h5CM9DxT8+cWo78ICXyeRxlD0PmJmzP5AB9k98/HNZsKjxS13W3kKSLebbxfzC6xeqAKV0REDyyO5QHQdG+SkA==
+      integrity: sha512-x4nm4n8RgEjy9te79FkGTIRBnE4tiiLnlqaS6axZbfb0MZyEf9aMN5l64SAdGQp0z0ASNc2x7km+ef0DPjA3uQ==
       tarball: 'file:projects/ssr-tests.tgz'
     version: 0.0.0
   'file:projects/styling.tgz':
@@ -16278,7 +16431,7 @@ packages:
     dev: false
     name: '@rush-temp/test-bundles'
     resolution:
-      integrity: sha512-rhFLlF2fgIxCeH4MAH/qf3WOhSajNt0X/k/oimXJyZkO1hFDvGjRm2Ta6zpSmNDKHLCpiy3MqOQDvK6aon9+Tw==
+      integrity: sha512-Ffjj3NJYO4pJ+szHwAIxvM+BgRC9EX5tcg5XS0xN0csJ7tDkEQ2hpA2UxnCWxId0H8ogAoevIWdQyvl0pEzbXw==
       tarball: 'file:projects/test-bundles.tgz'
     version: 0.0.0
   'file:projects/test-utilities.tgz':
@@ -16311,7 +16464,7 @@ packages:
     dev: false
     name: '@rush-temp/theme-samples'
     resolution:
-      integrity: sha512-nQK47AcTfztFFJk2aqMtqK9sAUawjvZ4L+zERMkQTmieSOXAgbJWVyO6YMoBN0x6BPWwoOm1wEWr0SuN+9+LyQ==
+      integrity: sha512-O0hhk+TObP2Nab4/g7E41PvwRy64O0sEKI5SCY5p+8XGCidlfDogFpWhq/pkzTHeXVINr65/Dd+zkfDRuM3Exg==
       tarball: 'file:projects/theme-samples.tgz'
     version: 0.0.0
   'file:projects/theming-designer.tgz':
@@ -16330,7 +16483,7 @@ packages:
     dev: false
     name: '@rush-temp/theming-designer'
     resolution:
-      integrity: sha512-lwwQ8S9MmIYRlBHDz1W4OHac6IpLlFCqbL8kGpRqVzTHHg3w0MVLgJOeFgWvFNIfZ/ikvqUHK9EJwK2vChsGIA==
+      integrity: sha512-9bYrIgKLlePSRs0uVGp1XmTHFA3I22vdaEtiP3r0YWDb0cKLqXFEPMbSvbq23by4I18Dx3iRmhIVgHzVrYu+nQ==
       tarball: 'file:projects/theming-designer.tgz'
     version: 0.0.0
   'file:projects/todo-app.tgz':
@@ -16350,7 +16503,7 @@ packages:
     dev: false
     name: '@rush-temp/todo-app'
     resolution:
-      integrity: sha512-tpmq4zQtyCOFC9jSWH37fnncjYBhUt8hKf89KuMB5oO51yiHGM1sDowNO7nV3SGqRrPbExL5lYZA01kXG3kIpw==
+      integrity: sha512-KrHW32swkYSJwON1zO25vM8DBdIOS4BSum//P8DbI6VkkRcij6L7kKH9K2F2o7NEWL/2ozyohnnsVAmzV5JQXw==
       tarball: 'file:projects/todo-app.tgz'
     version: 0.0.0
   'file:projects/tslint-rules.tgz':
@@ -16390,7 +16543,7 @@ packages:
     dev: false
     name: '@rush-temp/tsx-editor'
     resolution:
-      integrity: sha512-wwPP5X9L3DP7v+qEUvNdjbQi5v1OjsU7rmjAPmFv5d9Exh/iQpOi5Fdvq7EIVlx/3udSSUMmCmuP6FGyP+e/CA==
+      integrity: sha512-mc9ObZi2anJ2uNktZG62Zs6nn8D9cJl44oJ7OTuYm9D4bszip4Vl0zysxfJAQVJl2gqc00psY9VKoRfIpFhndQ==
       tarball: 'file:projects/tsx-editor.tgz'
     version: 0.0.0
   'file:projects/utilities.tgz':
@@ -16426,7 +16579,7 @@ packages:
     dev: false
     name: '@rush-temp/variants'
     resolution:
-      integrity: sha512-y4oL1RR+5zeSSuKWk4AnMtzcm6UMyQ/oOYNMUBhD2XeIYOMbMLBZabisFW3mDlFhJKsVDgIHZLEH5K8g+t3Mhg==
+      integrity: sha512-t3q/o8est9E+TBBfnwCYamw+QYa7hIWlOpUR7O2wq/pLQWVYQLertdz5BTXF+tiO8zXNGp3lieHrLb4T0PP6qQ==
       tarball: 'file:projects/variants.tgz'
     version: 0.0.0
   'file:projects/vr-tests.tgz':
@@ -16459,7 +16612,7 @@ packages:
     dev: false
     name: '@rush-temp/vr-tests'
     resolution:
-      integrity: sha512-rrTsdIuM3l+hBlzQRhFZBfWIA6aiI+h08SjZUmO534q0WAFb4tQXV7d5LbBfxBuMysBcVEHz8WdSSgIMNWLeNQ==
+      integrity: sha512-Dcg7Wj7s+p0ClEcLZ2PaApDS3NdcYeRibyZKCmBFi6cQja8r7mt7PnEC51+z6Vf9zRl7KIof//h8mx/n/UKMGw==
       tarball: 'file:projects/vr-tests.tgz'
     version: 0.0.0
   'file:projects/webpack-utils.tgz':
@@ -16487,6 +16640,7 @@ specifiers:
   '@microsoft/loader-load-themed-styles': ^1.6.0
   '@microsoft/node-core-library': ~3.9.0
   '@microsoft/tsdoc': 0.12.9
+  '@octokit/rest': ^16.28.2
   '@rush-temp/a11y-tests': 'file:./projects/a11y-tests.tgz'
   '@rush-temp/api-docs': 'file:./projects/api-docs.tgz'
   '@rush-temp/azure-themes': 'file:./projects/azure-themes.tgz'
@@ -16608,7 +16762,6 @@ specifiers:
   flamebearer: ^1.1.3
   fork-ts-checker-webpack-plugin: ^0.4.1
   fs-extra: ^7.0.1
-  github: ^7.0.0
   glob: ^7.1.2
   gzip-size: ^3.0.0
   highlight.js: ^9.12.0
@@ -16682,4 +16835,4 @@ specifiers:
   webpack-notifier: ^1.6.0
   whatwg-fetch: 2.0.4
   write-file-webpack-plugin: ^4.1.0
-  yargs: ^6.5.0
+  yargs: ^13.2.4

--- a/packages/codepen-loader/just.config.js
+++ b/packages/codepen-loader/just.config.js
@@ -1,6 +1,20 @@
+// @ts-check
+
 // NOTE: this package cannot take @uifabric/build as a dependency because of circular dependency
 // So, it will take just-scripts directly.
-const { taskPresets, task, series, parallel, tscTask, copyTask } = require('just-scripts');
+const {
+  taskPresets,
+  task,
+  series,
+  parallel,
+  option,
+  condition,
+  tscTask,
+  copyTask,
+  argv
+} = require('just-scripts');
+
+option('min', { alias: 'npm-install-mode' });
 
 taskPresets.lib();
 
@@ -18,4 +32,7 @@ task(
   )
 );
 
-task('build', series('clean', 'copy', parallel('jest', 'ts'))).cached();
+task(
+  'build',
+  series('clean', 'copy', parallel('ts', condition('jest', () => !argv().min)))
+).cached();

--- a/scripts/find-config.js
+++ b/scripts/find-config.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Find a config file path, starting in the current directory and looking up to the Git root directory
  * (which contain .git) or the drive root.
@@ -8,14 +10,15 @@ function findConfig(configName) {
   if (!configName) {
     return undefined;
   }
+
   const fs = require('fs');
   const path = require('path');
-  const rootPath = path.resolve('/');
 
   if (path.isAbsolute(configName)) {
     return configName;
   }
 
+  const rootPath = path.resolve('/');
   let cwd = process.cwd();
   let foundGitRoot = false;
 

--- a/scripts/just.config.js
+++ b/scripts/just.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { task, series, parallel, condition, option, argv, logger, addResolvePath } = require('just-scripts');
+const { task, series, parallel, condition, option, argv, addResolvePath } = require('just-scripts');
 
 const path = require('path');
 const fs = require('fs');

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -17,6 +17,7 @@
     "@microsoft/api-extractor": "7.1.6",
     "@microsoft/load-themed-styles": "^1.7.13",
     "@microsoft/loader-load-themed-styles": "^1.6.0",
+    "@octokit/rest": "^16.28.2",
     "@uifabric/codepen-loader": "^7.0.5",
     "@uifabric/prettier-rules": "^7.0.3",
     "async": "^2.6.1",
@@ -32,7 +33,6 @@
     "find-free-port": "~2.0.0",
     "fork-ts-checker-webpack-plugin": "^0.4.1",
     "fs-extra": "^7.0.1",
-    "github": "^7.0.0",
     "glob": "^7.1.2",
     "gzip-size": "^3.0.0",
     "jest": "24.1.0",
@@ -69,7 +69,7 @@
     "webpack-cli": "3.2.3",
     "webpack-dev-server": "3.1.14",
     "webpack-notifier": "^1.6.0",
-    "yargs": "^6.5.0"
+    "yargs": "^13.2.4"
   },
   "bundlesize": [
     {

--- a/scripts/updateReleaseNotes.js
+++ b/scripts/updateReleaseNotes.js
@@ -1,60 +1,97 @@
+// @ts-check
+
 'use strict';
 
 /**
  * This script sends release notes to github. The release notes are pulled from
  * CHANGELOG.json entries and are only sent if there aren't already notes for a
  * given tag.
+ *
+ * @typedef {{
+ *   comment: string;
+ *   commit?: string;
+ * }} ChangelogComment
+ *
+ * @typedef {{
+ *   comments: { major: ChangelogComment[]; minor: ChangelogComment[]; patch: ChangelogComment[]; };
+ *   name?: string;
+ *   date?: string;
+ *   tag?: string;
+ *   version: string;
+ *   body?: string;
+ * }} ChangelogEntry
+ *
+ * @typedef {{
+ *   number: number;
+ *   url: string;
+ *   author: string;
+ *   authorUrl: string;
+ * }} PullRequest
  */
 
-let path = require('path');
-let fs = require('fs');
-let argv = require('yargs').argv;
-let execSync = require('child_process').execSync;
-let GitHubApi = require('github');
+const path = require('path');
+const fs = require('fs');
+const yargs = require('yargs');
+const execSync = require('child_process').execSync;
+const GitHubApi = require('@octokit/rest');
+
+const argv = yargs
+  .option('token', {
+    describe: 'GitHub personal access token',
+    type: 'string',
+    required:
+      'A GitHub personal access token is required even for dry runs due to the potential high rate of requests.\n' +
+      'Generate one here: https://github.com/settings/tokens\n'
+  })
+  .option('apply', { describe: 'Actually apply changes (without this option, do a dry run)', type: 'boolean', default: false })
+  .option('patch', { describe: 'Patch existing release notes for releases less than `age` days old', type: 'boolean', default: false })
+  .option('patch-all', { describe: 'Patch ALL existing release notes (will likely hit rate limits)', type: 'boolean', default: false })
+  .option('debug', { describe: 'Use debug mode for the GitHub API', type: 'boolean', default: false })
+  // Default to checking the past 5 days in case there were any missed days or other issues
+  .option('age', { describe: 'Get tags/releases up to this many days old', type: 'number', default: 5 })
+  .option('owner', { describe: 'Owner of the repo to work against', type: 'string', default: 'OfficeDev' })
+  .option('repo', { describe: 'Repo to work against', type: 'string', default: 'office-ui-fabric-react' })
+  .version(false)
+  .help().argv;
 
 const EOL = '\n';
+const MILLIS_PER_DAY = 1000 * 60 * 60 * 24;
 
 const REPO_DETAILS = {
-  owner: "OfficeDev",
-  repo: "office-ui-fabric-react"
+  owner: argv.owner,
+  repo: argv.repo
 };
 
-const SHOULD_PATCH = argv.patch;
-const SHOULD_APPLY = argv.apply;
-
-// Get command line params.
-if (!argv.token) {
-  throw new Error("No token specified. Use --token=<token> to provide a token.");
+if (!argv.apply) {
+  console.log('NOTE: This is a test run only. To actually update release notes on GitHub, use the "--apply" flag.');
 }
 
-if (!SHOULD_APPLY) {
-  console.log('NOTE: this is a test run only. To update release notes to github, use the "--apply" flag.');
-}
-
-// Authenticate with github.
-let github = new GitHubApi({ debug: argv.debug });
-
-github.authenticate({
-  type: 'token',
-  token: argv.token
-});
+// Authenticate with github and set up logging if debug arg is provided
+const github = new GitHubApi({ ...(argv.debug ? { log: console } : {}), auth: 'token ' + argv.token });
 
 // Call the primary entry point.
-updateReleaseNotes(SHOULD_PATCH);
+updateReleaseNotes();
 
 /**
  * For each file within the folder tree that matches the filename, call the callback
  * with an object containing path/content.
+ * @param {string} folder
+ * @param {string} fileName
+ * @param {(result: { path: string; content: string; }) => void} cb
  */
 function forEachFileRecursive(folder, fileName, cb) {
   folder = folder || process.cwd();
 
-  let folderContent = fs.readdirSync(folder).filter(name => ['node_modules', '.git'].indexOf(name) < 0);
+  let folderContent = fs.readdirSync(folder).filter(name => !['node_modules', '.git'].includes(name));
 
-  folderContent.filter(itemName => itemName === fileName).forEach(matchedFileName => cb({
-    path: path.resolve(folder, matchedFileName),
-    content: fs.readFileSync(path.resolve(folder, matchedFileName), 'utf8')
-  }));
+  folderContent
+    .filter(itemName => itemName === fileName)
+    .forEach(matchedFileName =>
+      cb({
+        path: path.resolve(folder, matchedFileName),
+        content: fs.readFileSync(path.resolve(folder, matchedFileName), 'utf8')
+      })
+    );
 
   folderContent.forEach(itemName => {
     let itemPath = path.resolve(folder, itemName);
@@ -67,95 +104,97 @@ function forEachFileRecursive(folder, fileName, cb) {
 
 /**
  * Build up the markdown from the entry description.
+ * @param {ChangelogEntry} entry
  */
 async function getMarkdownForEntry(entry) {
-  let markdown = '';
-  let comments = '';
+  const comments =
+    (await getChangeComments('Breaking changes', entry.comments.major)) +
+    (await getChangeComments('Minor changes', entry.comments.minor)) +
+    (await getChangeComments('Patches', entry.comments.patch));
 
-  comments += await getChangeComments('Breaking changes', entry.comments.major);
-  comments += await getChangeComments('Minor changes', entry.comments.minor);
-  comments += await getChangeComments('Patches', entry.comments.patch);
-
-  if (!comments) {
-    markdown += '*Changes not tracked*' +
-      EOL + EOL;
-  }
-  else {
-    markdown += comments;
-  }
-
-  return markdown;
+  return comments || '*Changes not tracked*' + EOL + EOL;
 }
 
 /**
- * From a comment array, conditionally returns a section of markdown.
+ * Gets the release notes markdown corresponding to the comment array.
+ * @param {string} title Section title (probably change type, major/minor/patch)
+ * @param {ChangelogComment[]} comments Changelog comments for a version
  */
-async function getChangeComments(title, commentsArray) {
-  var comments = '';
-  if (commentsArray) {
-    comments = "# " + title + (EOL + EOL);
-
-    for (let i = 0; i < commentsArray.length; i++) {
-      var comment = commentsArray[i];
-      var searchResult;
-
-      comments += `- ${comment.comment}`;
+async function getChangeComments(title, comments) {
+  if (comments) {
+    const lines = ['## ' + title, ''];
+    for (const comment of comments) {
+      let line = `- ${comment.comment}`;
       if (comment.commit) {
-        comments += ` ([commit](https://github.com/${REPO_DETAILS.owner}/${REPO_DETAILS.repo}/commit/${comment.commit})`;
-        searchResult = await getPullRequest(comment.commit);
+        line += ` ([commit](https://github.com/${REPO_DETAILS.owner}/${REPO_DETAILS.repo}/commit/${comment.commit})`;
 
-        if (searchResult) {
-          comments += ` by [${searchResult.author}](${searchResult.authorUrl}), pr [#${searchResult.number}](${searchResult.url})`;
+        const pr = await getPullRequest(comment.commit);
+        if (pr) {
+          line += ` by [${pr.author}](${pr.authorUrl}), PR [#${pr.number}](${pr.url})`;
         }
 
-        comments += `)`;
+        line += `)`;
       }
-      comments += EOL;
+      lines.push(line);
     }
-    comments += EOL;
+    lines.push('');
+    return lines.join(EOL);
   }
-  return comments;
-};
+  return '';
+}
 
-function getPullRequest(commitHash) {
-  return new Promise((resolve, reject) => {
-
-    github.search.issues({ q: commitHash }, (response, result) => {
-      if (result && result.items && result.items.length >= 1) {
-        var item = result.items.find(
-          item => item.repository_url === `https://api.github.com/repos/${REPO_DETAILS.owner}/${REPO_DETAILS.repo}`
-        );
-
-        if (item) {
-          resolve({
-            number: item.number,
-            url: item.html_url,
-            author: item.user.login,
-            authorUrl: item.user.html_url
-          });
-
-          return;
-        }
-      }
-
-      resolve(null);
-    });
-
-  });
+/**
+ * Get the single pull request associated with the given commit.
+ * @param {string} commitHash
+ * @returns {Promise<PullRequest>}
+ */
+async function getPullRequest(commitHash) {
+  try {
+    const result = await github.repos.listPullRequestsAssociatedWithCommit({ commit_sha: commitHash, ...REPO_DETAILS });
+    // In case the commit has been in multiple PRs at some point but only one got merged
+    const prs = result.data.filter(result => !!result.merged_at);
+    if (prs.length > 1) {
+      // In case the commit was in PRs to multiple branches or something?
+      console.warn(`Multiple PRs found for ${commitHash}: ${prs.map(pr => '#' + pr.number).join(', ')}`);
+    }
+    if (prs[0]) {
+      return {
+        number: prs[0].number,
+        url: prs[0].html_url,
+        author: prs[0].user.login,
+        authorUrl: prs[0].user.html_url
+      };
+    } else {
+      console.warn('No PRs found for ' + commitHash);
+    }
+  } catch (ex) {
+    console.warn(`Error finding PR for ${commitHash}: ${ex}`);
+  }
+  return null;
 }
 
 /**
  * Builds a map of changelog tags to entries defined in CHANGELOG.json files.
+ * @param {number} [maxAgeDays] If provided, only include entries less than this many days old.
+ * Otherwise get all entries.
  */
-function getChangelogTagMap() {
+function getChangelogTagMap(maxAgeDays) {
+  /** @type {Map<string, ChangelogEntry>} */
   let map = new Map();
 
-  forEachFileRecursive(undefined, 'CHANGELOG.json', (result) => {
+  forEachFileRecursive(undefined, 'CHANGELOG.json', result => {
+    /** @type {{ entries: ChangelogEntry[]; name: string; }} */
     let changelog = JSON.parse(result.content);
-    changelog.entries.forEach(entry => {
-      entry.name = changelog.name;
-      map.set(entry.tag, entry);
-    });
+    for (const entry of changelog.entries) {
+      if (isNewEnough(entry.date, maxAgeDays)) {
+        entry.name = changelog.name;
+        map.set(entry.tag, entry);
+      } else {
+        // changelog entries should be in reverse chronological order, so stop after the first one
+        // that's too old
+        break;
+      }
+    }
   });
 
   return map;
@@ -163,115 +202,149 @@ function getChangelogTagMap() {
 
 /**
  * Gets all the tags in a repo using 'git tag'.
+ * @param {number} [maxAgeDays] If provided, only include entries less than this many days old.
+ * Otherwise get all entries.
  */
-function getTags() {
-  let tags = new Set();
-  let count = 0;
+function getTags(maxAgeDays) {
+  const cmd = [
+    'git',
+    'for-each-ref',
+    '--sort=-committerdate', // commit date descending
+    "--format='%(refname:short) -- %(committerdate)'",
+    'refs/tags'
+  ].join(' ');
 
-  execSync('git tag', {
-    cwd: process.cwd()
-  }).toString().split('\n').forEach(tag => {
-    if (tag) {
-      tags.add(tag);
-      count++;
+  let tagsAndDates = execSync(cmd, { cwd: process.cwd() })
+    .toString()
+    .split('\n')
+    .map(tag => tag.split(' -- '))
+    .filter(arr => arr.length === 2);
+
+  if (maxAgeDays) {
+    const endIndex = tagsAndDates.findIndex(([, date]) => !isNewEnough(date, maxAgeDays));
+    if (endIndex !== -1) {
+      tagsAndDates = tagsAndDates.slice(0, endIndex);
     }
-  });
+  }
 
-  console.log(`Found ${count} tag(s).`);
+  const tags = tagsAndDates.map(([tag]) => tag);
+
+  console.log(`Found ${tags.length} tag(s).`);
 
   return tags;
 }
 
 /**
- * Gets all releases from github.
+ * @param {string} dateStr String of a date
+ * @param {number} [maxAgeDays] If provided, only return true if entry is less than this many days old.
+ * If not provided, always return true.
  */
-function getReleases(cb) {
-  let releases = new Map();
-  let count = 0;
-
-  function onPageReceived(err, res) {
-    if (err) {
-      throw new Error('Could not get releases from github.\n' + err);
-    }
-
-    res.forEach(release => {
-      releases.set(release.tag_name, release);
-      count++;
-    });
-
-    if (github.hasNextPage(res)) {
-      github.getNextPage(res, onPageReceived);
-    } else {
-      console.log(`Found ${count} releases on github.`);
-
-      cb(releases);
-    }
-  }
-
-  github.repos.getReleases(REPO_DETAILS, onPageReceived);
+function isNewEnough(dateStr, maxAgeDays) {
+  return !maxAgeDays || Date.now() - new Date(dateStr).getTime() < maxAgeDays * MILLIS_PER_DAY;
 }
 
 /**
- * Adds new release notes, and if shouldPatchChangelog is true, will patch existing ones in the case
- * that they need to be regenerated.
+ * Gets all releases from github.
+ * @param {string[]} [tags] If provided, only get the releases for these tags (it's okay if a tag
+ * doesn't have a release yet). Otherwise get all the releases.
  */
-function updateReleaseNotes(shouldPatchChangelog) {
-  let changelogEntries = getChangelogTagMap();
-  let publishedTags = getTags();
-  getReleases((releases) => {
-    let count = 0;
+async function getReleases(tags) {
+  /** @type {Map<string, GitHubApi.ReposListReleasesResponseItem>} */
+  let releases = new Map();
 
-    publishedTags.forEach(async tag => {
-      let entry = changelogEntries.get(tag);
-      let hasBeenReleased = releases.has(tag);
-
-      if (entry) {
-        let releaseDetails = Object.assign({}, REPO_DETAILS, {
-          "tag_name": entry.tag,
-          "name": `${entry.name} v${entry.version}`,
-          "body": entry.body,
-          "draft": false,
-          "prerelease": false
-        });
-
-        if (!hasBeenReleased) {
-          console.log(`Creating release notes for ${entry.name} ${entry.version}`);
-          count++;
-
-          releaseDetails.body = await getMarkdownForEntry(entry);
-
-          if (SHOULD_APPLY) {
-            github.repos.createRelease(releaseDetails, (err, cb) => {
-              if (err) {
-                throw new Error(`Failed to commit release notes for ${entry.name} ${entry.version}.${EOL}${err}`);
-              }
-
-              console.log(`Successfully created release notes for ${entry.name} ${entry.version}`);
-            });
-          }
-        } else if (SHOULD_PATCH) {
-          console.log(`Patching release notes for ${entry.name} ${entry.version}`);
-          count++;
-
-          if (SHOULD_APPLY) {
-            releaseDetails.id = releases.get(tag).id;
-            releaseDetails.body = await getMarkdownForEntry(entry);
-
-            github.repos.editRelease(releaseDetails, (err, cb) => {
-              if (err) {
-                throw new Error(`Failed to commit release notes for ${entry.name} ${entry.version}.${EOL}${err}`);
-              }
-
-              console.log(`Successfully updated release notes for ${entry.name} ${entry.version}`);
-            });
-          }
+  if (tags) {
+    // Only get a subset of releases
+    for (const tag of tags) {
+      try {
+        const release = await github.repos.getReleaseByTag({ ...REPO_DETAILS, tag });
+        releases.set(release.data.tag_name, release.data);
+      } catch (err) {
+        if (err.status === 404) {
+          // This tag probably isn't released yet, which is fine in this context
+        } else {
+          throw new Error(`Could not get release for tag ${tag} from github.\n${err}`);
         }
       }
-    });
+    }
+  } else {
+    // Get all the releases
+    try {
+      /** @type {GitHubApi.ReposListReleasesResponseItem[]} */
+      const res = await github.paginate(github.repos.listReleases.endpoint.merge(REPO_DETAILS));
 
-    if (!count) {
-      console.log('No changes were applied.');
+      res.forEach(release => {
+        releases.set(release.tag_name, release);
+      });
+    } catch (err) {
+      throw new Error('Could not get releases from github.\n' + err);
+    }
+  }
+
+  console.log(`Found ${releases.size}${tags ? ' recent' : ''} releases on github.`);
+
+  return releases;
+}
+
+/**
+ * Adds new release notes, and if argv.patch is true, will patch existing ones in the case
+ * that they need to be regenerated.
+ */
+async function updateReleaseNotes() {
+  // If we're patching all release notes, get all the changelog entries/tags and all the releases
+  // (expensive operations). Otherwise only get changelog entries/tags from the past argv.age days,
+  // and corresponding releases (if they exist yet).
+  const changelogEntries = getChangelogTagMap(argv.patchAll ? undefined : argv.age);
+  const tagsToFetch = argv.patchAll ? undefined : Array.from(changelogEntries.keys());
+  const releasesByTag = await getReleases(tagsToFetch);
+  let count = 0;
+
+  const tags = getTags().filter(tag => changelogEntries.has(tag));
+  // do NOT use forEach here, since it doesn't handle async properly
+  for (const tag of tags) {
+    let entry = changelogEntries.get(tag);
+    let hasBeenReleased = releasesByTag.has(tag);
+
+    if (hasBeenReleased && !(argv.patch || argv.patchAll)) {
+      return; // nothing to do
     }
 
-  });
+    const entryInfo = `${entry.name} ${entry.version}`;
+    console.log(`${hasBeenReleased ? 'Patching' : 'Creating'} release notes for ${entryInfo}`);
+    count++;
+
+    /** @type {Partial<GitHubApi.ReposUpdateReleaseParams>} */
+    const releaseDetails = {
+      ...REPO_DETAILS,
+      tag_name: entry.tag,
+      name: `${entry.name} v${entry.version}`,
+      draft: false,
+      prerelease: false,
+      body: await getMarkdownForEntry(entry)
+    };
+    if (hasBeenReleased) {
+      releaseDetails.release_id = releasesByTag.get(tag).id;
+    }
+
+    if (argv.apply) {
+      try {
+        if (hasBeenReleased) {
+          await github.repos.updateRelease(/** @type {GitHubApi.ReposUpdateReleaseParams} */ (releaseDetails));
+        } else {
+          await github.repos.createRelease(/** @type {GitHubApi.ReposCreateReleaseParams} */ (releaseDetails));
+        }
+        console.log(`Successfully ${hasBeenReleased ? 'updated' : 'created'} release notes for ${entryInfo}`);
+      } catch (err) {
+        throw new Error(`Failed to commit release notes for ${entryInfo}.${EOL}${err}`);
+      }
+    } else {
+      // Log the expected output (with the body separate to get it nicely formatted, not as JSON)
+      const { body, ...rest } = releaseDetails;
+      console.log('\nRelease details: ' + JSON.stringify(rest, null, 2));
+      console.log('\n' + body);
+    }
+  }
+
+  if (!count) {
+    console.log('No changes were applied.');
+  }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Update the updateReleaseNotes script to use the latest GitHub API version (gets rid of a deprecation warning during install) and not fetch all the releases every time when it's not actually necessary.

This script could potentially become part of beachball or a related tool, since it works on changelogs following that format.

Also updated the website homepage.htm to match the latest version of the real file it mirrors, and other minor build updates.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9783)