### PR TITLE
Rating: fix aria label for readOnly mode and when using half star. Refactor out BaseComponent

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -6318,7 +6318,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-0\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-0\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -6350,7 +6350,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-1\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-1\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -6382,7 +6382,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-2\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-2\\" data-is-current=\\"true\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -6414,7 +6414,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-3\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-3\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -6446,7 +6446,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-18 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating15-star-4\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -6619,6 +6619,70 @@ Array [
     },
     "ruleId": "aria-allowed-role",
     "ruleIndex": 3,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#Rating12-star-0 > span",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<span id=\\"RatingLabel13-2.5\\" class=\\"ms-Rating-labelText labelText-9\\">2.5 of 5 stars selected</span>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Document has multiple static elements with the same id attribute.",
+      "text": "Fix any of the following: Document has multiple static elements with the same id attribute.",
+    },
+    "ruleId": "duplicate-id",
+    "ruleIndex": 20,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#Rating15-star-0 > span",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<span id=\\"RatingLabel16-2.5\\" class=\\"ms-Rating-labelText labelText-9\\">2.5 of 5 stars selected</span>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Document has multiple static elements with the same id attribute.",
+      "text": "Fix any of the following: Document has multiple static elements with the same id attribute.",
+    },
+    "ruleId": "duplicate-id",
+    "ruleIndex": 20,
   },
 ]
 `;

--- a/change/office-ui-fabric-react-2019-07-17-20-57-21-shield-RatingReadOnlyModeAriaLable.json
+++ b/change/office-ui-fabric-react-2019-07-17-20-57-21-shield-RatingReadOnlyModeAriaLable.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Rating: fix aria-label in `readOnly` mode and when use half stars.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "c7a16f7c1ca63270de8110b0a72de6f7dbf41f77",
+  "date": "2019-07-18T03:57:21.252Z"
+}

--- a/change/office-ui-fabric-react-2019-07-17-20-57-21-shield-RatingReadOnlyModeAriaLable.json
+++ b/change/office-ui-fabric-react-2019-07-17-20-57-21-shield-RatingReadOnlyModeAriaLable.json
@@ -2,7 +2,7 @@
   "comment": "Rating: fix aria-label in `readOnly` mode and when use half stars.",
   "type": "patch",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "vibraga@microsoft.com",
   "commit": "c7a16f7c1ca63270de8110b0a72de6f7dbf41f77",
   "date": "2019-07-18T03:57:21.252Z"
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8425,7 +8425,7 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
 export const Rating: React.StatelessComponent<IRatingProps>;
 
 // @public (undocumented)
-export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
+export class RatingBase extends React.Component<IRatingProps, IRatingState> {
     constructor(props: IRatingProps);
     // (undocumented)
     static defaultProps: IRatingProps;

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -139,7 +139,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
             [this._classNames.rootIsSmall]: size !== RatingSize.Large
           })}
           data-is-focusable={readOnly ? true : false}
-          defaultActiveElement={rating ? starIds[rating - 1] && '#' + starIds[rating - 1] : undefined}
+          defaultActiveElement={rating ? starIds[Math.ceil(rating) - 1] && '#' + starIds[Math.ceil(rating) - 1] : undefined}
           aria-label={readOnly ? ariaLabel : ''}
         >
           {stars}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -112,7 +112,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
             role="presentation"
             type="button"
           >
-            {this._getLabel(i)}
+            {this._getLabel((rating as number) % 1 ? rating : i)}
             <RatingStar key={i + 'rating'} {...ratingStarProps} />
           </button>
         );
@@ -153,7 +153,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
   }
 
   private _onFocus(value: number, ev: React.FocusEvent<HTMLElement>): void {
-    if (this.state.rating !== value) {
+    if (Math.ceil(this.state.rating!) !== value) {
       this.setState({
         rating: value
       } as IRatingState);

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, css, format, getId, divProperties, getNativeProps } from '../../Utilities';
+import {
+  warnDeprecations,
+  initializeComponentRef,
+  classNamesFunction,
+  css,
+  format,
+  getId,
+  divProperties,
+  getNativeProps
+} from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { Icon } from '../../Icon';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
@@ -31,7 +40,7 @@ const RatingStar = (props: IRatingStarProps) => {
   );
 };
 
-export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
+export class RatingBase extends React.Component<IRatingProps, IRatingState> {
   public static defaultProps: IRatingProps = {
     min: 1,
     max: 5
@@ -44,9 +53,9 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
   constructor(props: IRatingProps) {
     super(props);
 
-    this._warnDeprecations({
-      onChanged: 'onChange'
-    });
+    initializeComponentRef(this);
+
+    warnDeprecations('Rating', props, { onChanged: 'onChange' });
 
     this._id = getId('Rating');
     this._min = this.props.allowZeroStars ? 0 : 1;

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -9,8 +9,8 @@ const getClassNames = classNamesFunction<IRatingStyleProps, IRatingStyles>();
 
 interface IRatingStarProps extends React.AllHTMLAttributes<HTMLElement> {
   fillPercentage: number;
-  disabled: boolean;
-  readOnly: boolean;
+  disabled?: boolean;
+  readOnly?: boolean;
   classNames: IProcessedStyleSet<IRatingStyles>;
   icon?: string;
 }
@@ -61,9 +61,6 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
   }
 
   public render(): JSX.Element {
-    const id = this._id;
-    const stars = [];
-    const starIds = [];
     const {
       disabled,
       getAriaLabel,
@@ -75,8 +72,13 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
       icon = 'FavoriteStarFill',
       unselectedIcon = 'FavoriteStar'
     } = this.props;
+
+    const id = this._id;
+    const stars = [];
+    const starIds = [];
     const rating = this._getRating();
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
+
     this._classNames = getClassNames(styles!, {
       disabled,
       readOnly,
@@ -88,8 +90,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
         const fillPercentage = this._getFillingPercentage(i);
         const ratingStarProps: IRatingStarProps = {
           fillPercentage,
-          disabled: disabled ? true : false,
-          readOnly: readOnly ? true : false,
+          disabled,
           classNames: this._classNames,
           icon: fillPercentage > 0 ? icon : unselectedIcon
         };
@@ -118,13 +119,15 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
       }
     }
 
+    const ariaLabel = getAriaLabel ? getAriaLabel(rating ? rating : 0, max as number) : '';
+
     return (
       <div
         className={css('ms-Rating-star', this._classNames.root, {
           [this._classNames.rootIsLarge]: size === RatingSize.Large,
           [this._classNames.rootIsSmall]: size !== RatingSize.Large
         })}
-        aria-label={getAriaLabel ? getAriaLabel(rating ? rating : 0, this.props.max as number) : ''}
+        aria-label={!readOnly ? ariaLabel : ''}
         id={id}
         {...divProps}
       >
@@ -137,6 +140,7 @@ export class RatingBase extends BaseComponent<IRatingProps, IRatingState> {
           })}
           data-is-focusable={readOnly ? true : false}
           defaultActiveElement={rating ? starIds[rating - 1] && '#' + starIds[rating - 1] : undefined}
+          aria-label={readOnly ? ariaLabel : ''}
         >
           {stars}
         </FocusZone>

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.styles.ts
@@ -165,6 +165,7 @@ export function getStyles(props: IRatingStyleProps): IRatingStyles {
     ],
     labelText: [classNames.labelText, hiddenContentStyle],
     ratingFocusZone: [
+      getFocusStyle(theme),
       classNames.ratingFocusZone,
       {
         display: 'inline-block'

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -67,14 +67,15 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
   onChanged?: (rating: number) => void;
 
   /**
-   * Optional label format for star ratings, will be read by screen readers, defaults to ''.
-   * Can be used like "\{0\} of \{1\} stars selected".
-   * Where \{0\} will be subsituted by the current rating and \{1\} will be subsituted by the max rating.
+   * Optional label format for a rating star that will be read by screen readers.
+   * Can be used like "\{0\} of \{1\} stars selected",
+   * where \{0\} will be substituted by the current rating and \{1\} will be substituted by the max rating.
+   * @defaultvalue empty string.
    */
   ariaLabelFormat?: string;
 
   /**
-   * Deprecated: Optional id of label describing this instance of Rating. Use `getAriaLabel` instead.
+   * Deprecated: Optional id of label describing this instance of Rating.
    * @deprecated Use `getAriaLabel` instead.
    */
   ariaLabelId?: string;
@@ -85,7 +86,7 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
   readOnly?: boolean;
 
   /*
-   * Optional callback to set the arialabel for rating control.
+   * Optional callback to set the aria-label for rating control.
    */
   getAriaLabel?: (rating: number, max: number) => string;
 

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Rating renders correctly. 1`] = `
   id="Rating0"
 >
   <div
+    aria-label=""
     className=
         ms-FocusZone
         ms-Rating-focuszone
@@ -35,6 +36,22 @@ exports[`Rating renders correctly. 1`] = `
         }
         {
           display: inline-block;
+          outline: transparent;
+          position: relative;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
         }
         {
           height: 32px;

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
@@ -10,6 +10,7 @@ export class RatingBasicExample extends React.Component<
     smallStarRating?: number;
     tenStarRating?: number;
     themedStarRating?: number;
+    customIconStarRating?: number;
   }
 > {
   private _customTheme: ITheme;
@@ -21,7 +22,8 @@ export class RatingBasicExample extends React.Component<
       largeStarRating: undefined,
       smallStarRating: 3,
       tenStarRating: undefined,
-      themedStarRating: undefined
+      themedStarRating: undefined,
+      customIconStarRating: 2.5
     };
 
     this._customTheme = createTheme(getTheme());
