### PR TITLE
Allowing example title to show completely even when it goes past one line

### DIFF
--- a/change/@uifabric-example-app-base-2019-07-12-14-39-55-exampleCardName.json
+++ b/change/@uifabric-example-app-base-2019-07-12-14-39-55-exampleCardName.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Allowing example title to show completely even when it goes past one line.",
+  "type": "patch",
+  "packageName": "@uifabric/example-app-base",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "d4f8fb07f1043d4ecbc2200623e7ac8befd8aa82",
+  "date": "2019-07-12T21:39:54.972Z"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.styles.ts
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.styles.ts
@@ -99,6 +99,7 @@ export const getStyles: IStyleFunction<IExampleCardStyleProps, IExampleCardStyle
     header: [
       {
         borderBottom: `1px solid ${theme.palette.neutralTertiary}`,
+        display: 'flex',
         overflow: 'hidden',
         position: 'relative'
       },
@@ -110,15 +111,19 @@ export const getStyles: IStyleFunction<IExampleCardStyleProps, IExampleCardStyle
     title: [
       theme.fonts.medium,
       {
-        marginBottom: 10,
-        display: 'inline-block'
+        display: 'inline-flex',
+        flexGrow: 1,
+        flexShrink: 1,
+        marginBottom: 10
       },
       globalClassNames.title
     ],
     toggleButtons: [
       theme.fonts.medium,
       {
+        alignSelf: 'flex-end',
         display: 'flex',
+        flexShrink: 0,
         float: 'right'
       },
       globalClassNames.toggleButtons

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.styles.ts
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.styles.ts
@@ -100,8 +100,6 @@ export const getStyles: IStyleFunction<IExampleCardStyleProps, IExampleCardStyle
       {
         borderBottom: `1px solid ${theme.palette.neutralTertiary}`,
         overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
         position: 'relative'
       },
       isCodeVisible && {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9712
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Issue #9712 made it clear that example titles were not being visible when going past one line. This PR makes styling changes to the example card in order to allow the titles to be always visible.

__Before:__

![image](https://user-images.githubusercontent.com/7798177/61160449-6231a500-a4b4-11e9-8dc8-007a4cea34c1.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/61246287-5ab40b00-a703-11e9-9253-7df1a6090e52.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9796)