### PR TITLE
Panel: Change click listener to mousedown listener so that Panels aren't dismissed on mouseup (cherrypick of #5948)

### DIFF
--- a/common/changes/office-ui-fabric-react/panelDismiss_2019-07-17-18-46.json
+++ b/common/changes/office-ui-fabric-react/panelDismiss_2019-07-17-18-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Panel: Change click listener to mousedown listener so that Panels aren't dismissed on mouseup (cherrypick of #5948).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.tsx
@@ -62,7 +62,7 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     this._events.on(window, 'resize', this._updateFooterPosition);
 
     if (this._shouldListenForOuterClick(this.props)) {
-      this._events.on(document.body, 'click', this._dismissOnOuterClick, true);
+      this._events.on(document.body, 'mousedown', this._dismissOnOuterClick, true);
     }
 
     if (this.props.isOpen) {
@@ -75,9 +75,9 @@ export class Panel extends BaseComponent<IPanelProps, IPanelState> implements IP
     const previousShouldListenOnOuterClick = this._shouldListenForOuterClick(previousProps);
 
     if (shouldListenOnOuterClick && !previousShouldListenOnOuterClick) {
-      this._events.on(document.body, 'click', this._dismissOnOuterClick, true);
+      this._events.on(document.body, 'mousedown', this._dismissOnOuterClick, true);
     } else if (!shouldListenOnOuterClick && previousShouldListenOnOuterClick) {
-      this._events.off(document.body, 'click', this._dismissOnOuterClick, true);
+      this._events.off(document.body, 'mousedown', this._dismissOnOuterClick, true);
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9683
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Cherrypick into Fabric 5.0 of #5948 which fixed a bug introduced in #5552.

A cherrypick into Fabric 5.0 of #5552 was done in #5580 which introduced the bug described in #9683.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9840)