### PR TITLE
Panel: Making padding not change with screen width to match toolkit

### DIFF
--- a/change/office-ui-fabric-react-2019-07-16-14-51-10-panelPadding.json
+++ b/change/office-ui-fabric-react-2019-07-16-14-51-10-panelPadding.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Panel: Making padding not change with screen width to match toolkit.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "f0c357f33de7fb3d2924a0d8dcf9208a5ae36aa7",
+  "date": "2019-07-16T21:51:10.670Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -156,17 +156,7 @@ const commandBarHeight = '44px';
 
 const sharedPaddingStyles = {
   paddingLeft: '16px',
-  paddingRight: '16px',
-  selectors: {
-    [`@media screen and (min-width: ${ScreenWidthMinLarge}px)`]: {
-      paddingLeft: '32px',
-      paddingRight: '32px'
-    },
-    [`@media screen and (min-width: ${ScreenWidthMinXXLarge}px)`]: {
-      paddingLeft: '40px',
-      paddingRight: '40px'
-    }
-  }
+  paddingRight: '16px'
 };
 
 // // TODO -Issue #5689: Comment in once Button is converted to mergeStyles

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -326,14 +326,6 @@ exports[`Panel renders Panel correctly 1`] = `
                     padding-left: 16px;
                     padding-right: 16px;
                   }
-                  @media screen and (min-width: 640px){& {
-                    padding-left: 32px;
-                    padding-right: 32px;
-                  }
-                  @media screen and (min-width: 1366px){& {
-                    padding-left: 40px;
-                    padding-right: 40px;
-                  }
                   @media (min-width: 1024px){& {
                     margin-top: 30px;
                   }
@@ -381,14 +373,6 @@ exports[`Panel renders Panel correctly 1`] = `
                       padding-bottom: 20px;
                       padding-left: 16px;
                       padding-right: 16px;
-                    }
-                    @media screen and (min-width: 640px){& {
-                      padding-left: 32px;
-                      padding-right: 32px;
-                    }
-                    @media screen and (min-width: 1366px){& {
-                      padding-left: 40px;
-                      padding-right: 40px;
                     }
               >
                 <span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -411,14 +411,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                       padding-left: 16px;
                       padding-right: 16px;
                     }
-                    @media screen and (min-width: 640px){& {
-                      padding-left: 32px;
-                      padding-right: 32px;
-                    }
-                    @media screen and (min-width: 1366px){& {
-                      padding-left: 40px;
-                      padding-right: 40px;
-                    }
                     @media (min-width: 1024px){& {
                       margin-top: 30px;
                     }
@@ -466,14 +458,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                         padding-bottom: 20px;
                         padding-left: 16px;
                         padding-right: 16px;
-                      }
-                      @media screen and (min-width: 640px){& {
-                        padding-left: 32px;
-                        padding-right: 32px;
-                      }
-                      @media screen and (min-width: 1366px){& {
-                        padding-left: 40px;
-                        padding-right: 40px;
                       }
                 >
                   <span>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9716
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Make `Panel` padding not change with screen width changes so it matches toolkit padding of `16px`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9825)