### PR TITLE
temporary workaround and disables the generate-version step

### DIFF
--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/fabric-website-resources",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Office UI Fabric React website resources project",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/fabric-website",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "description": "Reusable React components for building experiences for Office 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -36,9 +36,11 @@ steps:
       node common/scripts/install-run-rush.js install --bypass-policy
     displayName: rush install
 
-  - script: |
-      npm run generate-version-files
-    displayName: npm run generate-version-files
+  # TODO: disable this step until a proper fix to this is found
+  #       root cause: this step is generating a set of changes that are not checked in and not accounted for in the change files
+  # - script: |
+  #     npm run generate-version-files
+  #   displayName: npm run generate-version-files
 
   - script: |
       node common/scripts/install-run-rush.js build --production --verbose

--- a/change/@uifabric-api-docs-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-api-docs-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/api-docs",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:25.250Z"
+}

--- a/change/@uifabric-azure-themes-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-azure-themes-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/azure-themes",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:26.487Z"
+}

--- a/change/@uifabric-charting-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-charting-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/charting",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:27.569Z"
+}

--- a/change/@uifabric-codepen-loader-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-codepen-loader-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/codepen-loader",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:28.657Z"
+}

--- a/change/@uifabric-date-time-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-date-time-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/date-time",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:29.719Z"
+}

--- a/change/@uifabric-example-app-base-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-example-app-base-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/example-app-base",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:30.933Z"
+}

--- a/change/@uifabric-experiments-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-experiments-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/experiments",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:33.613Z"
+}

--- a/change/@uifabric-fabric-website-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-fabric-website-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:23.945Z"
+}

--- a/change/@uifabric-fabric-website-resources-2019-07-17-10-48-33-fixpub.json
+++ b/change/@uifabric-fabric-website-resources-2019-07-17-10-48-33-fixpub.json
@@ -1,0 +1,8 @@
+{
+  "comment": "bumping versions to match what was published already",
+  "type": "none",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "kchau@microsoft.com",
+  "commit": "75e4ad16a2e6a54672e4929a9e003c7fd6f6ae52",
+  "date": "2019-07-17T17:48:22.532Z"
+}

--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/api-docs",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "A package that transforms .api.json files into page.json files",
   "main": "lib-commonjs/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/azure-themes",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Azure themes for Office UI Components",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/charting",
-  "version": "0.133.2",
+  "version": "0.133.3",
   "description": "Experimental React components for building experiences for Office 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/codepen-loader/package.json
+++ b/packages/codepen-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/codepen-loader",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Webpack loader for UI Fabric Codepen examples.",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/date-time",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Date and time related React components for building experiences for Office 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/example-app-base",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "Office UI Fabric example app base utilities for building example sites.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/experiments",
-  "version": "7.6.0",
+  "version": "7.6.1",
   "description": "Experimental React components for building experiences for Office 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

When I fixed the generate-version script (which had been broken a while back before 7.x switch over), it enabled the script to make changes that broke the publish because beachball publish makes sure everything is checked in before proceeding. We need to either relax that or make it configurable. I'm disabling this task for now since it wasn't working before.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9836)