### PR TITLE
Tooltip: remove BaseComponent and fix 2 issues

### DIFF
--- a/change/office-ui-fabric-react-2019-07-17-15-51-10-shield-TooltipCloseDelay.json
+++ b/change/office-ui-fabric-react-2019-07-17-15-51-10-shield-TooltipCloseDelay.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Tooltip: render tooltip only after the delay and make sure if provided `closeDelay` is bigger than `delay` not to flash the Tooltip.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "28b4e28c52a8d8b6554dd8d83316c954e15d4b1e",
+  "date": "2019-07-17T22:51:10.132Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7684,6 +7684,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
 // @public (undocumented)
 export interface ITooltipStyleProps {
     className?: string;
+    // @deprecated
     delay?: TooltipDelay;
     gapSpace?: number;
     maxWidth?: string;
@@ -9286,7 +9287,7 @@ export enum TooltipDelay {
 export const TooltipHost: React.StatelessComponent<ITooltipHostProps>;
 
 // @public (undocumented)
-export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHostState> implements ITooltipHost {
+export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltipHostState> implements ITooltipHost {
     constructor(props: ITooltipHostProps);
     // (undocumented)
     componentWillUnmount(): void;

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { classNamesFunction, divProperties, getNativeProps } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
-import { ITooltipProps, ITooltipStyleProps, ITooltipStyles, TooltipDelay } from './Tooltip.types';
+import { ITooltipProps, ITooltipStyleProps, ITooltipStyles } from './Tooltip.types';
 import { Callout } from '../../Callout';
 import { DirectionalHint } from '../../common/DirectionalHint';
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -11,7 +11,6 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
   // Specify default props values
   public static defaultProps: Partial<ITooltipProps> = {
     directionalHint: DirectionalHint.topCenter,
-    delay: TooltipDelay.medium,
     maxWidth: '364px',
     calloutProps: {
       isBeakVisible: true,
@@ -28,7 +27,6 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
     const {
       className,
       calloutProps,
-      delay,
       directionalHint,
       directionalHintForRTL,
       styles,
@@ -42,7 +40,6 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className: className || (calloutProps && calloutProps.className),
-      delay: delay!,
       gapSpace: calloutProps && calloutProps.gapSpace,
       maxWidth: maxWidth!
     });

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -2,7 +2,7 @@ import { ITooltipStyleProps, ITooltipStyles, TooltipDelay } from './Tooltip.type
 import { AnimationClassNames } from '../../Styling';
 
 export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
-  const { className, delay, gapSpace = 0, maxWidth, theme } = props;
+  const { className, gapSpace = 0, maxWidth, theme } = props;
   const { palette, fonts } = theme;
 
   const tooltipGapSpace = -15 - gapSpace;
@@ -15,7 +15,6 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
       {
         background: palette.white,
         padding: '8px',
-        animationDelay: '300ms',
         maxWidth: maxWidth,
         selectors: {
           ':after': {
@@ -27,12 +26,6 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
             top: tooltipGapSpace
           }
         }
-      },
-      delay === TooltipDelay.zero && {
-        animationDelay: '0s'
-      },
-      delay === TooltipDelay.long && {
-        animationDelay: '500ms'
       },
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -1,4 +1,4 @@
-import { ITooltipStyleProps, ITooltipStyles, TooltipDelay } from './Tooltip.types';
+import { ITooltipStyleProps, ITooltipStyles } from './Tooltip.types';
 import { AnimationClassNames } from '../../Styling';
 
 export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.test.tsx
@@ -38,7 +38,6 @@ describe('Tooltip', () => {
   it('uses default documented properties', () => {
     const component = mount(<TooltipBase />);
 
-    expect(component.prop('delay')).toEqual(TooltipDelay.medium);
     expect(component.prop('directionalHint')).toEqual(DirectionalHint.topCenter);
     expect(component.prop('maxWidth')).toEqual('364px');
     expect(component.prop('calloutProps')).toEqual(defaultCalloutProps);

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.test.tsx
@@ -6,7 +6,6 @@ import { mount } from 'enzyme';
 
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { TooltipBase } from './Tooltip.base';
-import { TooltipDelay } from './Tooltip.types';
 import { ICalloutProps } from '../../Callout';
 
 const defaultCalloutProps: ICalloutProps = {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -103,6 +103,7 @@ export interface ITooltipStyleProps {
 
   /**
    * Delay before tooltip appears.
+   * @deprecated Delay logic moved to TooltipHost vs relying on animation delay.
    */
   delay?: TooltipDelay;
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -92,7 +92,6 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
         {showTooltip && (
           <Tooltip
             id={tooltipId}
-            delay={delay}
             content={content}
             targetElement={this._getTargetElement()}
             directionalHint={directionalHint}
@@ -172,6 +171,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
       return;
     }
 
+    console.log('entering', ev.target);
     this._clearDismissTimer();
     this._clearOpenTimer();
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -55,7 +55,6 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
       calloutProps,
       children,
       content,
-      delay,
       directionalHint,
       directionalHintForRTL,
       hostClassName: className,

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -171,7 +171,6 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
       return;
     }
 
-    console.log('entering', ev.target);
     this._clearDismissTimer();
     this._clearOpenTimer();
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
-  BaseComponent,
+  initializeComponentRef,
+  Async,
   divProperties,
   getNativeProps,
   getId,
@@ -20,7 +21,7 @@ export interface ITooltipHostState {
 
 const getClassNames = classNamesFunction<ITooltipHostStyleProps, ITooltipHostStyles>();
 
-export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHostState> implements ITooltipHost {
+export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltipHostState> implements ITooltipHost {
   public static defaultProps = {
     delay: TooltipDelay.medium
   };
@@ -30,6 +31,7 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
   // The wrapping div that gets the hover events
   private _tooltipHost = React.createRef<HTMLDivElement>();
   private _classNames: { [key in keyof ITooltipHostStyles]: string };
+  private _async: Async;
 
   // The ID of the setTimeout that will eventually close the tooltip if the
   // the tooltip isn't hovered over.
@@ -39,9 +41,13 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
   constructor(props: ITooltipHostProps) {
     super(props);
 
+    initializeComponentRef(this);
+
     this.state = {
       isTooltipVisible: false
     };
+
+    this._async = new Async(this);
   }
 
   // Render
@@ -112,6 +118,8 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
     if (TooltipHostBase._currentVisibleTooltip && TooltipHostBase._currentVisibleTooltip === this) {
       TooltipHostBase._currentVisibleTooltip = undefined;
     }
+
+    this._async.dispose();
   }
 
   public show = (): void => {

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.test.tsx
@@ -97,6 +97,7 @@ describe('TooltipHost', () => {
       <TooltipHost
         calloutProps={calloutProps}
         content={content}
+        delay={TooltipDelay.zero}
         onTooltipToggle={() => {
           onTooltipToggleCalled = true;
           return null;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9773, #9321 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

1. Refactor out the `BaseComponent`
2. Fix issue #9773 where because of how the `Tooltip` was rendered with an animation delay in the case when we provide a `closeDelay` prop that is higher than the `delay` prop you would see a flash of the `Tooltip` if only pass the mouse cursor over the `Tooltip` target.
3. Fix issue #9321 that was forcing the `Tooltip` to render even if having a `delay` prop set by relying only on animation delay making it performance costly by instantiating a Callout (heavy component due its positioning logic) only if passing the mouse cursor over the target without the intend to see the tooltip.

#### Focus areas to test

All examples are still working as expected including the one with `closeDelay`.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9845)