### PR TITLE
Rating: fix controlled behavior

### DIFF
--- a/apps/vr-tests/src/stories/Rating.stories.tsx
+++ b/apps/vr-tests/src/stories/Rating.stories.tsx
@@ -20,6 +20,5 @@ storiesOf('Rating', module)
   ))
   .addStory('Root', () => <Rating min={1} max={5} />)
   .addStory('Rated', () => <Rating min={1} max={5} rating={2} />, { rtl: true })
-  .addStory('Allow Zero', () => <Rating allowZeroStars={true} max={5} rating={0} />)
   .addStory('Large', () => <Rating min={1} max={5} size={RatingSize.Large} />)
   .addStory('Disabled', () => <Rating min={1} max={5} disabled />);

--- a/change/office-ui-fabric-react-2019-07-12-19-42-35-master.json
+++ b/change/office-ui-fabric-react-2019-07-12-19-42-35-master.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Rating: ensure rating gets updated even when it has value of 0.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "9bc839d808db40145e4881b92490618c47e5a8fe",
+  "date": "2019-07-13T02:42:35.543Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -193,10 +193,10 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
   }
 
   private _getRating(): number {
-    if (this.props.rating) {
+    if (this.props.rating !== undefined) {
       return this._getClampedRating(this.props.rating);
     }
-    if (this.state.rating) {
+    if (this.state.rating !== undefined && this.state.rating !== null) {
       return this._getClampedRating(this.state.rating);
     }
     return 0;

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.test.tsx
@@ -6,13 +6,13 @@ import { mount, ReactWrapper } from 'enzyme';
 import { Rating } from './Rating';
 
 describe('Rating', () => {
-  it('Renders Rating correctly', () => {
+  it('renders correctly.', () => {
     const component = renderer.create(<Rating />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('Can change rating.', () => {
+  it('can change rating.', () => {
     const rating = mount(<Rating />);
 
     _checkState(rating, 1, '100%');
@@ -33,7 +33,7 @@ describe('Rating', () => {
     _checkState(rating, 5, '0%');
   });
 
-  it('Clamps input rating to allowed range.', () => {
+  it('clamps input rating to allowed range.', () => {
     const rating = mount(<Rating rating={10} />);
 
     expect(rating.find('.ms-Rating-button').length).toEqual(5);
@@ -45,7 +45,7 @@ describe('Rating', () => {
     _checkState(rating, 5, '100%');
   });
 
-  it('Half star is displayed when 2.5 value is passed.', () => {
+  it('displays half star when 2.5 value is passed.', () => {
     const rating = mount(<Rating rating={2.5} />);
 
     _checkState(rating, 1, '100%');
@@ -55,7 +55,7 @@ describe('Rating', () => {
     _checkState(rating, 5, '0%');
   });
 
-  it('When rating is disabled cannot change rating', () => {
+  it('can not change when disabled.', () => {
     const rating = mount(<Rating disabled={true} />);
     const ratingButtons = rating.find('.ms-Rating-button');
 
@@ -63,6 +63,17 @@ describe('Rating', () => {
       expect(ratingButtons.at(i).prop('disabled')).toEqual(true);
     }
   });
+});
+
+it('behaves correctly when controlled with allowZeroStars enabled', () => {
+  const rating = mount(<Rating rating={3} allowZeroStars />);
+  rating.setProps({ rating: 0 });
+
+  _checkState(rating, 1, '0%');
+  _checkState(rating, 2, '0%');
+  _checkState(rating, 3, '0%');
+  _checkState(rating, 4, '0%');
+  _checkState(rating, 5, '0%');
 });
 
 function _checkState(rating: ReactWrapper, ratingToCheck: number, state: string) {

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Rating Renders Rating correctly 1`] = `
+exports[`Rating renders correctly. 1`] = `
 <div
   aria-label=""
   className=


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9799 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

When using `Rating` in controlled manner updating the `rating` prop through the `onChange` callback was not working when `allowZeroStars` enabled. The `if` check will fail when the value is 0.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9805)