### PR TITLE
Get rid of npx inside the majority of package.jsons to speed up the build runs slightly

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "description": "A11y Tests for Office UI Fabric React",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "test": "npx just-scripts jest",
-    "code-style": "npx just-scripts code-style",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "test": "just-scripts jest",
+    "code-style": "just-scripts code-style",
+    "update-snapshots": "just-scripts jest -u"
   },
   "dependencies": {
     "@uifabric/fabric-website-resources": "^7.2.0",

--- a/apps/dom-tests/package.json
+++ b/apps/dom-tests/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "description": "App for test that use real browser.",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "jest-dom": "npx just-scripts ",
-    "just": "npx just-scripts",
-    "start": "npx just-scripts dev"
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "jest-dom": "just-scripts ",
+    "just": "just-scripts",
+    "start": "just-scripts dev"
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.7.13",

--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -16,13 +16,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -11,16 +11,16 @@
     "url": "https://github.com/OfficeDev/office-ui-fabric-react"
   },
   "scripts": {
-    "build": "npx just-scripts build",
-    "create-internal-flight-config": "npx just-scripts create-internal-flight-config",
-    "create-public-flight-config": "npx just-scripts create-public-flight-config",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
+    "build": "just-scripts build",
+    "create-internal-flight-config": "just-scripts create-internal-flight-config",
+    "create-public-flight-config": "just-scripts create-public-flight-config",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
     "production": "npx -n=--max_old_space_size=8192 just-scripts build --production",
     "dogfood": "npx -n=--max_old_space_size=8192 just-scripts build --dogfood",
-    "startuhf": "npx just-scripts dev --webpackConfig webpack.uhf.serve.config.js"
+    "startuhf": "just-scripts dev --webpackConfig webpack.uhf.serve.config.js"
   },
   "license": "MIT",
   "devDependencies": {

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -4,11 +4,11 @@
   "version": "7.0.0",
   "private": true,
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev"
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -4,8 +4,8 @@
   "description": "A site to be deployed as a static site to view what is built during PR",
   "main": "index.js",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "just": "just-scripts"
   },
   "license": "MIT",
   "dependencies": {

--- a/apps/server-rendered-app/package.json
+++ b/apps/server-rendered-app/package.json
@@ -7,10 +7,10 @@
     "lib/version.js"
   ],
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
     "start": "node ./server/index.js"
   },
   "devDependencies": {

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -15,11 +15,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev"
   },
   "devDependencies": {
     "@types/react": "16.8.11",

--- a/apps/theming-designer/package.json
+++ b/apps/theming-designer/package.json
@@ -4,11 +4,11 @@
   "version": "7.0.0",
   "private": true,
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev"
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -4,11 +4,11 @@
   "version": "7.0.0",
   "private": true,
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev"
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -4,13 +4,13 @@
   "version": "7.0.0",
   "private": true,
   "scripts": {
-    "build": "npx just-scripts build",
+    "build": "just-scripts build",
     "clean": "",
-    "code-style": "npx just-scripts code-style",
+    "code-style": "just-scripts code-style",
     "screener": "screener-storybook --conf screener.config.js",
     "screener:local": "screener-storybook --conf screener.local.config.js --debug",
     "start": "start-storybook --port 5555",
-    "just": "npx just-scripts"
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@storybook/addon-options": "=3.2.3",

--- a/change/@uifabric-api-docs-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-api-docs-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/api-docs",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:20.794Z"
+}

--- a/change/@uifabric-azure-themes-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-azure-themes-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/azure-themes",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:22.105Z"
+}

--- a/change/@uifabric-charting-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-charting-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/charting",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:23.450Z"
+}

--- a/change/@uifabric-codepen-loader-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-codepen-loader-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/codepen-loader",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:24.880Z"
+}

--- a/change/@uifabric-date-time-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-date-time-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/date-time",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:26.282Z"
+}

--- a/change/@uifabric-example-app-base-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-example-app-base-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/example-app-base",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:27.834Z"
+}

