### PR TITLE
Default Effects: Export from Styling index

### DIFF
--- a/change/@uifabric-styling-2019-07-17-13-56-39-export-defaulteffects.json
+++ b/change/@uifabric-styling-2019-07-17-13-56-39-export-defaulteffects.json
@@ -1,0 +1,8 @@
+{
+  "comment": "export default effects",
+  "type": "minor",
+  "packageName": "@uifabric/styling",
+  "email": "joschect@microsoft.com",
+  "commit": "53219bca13f9053fcb778358824bab5144d12e83",
+  "date": "2019-07-17T20:56:39.615Z"
+}

--- a/change/@uifabric-styling-2019-07-17-13-56-39-export-defaulteffects.json
+++ b/change/@uifabric-styling-2019-07-17-13-56-39-export-defaulteffects.json
@@ -1,5 +1,5 @@
 {
-  "comment": "export default effects",
+  "comment": "Export default effects",
   "type": "minor",
   "packageName": "@uifabric/styling",
   "email": "joschect@microsoft.com",

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -50,6 +50,11 @@ export function createFontStyles(localeCode: string | null): IFontStyles;
 // @public
 export function createTheme(theme: IPartialTheme, depComments?: boolean): ITheme;
 
+// Warning: (ae-incompatible-release-tags) The symbol "DefaultEffects" is marked as @public, but its signature references "IEffects" which is marked as @internal
+// 
+// @public (undocumented)
+export const DefaultEffects: IEffects;
+
 // @public (undocumented)
 export const DefaultFontStyles: IFontStyles;
 

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -50,8 +50,6 @@ export function createFontStyles(localeCode: string | null): IFontStyles;
 // @public
 export function createTheme(theme: IPartialTheme, depComments?: boolean): ITheme;
 
-// Warning: (ae-incompatible-release-tags) The symbol "DefaultEffects" is marked as @public, but its signature references "IEffects" which is marked as @internal
-// 
 // @public (undocumented)
 export const DefaultEffects: IEffects;
 
@@ -277,9 +275,7 @@ export namespace IconFontSizes {
 
 export { ICSPSettings }
 
-// Warning: (ae-internal-missing-underscore) The name "IEffects" should be prefixed with an underscore because the declaration is marked as @internal
-// 
-// @internal
+// @public
 export interface IEffects {
     elevation16: string;
     elevation4: string;
@@ -440,8 +436,6 @@ export { IRawStyle }
 // @public (undocumented)
 export interface IScheme {
     disableGlobalClassNames: boolean;
-    // Warning: (ae-incompatible-release-tags) The symbol "effects" is marked as @public, but its signature references "IEffects" which is marked as @internal
-    // 
     // (undocumented)
     effects: IEffects;
     // (undocumented)
@@ -688,7 +682,6 @@ export namespace ZIndexes {
 // Warnings were encountered during analysis:
 // 
 // lib/interfaces/ITheme.d.ts:68:5 - (ae-incompatible-release-tags) The symbol "spacing" is marked as @public, but its signature references "ISpacing" which is marked as @internal
-// lib/interfaces/ITheme.d.ts:69:5 - (ae-incompatible-release-tags) The symbol "effects" is marked as @public, but its signature references "IEffects" which is marked as @internal
 // lib/interfaces/ITheme.d.ts:70:5 - (ae-incompatible-release-tags) The symbol "schemes" is marked as @public, but its signature references "ISchemeNames" which is marked as @internal
 // lib/styles/PulsingBeaconAnimationStyles.d.ts:6:5 - (ae-forgotten-export) The symbol "_continuousPulseAnimationDouble" needs to be exported by the entry point index.d.ts
 // lib/styles/PulsingBeaconAnimationStyles.d.ts:7:5 - (ae-forgotten-export) The symbol "_continuousPulseAnimationSingle" needs to be exported by the entry point index.d.ts

--- a/packages/styling/src/interfaces/IEffects.ts
+++ b/packages/styling/src/interfaces/IEffects.ts
@@ -1,7 +1,6 @@
 import { IRawStyle } from '@uifabric/merge-styles';
 
 /**
- * @internal
  * Experimental interface for decorative styling in a theme.
  * {@docCategory IEffects}
  */

--- a/packages/styling/src/styles/index.ts
+++ b/packages/styling/src/styles/index.ts
@@ -1,5 +1,6 @@
 export { AnimationStyles, AnimationVariables } from './AnimationStyles';
 export { DefaultPalette } from './DefaultPalette';
+export { DefaultEffects } from './DefaultEffects';
 export { DefaultFontStyles, registerDefaultFontFaces } from './DefaultFontStyles';
 export { FontSizes, FontWeights, IconFontSizes, createFontStyles } from './fonts';
 export * from './getFocusStyle';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #9835
- [ ] Include a change request file using `$ npm run change`

#### Description of changes

Default effects should be export from styling index in the same way all of the other default styles are exported.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9843)