### PR TITLE
Fix pre-1880 date selection

### DIFF
--- a/change/office-ui-fabric-react-2019-07-18-14-37-17-user-phtucker-fixPre1880.json
+++ b/change/office-ui-fabric-react-2019-07-18-14-37-17-user-phtucker-fixPre1880.json
@@ -1,8 +1,0 @@
-{
-  "comment": "?",
-  "type": "patch",
-  "packageName": "office-ui-fabric-react",
-  "email": "phtucker@microsoft.com",
-  "commit": "ccbde87ce6f3495b7234ef8eba786a3f2217020a",
-  "date": "2019-07-18T18:37:17.683Z"
-}

--- a/change/office-ui-fabric-react-2019-07-18-14-37-17-user-phtucker-fixPre1880.json
+++ b/change/office-ui-fabric-react-2019-07-18-14-37-17-user-phtucker-fixPre1880.json
@@ -1,0 +1,8 @@
+{
+  "comment": "?",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "phtucker@microsoft.com",
+  "commit": "ccbde87ce6f3495b7234ef8eba786a3f2217020a",
+  "date": "2019-07-18T18:37:17.683Z"
+}

--- a/change/office-ui-fabric-react-2019-07-18-14-38-38-user-phtucker-fixPre1880.json
+++ b/change/office-ui-fabric-react-2019-07-18-14-38-38-user-phtucker-fixPre1880.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix Calendar day selection issue for pre-1880 dates.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "phtucker@microsoft.com",
+  "commit": "8a363c02f34115032e951d12ee2d076944e2a806",
+  "date": "2019-07-18T18:38:38.846Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -779,17 +779,17 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       for (let dayIndex = 0; dayIndex < DAYS_IN_WEEK; dayIndex++) {
         const originalDate = new Date(date.toString());
         const dayInfo: IDayInfo = {
-          key: date.toString(),
-          date: date.getDate().toString(),
+          key: originalDate.toString(),
+          date: originalDate.getDate().toString(),
           originalDate: originalDate,
-          isInMonth: date.getMonth() === navigatedDate.getMonth(),
-          isToday: compareDates(todaysDate, date),
-          isSelected: isInDateRangeArray(date, selectedDates),
+          isInMonth: originalDate.getMonth() === navigatedDate.getMonth(),
+          isToday: compareDates(todaysDate, originalDate),
+          isSelected: isInDateRangeArray(originalDate, selectedDates),
           onSelected: this._onSelectDate.bind(this, originalDate),
           isInBounds:
-            (minDate ? compareDatePart(minDate, date) < 1 : true) &&
-            (maxDate ? compareDatePart(date, maxDate) < 1 : true) &&
-            !this._getIsRestrictedDate(date)
+            (minDate ? compareDatePart(minDate, originalDate) < 1 : true) &&
+            (maxDate ? compareDatePart(originalDate, maxDate) < 1 : true) &&
+            !this._getIsRestrictedDate(originalDate)
         };
 
         week.push(dayInfo);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Day info objects for Calendar are being populated with inconsistent dates due to an issue with converting pre-1880 dates to and from strings. This change populates day info objects from a single date instance preventing the previous inconsistency.

#### Focus areas to test

DatePicker


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9857)