### PR TITLE
Mark all API reference tables as non-virtualized to avoid flash of content

### DIFF
--- a/change/@uifabric-example-app-base-2019-07-16-10-42-23-keco-property-tables-foc.json
+++ b/change/@uifabric-example-app-base-2019-07-16-10-42-23-keco-property-tables-foc.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix API reference tables' flash of content on scroll",
+  "type": "patch",
+  "packageName": "@uifabric/example-app-base",
+  "email": "706967+KevinTCoughlin@users.noreply.github.com",
+  "commit": "6d4359e282aa292691f661ff655fe5b1b42b21eb",
+  "date": "2019-07-16T17:42:23.118Z"
+}

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -278,7 +278,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
                 items={properties}
                 columns={isEnum ? this._enumColumns : this._defaultColumns}
                 onRenderRow={this._onRenderRow}
-                onShouldVirtualize={() => false}
+                onShouldVirtualize={this._onShouldVirtualize}
               />
             )}
       </Stack>
@@ -348,6 +348,10 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
     return textElements;
   }
 
+  private _onShouldVirtualize(): boolean {
+    return false;
+  }
+
   private _renderClass(): JSX.Element | undefined {
     const { properties, methods } = this.state;
 
@@ -362,7 +366,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
               items={properties}
               columns={this._defaultColumns}
               onRenderRow={this._onRenderRow}
-              onShouldVirtualize={() => false}
+              onShouldVirtualize={this._onShouldVirtualize}
             />
           </Stack>
         )}
@@ -375,7 +379,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
               items={methods}
               columns={this._methodColumns}
               onRenderRow={this._onRenderRow}
-              onShouldVirtualize={() => false}
+              onShouldVirtualize={this._onShouldVirtualize}
             />
           </Stack>
         )}

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -278,6 +278,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
                 items={properties}
                 columns={isEnum ? this._enumColumns : this._defaultColumns}
                 onRenderRow={this._onRenderRow}
+                onShouldVirtualize={() => false}
               />
             )}
       </Stack>
@@ -361,6 +362,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
               items={properties}
               columns={this._defaultColumns}
               onRenderRow={this._onRenderRow}
+              onShouldVirtualize={() => false}
             />
           </Stack>
         )}
@@ -373,6 +375,7 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
               items={methods}
               columns={this._methodColumns}
               onRenderRow={this._onRenderRow}
+              onShouldVirtualize={() => false}
             />
           </Stack>
         )}

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -348,9 +348,9 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
     return textElements;
   }
 
-  private _onShouldVirtualize(): boolean {
+  private _onShouldVirtualize = (): boolean => {
     return false;
-  }
+  };
 
   private _renderClass(): JSX.Element | undefined {
     const { properties, methods } = this.state;

--- a/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
@@ -139,10 +139,14 @@ class PropertiesTableBase extends React.PureComponent<IPropertiesTableProps> {
           groups={this._groups}
           columns={renderAsEnum ? ENUM_COLUMNS : DEFAULT_COLUMNS}
           styles={classNames.subComponentStyles.list}
-          onShouldVirtualize={() => false}
+          onShouldVirtualize={this._onShouldVirtualize}
         />
       </div>
     );
+  }
+
+  private _onShouldVirtualize(): boolean {
+    return false;
   }
 
   private _getGroups(): IGroup[] {

--- a/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
@@ -139,6 +139,7 @@ class PropertiesTableBase extends React.PureComponent<IPropertiesTableProps> {
           groups={this._groups}
           columns={renderAsEnum ? ENUM_COLUMNS : DEFAULT_COLUMNS}
           styles={classNames.subComponentStyles.list}
+          onShouldVirtualize={() => false}
         />
       </div>
     );

--- a/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
+++ b/packages/example-app-base/src/components/PropertiesTable/PropertiesTable.tsx
@@ -145,9 +145,9 @@ class PropertiesTableBase extends React.PureComponent<IPropertiesTableProps> {
     );
   }
 
-  private _onShouldVirtualize(): boolean {
+  private _onShouldVirtualize = (): boolean => {
     return false;
-  }
+  };
 
   private _getGroups(): IGroup[] {
     const groups: IGroup[] = [];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Modifies API reference tables used on local dev site to not virtualize their content. I believe the production site already marks its flavor of reference tables as non-virtualized.

**Before**

![api_foc_before](https://user-images.githubusercontent.com/706967/61317660-54339b00-a7b8-11e9-9163-f18f6226c4be.gif)

**After**

![api_foc_after](https://user-images.githubusercontent.com/706967/61317665-585fb880-a7b8-11e9-8e46-ef96d184a98d.gif)

Something subtle that was distracting me yesterday when looking at row render performance.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9824)