### PR TITLE
tslint fixed for windows

### DIFF
--- a/scripts/lint-staged/tslint.js
+++ b/scripts/lint-staged/tslint.js
@@ -1,8 +1,7 @@
 // @ts-check
 
-const execSync = require('../exec-sync');
+const { spawnSync } = require('child_process');
 const path = require('path');
-const fs = require('fs');
 const msCustomRulesMain = require.resolve('tslint-microsoft-contrib');
 const rulesPath = path.dirname(msCustomRulesMain);
 const tslintPath = require.resolve('tslint/lib/tslintCli.js');
@@ -65,6 +64,8 @@ function runTsLintOnFilesGroupedPerPackage(filesGroupedByPackage) {
       continue;
     }
 
-    execSync(`${process.execPath} ${tslintPath} --config ${tslintConfig} -t stylish -r ${rulesPath} ${filteredFiles.join(' ')}`);
+    spawnSync(process.execPath, [tslintPath, '--config', tslintConfig, '-t', 'stylish', '-r', rulesPath, ...filteredFiles], {
+      stdio: 'inherit'
+    });
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

execSync doesn't work with process.execPath when on windows platform. This is because of the SPACE in the "program files"

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9818)