### PR TITLE
Slider: Update active state color to match design toolkit and semantic Colors

### DIFF
--- a/change/office-ui-fabric-react-2019-07-11-17-36-35-marygans-shimmerUpdates.json
+++ b/change/office-ui-fabric-react-2019-07-11-17-36-35-marygans-shimmerUpdates.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Shimmer: Update palette references to semantic colors",
+  "type": "none",
+  "packageName": "office-ui-fabric-react",
+  "email": "marygans@microsoft.com",
+  "commit": "8cb86495c5b91eaf777c626a3697c973983de590",
+  "date": "2019-07-12T00:36:35.357Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -32,7 +32,7 @@ const shimmerAnimationRTL: string = keyframes({
 export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
   const { isDataLoaded, className, theme, transitionAnimationInterval, shimmerColor, shimmerWaveColor } = props;
 
-  const { palette } = theme;
+  const { semanticColors } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const isRTL = getRTL();
@@ -53,7 +53,7 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
         position: 'relative',
         overflow: 'hidden',
         transform: 'translateZ(0)',
-        backgroundColor: shimmerColor || palette.neutralLighter,
+        backgroundColor: shimmerColor || semanticColors.listItemBackgroundHovered,
         transition: `opacity ${transitionAnimationInterval}ms`,
         selectors: {
           '> *': {
@@ -88,12 +88,12 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
         left: 0,
         width: '100%',
         height: '100%',
-        background: `${shimmerColor || palette.neutralLighter}
+        background: `${shimmerColor || semanticColors.listItemBackgroundHovered}
                       linear-gradient(
                         to right,
-                        ${shimmerColor || palette.neutralLighter} 0%,
-                        ${shimmerWaveColor || palette.neutralLight} 50%,
-                        ${shimmerColor || palette.neutralLighter} 100%)
+                        ${shimmerColor || semanticColors.listItemBackgroundHovered} 0%,
+                        ${shimmerWaveColor || semanticColors.listItemBackgroundChecked} 50%,
+                        ${shimmerColor || semanticColors.listItemBackgroundHovered} 100%)
                       0 0 / 90% 100%
                       no-repeat`,
         transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.styles.ts
@@ -9,7 +9,7 @@ const GlobalClassNames = {
 export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles {
   const { height, borderStyle, theme } = props;
 
-  const { palette } = theme;
+  const { semanticColors } = theme;
   const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
@@ -25,7 +25,7 @@ export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles
         boxSizing: 'content-box',
         borderTopStyle: 'solid',
         borderBottomStyle: 'solid',
-        borderColor: palette.white,
+        borderColor: semanticColors.bodyBackground,
         selectors: {
           [HighContrastSelector]: {
             borderColor: 'Window'
@@ -38,7 +38,7 @@ export function getStyles(props: IShimmerCircleStyleProps): IShimmerCircleStyles
       globalClassNames.svg,
       {
         display: 'block',
-        fill: palette.white,
+        fill: semanticColors.bodyBackground,
         selectors: {
           [HighContrastSelector]: {
             fill: 'Window'

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.styles.ts
@@ -8,7 +8,7 @@ const GlobalClassNames = {
 export function getStyles(props: IShimmerGapStyleProps): IShimmerGapStyles {
   const { height, borderStyle, theme } = props;
 
-  const { palette } = theme;
+  const { semanticColors } = theme;
   const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
@@ -18,12 +18,12 @@ export function getStyles(props: IShimmerGapStyleProps): IShimmerGapStyles {
       globalClassNames.root,
       theme.fonts.medium,
       {
-        backgroundColor: palette.white,
+        backgroundColor: semanticColors.bodyBackground,
         height: `${height}px`,
         boxSizing: 'content-box',
         borderTopStyle: 'solid',
         borderBottomStyle: 'solid',
-        borderColor: palette.white,
+        borderColor: semanticColors.bodyBackground,
         selectors: {
           [HighContrastSelector]: {
             backgroundColor: 'Window',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -12,14 +12,14 @@ const GlobalClassNames = {
 export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
   const { height, borderStyle, theme } = props;
 
-  const { palette } = theme;
+  const { semanticColors } = theme;
   const globalClassNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const borderStyles: IRawStyle = !!borderStyle ? borderStyle : {};
 
   const sharedCornerStyles: IRawStyle = {
     position: 'absolute',
-    fill: palette.white
+    fill: semanticColors.bodyBackground
   };
 
   return {
@@ -32,7 +32,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
         position: 'relative',
         borderTopStyle: 'solid',
         borderBottomStyle: 'solid',
-        borderColor: palette.white,
+        borderColor: semanticColors.bodyBackground,
         selectors: {
           [HighContrastSelector]: {
             borderColor: 'Window',

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -74,6 +74,15 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
     }
   };
 
+  const slideBoxHoverThumbStyles = !disabled && {
+    border: `2px solid ${sliderHoverSectionColor}`,
+    selectors: {
+      [HighContrastSelector]: {
+        borderColor: 'Highlight'
+      }
+    }
+  };
+
   const slideBoxActiveZeroTickStyles = !props.disabled && {
     backgroundColor: theme.palette.themeLight,
     selectors: {
@@ -135,7 +144,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
           ':active $inactiveSection': slideBoxInactiveSectionStyles,
           ':hover $inactiveSection': slideBoxInactiveSectionStyles,
           ':active $thumb': slideBoxActiveThumbStyles,
-          ':hover $thumb': slideBoxActiveThumbStyles,
+          ':hover $thumb': slideBoxHoverThumbStyles,
           ':active $zeroTick': slideBoxActiveZeroTickStyles,
           ':hover $zeroTick': slideBoxActiveZeroTickStyles,
           $thumb: [

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -22,22 +22,22 @@ const GlobalClassNames = {
 
 export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
   const { className, titleLabelClassName, theme, vertical, disabled, showTransitions, showValue } = props;
-  const { palette } = theme;
+  const { semanticColors, palette } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   // Tokens
-  const sliderInteractedActiveSectionColor = palette.themeDarkAlt;
-  const sliderHoverSectionColor = palette.themePrimary;
+  const sliderInteractedActiveSectionColor = semanticColors.inputBackgroundCheckedHovered;
+  const sliderHoverSectionColor = semanticColors.inputBackgroundChecked;
   const sliderInteractedInactiveSectionColor = palette.themeLight;
-  const sliderRestActiveSectionColor = palette.neutralSecondary;
-  const sliderRestInactiveSectionColor = palette.neutralTertiaryAlt;
+  const sliderRestActiveSectionColor = semanticColors.smallInputBorder;
+  const sliderRestInactiveSectionColor = semanticColors.buttonBackgroundChecked;
 
-  const sliderDisabledActiveSectionColor = palette.neutralTertiary;
-  const sliderDisabledInactiveSectionColor = palette.neutralLight;
+  const sliderDisabledActiveSectionColor = semanticColors.variantBorderHovered;
+  const sliderDisabledInactiveSectionColor = semanticColors.variantBorder;
 
-  const sliderThumbBackgroundColor = palette.white;
-  const sliderThumbBorderColor = palette.neutralSecondary;
-  const sliderThumbDisabledBorderColor = palette.neutralTertiaryAlt;
+  const sliderThumbBackgroundColor = semanticColors.inputBackground;
+  const sliderThumbBorderColor = semanticColors.smallInputBorder;
+  const sliderThumbDisabledBorderColor = semanticColors.disabledBodySubtext;
 
   const slideBoxActiveSectionStyles = !disabled && {
     backgroundColor: sliderInteractedActiveSectionColor,
@@ -283,7 +283,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
       classNames.zeroTick,
       {
         position: 'absolute',
-        background: theme.palette.neutralTertiaryAlt,
+        background: sliderRestInactiveSectionColor,
         selectors: {
           [HighContrastSelector]: {
             backgroundColor: 'WindowText'
@@ -291,7 +291,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
         }
       },
       props.disabled && {
-        background: theme.palette.neutralLight,
+        background: sliderDisabledInactiveSectionColor,
         selectors: {
           [HighContrastSelector]: {
             backgroundColor: 'GrayText'

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -26,7 +26,8 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   // Tokens
-  const sliderInteractedActiveSectionColor = palette.themePrimary;
+  const sliderInteractedActiveSectionColor = palette.themeDarkAlt;
+  const sliderHoverSectionColor = palette.themePrimary;
   const sliderInteractedInactiveSectionColor = palette.themeLight;
   const sliderRestActiveSectionColor = palette.neutralSecondary;
   const sliderRestInactiveSectionColor = palette.neutralTertiaryAlt;
@@ -40,6 +41,14 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
 
   const slideBoxActiveSectionStyles = !disabled && {
     backgroundColor: sliderInteractedActiveSectionColor,
+    selectors: {
+      [HighContrastSelector]: {
+        backgroundColor: 'Highlight'
+      }
+    }
+  };
+  const slideHoverSectionStyles = !disabled && {
+    backgroundColor: sliderHoverSectionColor,
     selectors: {
       [HighContrastSelector]: {
         backgroundColor: 'Highlight'
@@ -122,7 +131,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
         alignItems: 'center',
         selectors: {
           ':active $activeSection': slideBoxActiveSectionStyles,
-          ':hover $activeSection': slideBoxActiveSectionStyles,
+          ':hover $activeSection': slideHoverSectionStyles,
           ':active $inactiveSection': slideBoxInactiveSectionStyles,
           ':hover $inactiveSection': slideBoxInactiveSectionStyles,
           ':active $thumb': slideBoxActiveThumbStyles,

--- a/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`Slider renders correctly 1`] = `
             z-index: 1;
           }
           &:active $activeSection {
-            background-color: #0078d4;
+            background-color: #106ebe;
           }
           @media screen and (-ms-high-contrast: active){&:active $activeSection {
             background-color: Highlight;
@@ -117,7 +117,7 @@ exports[`Slider renders correctly 1`] = `
             border-color: Highlight;
           }
           &:active $thumb {
-            border: 2px solid #0078d4;
+            border: 2px solid #106ebe;
           }
           @media screen and (-ms-high-contrast: active){&:active $thumb {
             border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -257,7 +257,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
                 z-index: 1;
               }
               &:active $activeSection {
-                background-color: #0078d4;
+                background-color: #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $activeSection {
                 background-color: Highlight;
@@ -281,7 +281,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
                 border-color: Highlight;
               }
               &:active $thumb {
-                border: 2px solid #0078d4;
+                border: 2px solid #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $thumb {
                 border-color: Highlight;
@@ -514,7 +514,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
                 z-index: 1;
               }
               &:active $activeSection {
-                background-color: #0078d4;
+                background-color: #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $activeSection {
                 background-color: Highlight;
@@ -538,7 +538,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
                 border-color: Highlight;
               }
               &:active $thumb {
-                border: 2px solid #0078d4;
+                border: 2px solid #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $thumb {
                 border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -558,7 +558,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 z-index: 1;
               }
               &:active $activeSection {
-                background-color: #0078d4;
+                background-color: #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $activeSection {
                 background-color: Highlight;
@@ -582,7 +582,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 border-color: Highlight;
               }
               &:active $thumb {
-                border: 2px solid #0078d4;
+                border: 2px solid #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $thumb {
                 border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -754,7 +754,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 z-index: 1;
               }
               &:active $activeSection {
-                background-color: #0078d4;
+                background-color: #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $activeSection {
                 background-color: Highlight;
@@ -778,7 +778,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 border-color: Highlight;
               }
               &:active $thumb {
-                border: 2px solid #0078d4;
+                border: 2px solid #106ebe;
               }
               @media screen and (-ms-high-contrast: active){&:active $thumb {
                 border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -115,7 +115,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -139,7 +139,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;
@@ -588,7 +588,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -612,7 +612,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;
@@ -845,7 +845,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -869,7 +869,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;
@@ -1102,7 +1102,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -1126,7 +1126,7 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
@@ -122,7 +122,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -146,7 +146,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;
@@ -631,7 +631,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -655,7 +655,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;
@@ -906,7 +906,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -930,7 +930,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;
@@ -1181,7 +1181,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -1205,7 +1205,7 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -170,7 +170,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -194,7 +194,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -1076,7 +1076,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       z-index: 1;
                     }
                     &:active $activeSection {
-                      background-color: #0078d4;
+                      background-color: #106ebe;
                     }
                     @media screen and (-ms-high-contrast: active){&:active $activeSection {
                       background-color: Highlight;
@@ -1100,7 +1100,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       border-color: Highlight;
                     }
                     &:active $thumb {
-                      border: 2px solid #0078d4;
+                      border: 2px solid #106ebe;
                     }
                     @media screen and (-ms-high-contrast: active){&:active $thumb {
                       border-color: Highlight;
@@ -1393,7 +1393,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -1417,7 +1417,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -1650,7 +1650,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -1674,7 +1674,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -1944,7 +1944,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -1968,7 +1968,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -2201,7 +2201,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -2225,7 +2225,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -2495,7 +2495,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -2519,7 +2519,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -2752,7 +2752,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -2776,7 +2776,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -138,7 +138,7 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -138,7 +138,7 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -150,7 +150,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                   z-index: 1;
                 }
                 &:active $activeSection {
-                  background-color: #0078d4;
+                  background-color: #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $activeSection {
                   background-color: Highlight;
@@ -174,7 +174,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                   border-color: Highlight;
                 }
                 &:active $thumb {
-                  border: 2px solid #0078d4;
+                  border: 2px solid #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $thumb {
                   border-color: Highlight;
@@ -423,7 +423,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                   z-index: 1;
                 }
                 &:active $activeSection {
-                  background-color: #0078d4;
+                  background-color: #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $activeSection {
                   background-color: Highlight;
@@ -447,7 +447,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                   border-color: Highlight;
                 }
                 &:active $thumb {
-                  border: 2px solid #0078d4;
+                  border: 2px solid #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $thumb {
                   border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -138,7 +138,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -171,7 +171,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -195,7 +195,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -1473,7 +1473,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -1497,7 +1497,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -2580,7 +2580,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -2604,7 +2604,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -2837,7 +2837,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -2861,7 +2861,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -3132,7 +3132,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -3156,7 +3156,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;
@@ -3389,7 +3389,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     z-index: 1;
                   }
                   &:active $activeSection {
-                    background-color: #0078d4;
+                    background-color: #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $activeSection {
                     background-color: Highlight;
@@ -3413,7 +3413,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     border-color: Highlight;
                   }
                   &:active $thumb {
-                    border: 2px solid #0078d4;
+                    border: 2px solid #106ebe;
                   }
                   @media screen and (-ms-high-contrast: active){&:active $thumb {
                     border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -138,7 +138,7 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -138,7 +138,7 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -150,7 +150,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                   z-index: 1;
                 }
                 &:active $activeSection {
-                  background-color: #0078d4;
+                  background-color: #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $activeSection {
                   background-color: Highlight;
@@ -174,7 +174,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                   border-color: Highlight;
                 }
                 &:active $thumb {
-                  border: 2px solid #0078d4;
+                  border: 2px solid #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $thumb {
                   border-color: Highlight;
@@ -423,7 +423,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                   z-index: 1;
                 }
                 &:active $activeSection {
-                  background-color: #0078d4;
+                  background-color: #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $activeSection {
                   background-color: Highlight;
@@ -447,7 +447,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                   border-color: Highlight;
                 }
                 &:active $thumb {
-                  border: 2px solid #0078d4;
+                  border: 2px solid #106ebe;
                 }
                 @media screen and (-ms-high-contrast: active){&:active $thumb {
                   border-color: Highlight;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
@@ -114,7 +114,7 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
               z-index: 1;
             }
             &:active $activeSection {
-              background-color: #0078d4;
+              background-color: #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $activeSection {
               background-color: Highlight;
@@ -138,7 +138,7 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
               border-color: Highlight;
             }
             &:active $thumb {
-              border: 2px solid #0078d4;
+              border: 2px solid #106ebe;
             }
             @media screen and (-ms-high-contrast: active){&:active $thumb {
               border-color: Highlight;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Update active state color from `themePrimary` to `neutralDarkAlt` to match what is in design toolkit. Also update to palette references to semantic color slots.

**Before:** 
![slider-before](https://user-images.githubusercontent.com/38991459/61151959-08bd7c00-a49c-11e9-9f8f-4bcf91c5e5e9.png)

**After:** 
![slider-after](https://user-images.githubusercontent.com/38991459/61151965-0c510300-a49c-11e9-8d73-866433532bcc.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9790)