### PR TITLE
ColorPicker: fluent update

### DIFF
--- a/change/office-ui-fabric-react-2019-07-22-12-52-52-v-mare-ColorPicker-fluent-fab6-to-fab7-port.json
+++ b/change/office-ui-fabric-react-2019-07-22-12-52-52-v-mare-ColorPicker-fluent-fab6-to-fab7-port.json
@@ -1,0 +1,8 @@
+{
+  "comment": "ColorPicker: Updates margin bottom of the color rectangle to match web fluent toolkit.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "f560ff800795f17a5f2feb2457d28c319fe38b9b",
+  "date": "2019-07-22T19:52:52.271Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
@@ -10,7 +10,7 @@ export const getStyles = (props: IColorRectangleStyleProps): IColorRectangleStyl
       'ms-ColorPicker-colorRect',
       {
         position: 'relative',
-        marginBottom: 10,
+        marginBottom: 8,
         border: `1px solid ${palette.neutralLighter}`,
         borderRadius: effects.roundedCorner2,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/__snapshots__/ColorRectangle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/__snapshots__/ColorRectangle.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ColorRectangle renders correctly 1`] = `
       {
         border-radius: 2px;
         border: 1px solid #f3f2f1;
-        margin-bottom: 10px;
+        margin-bottom: 8px;
         position: relative;
       }
       @media screen and (-ms-high-contrast: active){& {

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ColorPicker renders correctly 1`] = `
           {
             border-radius: 2px;
             border: 1px solid #f3f2f1;
-            margin-bottom: 10px;
+            margin-bottom: 8px;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -37,7 +37,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             {
               border-radius: 2px;
               border: 1px solid #f3f2f1;
-              margin-bottom: 10px;
+              margin-bottom: 8px;
               position: relative;
             }
             @media screen and (-ms-high-contrast: active){& {


### PR DESCRIPTION
#### Pull request checklist

- [x] Fabric 7 port of Fabric 6 fluent-theme package change from #9564
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Porting over fluent changes made in 6.0 to Fabric 7 master. Specifically, the margin bottom of the color rectangle from 10px to 8px.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9892)