### PR TITLE
Remove FluentCustomizations from the theme dropdown on demo pages

### DIFF
--- a/apps/fabric-website-resources/src/customizations/customizations.ts
+++ b/apps/fabric-website-resources/src/customizations/customizations.ts
@@ -1,11 +1,10 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
-import { FluentCustomizations } from '@uifabric/fluent-theme';
 import { MDL2Customizations } from '@uifabric/mdl2-theme';
 import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
-import { TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
+import { TeamsCustomizations, WordCustomizations, DefaultCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
-  { title: 'Default', customizations: FluentCustomizations },
+  { title: 'Default', customizations: DefaultCustomizations },
   { title: 'Word', customizations: WordCustomizations },
   { title: 'Teams', customizations: TeamsCustomizations },
   { title: 'Azure', customizations: AzureCustomizationsLight },

--- a/change/@uifabric-experiments-2019-07-12-18-21-31-shield-customizations.json
+++ b/change/@uifabric-experiments-2019-07-12-18-21-31-shield-customizations.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Remove fluent customizations.",
+  "type": "patch",
+  "packageName": "@uifabric/experiments",
+  "email": "vibraga@microsoft.com",
+  "commit": "6931990896b08f816e10d3936d36a92b82aa794a",
+  "date": "2019-07-13T01:21:31.353Z"
+}

--- a/change/@uifabric-fabric-website-resources-2019-07-12-18-21-31-shield-customizations.json
+++ b/change/@uifabric-fabric-website-resources-2019-07-12-18-21-31-shield-customizations.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Replace fluent customizations with default ones.",
+  "type": "patch",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "vibraga@microsoft.com",
+  "commit": "6931990896b08f816e10d3936d36a92b82aa794a",
+  "date": "2019-07-13T01:21:08.787Z"
+}

--- a/packages/experiments/src/demo/customizations.ts
+++ b/packages/experiments/src/demo/customizations.ts
@@ -1,11 +1,9 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
-import { FluentCustomizations } from '@uifabric/fluent-theme';
 import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
 import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Default', customizations: DefaultCustomizations },
-  { title: 'Fluent', customizations: FluentCustomizations },
   { title: 'Word', customizations: WordCustomizations },
   { title: 'Teams', customizations: TeamsCustomizations },
   { title: 'Azure', customizations: AzureCustomizationsLight },


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ npm run change`

#### Description of changes

Removing `FluentCustomizations` from the theme dropdown because we are fluent by default on master now and this was actually causing issues for when developing locally and making changes to component styles and it happened that `fluent-theme` was overriding that style you would not see your change in dev tools leaving you scratching your head 😄.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9803)