### PR TITLE
ContextualMenu: fluent update

### DIFF
--- a/change/office-ui-fabric-react-2019-07-22-11-52-33-v-mare-ContextualMenu-fluent-fab6-to-fab7-port.json
+++ b/change/office-ui-fabric-react-2019-07-22-11-52-33-v-mare-ContextualMenu-fluent-fab6-to-fab7-port.json
@@ -1,0 +1,8 @@
+{
+  "comment": "ContextualMenu: Updates split button hover state to only highlight either primary button or the menu button",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "128e0d0a3feeaa9df992bf6b904bafd869cb3443",
+  "date": "2019-07-22T18:52:33.047Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.classNames.ts
@@ -141,7 +141,6 @@ export const getItemClassNames = memoizeFunction(
             {
               selectors: {
                 ':hover': styles.rootHovered,
-                ':hover ~ $splitMenu': styles.rootHovered, // when hovering over the splitPrimary also affect the splitMenu
                 ':active': styles.rootPressed,
                 [`.${IsFocusVisibleClassName} &:focus, .${IsFocusVisibleClassName} &:focus:hover`]: styles.rootFocused,
                 [`.${IsFocusVisibleClassName} &:hover`]: { background: 'inherit;' }


### PR DESCRIPTION
#### Pull request checklist

- [x] Fabric 7 port of Fabric 6 fluent-theme package change from: #9553
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Porting over fluent changes made in 6.0 to Fabric 7 master. Hovering on the SplitPrimary button in the ContextualMenu would highlight the entire list  item so this update isolates the highlight to only the primary button.

New:
![Screen Shot 2019-07-26 at 10 22 14 AM](https://user-images.githubusercontent.com/13246181/61969474-76cf6c00-af8f-11e9-97d0-cfadb32f67f3.png)

Current:
![Screen Shot 2019-07-29 at 12 13 59 PM](https://user-images.githubusercontent.com/13246181/62075629-6e2e9e00-b1fa-11e9-8cbd-5e9e174d8768.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9891)