@@ -89,9 +91,11 @@ export class RatingBasicExample extends React.Component<
         <Rating
           min={1}
           max={5}
-          rating={2.5}
+          rating={this.state.customIconStarRating}
+          onChange={this._onCustomIconStarChange}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
           getAriaLabel={this._getRatingComponentAriaLabel}
-          readOnly={true}
           ariaLabelFormat={'{0} of {1} stars selected'}
           icon="StarburstSolid"
           unselectedIcon="Starburst"
@@ -134,6 +138,10 @@ export class RatingBasicExample extends React.Component<
 
   private _onThemedStarChange = (ev: React.FocusEvent<HTMLElement>, rating: number): void => {
     this.setState({ themedStarRating: rating });
+  };
+
+  private _onCustomIconStarChange = (ev: React.FocusEvent<HTMLElement>, rating: number): void => {
+    this.setState({ customIconStarRating: rating });
   };
 
   private _getRatingComponentAriaLabel(rating: number, maxRating: number): string {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -4085,9 +4085,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-1"
+          id="RatingLabel13-2.5"
         >
-          1 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -4224,9 +4224,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-2"
+          id="RatingLabel13-2.5"
         >
-          2 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -4364,9 +4364,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-3"
+          id="RatingLabel13-2.5"
         >
-          3 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -4503,9 +4503,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-4"
+          id="RatingLabel13-2.5"
         >
-          4 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -4642,9 +4642,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-5"
+          id="RatingLabel13-2.5"
         >
-          5 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -4868,9 +4868,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-1"
+          id="RatingLabel16-2.5"
         >
-          1 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -5025,9 +5025,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-2"
+          id="RatingLabel16-2.5"
         >
-          2 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -5183,9 +5183,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-3"
+          id="RatingLabel16-2.5"
         >
-          3 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -5340,9 +5340,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-4"
+          id="RatingLabel16-2.5"
         >
-          4 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=
@@ -5497,9 +5497,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-5"
+          id="RatingLabel16-2.5"
         >
-          5 of 5 stars selected
+          2.5 of 5 stars selected
         </span>
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -33,6 +33,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
+      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -42,6 +43,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 36px;
@@ -871,6 +888,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
+      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -880,6 +898,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;
@@ -1709,6 +1743,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
+      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -1718,6 +1753,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;
@@ -3325,6 +3376,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
+      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -3334,6 +3386,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;
@@ -3891,7 +3959,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   Half star in readOnly mode:
   <div
-    aria-label="Rating value is 2.5 of 5"
+    aria-label=""
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -3909,6 +3977,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     id="Rating12"
   >
     <div
+      aria-label="Rating value is 2.5 of 5"
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -3918,6 +3987,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;
@@ -4642,12 +4727,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+        &:hover .ms-RatingStar-back {
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-RatingStar-back {
+          color: Highlight;
+        }
         {
           height: 32px;
         }
     id="Rating15"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
   >
     <div
+      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -4657,17 +4752,33 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;
           }
       data-focuszone-id="FocusZone17"
-      data-is-focusable={true}
+      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
       role="presentation"
-      tabIndex={0}
+      tabIndex={-1}
     >
       <button
         className=
@@ -4709,12 +4820,30 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             &[disabled] {
               cursor: default;
             }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
             {
               font-size: 16px;
               height: 16px;
               line-height: 16px;
             }
-        disabled={true}
+        disabled={false}
         id="Rating15-star-0"
         onClick={[Function]}
         onFocus={[Function]}
@@ -4848,12 +4977,30 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             &[disabled] {
               cursor: default;
             }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
             {
               font-size: 16px;
               height: 16px;
               line-height: 16px;
             }
-        disabled={true}
+        disabled={false}
         id="Rating15-star-1"
         onClick={[Function]}
         onFocus={[Function]}
@@ -4987,13 +5134,31 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             &[disabled] {
               cursor: default;
             }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
             {
               font-size: 16px;
               height: 16px;
               line-height: 16px;
             }
         data-is-current={true}
-        disabled={true}
+        disabled={false}
         id="Rating15-star-2"
         onClick={[Function]}
         onFocus={[Function]}
@@ -5127,12 +5292,30 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             &[disabled] {
               cursor: default;
             }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
             {
               font-size: 16px;
               height: 16px;
               line-height: 16px;
             }
-        disabled={true}
+        disabled={false}
         id="Rating15-star-3"
         onClick={[Function]}
         onFocus={[Function]}
@@ -5266,12 +5449,30 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             &[disabled] {
               cursor: default;
             }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-back {
+              color: WindowText;
+            }
+            &:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover ~ .ms-Rating-button .ms-RatingStar-front {
+              color: WindowText;
+            }
+            &:hover .ms-RatingStar-back {
+              color: #0078d4;
+            }
+            &:hover .ms-RatingStar-front {
+              color: #005a9e;
+            }
             {
               font-size: 16px;
               height: 16px;
               line-height: 16px;
             }
-        disabled={true}
+        disabled={false}
         id="Rating15-star-4"
         onClick={[Function]}
         onFocus={[Function]}
@@ -5396,6 +5597,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
+      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -5405,6 +5607,22 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -5,7 +5,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
   className="ms-RatingButtonControlledExample"
 >
   <div
-    aria-label="Rating value is 0 of 5"
+    aria-label=""
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -23,6 +23,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
     id="Rating0"
   >
     <div
+      aria-label="Rating value is 0 of 5"
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -32,6 +33,22 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           }
           {
             display: inline-block;
+            outline: transparent;
+            position: relative;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 1px solid #ffffff;
+            bottom: 1px;
+            content: "";
+            left: 1px;
+            outline: 1px solid #605e5c;
+            position: absolute;
+            right: 1px;
+            top: 1px;
+            z-index: 1;
           }
           {
             height: 32px;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9787 
- [X] Include a change request file using `$ npm run change`

#### Description of changes

1. Fixing readout of screen readers for `readOnly` mode. This includes adding a focus rectangle around the FocusZone div when in focus.
2. Fixing some examples noticed that the half star scenario when focused was automatically seting the Rating to 1 so had to put extra `Math.ceil()` and conditionally set the label of the star to read the correct value selected when first time focused. One scenario have no idea how to fix is when initially having a half star rating in the uncontrolled mode there is no way to change it back to half start and even in controlled mode there is currently no way to differentiate the clicks on a star to decide if it's a half star or full star click.
3. Refactor out the BaseComponent.

#### Focus areas to test

Test the screen reader output for every `Rating` example on the demo page.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9848)