--- a/change/@uifabric-experiments-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-experiments-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/experiments",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:29.353Z"
+}

--- a/change/@uifabric-fabric-website-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-fabric-website-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:17.867Z"
+}

--- a/change/@uifabric-fabric-website-resources-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-fabric-website-resources-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:15.114Z"
+}

--- a/change/@uifabric-file-type-icons-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-file-type-icons-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:30.816Z"
+}

--- a/change/@uifabric-fluent-theme-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-fluent-theme-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/fluent-theme",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:32.385Z"
+}

--- a/change/@uifabric-foundation-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-foundation-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/foundation",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:35.923Z"
+}

--- a/change/@uifabric-foundation-scenarios-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-foundation-scenarios-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/foundation-scenarios",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:34.169Z"
+}

--- a/change/@uifabric-icons-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-icons-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/icons",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:37.534Z"
+}

--- a/change/@uifabric-jest-serializer-merge-styles-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-jest-serializer-merge-styles-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/jest-serializer-merge-styles",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:38.924Z"
+}

--- a/change/@uifabric-mdl2-theme-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-mdl2-theme-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/mdl2-theme",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:40.269Z"
+}

--- a/change/@uifabric-merge-styles-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-merge-styles-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/merge-styles",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:41.828Z"
+}

--- a/change/@uifabric-migration-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-migration-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/migration",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:43.206Z"
+}

--- a/change/@uifabric-pr-deploy-site-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-pr-deploy-site-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/pr-deploy-site",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:19.370Z"
+}

--- a/change/@uifabric-react-cards-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-react-cards-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/react-cards",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:45.925Z"
+}

--- a/change/@uifabric-set-version-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-set-version-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/set-version",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:49.404Z"
+}

--- a/change/@uifabric-styling-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-styling-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/styling",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:51.051Z"
+}

--- a/change/@uifabric-test-utilities-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-test-utilities-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/test-utilities",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:52.453Z"
+}

--- a/change/@uifabric-theme-samples-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-theme-samples-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/theme-samples",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:53.773Z"
+}

--- a/change/@uifabric-utilities-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-utilities-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/utilities",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:55.084Z"
+}

--- a/change/@uifabric-variants-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-variants-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/variants",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:56.452Z"
+}

--- a/change/@uifabric-webpack-utils-2019-07-15-08-51-57-just-scripts.json
+++ b/change/@uifabric-webpack-utils-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "@uifabric/webpack-utils",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:57.941Z"
+}

--- a/change/office-ui-fabric-react-2019-07-15-08-51-57-just-scripts.json
+++ b/change/office-ui-fabric-react-2019-07-15-08-51-57-just-scripts.json
@@ -1,0 +1,8 @@
+{
+  "comment": "get rid of npx",
+  "type": "none",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "472993033369aa470e59197a534045c02c24e852",
+  "date": "2019-07-15T15:51:44.562Z"
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rush-update": "node common/scripts/install-run-rush.js update",
     "generate": "npm run rush-update",
     "bundlesize": "cd scripts && npm run bundlesize",
-    "bundlesizecollect": "cd scripts && npx just-scripts bundle-size-collect",
+    "bundlesizecollect": "cd scripts && just-scripts bundle-size-collect",
     "create-component": "node scripts/create-component.js",
     "create-package": "node scripts/create-package.js",
     "create-page": "node scripts/create-page.js",
@@ -39,12 +39,12 @@
     "update-api": "cd packages/office-ui-fabric-react && npm run update-api",
     "update-snapshots": "cd packages/office-ui-fabric-react && npm run update-snapshots",
     "update-a11y": "cd apps/a11y-tests && npm run update-snapshots",
-    "check-for-changed-files": "cd scripts && npx just-scripts check-for-modified-files",
+    "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",
     "prettier": "node scripts/prettier.js",
-    "generate-version-files": "cd scripts && npx just-scripts generate-version-files",
+    "generate-version-files": "cd scripts && just-scripts generate-version-files",
     "codepen": "cd packages/office-ui-fabric-react && node ../../scripts/local-codepen.js",
     "precommit": "node scripts/node_modules/lint-staged/index.js",
-    "dom-test": "cd apps/dom-tests && npx just-scripts jest-dom-with-webpack"
+    "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack"
   },
   "license": "MIT",
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rush-update": "node common/scripts/install-run-rush.js update",
     "generate": "npm run rush-update",
     "bundlesize": "cd scripts && npm run bundlesize",
