### PR TITLE
ChoiceGroup: remove inline styles to allow override

### DIFF
--- a/change/office-ui-fabric-react-2019-07-12-18-10-18-shield-choiceGroupMaxWidth.json
+++ b/change/office-ui-fabric-react-2019-07-12-18-10-18-shield-choiceGroupMaxWidth.json
@@ -1,0 +1,8 @@
+{
+  "comment": "ChoiceGroupOption: move the inline styles into getStyles function to allow override.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "3ea233343ac97179ef22e58d4a598654443ffbb6",
+  "date": "2019-07-13T01:10:18.308Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2242,7 +2242,11 @@ export interface IChoiceGroupOptionStyleProps {
     // (undocumented)
     hasImage?: boolean;
     // (undocumented)
+    imageHeight?: number;
+    // (undocumented)
     imageIsLarge?: boolean;
+    // (undocumented)
+    imageWidth?: number;
     // (undocumented)
     theme: ITheme;
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2229,25 +2229,18 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
     theme?: ITheme;
 }
 
-// @public (undocumented)
+// @public
 export interface IChoiceGroupOptionStyleProps {
-    // (undocumented)
     checked?: boolean;
-    // (undocumented)
     disabled?: boolean;
-    // (undocumented)
     focused?: boolean;
-    // (undocumented)
     hasIcon?: boolean;
-    // (undocumented)
     hasImage?: boolean;
-    // (undocumented)
-    imageHeight?: number;
-    // (undocumented)
     imageIsLarge?: boolean;
-    // (undocumented)
-    imageWidth?: number;
-    // (undocumented)
+    imageSize?: {
+        height: number;
+        width: number;
+    };
     theme: ITheme;
 }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -39,6 +39,8 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       checked,
       disabled,
       imageIsLarge: !!imageSrc && (imageSize.width > 71 || imageSize.height > 71),
+      imageHeight: imageSize.height,
+      imageWidth: imageSize.width,
       focused
     });
 
@@ -97,7 +99,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
     return (
       <label htmlFor={id} className={this._classNames.field}>
         {imageSrc && (
-          <div className={this._classNames.innerField} style={{ height: imageSize.height, width: imageSize.width }}>
+          <div className={this._classNames.innerField}>
             <div className={this._classNames.imageWrapper}>
               <Image src={imageSrc} alt={imageAlt ? imageAlt : ''} width={imageSize.width} height={imageSize.height} />
             </div>
@@ -113,13 +115,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
             </div>
           </div>
         ) : null}
-        {imageSrc || iconProps ? (
-          <div className={this._classNames.labelWrapper} style={{ maxWidth: imageSize.width * 2 }}>
-            {onRenderLabel!(props)}
-          </div>
-        ) : (
-          onRenderLabel!(props)
-        )}
+        {imageSrc || iconProps ? <div className={this._classNames.labelWrapper}>{onRenderLabel!(props)}</div> : onRenderLabel!(props)}
       </label>
     );
   };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -39,8 +39,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       checked,
       disabled,
       imageIsLarge: !!imageSrc && (imageSize.width > 71 || imageSize.height > 71),
