### PR TITLE
DropDown: Adding null check in onPositioned call

### DIFF
--- a/change/office-ui-fabric-react-2019-07-15-16-56-39-dropDownFocusZoneNullCheck.json
+++ b/change/office-ui-fabric-react-2019-07-15-16-56-39-dropDownFocusZoneNullCheck.json
@@ -1,0 +1,8 @@
+{
+  "comment": "DropDown: Adding null check in onPositioned call.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "30890297bb5b45cece99eee5f770a175f33ee259",
+  "date": "2019-07-15T23:56:38.953Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -640,11 +640,13 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       // frame can improve perf significantly.
       this._requestAnimationFrame(() => {
         const selectedIndices = this.state.selectedIndices;
-        if (selectedIndices && selectedIndices[0] && !this.props.options[selectedIndices[0]].disabled) {
-          const element: HTMLElement = getDocument()!.querySelector(`#${this._id}-list${selectedIndices[0]}`) as HTMLElement;
-          this._focusZone.current!.focusElement(element);
-        } else {
-          this._focusZone.current!.focus();
+        if (this._focusZone.current) {
+          if (selectedIndices && selectedIndices[0] && !this.props.options[selectedIndices[0]].disabled) {
+            const element: HTMLElement = getDocument()!.querySelector(`#${this._id}-list${selectedIndices[0]}`) as HTMLElement;
+            this._focusZone.current.focusElement(element);
+          } else {
+            this._focusZone.current.focus();
+          }
         }
       });
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9715
- [x] Include a change request file using `$ npm run change`

#### Description of changes

This PR adds a `null` check for the `focusZone` reference inside `Dropdown.base.tsx` on the `_onPosition` call so that we ensure we're only executing our code if the `focusZone` ref does exist.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9812)