-    "bundlesizecollect": "cd scripts && just-scripts bundle-size-collect",
+    "bundlesizecollect": "cd scripts && npx just-scripts bundle-size-collect",
     "create-component": "node scripts/create-component.js",
     "create-package": "node scripts/create-package.js",
     "create-page": "node scripts/create-page.js",
@@ -39,12 +39,12 @@
     "update-api": "cd packages/office-ui-fabric-react && npm run update-api",
     "update-snapshots": "cd packages/office-ui-fabric-react && npm run update-snapshots",
     "update-a11y": "cd apps/a11y-tests && npm run update-snapshots",
-    "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",
+    "check-for-changed-files": "cd scripts && npx just-scripts check-for-modified-files",
     "prettier": "node scripts/prettier.js",
-    "generate-version-files": "cd scripts && just-scripts generate-version-files",
+    "generate-version-files": "cd scripts && npx just-scripts generate-version-files",
     "codepen": "cd packages/office-ui-fabric-react && node ../../scripts/local-codepen.js",
     "precommit": "node scripts/node_modules/lint-staged/index.js",
-    "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack"
+    "dom-test": "cd apps/dom-tests && npx just-scripts jest-dom-with-webpack"
   },
   "license": "MIT",
   "lint-staged": {

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -6,9 +6,9 @@
   "typings": "lib/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean"
   },
   "devDependencies": {
     "@types/node": "^8.10.29",

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -14,9 +14,9 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "code-style": "npx just-scripts code-style",
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "code-style": "just-scripts code-style",
     "clean": "node node_modules/@uifabric/build/just-scripts.js clean"
   },
   "devDependencies": {

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/codepen-loader/package.json
+++ b/packages/codepen-loader/package.json
@@ -11,13 +11,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
     "rebuild": "npm run clean && npm run build",
-    "code-style": "npx just-scripts code-style",
-    "just": "npx just-scripts",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/babylon": "^6.16.5",

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -14,14 +14,14 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u",
-    "update-api": "npx just-scripts update-api"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u",
+    "update-api": "just-scripts update-api"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -11,11 +11,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev"
   },
   "devDependencies": {
     "@types/color-check": "0.0.0",

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/deep-assign": "^0.1.1",

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -14,10 +14,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style"
   },
   "devDependencies": {
     "@types/react": "16.8.11",

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -14,10 +14,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "code-style": "npx just-scripts code-style",
-    "clean": "npx just-scripts clean"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "code-style": "just-scripts code-style",
+    "clean": "just-scripts clean"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/foundation-scenarios/package.json
+++ b/packages/foundation-scenarios/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -14,10 +14,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style"
   },
   "devDependencies": {
     "@uifabric/prettier-rules": "^7.0.2",

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -14,11 +14,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start-test": "npx just-scripts jest-watch"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/lists/package.json
+++ b/packages/lists/package.json
@@ -15,14 +15,14 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-api": "npx just-scripts update-api",
-    "update-snapshots": "npx just-scripts jest -u",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-api": "just-scripts update-api",
+    "update-snapshots": "just-scripts jest -u",
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/mdl2-theme/package.json
+++ b/packages/mdl2-theme/package.json
@@ -14,10 +14,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@uifabric/build": "^7.0.0",

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -14,12 +14,12 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start-test": "npx just-scripts jest-watch",
-    "update-api": "npx just-scripts update-api"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start-test": "just-scripts jest-watch",
+    "update-api": "just-scripts update-api"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/migration/package.json
+++ b/packages/migration/package.json
@@ -13,13 +13,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u",
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -17,15 +17,15 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
     "start": "cd ../../apps/fabric-website-resources && npm start",
-    "start-test": "npx just-scripts jest-watch",
+    "start-test": "just-scripts jest-watch",
     "update-sass-theme-files": "node ./scripts/generateDefaultThemeSassFiles.js",
-    "update-snapshots": "npx just-scripts jest -u",
-    "update-api": "npx just-scripts update-api",
+    "update-snapshots": "just-scripts jest -u",
+    "update-api": "just-scripts update-api",
     "codepen": "node ../../scripts/local-codepen.js"
   },
   "devDependencies": {

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/set-version/package.json
+++ b/packages/set-version/package.json
@@ -14,9 +14,9 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "code-style": "npx just-scripts code-style",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "code-style": "just-scripts code-style",
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -12,13 +12,13 @@
   "sideEffects": true,
   "typings": "lib/index.d.ts",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start-test": "npx just-scripts jest-watch",
-    "update-api": "npx just-scripts update-api",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start-test": "just-scripts jest-watch",
+    "update-api": "just-scripts update-api",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-api": "npx just-scripts update-api"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-api": "just-scripts update-api"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -14,10 +14,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "code-style": "npx just-scripts code-style",
-    "clean": "npx just-scripts clean"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "code-style": "just-scripts code-style",
+    "clean": "just-scripts clean"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/tsx-editor/package.json
+++ b/packages/tsx-editor/package.json
@@ -15,13 +15,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u",
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "code-style": "npx just-scripts code-style",
-    "clean": "npx just-scripts clean",
-    "start-test": "npx just-scripts jest-watch",
-    "update-api": "npx just-scripts update-api",
-    "update-snapshots": "npx just-scripts jest -u"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "code-style": "just-scripts code-style",
+    "clean": "just-scripts clean",
+    "start-test": "just-scripts jest-watch",
+    "update-api": "just-scripts update-api",
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.13",

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -14,11 +14,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "just": "npx just-scripts",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start-test": "npx just-scripts jest-watch"
+    "build": "just-scripts build",
+    "just": "just-scripts",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/packages/webpack-utils/package.json
+++ b/packages/webpack-utils/package.json
@@ -8,11 +8,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "code-style": "npx just-scripts code-style",
-    "clean": "npx just-scripts clean",
+    "build": "just-scripts build",
+    "code-style": "just-scripts code-style",
+    "clean": "just-scripts clean",
     "start": "node ../../scripts/node_modules/typescript/bin/tsc -w --outDir lib -m commonjs -t es5",
-    "just": "npx just-scripts"
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@types/jest": "23.0.0",

--- a/scripts/templates/create-package/EmptyPackageJson.mustache
+++ b/scripts/templates/create-package/EmptyPackageJson.mustache
@@ -14,13 +14,13 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "npx just-scripts build",
-    "clean": "npx just-scripts clean",
-    "code-style": "npx just-scripts code-style",
-    "start": "npx just-scripts dev",
-    "start-test": "npx just-scripts jest-watch",
-    "update-snapshots": "npx just-scripts jest -u",
-    "just": "npx just-scripts"
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "code-style": "just-scripts code-style",
+    "start": "just-scripts dev",
+    "start-test": "just-scripts jest-watch",
+    "update-snapshots": "just-scripts jest -u",
+    "just": "just-scripts"
   },
   "devDependencies": {
     "@types/enzyme": "{{{typesEnzyme}}}",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

There is a lot of logic contained inside npx that we do not need for the case of npm run scripts because `just-scripts` is already a "npm binary" from the `@uifabric/build` project. This change gets rid of the majority of `npx` calls. The root package.json still requires it, however - lots of those are in the form `cd foo && npx just-scripts do-some-foo-task`

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9809)