-      imageHeight: imageSize.height,
-      imageWidth: imageSize.width,
+      imageSize,
       focused
     });
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -88,7 +88,7 @@ function getImageWrapperStyle(isSelectedImageWrapper: boolean, className?: strin
 }
 
 export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOptionStyles => {
-  const { theme, hasIcon, hasImage, checked, disabled, imageIsLarge, focused, imageHeight, imageWidth } = props;
+  const { theme, hasIcon, hasImage, checked, disabled, imageIsLarge, focused, imageSize } = props;
   const { palette, semanticColors } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
@@ -356,8 +356,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
     innerField: [
       classNames.innerField,
       hasImage && {
-        height: imageHeight,
-        width: imageWidth
+        height: imageSize!.height, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
+        width: imageSize!.width
       },
       (hasIcon || hasImage) && {
         position: 'relative',
@@ -399,7 +399,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         margin: '4px 8px',
         height: labelWrapperLineHeight * 2,
         lineHeight: labelWrapperLineHeight,
-        maxWidth: imageWidth! * 2, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
+        maxWidth: imageSize!.width * 2, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
         overflow: 'hidden',
         whiteSpace: 'pre-wrap',
         textOverflow: 'ellipsis',

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -88,7 +88,7 @@ function getImageWrapperStyle(isSelectedImageWrapper: boolean, className?: strin
 }
 
 export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOptionStyles => {
-  const { theme, hasIcon, hasImage, checked, disabled, imageIsLarge, focused } = props;
+  const { theme, hasIcon, hasImage, checked, disabled, imageIsLarge, focused, imageHeight, imageWidth } = props;
   const { palette, semanticColors } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
@@ -355,6 +355,10 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
     ],
     innerField: [
       classNames.innerField,
+      hasImage && {
+        height: imageHeight,
+        width: imageWidth
+      },
       (hasIcon || hasImage) && {
         position: 'relative',
         display: 'inline-block',
@@ -395,6 +399,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         margin: '4px 8px',
         height: labelWrapperLineHeight * 2,
         lineHeight: labelWrapperLineHeight,
+        maxWidth: imageWidth! * 2, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
         overflow: 'hidden',
         whiteSpace: 'pre-wrap',
         textOverflow: 'ellipsis',

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -60,17 +60,35 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
 }
 
 /**
+ * Defines props needed to construct styles. This represents the simplified set of immutable things which control the class names.
  * {@docCategory ChoiceGroup}
  */
 export interface IChoiceGroupOptionStyleProps {
+  /** Theme provided by High-Order Component. */
   theme: ITheme;
+
+  /** Whether the option has an icon. */
   hasIcon?: boolean;
+
+  /** Whether the option icon is an image. */
   hasImage?: boolean;
+
+  /** Whether the option is checked or not. */
   checked?: boolean;
+
+  /** Whether the option is disabled or not. */
   disabled?: boolean;
+
+  /** Whether the image width or height are higher than `71`. */
   imageIsLarge?: boolean;
-  imageHeight?: number;
-  imageWidth?: number;
+
+  /**
+   * Image sizes used when `hasImage` or `hasIcon` style props are enabled.
+   * @defaultvalue \{height: 32, width: 32\}
+   */
+  imageSize?: { height: number; width: number };
+
+  /** Whether the option is in focus or not. */
   focused?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -69,6 +69,8 @@ export interface IChoiceGroupOptionStyleProps {
   checked?: boolean;
   disabled?: boolean;
   imageIsLarge?: boolean;
+  imageHeight?: number;
+  imageWidth?: number;
   focused?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -864,16 +864,12 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
+                max-width: 64px;
                 overflow: hidden;
                 position: relative;
                 text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
-          style={
-            Object {
-              "maxWidth": 64,
-            }
-          }
         >
           <span
             className="ms-ChoiceFieldLabel"
@@ -1093,16 +1089,12 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
+                max-width: 64px;
                 overflow: hidden;
                 position: relative;
                 text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
-          style={
-            Object {
-              "maxWidth": 64,
-            }
-          }
         >
           <span
             className="ms-ChoiceFieldLabel"
@@ -1320,16 +1312,12 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
+                max-width: 64px;
                 overflow: hidden;
                 position: relative;
                 text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
-          style={
-            Object {
-              "maxWidth": 64,
-            }
-          }
         >
           <span
             className="ms-ChoiceFieldLabel"
@@ -1523,16 +1511,12 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
+                max-width: 64px;
                 overflow: hidden;
                 position: relative;
                 text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
-          style={
-            Object {
-              "maxWidth": 64,
-            }
-          }
         >
           <span
             className="ms-ChoiceFieldLabel"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -267,16 +267,12 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
+                    max-width: 64px;
                     overflow: hidden;
                     position: relative;
                     text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
-              style={
-                Object {
-                  "maxWidth": 64,
-                }
-              }
             >
               <span
                 className="ms-ChoiceFieldLabel"
@@ -480,16 +476,12 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
+                    max-width: 64px;
                     overflow: hidden;
                     position: relative;
                     text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
-              style={
-                Object {
-                  "maxWidth": 64,
-                }
-              }
             >
               <span
                 className="ms-ChoiceFieldLabel"
@@ -688,16 +680,12 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
+                    max-width: 64px;
                     overflow: hidden;
                     position: relative;
                     text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
-              style={
-                Object {
-                  "maxWidth": 64,
-                }
-              }
             >
               <span
                 className="ms-ChoiceFieldLabel"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -221,16 +221,12 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                     ms-ChoiceField-innerField
                     {
                       display: inline-block;
+                      height: 32px;
                       padding-left: 30px;
                       padding-right: 30px;
                       position: relative;
+                      width: 32px;
                     }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
               >
                 <div
                   className=
@@ -356,16 +352,12 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                       margin-left: 8px;
                       margin-right: 8px;
                       margin-top: 4px;
+                      max-width: 64px;
                       overflow: hidden;
                       position: relative;
                       text-overflow: ellipsis;
                       white-space: pre-wrap;
                     }
-                style={
-                  Object {
-                    "maxWidth": 64,
-                  }
-                }
               >
                 <span
                   className="ms-ChoiceFieldLabel"
@@ -522,16 +514,12 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                     ms-ChoiceField-innerField
                     {
                       display: inline-block;
+                      height: 32px;
                       padding-left: 30px;
                       padding-right: 30px;
                       position: relative;
+                      width: 32px;
                     }
-                style={
-                  Object {
-                    "height": 32,
-                    "width": 32,
-                  }
-                }
               >
                 <div
                   className=
@@ -657,16 +645,12 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                       margin-left: 8px;
                       margin-right: 8px;
                       margin-top: 4px;
+                      max-width: 64px;
                       overflow: hidden;
                       position: relative;
                       text-overflow: ellipsis;
                       white-space: pre-wrap;
                     }
-                style={
-                  Object {
-                    "maxWidth": 64,
-                  }
-                }
               >
                 <span
                   className="ms-ChoiceFieldLabel"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-522:hover + .headerDividerBar-523 {
+      & .headerDivider-523:hover + .headerDividerBar-524 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9797 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Remove inline styles and pass them as style props to allow css-in-js override.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9802)