### PR TITLE
Chiclet: Removes imageHeight and imageWidth props

### DIFF
--- a/change/@uifabric-experiments-2019-07-16-16-04-11-chicletPreviewSizingFix.json
+++ b/change/@uifabric-experiments-2019-07-16-16-04-11-chicletPreviewSizingFix.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Chiclet: removes imageHeight and imageWidth props",
+  "type": "minor",
+  "packageName": "@uifabric/experiments",
+  "email": "t-stcar@microsoft.com",
+  "commit": "7852d0520f5ee54d4dacbb8fcc22f1b748dac9b6",
+  "date": "2019-07-16T23:04:11.089Z"
+}

--- a/packages/experiments/src/components/Chiclet/Chiclet.types.ts
+++ b/packages/experiments/src/components/Chiclet/Chiclet.types.ts
@@ -47,16 +47,6 @@ export interface IChicletProps extends React.HTMLAttributes<HTMLElement> {
   image?: string;
 
   /**
-   * Image Width to render for the component.
-   */
-  imageWidth?: number | string;
-
-  /**
-   * Image Height to render for the component.
-   */
-  imageHeight?: number | string;
-
-  /**
    * Alternate image to render for the component.
    */
   imageAlt?: string;

--- a/packages/experiments/src/components/Chiclet/ChicletCard.base.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletCard.base.tsx
@@ -26,7 +26,7 @@ export class ChicletCardBase extends BaseComponent<IChicletCardProps, {}> {
 
     return (
       <div tabIndex={tabIndex} role={role} onClick={actionable ? this._onClick : undefined} className={this._classNames.root}>
-        {generatePreview(this.props, false, this._classNames.icon, this._classNames.preview, PREVIEW_IMAGE_HEIGHT, PREVIEW_IMAGE_WIDTH)}
+        {generatePreview(this.props, false, this._classNames, PREVIEW_IMAGE_HEIGHT, PREVIEW_IMAGE_WIDTH)}
         <div className={this._classNames.info}>
           <div className={this._classNames.title}>{title ? title : null}</div>
           <div className={this._classNames.description}>{description ? description : url}</div>

--- a/packages/experiments/src/components/Chiclet/ChicletCard.base.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletCard.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseComponent, classNamesFunction } from '../../Utilities';
 import { IChicletCardStyles, IChicletCardStyleProps, IChicletCardProps } from './ChicletCard.types';
-import { generateCommonHTML } from '../../utilities/chicletHelper';
+import { generatePreview } from '../../utilities/chicletHelper';
 
 const getClassNames = classNamesFunction<IChicletCardStyleProps, IChicletCardStyles>();
 
@@ -9,11 +9,6 @@ const PREVIEW_IMAGE_WIDTH = '198px';
 const PREVIEW_IMAGE_HEIGHT = '122px';
 
 export class ChicletCardBase extends BaseComponent<IChicletCardProps, {}> {
-  public static defaultProps: IChicletCardProps = {
-    imageWidth: PREVIEW_IMAGE_WIDTH,
-    imageHeight: PREVIEW_IMAGE_HEIGHT
-  };
-
   private _classNames: { [key in keyof IChicletCardStyles]: string };
 
   public render(): JSX.Element {
@@ -31,7 +26,7 @@ export class ChicletCardBase extends BaseComponent<IChicletCardProps, {}> {
 
     return (
       <div tabIndex={tabIndex} role={role} onClick={actionable ? this._onClick : undefined} className={this._classNames.root}>
-        {generateCommonHTML(this.props, false, this._classNames.icon, this._classNames.preview)}
+        {generatePreview(this.props, false, this._classNames.icon, this._classNames.preview, PREVIEW_IMAGE_HEIGHT, PREVIEW_IMAGE_WIDTH)}
         <div className={this._classNames.info}>
           <div className={this._classNames.title}>{title ? title : null}</div>
           <div className={this._classNames.description}>{description ? description : url}</div>

--- a/packages/experiments/src/components/Chiclet/ChicletCard.styles.ts
+++ b/packages/experiments/src/components/Chiclet/ChicletCard.styles.ts
@@ -80,7 +80,7 @@ export const getStyles = (props: IChicletCardStyleProps): IChicletCardStyles => 
         color: palette.neutralPrimary,
         letterSpacing: 'normal',
         textAlign: 'left',
-        height: 41, // Two lines of text, making sure the third line is hidden
+        height: 37, // Two lines of text, making sure the third line is hidden
         width: 363,
         lineHeight: '1.25',
         overflow: 'hidden',

--- a/packages/experiments/src/components/Chiclet/ChicletXsmall.base.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletXsmall.base.tsx
@@ -26,14 +26,7 @@ export class ChicletXsmallBase extends React.Component<IChicletCardProps, {}> {
 
     return (
       <div tabIndex={tabIndex} role={role} onClick={this._onClick} className={this._classNames.root}>
-        {generatePreview(
-          this.props,
-          imageProvided,
-          this._classNames.icon,
-          this._classNames.preview,
-          PREVIEW_IMAGE_HEIGHT,
-          PREVIEW_IMAGE_WIDTH
-        )}
+        {generatePreview(this.props, imageProvided, this._classNames, PREVIEW_IMAGE_HEIGHT, PREVIEW_IMAGE_WIDTH)}
         <div className={this._classNames.info}>
           <div className={this._classNames.title}>{title ? title : null}</div>
           <div className={this._classNames.url}>{url ? url : null}</div>

--- a/packages/experiments/src/components/Chiclet/ChicletXsmall.base.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletXsmall.base.tsx
@@ -2,9 +2,12 @@ import * as React from 'react';
 import { classNamesFunction } from '../../Utilities';
 import { IChicletCardStyles, IChicletCardStyleProps } from './ChicletCard.types';
 import { IChicletCardProps } from './ChicletCard.types';
-import { generateCommonHTML } from '../../utilities/chicletHelper';
+import { generatePreview } from '../../utilities/chicletHelper';
 
 const getClassNames = classNamesFunction<IChicletCardStyleProps, IChicletCardStyles>();
+
+const PREVIEW_IMAGE_WIDTH = '61px';
+const PREVIEW_IMAGE_HEIGHT = '59px';
 
 export class ChicletXsmallBase extends React.Component<IChicletCardProps, {}> {
   private _classNames: { [key in keyof IChicletCardStyles]: string };
@@ -23,7 +26,14 @@ export class ChicletXsmallBase extends React.Component<IChicletCardProps, {}> {
 
     return (
       <div tabIndex={tabIndex} role={role} onClick={this._onClick} className={this._classNames.root}>
-        {generateCommonHTML(this.props, imageProvided, this._classNames.icon, this._classNames.preview)}
+        {generatePreview(
+          this.props,
+          imageProvided,
+          this._classNames.icon,
+          this._classNames.preview,
+          PREVIEW_IMAGE_HEIGHT,
+          PREVIEW_IMAGE_WIDTH
+        )}
         <div className={this._classNames.info}>
           <div className={this._classNames.title}>{title ? title : null}</div>
           <div className={this._classNames.url}>{url ? url : null}</div>

--- a/packages/experiments/src/components/Chiclet/__snapshots__/ChicletCard.test.tsx.snap
+++ b/packages/experiments/src/components/Chiclet/__snapshots__/ChicletCard.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`Dialog renders chiclet with title, icon, onClick, and url 1`] = `
             font-stretch: normal;
             font-style: normal;
             font-weight: normal;
-            height: 41px;
+            height: 37px;
             letter-spacing: normal;
             line-height: 1.25;
             overflow: hidden;

--- a/packages/experiments/src/components/Chiclet/__snapshots__/ChicletXsmall.test.tsx.snap
+++ b/packages/experiments/src/components/Chiclet/__snapshots__/ChicletXsmall.test.tsx.snap
@@ -156,8 +156,8 @@ exports[`Chiclet renders chiclet with title, preview, onClick, and url 1`] = `
           }
       style={
         Object {
-          "height": undefined,
-          "width": undefined,
+          "height": "59px",
+          "width": "61px",
         }
       }
     >
@@ -169,7 +169,9 @@ exports[`Chiclet renders chiclet with title, preview, onClick, and url 1`] = `
             is-fadeIn
             {
               display: block;
+              height: 100%;
               opacity: 0;
+              width: 100%;
             }
         onError={[Function]}
         onLoad={[Function]}

--- a/packages/experiments/src/utilities/chicletHelper.tsx
+++ b/packages/experiments/src/utilities/chicletHelper.tsx
@@ -98,8 +98,7 @@ export function findIcon(title: string): string | undefined {
  *
  * @param props - Chiclet props
  * @param imageProvided - Boolean that indicates if an image was provided
- * @param iconStyle - Icon styling
- * @param previewStyle - Preview image styling
+ * @param classNames - Styling
  * @param height - Height for the preview
  * @param width - Width for the preview
  */

--- a/packages/experiments/src/utilities/chicletHelper.tsx
+++ b/packages/experiments/src/utilities/chicletHelper.tsx
@@ -4,6 +4,15 @@ import { IChicletCardProps } from '../components/Chiclet/ChicletCard.types';
 
 const ASSET_CDN_BASE_URL = 'https://static2.sharepointonline.com/files/fabric/assets';
 
+/**
+ * Returns an Image tag with filled in info
+ *
+ * @param imageUrl - Image url
+ * @param imageHeight - Preview image height
+ * @param imageWidth - Preview image width
+ * @param imageAlt - Alternate image
+ * @returns - Image tag with filled in info
+ */
 export function renderPreview(
   imageUrl?: string,
   imageHeight?: string | number,
@@ -17,6 +26,14 @@ export function renderPreview(
   return image;
 }
 
+/**
+ * Uses itemType to find the proper icon and return an img tag containing the icon url
+ *
+ * @param itemType - File type (Word, Excel, or PowerPoint)
+ * @param style - Icon styling
+ * @param imageProvided - Boolean that indicates if an image was provided
+ * @returns - img tag that contains the url for the specified file type
+ */
 export function renderIcon(
   itemType?: string,
   style?: string,
@@ -51,6 +68,12 @@ export function renderIcon(
   return icon;
 }
 
+/**
+ * Uses the file title to determine file type
+ *
+ * @param title - File title
+ * @returns - An extension or undefined
+ */
 export function findIcon(title: string): string | undefined {
   let extensionIndex;
   let pos;
@@ -70,16 +93,28 @@ export function findIcon(title: string): string | undefined {
   return undefined;
 }
 
-export function generateCommonHTML(
+/**
+ * Generates the HTML for a preview image and/or file icon
+ *
+ * @param props - Chiclet props
+ * @param imageProvided - Boolean that indicates if an image was provided
+ * @param iconStyle - Icon styling
+ * @param previewStyle - Preview image styling
+ * @param height - Height for the preview
+ * @param width - Width for the preview
+ */
+export function generatePreview(
   props: IChicletCardProps,
   imageProvided: boolean,
-  icon?: string,
-  preview?: string
+  iconStyle?: string,
+  previewStyle?: string,
+  height?: string,
+  width?: string
 ): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> | undefined {
   return (
-    <div className={preview}>
-      {renderPreview(props.image, props.imageHeight, props.imageWidth, props.imageAlt)}
-      {renderIcon(props.itemType || (props.title && findIcon(props.title)), icon, imageProvided)}
+    <div className={previewStyle}>
+      {renderPreview(props.image, height, width, props.imageAlt)}
+      {renderIcon(props.itemType || (props.title && findIcon(props.title)), iconStyle, imageProvided)}
     </div>
   );
 }

--- a/packages/experiments/src/utilities/chicletHelper.tsx
+++ b/packages/experiments/src/utilities/chicletHelper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Image } from 'office-ui-fabric-react/lib/Image';
-import { IChicletCardProps } from '../components/Chiclet/ChicletCard.types';
+import { IChicletCardProps, IChicletCardStyles } from '../components/Chiclet/ChicletCard.types';
 
 const ASSET_CDN_BASE_URL = 'https://static2.sharepointonline.com/files/fabric/assets';
 
@@ -106,15 +106,14 @@ export function findIcon(title: string): string | undefined {
 export function generatePreview(
   props: IChicletCardProps,
   imageProvided: boolean,
-  iconStyle?: string,
-  previewStyle?: string,
+  classNames: { [key in keyof IChicletCardStyles]: string },
   height?: string,
   width?: string
 ): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> | undefined {
   return (
-    <div className={previewStyle}>
+    <div className={classNames.preview}>
       {renderPreview(props.image, height, width, props.imageAlt)}
-      {renderIcon(props.itemType || (props.title && findIcon(props.title)), iconStyle, imageProvided)}
+      {renderIcon(props.itemType || (props.title && findIcon(props.title)), classNames.icon, imageProvided)}
     </div>
   );
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

This PR removes the imageHeight and imageWidth Chiclet Props because the user should not be able to provide those. Instead, height and width values for the Chiclet preview images are specifically defined.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9828)