### PR TITLE
Fix Donut chart transform when height and width props change

### DIFF
--- a/change/@uifabric-charting-2019-07-12-16-28-00-fixDonutChartTrasform.json
+++ b/change/@uifabric-charting-2019-07-12-16-28-00-fixDonutChartTrasform.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix donut chart transform when height and width props change",
+  "type": "patch",
+  "packageName": "@uifabric/charting",
+  "email": "v-ragor@microsoft.com",
+  "commit": "7c5619a4fdf31fdbb966a1e50c9cc12a2dcb0180",
+  "date": "2019-07-12T10:58:00.696Z"
+}

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -10,19 +10,18 @@ import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 
 const getClassNames = classNamesFunction<IDonutChartStyleProps, IDonutChartStyles>();
 
-export class DonutChartBase extends React.Component<
-  IDonutChartProps,
-  {
-    showHover: boolean;
-    value: string | undefined;
-    legend: string | undefined;
-    _width: number | undefined;
-    _height: number | undefined;
-    activeLegend: string;
-    color: string | undefined;
-    isLegendSelected: boolean;
-  }
-> {
+interface IDonutChartState {
+  showHover?: boolean;
+  value?: string | undefined;
+  legend?: string | undefined;
+  _width?: number | undefined;
+  _height?: number | undefined;
+  activeLegend?: string;
+  color?: string | undefined;
+  isLegendSelected?: boolean;
+}
+
+export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChartState> {
   public static defaultProps: Partial<IDonutChartProps> = {
     innerRadius: 0
   };
@@ -32,6 +31,14 @@ export class DonutChartBase extends React.Component<
   private _uniqText: string;
   // tslint:disable:no-any
   private _currentHoverElement: any;
+  public static getDerivedStateFromProps(nextProps: IDonutChartProps, prevState: IDonutChartState): IDonutChartState {
+    if (nextProps.height && nextProps.height !== prevState._height && nextProps.width !== prevState._width) {
+      const reducedHeight = nextProps.height / 5;
+      return { _width: nextProps.width, _height: nextProps.height - reducedHeight };
+    } else {
+      return prevState;
+    }
+  }
   constructor(props: IDonutChartProps) {
     super(props);
     this.state = {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes
Fix Donut chart transform when height and width props change

before 
![image](https://user-images.githubusercontent.com/13463251/61123689-a1ff8900-a4c2-11e9-90e5-9615c8eb42ae.png)
![after click](https://user-images.githubusercontent.com/13463251/61124860-be50f500-a4c5-11e9-8328-3c8f78922bfd.jpg)

After fix
![image](https://user-images.githubusercontent.com/13463251/61123764-d4a98180-a4c2-11e9-8fe4-771aa1e4d0eb.png)


#### Bug info
https://office.visualstudio.com/OC/_workitems/edit/3409458/



(give an overview)

#### Focus areas to test

(optional)
